### PR TITLE
Visualize when a Defender can attack + fix Mistbreath Elder upkeep text

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1055,6 +1055,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   turn as though it didn't have defender. Adds a transient `CanAttackDespiteDefenderThisTurnComponent`
   honored by the defender attack-restriction rule and cleaned up at end of turn. The
   activated/temporary counterpart to the static `CanAttackDespiteDefender` ability (Krotiq Nestguard).
+  Both the static ability and this transient grant are read directly by the attack-restriction rule
+  (via the shared `DefenderBypass` helper), never through the layer system — so while a Defender's
+  restriction is lifted, `ClientStateTransformer` surfaces a "Can attack despite defender"
+  `activeEffects` badge on the card (mirroring how Akawalli's descend-8 block restriction is shown),
+  letting the player see the creature can attack the moment the condition is met (e.g. after an
+  artifact enters for Shipwreck Sentry / Mechan Shieldmate).
 - `Effects.Goad(target = ContextTarget(0))` (`GoadEffect`) — goad target creature (CR 701.15).
   Tags the creature with `GoadedComponent(goaderIds: Set<EntityId>)`; the effect's controller at
   resolution is recorded as the goader. While goaded the creature (a) must attack each combat if able

--- a/manual-scenarios/cards/m/mistbreath-elder-bounce-and-counter.json
+++ b/manual-scenarios/cards/m/mistbreath-elder-bounce-and-counter.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Mistbreath Elder", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "BEGINNING",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/cards/s/shipwreck-sentry-can-attack-badge.json
+++ b/manual-scenarios/cards/s/shipwreck-sentry-can-attack-badge.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Ornithopter"],
+    "battlefield": [
+      {"name": "Shipwreck Sentry", "summoningSickness": false},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MistbreathElder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MistbreathElder.kt
@@ -39,6 +39,12 @@ val MistbreathElder = card("Mistbreath Elder") {
 
     triggeredAbility {
         trigger = Triggers.YourUpkeep
+        // The effect tree below (Exists → Gather → Select → Move) would otherwise render a
+        // garbled auto-description ("...look at all other creature permanents...Put those cards
+        // into a hand..."), so pin the player-facing text to the oracle wording.
+        description = "At the beginning of your upkeep, return another creature you control to " +
+            "its owner's hand. If you do, put a +1/+1 counter on this creature. Otherwise, you " +
+            "may return this creature to its owner's hand."
         effect = ConditionalEffect(
             condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature.youControl(), excludeSelf = true),
             // If you control another creature: bounce one of them (Gather → Select → Move;

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -12020,7 +12020,8 @@
                             "destination": "Hand"
                         }
                     }
-                }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, return another creature you control to its owner's hand. If you do, put a +1/+1 counter on this creature. Otherwise, you may return this creature to its owner's hand."
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
-import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -15,9 +14,7 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.InAdditionalCombatPhaseComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
 import com.wingedsheep.sdk.scripting.CantAttackUnless
-import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
 
 // =========================================================================
@@ -91,32 +88,17 @@ class DefenderAttackRule : AttackRestrictionRule {
     override fun check(ctx: AttackCheckContext): String? {
         if (!ctx.projected.hasKeyword(ctx.attackerId, Keyword.DEFENDER)) return null
 
-        val container = ctx.state.getEntity(ctx.attackerId) ?: return errorMsg(ctx)
+        // The Defender restriction is lifted by a temporary "attack this turn as though it didn't
+        // have defender" grant or a satisfied CanAttackDespiteDefender static ability. Both live in
+        // DefenderBypass so this enforcement path and the client's "can attack" badge agree exactly.
+        if (DefenderBypass.isActive(ctx.state, ctx.attackerId, ctx.attackingPlayer, ctx.cardRegistry)) return null
 
-        // Temporary "can attack this turn as though it didn't have defender" grant
-        // (e.g. Krotiq Nestguard's activated ability). The marker is removed at end of turn.
-        if (container.has<CanAttackDespiteDefenderThisTurnComponent>()) return null
-
-        val cardComp = container.get<CardComponent>() ?: return errorMsg(ctx)
-        val cardDef = ctx.cardRegistry.getCard(cardComp.cardDefinitionId) ?: return errorMsg(ctx)
-
-        val effectContext = EffectContext(sourceId = ctx.attackerId, controllerId = ctx.attackingPlayer)
-        val canAttackDespite = cardDef.staticAbilities
-            .filterIsInstance<CanAttackDespiteDefender>()
-            .filter { it.filter.scope is Scope.Self }
-            .any { conditionEvaluator.evaluate(ctx.state, it.condition, effectContext) }
-
-        if (canAttackDespite) return null
         return errorMsg(ctx)
     }
 
     private fun errorMsg(ctx: AttackCheckContext): String {
         val name = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>()?.name ?: "Creature"
         return "$name has defender and cannot attack"
-    }
-
-    companion object {
-        private val conditionEvaluator = ConditionEvaluator()
     }
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/DefenderBypass.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/DefenderBypass.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.mechanics.combat.rules
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.filters.unified.Scope
+
+/**
+ * Single source of truth for "is the Defender restriction currently lifted for this creature?".
+ *
+ * A creature with defender can't attack (CR 702.3b) unless an effect lets it. Two things can lift
+ * that restriction:
+ *  - a temporary "attack this turn as though it didn't have defender" grant
+ *    ([CanAttackDespiteDefenderThisTurnComponent], e.g. Krotiq Nestguard's activated ability), or
+ *  - a [CanAttackDespiteDefender] static ability scoped to the creature itself whose condition
+ *    currently holds (e.g. Shipwreck Sentry / Mechan Shieldmate once an artifact entered this turn).
+ *
+ * This does NOT check whether the creature actually has the Defender keyword — callers gate on that
+ * (attack legality only cares when Defender is present; the display badge only shows on defenders).
+ * Consulted by both [DefenderAttackRule] (enforcement) and `ClientStateTransformer` (the display
+ * badge), so what the player SEES stays in sync with what the rules let them DO.
+ */
+object DefenderBypass {
+    private val conditionEvaluator = ConditionEvaluator()
+
+    fun isActive(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        cardRegistry: CardRegistry
+    ): Boolean {
+        val container = state.getEntity(entityId) ?: return false
+
+        // Temporary this-turn grant.
+        if (container.has<CanAttackDespiteDefenderThisTurnComponent>()) return true
+
+        // Static "can attack despite defender as long as <condition>" printed on the creature.
+        val cardComp = container.get<CardComponent>() ?: return false
+        val cardDef = cardRegistry.getCard(cardComp.cardDefinitionId) ?: return false
+        val effectContext = EffectContext(sourceId = entityId, controllerId = controllerId)
+        return cardDef.staticAbilities
+            .filterIsInstance<CanAttackDespiteDefender>()
+            .filter { it.filter.scope is Scope.Self }
+            .any { conditionEvaluator.evaluate(state, it.condition, effectContext) }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.engine.mechanics.combat.rules.DefenderBypass
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Subtype
@@ -2692,6 +2693,30 @@ class ClientStateTransformer(
                         )
                     }
                 }
+            }
+        }
+
+        // Printed "can attack despite defender" (Shipwreck Sentry, Mechan Shieldmate, …) and the
+        // temporary Krotiq-style grant are read directly by AttackRestrictionRules, never through the
+        // layer system, so they never reach the projected keyword set / abilityFlags. Surface a badge
+        // while the creature actually has Defender AND the restriction is currently lifted, so the
+        // player can see a Defender that can presently attack (e.g. after an artifact entered this
+        // turn). Shares DefenderBypass with the attack-legality rule so the badge shows exactly when
+        // the attack would be allowed.
+        if (restrictionController != null &&
+            state.projectedState.hasKeyword(entityId, Keyword.DEFENDER) &&
+            DefenderBypass.isActive(state, entityId, restrictionController, cardRegistry)
+        ) {
+            val description = "Can attack despite defender"
+            if (seenGrantDescriptions.add(description)) {
+                effects.add(
+                    ClientCardEffect(
+                        effectId = "can_attack_despite_defender",
+                        name = "Can Attack",
+                        description = description,
+                        icon = "can-attack"
+                    )
+                )
             }
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShipwreckSentryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShipwreckSentryScenarioTest.kt
@@ -3,12 +3,15 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.mtg.sets.definitions.atq.cards.Ornithopter
 import com.wingedsheep.mtg.sets.definitions.lci.cards.ShipwreckSentry
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -85,6 +88,58 @@ class ShipwreckSentryScenarioTest : FunSpec({
         }
         withClue("Sentry is now an attacker") {
             driver.state.getEntity(sentry)?.get<AttackingComponent>().shouldNotBeNull()
+        }
+    }
+
+    // The client "can attack despite defender" badge (ClientCardEffect on the ClientCard) shares
+    // DefenderBypass with the attack-legality rule, so it appears exactly when the Sentry could be
+    // declared — and, crucially, already in the main phase after the artifact resolves, before the
+    // declare-attackers step. That early reveal is the whole point: the player sees the Defender can
+    // now attack right after playing an artifact.
+    fun hasCanAttackBadge(driver: GameTestDriver, viewer: com.wingedsheep.sdk.model.EntityId, card: com.wingedsheep.sdk.model.EntityId): Boolean =
+        ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewer)
+            .cards[card]?.activeEffects
+            ?.any { it.description == "Can attack despite defender" } ?: false
+
+    test("no 'can attack despite defender' badge when no artifact entered this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val sentry = driver.putCreatureOnBattlefield(you, "Shipwreck Sentry")
+        driver.removeSummoningSickness(sentry)
+
+        withClue("Defender with no artifact having entered shows no can-attack badge") {
+            hasCanAttackBadge(driver, you, sentry).shouldBeFalse()
+        }
+    }
+
+    test("badge reveals the Sentry can attack in the main phase, right after an artifact enters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        val sentry = driver.putCreatureOnBattlefield(you, "Shipwreck Sentry")
+        driver.removeSummoningSickness(sentry)
+
+        withClue("No badge before any artifact enters") {
+            hasCanAttackBadge(driver, you, sentry).shouldBeFalse()
+        }
+
+        val thopter = driver.putCardInHand(you, "Ornithopter")
+        driver.castSpell(you, thopter).isSuccess shouldBe true
+        driver.bothPass() // resolve Ornithopter — an artifact enters under your control this turn
+
+        // Still the precombat main phase — the reveal happens here, not only at declare-attackers.
+        driver.state.step shouldBe Step.PRECOMBAT_MAIN
+        withClue("Badge appears for you once an artifact entered this turn") {
+            hasCanAttackBadge(driver, you, sentry).shouldBeTrue()
+        }
+        withClue("The bypass is public information, so the opponent sees the badge too") {
+            hasCanAttackBadge(driver, opponent, sentry).shouldBeTrue()
         }
     }
 })

