### PR TITLE
Fix Virulent Silencer poison trigger placing no counters (#1300)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersExecutor.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
 
 /**
@@ -26,8 +27,14 @@ class AddCountersExecutor : EffectExecutor<AddCountersEffect> {
         effect: AddCountersEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolveTarget(effect.target, state)
-            ?: return EffectResult.error(state, "No valid target for counters")
+        // Counters usually go on a permanent, but "that player gets two poison counters"
+        // (Virulent Silencer) puts them on a player — a PlayerRef target only resolves through
+        // the player-resolution path, so try it when the target denotes a player.
+        val targetId = if (effect.target is EffectTarget.PlayerRef) {
+            context.resolvePlayerTarget(effect.target, state)
+        } else {
+            context.resolveTarget(effect.target, state)
+        } ?: return EffectResult.error(state, "No valid target for counters")
 
         if (!state.projectedState.canReceiveCounters(targetId)) {
             return EffectResult.success(state, emptyList())

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirulentSilencerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirulentSilencerScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Virulent Silencer (EOE #248) — {3} Artifact Creature, Uncommon.
+ *
+ * "Whenever a nontoken artifact creature you control deals combat damage to a player,
+ *  that player gets two poison counters."
+ *
+ * Regression for issue #1300: the trigger fired but placed no poison counters, both when
+ * Virulent Silencer itself dealt the damage and when another nontoken artifact creature did.
+ * "That player" must resolve to the *damaged* player (the trigger's recipient).
+ */
+class VirulentSilencerScenarioTest : ScenarioTestBase() {
+
+    private fun poisonCounters(playerNumber: Int, game: TestGame): Int {
+        val playerId = EntityId.of("player-$playerNumber")
+        return game.state.getEntity(playerId)?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0
+    }
+
+    init {
+        context("Virulent Silencer") {
+
+            test("gives the damaged player two poison counters when it deals combat damage itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Virulent Silencer")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("no poison counters before combat") {
+                    poisonCounters(2, game) shouldBe 0
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Virulent Silencer" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Virulent Silencer's combat damage gives the opponent two poison counters") {
+                    poisonCounters(2, game) shouldBe 2
+                }
+                withClue("the opponent took 2 combat damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("gives the damaged player two poison counters when another artifact creature deals the damage") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Virulent Silencer")
+                    .withCardOnBattlefield(1, "Alpha Myr") // 2/1 nontoken artifact creature
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Alpha Myr" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Alpha Myr (a nontoken artifact creature you control) triggers Virulent Silencer") {
+                    poisonCounters(2, game) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1300.

## Problem

Virulent Silencer's ability — *"Whenever a nontoken artifact creature you control deals combat damage to a player, that player gets two poison counters."* — triggered but placed **no** poison counters. This happened both when Virulent Silencer itself dealt the combat damage and when another nontoken artifact creature under the same player's control did.

## Root cause

`AddCountersEffect.target` is a generic `EffectTarget`. Normally it denotes a permanent (`+1/+1` counters), but here it denotes a **player** (`Player.TriggeringPlayer` = the damaged player).

`AddCountersExecutor` resolved the target through the entity-oriented `context.resolveTarget(target, state)`. Its state-aware implementation in `TargetResolutionUtils` has no `EffectTarget.PlayerRef` branch and falls through to `else -> null`, so a player target resolved to `null`. The executor then returned `EffectResult.error("No valid target for counters")` and silently placed nothing.

Player targets in this codebase resolve through `resolvePlayerTarget`, which does handle `PlayerRef`.

## Fix

In `AddCountersExecutor`, resolve a `PlayerRef` target through `context.resolvePlayerTarget(...)` (falling back to the existing entity path for permanent targets). "That player" now correctly resolves to the damaged player, who receives the two poison counters.

## Tests

New `VirulentSilencerScenarioTest` covers both reported cases:
- Virulent Silencer deals the combat damage itself → opponent gets 2 poison counters.
- Another nontoken artifact creature (Alpha Myr) deals the combat damage → opponent gets 2 poison counters.

Both failed before the fix and pass after. Full `rules-engine` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)