### PR TITLE
Thread granting permanent through granted triggered abilities (Dire Blunderbuss)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2580,7 +2580,13 @@ work for abilities-on-stack (which carry no `CardComponent`).
   excluding *only* the specific granter (a second same-named copy or another attachment stays legal). The
   granter is threaded to granted triggered abilities via `PendingTrigger.granterId` →
   `TriggeredAbilityOnStackComponent.granterId` → `EffectContext.granterId` → `PredicateContext.granterId`;
-  false with no granter context (an ungranted ability).
+  false with no granter context (an ungranted ability). `TriggerDetector.assignGranterIds` stamps the
+  granter on every event-based trigger (`detectTriggers`, including the batch/duplicate detectors) and on
+  phase/step triggers (`detectPhaseStepTriggers`), so a granted attack *or* upkeep trigger is covered;
+  identical co-attached granters are told apart by a per-`(source, ability)` cursor so N fired triggers map
+  1:1 onto the N granters. Not populated for leaves-the-battlefield granted triggers (a granted "dies"
+  ability): the source is already gone when the trigger fires, so the granter can't be recovered from its
+  attachment index — reference the granter by other means there, or scope with `notAttachedToSource()`.
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2570,9 +2570,17 @@ work for abilities-on-stack (which carry no `CardComponent`).
   `AttachedToComponent.targetId == sourceId`. Use it to scope a static ability on the *host* to its own
   attachments — Cloud, Midgar Mercenary's "an Equipment attached to it" via
   `GameObjectFilter.Artifact.withSubtype("Equipment").attachedToSource()`. Source-relative; inert with no