--- a/web-client/src/components/game/card/CardOverlays.tsx
+++ b/web-client/src/components/game/card/CardOverlays.tsx
@@ -216,6 +216,12 @@ function getBadgeStyle(icon?: string): React.CSSProperties {
         backgroundColor: 'rgba(180, 60, 60, 0.9)',
         border: '1px solid rgba(255, 140, 140, 0.5)',
       }
+    case 'can-attack':
+      // Positive/green — a Defender that can attack right now (e.g. after an artifact entered).
+      return {
+        backgroundColor: 'rgba(40, 120, 60, 0.9)',
+        border: '1px solid rgba(120, 220, 140, 0.5)',
+      }
     case 'exile-on-death':
       return {
         backgroundColor: 'rgba(120, 60, 140, 0.9)',
@@ -268,6 +274,8 @@ function getTooltipBorderColor(icon?: string): string {
     case 'cant-block':
     case 'cant-attack':
       return 'rgba(180, 60, 60, 0.5)'
+    case 'can-attack':
+      return 'rgba(120, 220, 140, 0.5)'
     case 'must-attack':
       return 'rgba(200, 120, 20, 0.5)'
     case 'condition-met':


### PR DESCRIPTION

<img width="506" height="554" alt="image" src="https://github.com/user-attachments/assets/928e50d9-35ca-4e22-ae73-e575888f7800" />

<img width="175" height="361" alt="image" src="https://github.com/user-attachments/assets/7e4b7786-0121-462f-80bd-7b13a332b8c6" />


## What

Two small fixes plus the UX affordance that ties them together:

1. **Visualize when a Defender can attack** — a green "Can Attack" badge on any creature that
   has Defender but whose attack restriction is currently lifted (e.g. Shipwreck Sentry /
   Mechan Shieldmate once an artifact has entered under your control this turn, or a
   Krotiq-style temporary "attack as though it didn't have defender" grant). The badge appears
   the moment the condition is met — already in the main phase, before declare-attackers — so
   the player can see the Defender can now attack right after playing the artifact.

2. **Fix Mistbreath Elder's garbled upkeep text** — the `Exists → Gather → Select → Move`
   effect tree auto-rendered as garbled prose ("…look at all other creature permanents…Put
   those cards into a hand…"). Pinned the ability description to the oracle wording.

## How

- Extracted the "is the Defender restriction currently lifted?" logic out of `DefenderAttackRule`
  into a shared `DefenderBypass` helper (`rules-engine/.../combat/rules/DefenderBypass.kt`).
  Both the attack-legality rule (enforcement) and `ClientStateTransformer` (the display badge)
  now consult it, so **what the player sees stays exactly in sync with what the rules allow**.
  No new SDK type — the rule file gets smaller.
- The badge follows the existing Akawalli descend-8 block-restriction precedent in
  `ClientStateTransformer`: these restrictions are read directly by combat, never through the
  layer system, so they never reach the projected keyword set / `abilityFlags` and get no
  keyword chip — hence a badge. Gated on **projected** `hasKeyword(DEFENDER)`.
- Web client: `can-attack` icon gets a green badge style + tooltip border (`CardOverlays.tsx`).
- `MistbreathElder.kt` gets a `description` override matching the Scryfall oracle text; `BLB.json`
  snapshot re-blessed accordingly.
- `docs/card-sdk-language-reference.md` updated to describe the badge behavior.

## Tests

`rules-engine` `ShipwreckSentryScenarioTest` — all 4 green (`just test-class
ShipwreckSentryScenarioTest`, BUILD SUCCESSFUL):

- cannot attack when no artifact entered this turn
- can attack once an artifact entered this turn
- **no badge when no artifact entered this turn** (new)
- **badge reveals the Sentry can attack in the main phase, right after an artifact enters**, and
  the opponent sees it too (public info) (new)

Manual self-play scenarios added for both fixes under `manual-scenarios/cards/`.

CR 702.3b ("A creature with defender can't attack") verified against the Comprehensive Rules;
Mistbreath Elder oracle text verified against Scryfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
