### PR TITLE
Add three Foundations cards: Starlight Snare, Harmless Offering, Undying Malice

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 117 / 272
+**Implemented:** 118 / 272
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -245,7 +245,7 @@
 - [ ] Twinblade Geist
 - [ ] Ulvenwald Oddity
 - [x] Undead Butler
-- [ ] Undying Malice
+- [x] Undying Malice
 - [x] Unhallowed Phalanx
 - [x] Unholy Officiant
 - [x] Valorous Stance

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HarmlessOffering.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HarmlessOffering.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Harmless Offering
+ * {2}{R}
+ * Sorcery
+ *
+ * Target opponent gains control of target permanent you control.
+ *
+ * Two targets, declared in oracle order: the opponent who receives control (context 0) and the
+ * permanent you control that changes hands (context 1). The permanent moves permanently — the
+ * classic "donate" gift, weaponized with cards that punish their new controller.
+ */
+val HarmlessOffering = card("Harmless Offering") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent gains control of target permanent you control."
+
+    spell {
+        val opponent = target("opponent", TargetOpponent())
+        val permanent = target("permanent", TargetPermanent(filter = TargetFilter.PermanentYouControl))
+        effect = GiveControlToTargetPlayerEffect(
+            permanent = permanent,
+            newController = opponent
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Howard Lyon"
+        flavorText = "\"Such an adorable face!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg?1783937459"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HarmlessOfferingReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HarmlessOfferingReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harmless Offering reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (spell script) lives in EMN's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val HarmlessOfferingReprint = Printing(
+    oracleId = "f5d32e5f-066b-42cf-8dd1-072a96275313",
+    name = "Harmless Offering",
+    setCode = "FDN",
+    collectorNumber = "625",
+    scryfallId = "47082081-bf52-4914-bac2-ace398beff56",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg?1783908922",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/StarlightSnare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/StarlightSnare.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Starlight Snare
+ * {2}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ *
+ * Functionally a Claustrophobia variant (cf. Charmed Sleep): the ETB taps the enchanted
+ * creature, and the DOESNT_UNTAP static keeps it tapped through its controller's untap step.
+ */
+val StarlightSnare = card("Starlight Snare") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "514"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg?1783908961"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/UndyingMaliceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/UndyingMaliceReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undying Malice reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (spell script) lives in VOW's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val UndyingMaliceReprint = Printing(
+    oracleId = "8b061702-1bc3-45aa-a758-446b25034801",
+    name = "Undying Malice",
+    setCode = "FDN",
+    collectorNumber = "528",
+    scryfallId = "97b3cf11-e352-4ee1-8c03-13898f576ef9",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97b3cf11-e352-4ee1-8c03-13898f576ef9.jpg?1783908956",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UndyingMalice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UndyingMalice.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Undying Malice
+ * {B}
+ * Instant
+ *
+ * Until end of turn, target creature gains "When this creature dies, return it to the
+ * battlefield tapped under its owner's control with a +1/+1 counter on it."
+ *
+ * Models the granted clause as a SELF-bound dies trigger (battlefield → graveyard) granted for the
+ * turn — the same leaves-the-battlefield return shape used by Earthbend's return-tapped clause. On
+ * resolution the creature is moved graveyard → battlefield tapped (gated with `fromZone = GRAVEYARD`
+ * so it no-ops if it already left the graveyard), then a +1/+1 counter is placed on it. The
+ * graveyard → battlefield return keeps the same entity id, so `EffectTarget.Self` in the follow-up
+ * [AddCountersEffect] lands on the returned permanent. `MoveToZoneEffect` returns under the owner's
+ * control by default, matching "under its owner's control".
+ */
+val UndyingMalice = card("Undying Malice") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\""
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = GrantTriggeredAbilityEffect(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Dies.event,
+                binding = Triggers.Dies.binding,
+                effect = Effects.Composite(
+                    Effects.Move(
+                        target = EffectTarget.Self,
+                        destination = Zone.BATTLEFIELD,
+                        placement = ZonePlacement.Tapped,
+                        fromZone = Zone.GRAVEYARD
+                    ),
+                    AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                ),
+                descriptionOverride = "When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it."
+            ),
+            target = t,
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Igor Kieryluk"
+        flavorText = "Few take kindly to being put in their place, especially if their place is the grave."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg?1783924849"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -756,6 +756,50 @@
     "colorIdentityOverride": []
 }
 
+// Harmless Offering
+{
+    "name": "Harmless Offering",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent gains control of target permanent you control.",
+    "script": {
+        "spellEffect": {
+            "type": "GiveControlToTargetPlayer",
+            "permanent": {
+                "type": "BoundVariable",
+                "name": "permanent"
+            },
+            "newController": {
+                "type": "BoundVariable",
+                "name": "opponent"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "opponent"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent ctrl:you"
+                },
+                "id": "permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Such an adorable face!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8f3cc4f-7943-4025-b332-b40653b13014.jpg?1783937459"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Haunted Dead
 {
     "name": "Haunted Dead",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -6357,6 +6357,49 @@
     ]
 }
 
+// Starlight Snare
+{
+    "name": "Starlight Snare",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "514",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74fb19b2-4f6c-4cbd-8756-a7eb5c7c9ef6.jpg?1783908961"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Strix Lookout
 {
     "name": "Strix Lookout",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -7279,6 +7279,68 @@
     ]
 }
 
+// Undying Malice
+{
+    "name": "Undying Malice",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
+    "script": {
+        "spellEffect": {
+            "type": "GrantTriggeredAbility",
+            "ability": {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield",
+                            "placement": "Tapped",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it."
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Few take kindly to being put in their place, especially if their place is the grave.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8eb38041-043a-4b18-9d9a-f1283684e8f1.jpg?1783924849"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Unhallowed Phalanx
 {
     "name": "Unhallowed Phalanx",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndyingMaliceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndyingMaliceScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.vow.InnistradCrimsonVowSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Undying Malice (VOW).
+ *
+ * "Until end of turn, target creature gains 'When this creature dies, return it to the
+ * battlefield tapped under its owner's control with a +1/+1 counter on it.'"
+ *
+ * Not a new engine keyword — the granted clause composes a SELF-bound dies trigger
+ * (battlefield → graveyard) that moves the card graveyard → battlefield tapped and then
+ * adds a +1/+1 counter. The graveyard → battlefield return keeps the same entity id, so the
+ * follow-up AddCounters lands on the returned permanent. These tests prove the granted
+ * self-trigger rides the engine's trigger pipeline and returns the creature exactly once.
+ */
+class UndyingMaliceScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + InnistradCrimsonVowSet.cards)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("granted creature dies — returns tapped with a +1/+1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A 2/2 red Goblin Guide is our target — nonblack, so Doom Blade can kill it.
+        val goblin = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+
+        val malice = driver.putCardInHand(you, "Undying Malice")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.castSpell(you, malice, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Undying Malice — grant applied for the turn
+
+        // Kill the granted creature.
+        val doomBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, doomBlade, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass()  // resolve Doom Blade — Goblin dies, granted "when this dies" trigger goes on stack
+        driver.bothPass()  // resolve the granted return trigger
+
+        // Same entity id is back on the battlefield…
+        driver.state.getBattlefield().contains(goblin) shouldBe true
+        // …tapped…
+        driver.isTapped(goblin) shouldBe true
+        // …with exactly one +1/+1 counter.
+        plusOneCounters(driver, goblin) shouldBe 1
+    }
+
+    test("returns exactly once — the returned creature is a fresh object without the grant (CR 400.7)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val goblin = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+
+        val malice = driver.putCardInHand(you, "Undying Malice")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.castSpell(you, malice, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // While the grant is live it rides the creature.
+        driver.state.grantedTriggeredAbilities.any { it.entityId == goblin } shouldBe true
+
+        val doomBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.castSpell(you, doomBlade, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass()  // Doom Blade resolves — Goblin dies
+        driver.bothPass()  // return trigger resolves — Goblin comes back
+
+        driver.state.getBattlefield().contains(goblin) shouldBe true
+        // CR 400.7: the returned Goblin is a new object — the until-end-of-turn grant did not
+        // follow it, so a second death would NOT return it again (no infinite loop).
+        driver.state.grantedTriggeredAbilities.any { it.entityId == goblin } shouldBe false
+    }
+})


### PR DESCRIPTION
Implements a handful of Foundations (FDN) cards, each via the `add-card` flow. All three
compose existing SDK primitives — **no new engine/SDK types were introduced**, so the SDK
reference needed no changes.

## Cards

| Card | Color | Canonical set | FDN row |
|------|-------|---------------|---------|
| **Starlight Snare** `{2}{U}` — tap-down Aura | U | FDN (native) | canonical |
| **Harmless Offering** `{2}{R}` — donate a permanent to an opponent | R | EMN (earliest printing) | reprint |
| **Undying Malice** `{B}` — grant a dies→return-tapped-with-counter trigger | B | VOW (earliest printing) | reprint |

Canonical `CardDefinition`s live in each card's **earliest real printing** per the reprint
rule; Foundations contributes only `Printing` rows for the two reprints. `just
check-card-printing` passes for all three.

### Implementation notes
- **Starlight Snare** — functionally Charmed Sleep: ETB `Tap(EnchantedCreature)` + the
  `DOESNT_UNTAP` static.
- **Harmless Offering** — two targets in oracle order (target opponent + target permanent you
  control) feeding the existing `GiveControlToTargetPlayerEffect` (same effect Custody Battle
  uses), permanent duration.
- **Undying Malice** — grants a SELF-bound dies trigger for the turn that moves the creature
  graveyard→battlefield tapped (gated `fromZone = GRAVEYARD`), then places a +1/+1 counter.
  The return reuses the same entity id, so the follow-up counter lands on the returned
  permanent; `Move` returns under the owner's control by default. Same shape as Earthbend's
  return-tapped grant.

## Tests
- `UndyingMaliceScenarioTest` (rules-engine) — proves return-tapped-with-a-+1/+1-counter and
  the CR 400.7 return-exactly-once (no infinite loop) guarantee. Both pass.
- Starlight Snare and Harmless Offering reuse already-tested effects, so they're covered by the
  card snapshot / lint / facade nets.
- `CardDefinitionSnapshotTest` re-blessed — diff is additive only (149 insertions, no other
  card changed). `:mtg-sets:test` (snapshot + lint + facade-boundary) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)