-  source context. Negated builder `notAttachedToSource()` — excludes the source's own attachments, backing
-  "an artifact other than [this granting Equipment]" on a granted triggered ability whose source is the
-  equipped creature (Dire Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss").
+  source context. Negated builder `notAttachedToSource()` — excludes all of the source's own attachments.
+- `IsGrantingPermanent` (negated builder `notGrantingPermanent()`) — matches the *granting permanent* of the
+  resolving ability: the Equipment/Aura/permanent whose `GrantActivatedAbility`/`GrantTriggeredAbility` static
+  granted the ability, read from the evaluation context's `granterId`. For a granted triggered ability the
+  ability's source is the equipped creature but the granter is the Equipment attached to it. Negate for
+  "an artifact other than [this granting Equipment]" exclusions (CR 201.5a) — Dire Blunderbuss's "sacrifice an
+  artifact other than Dire Blunderbuss" uses `GameObjectFilter.Artifact.youControl().notGrantingPermanent()`,
+  excluding *only* the specific granter (a second same-named copy or another attachment stays legal). The
+  granter is threaded to granted triggered abilities via `PendingTrigger.granterId` →
+  `TriggeredAbilityOnStackComponent.granterId` → `EffectContext.granterId` → `PredicateContext.granterId`;
+  false with no granter context (an ungranted ability).
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -719,13 +719,22 @@ data class GameObjectFilter(
 
     /**
      * Must NOT be an Aura/Equipment attached to the effect's source permanent — the negation of
-     * [attachedToSource]. Backs "an artifact other than [this granting Equipment]"-style
-     * exclusions on a granted triggered ability whose source is the equipped creature: the
-     * granting Equipment is the one attached to that creature, so this excludes it (Dire
-     * Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss").
+     * [attachedToSource].
      */
     fun notAttachedToSource() = copy(
         statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsAttachedToSource)
+    )
+
+    /**
+     * Must NOT be the *granting permanent* of the resolving ability — excludes exactly the
+     * Equipment/Aura/permanent whose static ability granted the ability (read from the evaluation
+     * context's `granterId`, CR 201.5a). Backs "an artifact other than [this granting Equipment]"
+     * on a granted triggered ability whose source is the equipped creature (Dire Blunderbuss's
+     * "sacrifice an artifact other than Dire Blunderbuss"): unlike [notAttachedToSource] it
+     * excludes only the specific granter, leaving other attachments and same-named copies legal.
+     */
+    fun notGrantingPermanent() = copy(
+        statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsGrantingPermanent)
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -544,6 +544,23 @@ sealed interface StatePredicate {
     }
 
     /**
+     * The candidate permanent is the *granting permanent* of the ability being resolved — the
+     * Equipment/Aura/permanent whose static ability granted the currently-resolving activated or
+     * triggered ability (read from the evaluation context's `granterId`). Source-relative to the
+     * grant rather than the ability's own source: for a granted triggered ability the source is
+     * the equipped creature, but the granter is the Equipment attached to it.
+     *
+     * Negate with [Not] for "other than [this granting permanent]" exclusions (CR 201.5a) — e.g.
+     * Dire Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss". False with no
+     * granter context (an ungranted ability).
+     */
+    @SerialName("IsGrantingPermanent")
+    @Serializable
+    data object IsGrantingPermanent : Entity {
+        override val description: String = "the granting permanent"
+    }
+
+    /**
      * The candidate permanent is the permanent the effect's source is attached to — i.e. the
      * creature/permanent enchanted or equipped by the source (read from the source's
      * `AttachedToComponent`). Source-relative: resolves against the source supplied in the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DireFlail.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DireFlail.kt
@@ -55,16 +55,12 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  *    is the equipped creature; the damage source defaults to it, matching "this creature deals").
  *
  * "an artifact other than Dire Blunderbuss" — CR 201.5a: the name refers only to the specific
- * granting Equipment. A granted *triggered* ability resolves with the equipped creature as its
- * source (not the Equipment), and the engine threads a `granterId` only into granted *activated*
- * abilities, so the granter can't be referenced by entity here. Instead the exclusion is scoped
- * with `.notAttachedToSource()`: the granting Blunderbuss is the Equipment attached to the
- * attacking creature (the source), so this excludes exactly it while leaving a *second* Dire
- * Blunderbuss elsewhere (on another creature or unattached) sacrificable — fixing the corner the
- * old `notNamed("Dire Blunderbuss")` filter mis-handled. Residual, rarer corner: another artifact
- * Equipment/Aura *also* attached to the same creature is likewise excluded (it shouldn't be); the
- * fully-correct fix is an entity-based exclusion once granterId is threaded through granted
- * triggered abilities.
+ * granting Equipment. The engine threads the granting permanent through granted *triggered*
+ * abilities (`PendingTrigger.granterId` → `TriggeredAbilityOnStackComponent.granterId` →
+ * `EffectContext.granterId` → `PredicateContext.granterId`), so the exclusion is the entity-based
+ * `.notGrantingPermanent()`: it excludes *exactly* this granting Blunderbuss and nothing else — a
+ * second Dire Blunderbuss elsewhere and any other Equipment attached to the same creature all stay
+ * sacrificable, matching the printed card in every case.
  */
 
 private val DireFlailFront = card("Dire Flail") {
@@ -129,7 +125,7 @@ private val DireBlunderbuss = card("Dire Blunderbuss") {
                                 filter = TargetFilter(
                                     GameObjectFilter.Artifact
                                         .youControl()
-                                        .notAttachedToSource()
+                                        .notGrantingPermanent()
                                 )
                             ),
                             storeAs = "toSacrifice"

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4795,7 +4795,7 @@
                                                     "statePredicates": [
                                                         {
                                                             "type": "StateNot",
-                                                            "predicate": "IsAttachedToSource"
+                                                            "predicate": "IsGrantingPermanent"
                                                         }
                                                     ],
                                                     "controllerPredicate": "ControlledByYou"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -425,6 +425,8 @@ class BeginningPhaseManager(
     ): Boolean = when (predicate) {
         // Graveyard-only predicate; untap filters never see a card with the marker.
         StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
+        // No granter context in untap filtering — granter-relative exclusion is resolution-time only.
+        StatePredicate.IsGrantingPermanent -> false
         is StatePredicate.HasCounter -> {
             val countersComponent = container.get<CountersComponent>()
             if (countersComponent == null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/PendingTrigger.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/PendingTrigger.kt
@@ -12,6 +12,14 @@ data class PendingTrigger(
     val sourceId: EntityId,
     val sourceName: String,
     val controllerId: EntityId,
+    /**
+     * The permanent whose `GrantTriggeredAbility` static granted this triggered ability, when it is
+     * a granted ability (e.g. an Equipment granting an attack trigger to the equipped creature).
+     * Carried onto the stack so the resolving effect can reference the granter (CR 201.5a) via
+     * [com.wingedsheep.engine.handlers.EffectContext.granterId] — e.g. Dire Blunderbuss's "sacrifice
+     * an artifact other than Dire Blunderbuss". Null for the source's own printed abilities.
+     */
+    val granterId: EntityId? = null,
     val triggerContext: TriggerContext,
     /**
      * When set, this pending trigger came from a one-shot event-based delayed triggered

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -329,16 +329,23 @@ class TriggerAbilityResolver(
      * Triggered abilities granted by Auras/Equipment attached to this entity.
      */
     /**
-     * The permanent whose `GrantTriggeredAbility` static granted the triggered ability [abilityId]
-     * to [entityId], or null when [abilityId] is one of [entityId]'s own printed abilities.
-     * Populates [com.wingedsheep.engine.handlers.EffectContext.granterId] so a granted ability can
-     * reference its granter (CR 201.5a) — e.g. Dire Blunderbuss's "sacrifice an artifact other than
-     * Dire Blunderbuss". Only inspects the entity's own attachments (the Equipment/Aura grant case)
-     * via the maintained [AttachmentsComponent] reverse index, so it is O(1) for the un-attached
+     * The permanents whose `GrantTriggeredAbility` static granted the triggered ability [abilityId]
+     * to [entityId], in attachment (reverse-index) order — empty when [abilityId] is one of
+     * [entityId]'s own printed abilities. Populates
+     * [com.wingedsheep.engine.handlers.EffectContext.granterId] so a granted ability can reference
+     * its granter (CR 201.5a) — e.g. Dire Blunderbuss's "sacrifice an artifact other than Dire
+     * Blunderbuss". Only inspects the entity's own attachments (the Equipment/Aura grant case) via
+     * the maintained [AttachmentsComponent] reverse index, so it is O(1) for the un-attached
      * majority and never scans the whole battlefield.
+     *
+     * Returns a *list* rather than a single id so two identical granters attached to the same
+     * creature (two copies of the same Equipment, granting the same `abilityId`) can be told apart:
+     * the caller matches the N fired triggers 1:1 onto these N granters instead of collapsing them
+     * onto whichever attachment happens to come first.
      */
-    fun resolveGranterId(state: GameState, entityId: EntityId, abilityId: AbilityId): EntityId? {
-        val attachments = state.getEntity(entityId)?.get<AttachmentsComponent>()?.attachedIds ?: return null
+    fun resolveGranterIds(state: GameState, entityId: EntityId, abilityId: AbilityId): List<EntityId> {
+        val attachments = state.getEntity(entityId)?.get<AttachmentsComponent>()?.attachedIds ?: return emptyList()
+        val granters = mutableListOf<EntityId>()
         for (attachmentId in attachments) {
             val container = state.getEntity(attachmentId) ?: continue
             if (container.has<FaceDownComponent>()) continue
@@ -352,10 +359,13 @@ class TriggerAbilityResolver(
                     else -> null
                 } ?: continue
                 if (grant.filter.scope !is Scope.AttachedTo) continue
-                if (grant.ability.id == abilityId) return attachmentId
+                if (grant.ability.id == abilityId) {
+                    granters.add(attachmentId)
+                    break
+                }
             }
         }
-        return null
+        return granters
     }
 
     private fun getAttachedGrantedTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.state.components.battlefield.SuspendedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.RingBearerComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.player.TheRingComponent
@@ -327,6 +328,36 @@ class TriggerAbilityResolver(
     /**
      * Triggered abilities granted by Auras/Equipment attached to this entity.
      */
+    /**
+     * The permanent whose `GrantTriggeredAbility` static granted the triggered ability [abilityId]
+     * to [entityId], or null when [abilityId] is one of [entityId]'s own printed abilities.
+     * Populates [com.wingedsheep.engine.handlers.EffectContext.granterId] so a granted ability can
+     * reference its granter (CR 201.5a) — e.g. Dire Blunderbuss's "sacrifice an artifact other than
+     * Dire Blunderbuss". Only inspects the entity's own attachments (the Equipment/Aura grant case)
+     * via the maintained [AttachmentsComponent] reverse index, so it is O(1) for the un-attached
+     * majority and never scans the whole battlefield.
+     */
+    fun resolveGranterId(state: GameState, entityId: EntityId, abilityId: AbilityId): EntityId? {
+        val attachments = state.getEntity(entityId)?.get<AttachmentsComponent>()?.attachedIds ?: return null
+        for (attachmentId in attachments) {
+            val container = state.getEntity(attachmentId) ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val cardDefId = container.get<CardComponent>()?.cardDefinitionId ?: continue
+            val cardDef = cardRegistry.getCard(cardDefId) ?: continue
+            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+                val grant = when (ability) {
+                    is GrantTriggeredAbility -> ability
+                    is ConditionalStaticAbility -> ability.ability as? GrantTriggeredAbility
+                    else -> null
+                } ?: continue
+                if (grant.filter.scope !is Scope.AttachedTo) continue
+                if (grant.ability.id == abilityId) return attachmentId
+            }
+        }
+        return null
+    }
+
     private fun getAttachedGrantedTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> {
         val result = mutableListOf<TriggeredAbility>()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1417,7 +1417,14 @@ class TriggerDetector(
             detectExploitedSelfSacrificeTriggers(state, event, triggers)
         }
 
-        return triggers
+        // Record the granting permanent for any granted triggered ability (Equipment/Aura granting
+        // a trigger to the attached creature), so the resolving effect can reference its granter
+        // (CR 201.5a) via EffectContext.granterId. Cheap: resolveGranterId is O(1) for the
+        // un-attached majority.
+        return triggers.map { trigger ->
+            val granterId = abilityResolver.resolveGranterId(state, trigger.sourceId, trigger.ability.id)
+            if (granterId != null) trigger.copy(granterId = granterId) else trigger
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -355,7 +355,42 @@ class TriggerDetector(
         val filteredTriggers = capOncePerTurnTriggers(state, triggers)
 
         // Rule 603.4: Filter out triggers with unmet intervening-if conditions
-        return matcher.sortByApnapOrder(state, matcher.filterByTriggerCondition(state, filteredTriggers))
+        return matcher.sortByApnapOrder(
+            state,
+            matcher.filterByTriggerCondition(state, assignGranterIds(state, filteredTriggers))
+        )
+    }
+
+    /**
+     * Stamp each granted triggered ability with the permanent that granted it (an Equipment/Aura
+     * granting a trigger to the attached creature), so the resolving effect can reference its
+     * granter (CR 201.5a) via [com.wingedsheep.engine.handlers.EffectContext.granterId] — e.g. Dire
+     * Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss". Applied uniformly to every
+     * event-based path (per-event scan plus the batch/duplicate detectors that append directly to
+     * the trigger list) and to [detectPhaseStepTriggers], so a granted upkeep/step trigger is
+     * covered too — not just the attack-trigger case.
+     *
+     * When several identical granters are attached to the same creature (two copies of the same
+     * Equipment), each fires its own trigger with an identical `abilityId`; a per-`(source, ability)`
+     * cursor hands the granting attachments out in index order so the N triggers map 1:1 onto the N
+     * granters instead of all collapsing onto the first. Triggers beyond the granter count (e.g. a
+     * Panharmonicon-doubled copy) clamp to the last granter, keeping the doubled copy pointed at the
+     * same Equipment. Cheap: [TriggerAbilityResolver.resolveGranterIds] is O(1) for the un-attached
+     * majority.
+     */
+    private fun assignGranterIds(
+        state: GameState,
+        triggers: List<PendingTrigger>
+    ): List<PendingTrigger> {
+        val cursor = HashMap<Pair<EntityId, com.wingedsheep.sdk.scripting.AbilityId>, Int>()
+        return triggers.map { trigger ->
+            val granters = abilityResolver.resolveGranterIds(state, trigger.sourceId, trigger.ability.id)
+            if (granters.isEmpty()) return@map trigger
+            val key = trigger.sourceId to trigger.ability.id
+            val i = cursor.getOrDefault(key, 0)
+            cursor[key] = i + 1
+            trigger.copy(granterId = granters.getOrElse(i) { granters.last() })
+        }
     }
 
     /**
@@ -574,7 +609,10 @@ class TriggerDetector(
         val filteredTriggers = capOncePerTurnTriggers(state, triggers)
 
         // Rule 603.4: Filter out triggers with unmet intervening-if conditions
-        return matcher.sortByApnapOrder(state, matcher.filterByTriggerCondition(state, filteredTriggers))
+        return matcher.sortByApnapOrder(
+            state,
+            matcher.filterByTriggerCondition(state, assignGranterIds(state, filteredTriggers))
+        )
     }
 
     /**
@@ -1417,14 +1455,7 @@ class TriggerDetector(
             detectExploitedSelfSacrificeTriggers(state, event, triggers)
         }
 
-        // Record the granting permanent for any granted triggered ability (Equipment/Aura granting
-        // a trigger to the attached creature), so the resolving effect can reference its granter
-        // (CR 201.5a) via EffectContext.granterId. Cheap: resolveGranterId is O(1) for the
-        // un-attached majority.
-        return triggers.map { trigger ->
-            val granterId = abilityResolver.resolveGranterId(state, trigger.sourceId, trigger.ability.id)
-            if (granterId != null) trigger.copy(granterId = granterId) else trigger
-        }
+        return triggers
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1702,6 +1702,8 @@ class TriggerMatcher(
         }
         // Graveyard-zone-only predicate; trigger gating never sees a stamped entity here.
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
+        // No granter context in trigger gating — granter-relative exclusion is resolution-time only.
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsGrantingPermanent -> false
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Or ->
             predicate.predicates.any { matchesStatePredicateForTrigger(it, state, entityId) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.And ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -715,6 +715,7 @@ class TriggerProcessor(
             effect = effectOverride ?: ability.effect,
             description = ability.description,
             abilityIdentity = state.abilityIdentityOf(trigger.sourceId, ability.id),
+            granterId = trigger.granterId,
             descriptionOverride = ability.descriptionOverride,
             triggerDamageAmount = trigger.triggerContext.damageAmount,
             triggeringEntityId = trigger.triggerContext.triggeringEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1118,6 +1118,7 @@ class PredicateEvaluator {
             // PreventActivatedAbilities form (Braided Net), where the activation-legality
             // check supplies the grant's holder as the source. False with no source context.
             StatePredicate.IsSource -> context?.sourceId == entityId
+            StatePredicate.IsGrantingPermanent -> context?.granterId != null && context.granterId == entityId
 
             // Source-relative — the candidate is the permanent the effect's source is attached
             // to (its enchanted/equipped creature). Read the source's AttachedToComponent and
@@ -1377,6 +1378,13 @@ data class PredicateContext(
     val sourceId: EntityId? = null,
     /** Owner of the entity being evaluated (for graveyard targeting) */
     val ownerId: EntityId? = null,
+    /**
+     * The permanent whose static ability granted the resolving ability (the Equipment/Aura bearing
+     * a `GrantActivatedAbility`/`GrantTriggeredAbility`). Lets a target filter resolve
+     * [StatePredicate.IsGrantingPermanent] — e.g. "an artifact other than [this granting Equipment]"
+     * (Dire Blunderbuss). Null for ungranted abilities.
+     */
+    val granterId: EntityId? = null,
     /** The entity that caused the trigger to fire (for SharesCreatureTypeWithTriggeringEntity) */
     val triggeringEntityId: EntityId? = null,
     /**
@@ -1474,6 +1482,7 @@ data class PredicateContext(
                 targetOpponentId = chosenPlayerTarget,
                 targetPlayerId = chosenPlayerTarget,
                 sourceId = context.sourceId,
+                granterId = context.granterId,
                 triggeringEntityId = context.triggeringEntityId,
                 triggeringPlayerId = context.triggeringPlayerId,
                 affectedEntityId = context.affectedEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -156,7 +156,15 @@ class ReflexiveTriggerEffectExecutor(
             state = state,
             requirement = action.requirement,
             controllerId = context.controllerId,
-            sourceId = context.sourceId
+            sourceId = context.sourceId,
+            // Carry granterId so the "may" feasibility check honors a granter-relative exclusion —
+            // e.g. Dire Blunderbuss must NOT offer the sacrifice when the only artifact is the
+            // granting Equipment itself. Minimal context (granterId only) matches the actual
+            // selection path in SelectTargetPipelineExecutor, so feasibility and execution agree.
+            pipelineContext = com.wingedsheep.engine.handlers.PredicateContext(
+                controllerId = context.controllerId,
+                granterId = context.granterId
+            )
         ).isNotEmpty()
         is SacrificeEffect -> {
             // You can only sacrifice permanents you control that match the filter (mirrors

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectTargetPipelineExecutor.kt
@@ -38,7 +38,15 @@ class SelectTargetPipelineExecutor(
             state = state,
             requirement = effect.requirement,
             controllerId = controllerId,
-            sourceId = sourceId
+            sourceId = sourceId,
+            // Carry the resolving ability's granter so a target filter can exclude it via
+            // StatePredicate.IsGrantingPermanent — e.g. Dire Blunderbuss's "an artifact other than
+            // Dire Blunderbuss" (CR 201.5a). Only granterId is threaded; other context fields keep
+            // their prior (null) defaults so no existing SelectTargetEffect changes behavior.
+            pipelineContext = com.wingedsheep.engine.handlers.PredicateContext(
+                controllerId = controllerId,
+                granterId = context.granterId
+            )
         )
 
         if (legalTargets.isEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -430,6 +430,8 @@ internal class AffectsFilterResolver {
         // its own source, use GroupFilter's Scope.Self instead. Only meaningful in point-of-use
         // checks (activation legality) via PredicateEvaluator. Never match here.
         StatePredicate.IsSource -> false
+        // No granter context during projection — granter-relative exclusion is resolution-time only.
+        StatePredicate.IsGrantingPermanent -> false
         // Source-relative exile linkage (LinkedExileComponent on the effect source). Only
         // meaningful in target/gather-filter contexts via PredicateEvaluator; never match in
         // group-static projection.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2168,6 +2168,7 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
+            granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
             targets = resolvedTargets2,
             triggerDamageAmount = abilityComponent.triggerDamageAmount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -141,6 +141,14 @@ data class TriggeredAbilityOnStackComponent(
     /** Power of the aura/equipment's attached creature, captured at trigger time; LKI for
      *  "enchanted creature ... its power" reads when the creature has left (CR 608.2h). */
     val enchantedCreatureLastKnownPower: Int? = null,
+    /**
+     * The permanent whose `GrantTriggeredAbility` static granted this triggered ability (an
+     * Equipment/Aura granting the ability to the attached creature). Read at resolution into
+     * [com.wingedsheep.engine.handlers.EffectContext.granterId] so the effect can reference its
+     * granter (CR 201.5a) — e.g. Dire Blunderbuss's "sacrifice an artifact other than Dire
+     * Blunderbuss". Null for the source's own printed abilities.
+     */
+    val granterId: EntityId? = null,
     /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,
     /** Damage past lethal dealt to the trigger's creature recipient (CR 120.4a). Null for non-damage triggers. */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
@@ -74,11 +74,22 @@ class DireFlailScenarioTest : FunSpec({
         oracleText = ""
     )
 
+    // 0/20 wall: a durable reflexive-damage target that survives repeated hits, so a scenario
+    // with two attack triggers always has a legal creature to point the "deals damage" at.
+    val wall = CardDefinition.creature(
+        name = "Test Big Wall",
+        manaCost = ManaCost.parse("{4}"),
+        subtypes = setOf(Subtype("Wall")),
+        power = 0,
+        toughness = 20,
+        oracleText = ""
+    )
+
     val projector = StateProjector()
 
     fun setup(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(trinket, ox))
+        driver.registerCards(TestCards.all + listOf(trinket, ox, wall))
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
         return driver
     }
@@ -391,6 +402,63 @@ class DireFlailScenarioTest : FunSpec({
         // The co-attached Dire Flail (not the granter) was sacrificed; the granting Blunderbuss is intact.
         driver.getGraveyard(p1).shouldContain(coEquip)
         driver.state.getEntity(blunderbuss)?.get<AttachedToComponent>()?.targetId shouldBe courser
+    }
+
+    test("two identical granters on one creature are told apart: each excludes only itself, so both can be sacrificed") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        // Two Dire Blunderbusses, both equipped to the same creature. No other artifact exists.
+        val b1 = driver.craftToBlunderbuss(p1)
+        val b2 = driver.craftToBlunderbuss(p1)
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        driver.equipBlunderbuss(p1, b1, courser)
+        driver.equipBlunderbuss(p1, b2, courser)
+
+        // Durable target: the equipped 3/3 is 9/3 with two Blunderbusses, so the reflexive damage
+        // would kill a small creature and leave the second trigger no legal creature target. A 0/20
+        // wall survives both hits, keeping the test focused on the sacrifice-exclusion behavior.
+        val victim = driver.putCreatureOnBattlefield(opponent, "Test Big Wall") // 0/20
+
+        // Both grants fire an attack trigger (the ability isn't once-per-turn). Each grant excludes
+        // ONLY its own granter, so b1's trigger can sacrifice b2 and b2's trigger can sacrifice b1.
+        // Under the old first-match `granterId` derivation both triggers pinned the granter to
+        // whichever copy sorted first, so after the first sacrifice the second trigger saw no legal
+        // fodder — proving the per-(source, ability) cursor now maps the two triggers 1:1 onto the
+        // two granters.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(courser), opponent).error shouldBe null
+
+        driver.resolveUntilDecision()
+        var guard = 0
+        while (driver.pendingDecision != null && guard++ < 20) {
+            when (val d = driver.pendingDecision) {
+                is YesNoDecision -> driver.submitYesNo(p1, true).error shouldBe null
+                is ChooseTargetsDecision -> {
+                    val legal = d.legalTargets[0].orEmpty()
+                    // A Blunderbuss in the legal set means this is the sacrifice-target choice
+                    // (the other copy); otherwise it's the reflexive damage's creature target.
+                    val pick = when {
+                        b1 in legal -> b1
+                        b2 in legal -> b2
+                        else -> victim
+                    }
+                    driver.submitTargetSelection(p1, listOf(pick)).error shouldBe null
+                }
+                is SelectCardsDecision -> {
+                    val pick = d.options.firstOrNull { it == b1 || it == b2 } ?: d.options.first()
+                    driver.submitCardSelection(p1, listOf(pick))
+                }
+                else -> break
+            }
+            if (driver.pendingDecision == null) driver.drainStack()
+        }
+
+        // Both Blunderbusses ended up sacrificed — each trigger found the *other* copy as fodder.
+        driver.getGraveyard(p1).shouldContain(b1)
+        driver.getGraveyard(p1).shouldContain(b2)
     }
 
     test("negative: craft rejected when the supplied material is a creature, not an artifact") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
@@ -293,7 +293,7 @@ class DireFlailScenarioTest : FunSpec({
         driver.state.getEntity(blunderbuss)?.get<AttachedToComponent>()?.targetId shouldBe courser
     }
 
-    test("a second Dire Blunderbuss (unattached) is a legal sacrifice; the granting one is excluded by attachment") {
+    test("a second Dire Blunderbuss (unattached) is a legal sacrifice; only the granting one is excluded") {
         val driver = setup()
         val p1 = driver.activePlayer!!
         val opponent = driver.getOpponent(p1)
@@ -310,8 +310,8 @@ class DireFlailScenarioTest : FunSpec({
         driver.declareAttackers(p1, listOf(courser), opponent).error shouldBe null
 
         // Under the old `notNamed("Dire Blunderbuss")` filter both copies were excluded, leaving
-        // no fodder — so no sacrifice, no damage. With `.notAttachedToSource()` only the attached
-        // granting copy (b1) is excluded; the unattached b2 is legal fodder.
+        // no fodder — so no sacrifice, no damage. With `.notGrantingPermanent()` only the specific
+        // granting copy (b1) is excluded; the second copy b2 is legal fodder.
         driver.resolveUntilDecision()
         var guard = 0
         while (driver.pendingDecision != null && guard++ < 10) {
@@ -336,6 +336,61 @@ class DireFlailScenarioTest : FunSpec({
         driver.getGraveyard(p1).shouldContain(b2)
         driver.state.getEntity(b1)?.get<AttachedToComponent>()?.targetId shouldBe courser
         driver.findPermanent(opponent, "Test Sturdy Ox") shouldBe null
+    }
+
+    test("only the granter is excluded: another Equipment co-attached to the same creature is still sacrificable") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val blunderbuss = driver.craftToBlunderbuss(p1) // the granter
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        driver.equipBlunderbuss(p1, blunderbuss, courser)
+
+        // A second Equipment (a Dire Flail front face) also equipped to the SAME creature.
+        // Under the old `.notAttachedToSource()` filter it was wrongly excluded (attached to the
+        // source); `.notGrantingPermanent()` excludes only the granting Blunderbuss, so it's legal.
+        val coEquip = driver.putPermanentOnBattlefield(p1, "Dire Flail")
+        driver.giveColorlessMana(p1, 1)
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = coEquip,
+                abilityId = frontEquipAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(courser))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(coEquip)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Test Sturdy Ox") // 2/4
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(courser), opponent).error shouldBe null
+
+        driver.resolveUntilDecision()
+        var guard = 0
+        while (driver.pendingDecision != null && guard++ < 10) {
+            when (val d = driver.pendingDecision) {
+                is YesNoDecision -> driver.submitYesNo(p1, true).error shouldBe null
+                is ChooseTargetsDecision -> {
+                    val legal = d.legalTargets[0].orEmpty()
+                    when {
+                        coEquip in legal || blunderbuss in legal ->
+                            driver.submitTargetSelection(p1, listOf(coEquip)).error shouldBe null
+                        else -> driver.submitTargetSelection(p1, listOf(victim)).error shouldBe null
+                    }
+                }
+                is SelectCardsDecision -> driver.submitCardSelection(p1, listOf(coEquip))
+                else -> break
+            }
+            if (driver.pendingDecision == null) driver.drainStack()
+        }
+
+        // The co-attached Dire Flail (not the granter) was sacrificed; the granting Blunderbuss is intact.
+        driver.getGraveyard(p1).shouldContain(coEquip)
+        driver.state.getEntity(blunderbuss)?.get<AttachedToComponent>()?.targetId shouldBe courser
     }
 
     test("negative: craft rejected when the supplied material is a creature, not an artifact") {


### PR DESCRIPTION
## Thread the granting permanent through granted triggered abilities (Dire Blunderbuss)

Adds a first-class way for a *granted* triggered ability to reference the permanent that
granted it (its Equipment/Aura), so filters can express "other than [this granting
Equipment]" precisely — implementing **Dire Blunderbuss** (LCI #145 back face) correctly.

### The card

> **Dire Blunderbuss** — Equipped creature gets +3/+0 and has "Whenever this creature
> attacks, you may sacrifice an artifact **other than Dire Blunderbuss**. When you do, this
> creature deals damage equal to its power to target creature." Equip {1}.

The exclusion is CR 201.5a: the name refers only to *that specific* granting Equipment. The
tricky part is that a granted *triggered* ability resolves with the **equipped creature** as
its source, not the Equipment — so the granter can't be reached as "the source".

### What's added

- **SDK:** `StatePredicate.IsGrantingPermanent` + filter builder `notGrantingPermanent()`.
  It matches the granting permanent read from the evaluation context's `granterId`, so
  `GameObjectFilter.Artifact.youControl().notGrantingPermanent()` excludes *only* the
  specific granter — a second same-named copy, and any other Equipment on the same creature,
  stay legal.
- **Engine:** the granter is threaded onto the stack and into filter evaluation via
  `PendingTrigger.granterId` → `TriggeredAbilityOnStackComponent.granterId` →
  `EffectContext.granterId` → `PredicateContext.granterId`. `TriggerDetector.assignGranterIds`
  stamps it uniformly across every event-based path (`detectTriggers`, including the
  batch/duplicate detectors) and phase/step triggers (`detectPhaseStepTriggers`).
  `ReflexiveTriggerEffectExecutor` and `SelectTargetPipelineExecutor` both carry `granterId`
  so the optional "may" feasibility check and the actual selection agree.

This replaces an earlier proximity approximation (`notAttachedToSource()`, which also excluded
any *other* Equipment co-attached to the same creature) with an exact, entity-based exclusion.

### Coverage & edge cases

- **Identical co-attached granters:** two copies of the same Equipment on one creature each
  grant a trigger with the same `abilityId`. `resolveGranterIds` returns all granting
  attachments in index order and `assignGranterIds` uses a per-`(source, ability)` cursor to
  map the N fired triggers 1:1 onto the N granters, so each trigger excludes only its own copy.
- **Not covered (documented):** leaves-the-battlefield granted triggers (a granted "dies"
  ability) — the source is gone before the trigger fires, so the granter can't be recovered
  from the attachment index. Noted in the SDK reference.

### Tests

`DireFlailScenarioTest` (rules-engine) — 9 scenarios, all green: front/back equip and stat
grants, craft end-to-end, the granted attack-trigger happy path, declining the optional
sacrifice, the self-exclusion (no prompt when the only artifact is the Blunderbuss itself), a
second unattached Blunderbuss staying sacrificable, a co-attached *different* Equipment staying
sacrificable, and two identical Blunderbusses on one creature each excluding only themselves
(so both can be sacrificed).

### SDK reference

`docs/card-sdk-language-reference.md` updated for `IsGrantingPermanent` / `notGrantingPermanent()`,
including the threading path and the precise coverage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
