### PR TITLE
Fire ward when a modal triggered ability targets (CR 603.3c)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6285,6 +6285,22 @@ modal(
 ) { /* modes */ }
 ```
 
+**Modal triggered abilities (CR 603.3c).** A modal *triggered* ability with at least one
+**targeting** mode picks its mode **and** that mode's targets as the ability is put onto the
+stack — same moment a modal spell's caster does — not while it resolves. This is what makes the
+choice observable: the chosen targets only "become targets" once the ability is on the stack, and
+that is what ward (CR 702.21), "whenever this becomes the target of a spell or ability", and
+shroud/hexproof checks all key on. Two consequences for authoring and testing:
+
+- A mode whose mandatory target has no legal choice **isn't offered at all** — e.g. Hullbreaker
+  Horror's "target spell you don't control" is absent when the only spell on the stack is your own.
+  If no mode can be chosen, the ability is removed from the stack (both CR 603.3c).
+- In a scenario test the mode / target decisions surface *before* the ability resolves, so the
+  chosen mode's effect needs a further `resolveStack()`.
+
+Modal triggers whose modes never target keep the simpler resolution-time pick, as do
+`chooseUpToDynamic` (the cap needs the resolving state) and `chooseOneNotYetChosen`.
+
 **"Choose one that hasn't been chosen"** — `ModalEffect.chooseOneNotYetChosen(*modes)` for a
 repeatable modal *ability* whose source remembers which modes it has already chosen across the
 game and never offers them again (Gandalf the Grey). Equivalent raw shape:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalTriggerContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalTriggerContinuations.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import kotlinx.serialization.Serializable
+
+/**
+ * Put-on-stack mode selection for a modal **triggered** ability (CR 603.3c).
+ *
+ * A triggered ability's controller chooses its modes *and* its targets as the ability is put onto
+ * the stack — the same moment a modal spell's caster does (CR 601.2b–c). Deferring that choice to
+ * resolution would mean the chosen targets never "become the target" of anything on the stack, so
+ * ward, "whenever this becomes the target of a spell or ability", and shroud/hexproof checks would
+ * all be bypassed.
+ *
+ * The trigger-time twin of [CastModalModeSelectionContinuation]: each resume captures one mode
+ * pick and re-pushes until `chooseCount` modes are picked (or "Done" once `minChooseCount` is
+ * reached), then hands off to [TriggerModalTargetSelectionContinuation]. Unlike the cast-time
+ * flow, there is nothing to cancel back to — a trigger is already on its way to the stack.
+ *
+ * @property ability The fully built stack component, held until modes/targets are known.
+ * @property outerTargets Targets already chosen for the ability's own (non-modal) requirements.
+ */
+@Serializable
+data class TriggerModalModeSelectionContinuation(
+    override val decisionId: String,
+    val ability: TriggeredAbilityOnStackComponent,
+    val outerTargets: List<ChosenTarget>,
+    val outerTargetRequirements: List<@Serializable TargetRequirement>,
+    val modes: List<@Serializable Mode>,
+    val chooseCount: Int,
+    val minChooseCount: Int,
+    val allowRepeat: Boolean,
+    val offeredIndices: List<Int>,
+    val availableIndices: List<Int>? = null,
+    val selectedModeIndices: List<Int> = emptyList(),
+    val doneOptionOffered: Boolean = false,
+    val causedByAttack: Boolean = false
+) : ContinuationFrame
+
+/**
+ * Put-on-stack per-mode target selection for a modal triggered ability (CR 603.3c).
+ *
+ * Pushed once mode selection completes and some chosen mode has target requirements. One resume
+ * per targeting mode; [resolvedModeTargets] stays aligned 1:1 with [chosenModeIndices] (modes with
+ * no requirements get an empty slot). When the last mode is resolved the ability finally goes on
+ * the stack with its modal fields populated, emitting the `BecomesTargetEvent`s that ward keys on.
+ */
+@Serializable
+data class TriggerModalTargetSelectionContinuation(
+    override val decisionId: String,
+    val ability: TriggeredAbilityOnStackComponent,
+    val outerTargets: List<ChosenTarget>,
+    val outerTargetRequirements: List<@Serializable TargetRequirement>,
+    val modes: List<@Serializable Mode>,
+    val chosenModeIndices: List<Int>,
+    val resolvedModeTargets: List<List<ChosenTarget>>,
+    val currentOrdinal: Int,
+    val causedByAttack: Boolean = false
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -245,6 +245,8 @@ val engineSerializersModule = SerializersModule {
         subclass(CastWithCreatureTypeContinuation::class)
         subclass(CastModalModeSelectionContinuation::class)
         subclass(CastModalTargetSelectionContinuation::class)
+        subclass(TriggerModalModeSelectionContinuation::class)
+        subclass(TriggerModalTargetSelectionContinuation::class)
         subclass(MoveCollectionAuraTargetContinuation::class)
         subclass(PutOntoBattlefieldAttachedToChosenContinuation::class)
         subclass(ChainCopyAfterActionContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -20,7 +20,9 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor
 import com.wingedsheep.engine.handlers.effects.composite.asMayDecide
 import com.wingedsheep.engine.handlers.effects.composite.asOptionalManaPayment
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
@@ -774,11 +776,322 @@ class TriggerProcessor(
             sagaChapterInfo = trigger.sagaChapterInfo
         )
 
+        val causedByAttack = isAttackCausedTrigger(trigger)
+        val outerRequirements = listOfNotNull(ability.targetRequirement)
+
+        // CR 603.3c — a modal triggered ability's modes and targets are chosen as the ability is
+        // put onto the stack, not while it resolves. Pause here so the choices are locked in
+        // before the ability hits the stack; only then do the chosen targets actually *become*
+        // targets, which is what ward (CR 702.21) and "becomes the target" triggers key on.
+        modalNeedingPutOnStackSelection(abilityComponent.effect)?.let { modal ->
+            return presentTriggerModalModeDecision(
+                state = state,
+                ability = abilityComponent,
+                outerTargets = targets,
+                outerTargetRequirements = outerRequirements,
+                modal = modal,
+                selectedModeIndices = emptyList(),
+                availableIndices = null,
+                causedByAttack = causedByAttack
+            )
+        }
+
         return stackResolver.putTriggeredAbility(
             state, abilityComponent, targets,
-            targetRequirements = listOfNotNull(ability.targetRequirement),
-            causedByAttack = isAttackCausedTrigger(trigger)
+            targetRequirements = outerRequirements,
+            causedByAttack = causedByAttack
         )
+    }
+
+    /**
+     * The top-level [ModalEffect] whose modes must be picked *before* the trigger reaches the
+     * stack, or null when the effect can keep the simpler resolution-time mode picking.
+     *
+     * Only modal effects with at least one *targeting* mode need the earlier pick: those are the
+     * ones where a resolution-time choice would silently skip the "becomes the target" step. Modes
+     * that only affect the controller's own board carry no such observable, so they stay on the
+     * resolution-time path ([com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor]).
+     *
+     * Two shapes are deliberately excluded because they need state that only exists at resolution:
+     * a `dynamicChooseCount` (evaluated against the resolving game state) and
+     * `excludePreviouslyChosenModes` (Gandalf the Grey's per-source memory, recorded by the
+     * resolution-time continuation).
+     */
+    private fun modalNeedingPutOnStackSelection(effect: Effect): ModalEffect? {
+        val modal = effect as? ModalEffect ?: return null
+        if (modal.dynamicChooseCount != null) return null
+        if (modal.excludePreviouslyChosenModes) return null
+        if (modal.modes.none { it.targetRequirements.isNotEmpty() }) return null
+        return modal
+    }
+
+    /**
+     * Build the next mode-pick decision for a modal triggered ability going on the stack, or move
+     * straight to per-mode target selection once enough modes are picked.
+     *
+     * CR 603.3c: a mode that would be illegal — no legal targets, say — can't be chosen, so
+     * unselectable modes are filtered out of the offer. When no mode can be chosen and the minimum
+     * hasn't been met, the ability is removed from the stack.
+     */
+    internal fun presentTriggerModalModeDecision(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        outerTargets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
+        outerTargetRequirements: List<TargetRequirement>,
+        modal: ModalEffect,
+        selectedModeIndices: List<Int>,
+        availableIndices: List<Int>?,
+        causedByAttack: Boolean
+    ): ExecutionResult {
+        val candidateIndices = availableIndices ?: modal.modes.indices.toList()
+        val offerIndices = candidateIndices.filter { index ->
+            modeHasLegalTargets(state, ability, modal.modes[index])
+        }
+
+        if (offerIndices.isEmpty() && selectedModeIndices.size < modal.minChooseCount) {
+            // No mode can legally be chosen — the ability is removed from the stack (CR 603.3c).
+            return ExecutionResult.success(
+                state,
+                listOf(
+                    AbilityFizzledEvent(
+                        ability.sourceId,
+                        ability.description,
+                        "No legal targets available"
+                    )
+                )
+            )
+        }
+
+        if (offerIndices.isEmpty()) {
+            return presentTriggerModalTargetDecision(
+                state, ability, outerTargets, outerTargetRequirements,
+                modal.modes, selectedModeIndices, emptyList(), currentOrdinal = 0, causedByAttack
+            )
+        }
+
+        val doneOffered = selectedModeIndices.size >= modal.minChooseCount &&
+            selectedModeIndices.size < modal.chooseCount
+        // Same decline label the resolution-time modal path uses, so clients (and tests) can
+        // recognise "choose up to one"'s opt-out wherever the mode question is raised.
+        val optionLabels = offerIndices.map { modal.modes[it].description } +
+            (if (doneOffered) listOf(ModalEffectExecutor.DECLINE_MODE_LABEL) else emptyList())
+
+        val decisionId = java.util.UUID.randomUUID().toString()
+        val pickNumber = selectedModeIndices.size + 1
+        val alreadyPicked = if (selectedModeIndices.isEmpty()) "" else {
+            "\nAlready picked: ${selectedModeIndices.joinToString("; ") { modal.modes[it].description }}"
+        }
+        val basePrompt = "Choose a mode for ${ability.sourceName}"
+        val prompt = if (modal.chooseCount > 1) {
+            "$basePrompt ($pickNumber of ${modal.chooseCount})$alreadyPicked"
+        } else basePrompt
+
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = ability.controllerId,
+            prompt = prompt,
+            context = DecisionContext(
+                sourceId = ability.sourceId,
+                sourceName = ability.sourceName,
+                // The ability isn't on the stack yet, but from the player's seat this is the
+                // trigger going on the stack, not a spell being cast.
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = optionLabels
+        )
+
+        val continuation = TriggerModalModeSelectionContinuation(
+            decisionId = decisionId,
+            ability = ability,
+            outerTargets = outerTargets,
+            outerTargetRequirements = outerTargetRequirements,
+            modes = modal.modes,
+            chooseCount = modal.chooseCount,
+            minChooseCount = modal.minChooseCount,
+            allowRepeat = modal.allowRepeat,
+            offeredIndices = offerIndices,
+            availableIndices = availableIndices,
+            selectedModeIndices = selectedModeIndices,
+            doneOptionOffered = doneOffered,
+            causedByAttack = causedByAttack
+        )
+
+        return ExecutionResult.paused(
+            state.pushContinuation(continuation).withPendingDecision(decision),
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = ability.controllerId,
+                    decisionType = "CHOOSE_OPTION",
+                    prompt = decision.prompt
+                )
+            )
+        )
+    }
+
+    /**
+     * Collect targets for the chosen modes, one decision per targeting mode, then put the ability
+     * on the stack. Modes with no requirements take an empty slot so [resolvedModeTargets] stays
+     * aligned 1:1 with [chosenModeIndices]; a sole legal player target is auto-selected rather than
+     * prompted for, matching the non-modal trigger path.
+     */
+    internal fun presentTriggerModalTargetDecision(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        outerTargets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
+        outerTargetRequirements: List<TargetRequirement>,
+        modes: List<com.wingedsheep.sdk.scripting.effects.Mode>,
+        chosenModeIndices: List<Int>,
+        resolvedModeTargets: List<List<com.wingedsheep.engine.state.components.stack.ChosenTarget>>,
+        currentOrdinal: Int,
+        causedByAttack: Boolean
+    ): ExecutionResult {
+        var ordinal = currentOrdinal
+        var targetsAccum = resolvedModeTargets
+
+        while (ordinal < chosenModeIndices.size) {
+            val mode = modes[chosenModeIndices[ordinal]]
+            if (mode.targetRequirements.isEmpty()) {
+                targetsAccum = targetsAccum + listOf(emptyList())
+                ordinal++
+                continue
+            }
+
+            val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
+            val requirementInfos = mode.targetRequirements.mapIndexed { index, req ->
+                legalTargetsMap[index] = findModeLegalTargets(state, ability, req)
+                TargetRequirementInfo(
+                    index = index,
+                    description = req.description,
+                    minTargets = req.effectiveMinCount,
+                    maxTargets = req.count
+                )
+            }
+
+            // Auto-select the lone legal player target instead of prompting (mirrors
+            // processTargetedTrigger's single-player-target shortcut).
+            val soleReq = mode.targetRequirements.singleOrNull()
+            val soleLegal = legalTargetsMap[0].orEmpty()
+            val isPlayerTarget = soleReq is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
+                soleReq is com.wingedsheep.sdk.scripting.targets.TargetOpponent
+            if (isPlayerTarget && soleLegal.size == 1 && soleReq!!.count == 1) {
+                targetsAccum = targetsAccum + listOf(listOf(createChosenTarget(state, soleLegal.first())))
+                ordinal++
+                continue
+            }
+
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val pickNumber = ordinal + 1
+            val prompt = if (chosenModeIndices.size > 1) {
+                "Choose targets for ${ability.sourceName} — ${mode.description} ($pickNumber of ${chosenModeIndices.size})"
+            } else {
+                "Choose targets for ${ability.sourceName} — ${mode.description}"
+            }
+            val decision = ChooseTargetsDecision(
+                id = decisionId,
+                playerId = ability.controllerId,
+                prompt = prompt,
+                context = DecisionContext(
+                    sourceId = ability.sourceId,
+                    sourceName = ability.sourceName,
+                    phase = DecisionPhase.RESOLUTION,
+                    effectHint = mode.description
+                ),
+                targetRequirements = requirementInfos,
+                legalTargets = legalTargetsMap
+            )
+
+            val continuation = TriggerModalTargetSelectionContinuation(
+                decisionId = decisionId,
+                ability = ability,
+                outerTargets = outerTargets,
+                outerTargetRequirements = outerTargetRequirements,
+                modes = modes,
+                chosenModeIndices = chosenModeIndices,
+                resolvedModeTargets = targetsAccum,
+                currentOrdinal = ordinal,
+                causedByAttack = causedByAttack
+            )
+
+            return ExecutionResult.paused(
+                state.pushContinuation(continuation).withPendingDecision(decision),
+                decision,
+                listOf(
+                    DecisionRequestedEvent(
+                        decisionId = decisionId,
+                        playerId = ability.controllerId,
+                        decisionType = "CHOOSE_TARGETS",
+                        prompt = decision.prompt
+                    )
+                )
+            )
+        }
+
+        return finalizeModalTrigger(
+            state, ability, outerTargets, outerTargetRequirements,
+            modes, chosenModeIndices, targetsAccum, causedByAttack
+        )
+    }
+
+    /**
+     * Put the modal trigger on the stack with its modes and per-mode targets baked in.
+     *
+     * The per-mode targets join the flat `targets` list so [StackResolver.putTriggeredAbility]
+     * emits a `BecomesTargetEvent` for each — the whole point of choosing them here — and so
+     * CR 608.2b re-validation runs against them on resolution.
+     */
+    private fun finalizeModalTrigger(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        outerTargets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
+        outerTargetRequirements: List<TargetRequirement>,
+        modes: List<com.wingedsheep.sdk.scripting.effects.Mode>,
+        chosenModeIndices: List<Int>,
+        resolvedModeTargets: List<List<com.wingedsheep.engine.state.components.stack.ChosenTarget>>,
+        causedByAttack: Boolean
+    ): ExecutionResult {
+        val component = ability.copy(
+            chosenModes = chosenModeIndices,
+            modeTargetsOrdered = resolvedModeTargets,
+            modeTargetRequirements = chosenModeIndices.associateWith { modes[it].targetRequirements }
+        )
+        val flatTargets = outerTargets + resolvedModeTargets.flatten()
+        val flatRequirements = outerTargetRequirements +
+            chosenModeIndices.flatMap { modes[it].targetRequirements }
+
+        return stackResolver.putTriggeredAbility(
+            state, component, flatTargets,
+            targetRequirements = flatRequirements,
+            causedByAttack = causedByAttack
+        )
+    }
+
+    /** Legal targets for one of a mode's requirements, in the trigger's own targeting context. */
+    private fun findModeLegalTargets(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        requirement: TargetRequirement
+    ): List<EntityId> = targetFinder.findLegalTargets(
+        state = state,
+        requirement = requirement,
+        controllerId = ability.controllerId,
+        sourceId = ability.sourceId,
+        triggeringEntityId = ability.triggeringEntityId,
+        pipelineContext = com.wingedsheep.engine.handlers.PredicateContext(
+            controllerId = ability.controllerId,
+            triggeringEntityId = ability.triggeringEntityId,
+            triggeringPlayerId = ability.triggeringPlayerId,
+        ),
+    )
+
+    /** True when every mandatory target requirement of [mode] has at least one legal target. */
+    private fun modeHasLegalTargets(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        mode: com.wingedsheep.sdk.scripting.effects.Mode
+    ): Boolean = mode.targetRequirements.all { req ->
+        req.effectiveMinCount == 0 || findModeLegalTargets(state, ability, req).isNotEmpty()
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -48,6 +48,7 @@ class ContinuationHandler(
         registerModule(ModalAndCloneContinuationResumer(services))
         registerModule(RoomDoorContinuationResumer(services))
         registerModule(CastModalContinuationResumer(services))
+        registerModule(ModalTriggerContinuationResumer(services))
         registerModule(TokenContinuationResumer(services))
         registerModule(RingTemptContinuationResumer(services))
         registerModule(AmassContinuationResumer(services))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ContinuationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ContinuationUtils.kt
@@ -11,22 +11,26 @@ import com.wingedsheep.sdk.model.EntityId
 /**
  * Converts an entity ID to the appropriate [ChosenTarget] subtype
  * based on the entity's current zone.
+ *
+ * Every card zone is searched, not just the graveyard: a [ChosenTarget.Permanent] fallback for a
+ * card sitting in exile (Blade of the Swarm targeting a warp-exiled card) or in hand is treated as
+ * "not on the battlefield" by resolution-time re-validation and fizzles the whole spell/ability.
  */
+private val CARD_ZONES = listOf(Zone.GRAVEYARD, Zone.EXILE, Zone.HAND, Zone.LIBRARY)
+
 fun entityIdToChosenTarget(state: GameState, entityId: EntityId): ChosenTarget {
     return when {
         entityId in state.turnOrder -> ChosenTarget.Player(entityId)
         entityId in state.getBattlefield() -> ChosenTarget.Permanent(entityId)
         entityId in state.stack -> ChosenTarget.Spell(entityId)
         else -> {
-            val graveyardOwner = state.turnOrder.find { playerId ->
-                val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
-                entityId in state.getZone(graveyardZone)
+            for (zone in CARD_ZONES) {
+                val owner = state.turnOrder.find { playerId ->
+                    entityId in state.getZone(ZoneKey(playerId, zone))
+                }
+                if (owner != null) return ChosenTarget.Card(entityId, owner, zone)
             }
-            if (graveyardOwner != null) {
-                ChosenTarget.Card(entityId, graveyardOwner, Zone.GRAVEYARD)
-            } else {
-                ChosenTarget.Permanent(entityId)
-            }
+            ChosenTarget.Permanent(entityId)
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -152,7 +152,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -195,7 +195,7 @@ class ManaPaymentContinuationResumer(
                         controllerId = continuation.controllerId ?: continuation.payingPlayerId
                     )
                 } else {
-                    services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                    services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
                 }
                 return checkForMore(counterResult.newState, counterResult.events)
             }
@@ -225,7 +225,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -260,7 +260,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -288,7 +288,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -362,7 +362,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -415,7 +415,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -536,7 +536,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(state, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, counterResult.events)
         }
@@ -1516,7 +1516,7 @@ class ManaPaymentContinuationResumer(
                     controllerId = continuation.controllerId ?: continuation.payingPlayerId
                 )
             } else {
-                services.stackResolver.counterSpell(currentState, continuation.spellEntityId)
+                services.stackResolver.counterSpellOrAbility(currentState, continuation.spellEntityId)
             }
             return checkForMore(counterResult.newState, events + counterResult.events)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTriggerContinuationResumer.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.handlers.continuations
+
+import com.wingedsheep.engine.core.DecisionResponse
+import com.wingedsheep.engine.core.EngineServices
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.TriggerModalModeSelectionContinuation
+import com.wingedsheep.engine.core.TriggerModalTargetSelectionContinuation
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Drives mode + target selection for a modal **triggered** ability on its way to the stack
+ * (CR 603.3c) — the trigger-time twin of [CastModalContinuationResumer].
+ *
+ * 1. [TriggerModalModeSelectionContinuation] iterates until `chooseCount` modes are picked (or
+ *    "Done" is chosen once `minChooseCount` is met).
+ * 2. [TriggerModalTargetSelectionContinuation] then collects one mode's targets per resume.
+ * 3. The last step puts the ability on the stack with `chosenModes` / `modeTargetsOrdered`
+ *    populated, which is what emits the `BecomesTargetEvent`s ward keys on.
+ *
+ * Neither pause is cancellable: unlike a cast, a trigger is already on its way to the stack and
+ * the player has no legal way to back out. Both hand off to `checkForMore` afterwards so any
+ * sibling triggers waiting on a [com.wingedsheep.engine.core.PendingTriggersContinuation] still
+ * reach the stack.
+ */
+class ModalTriggerContinuationResumer(
+    private val services: EngineServices
+) : ContinuationResumerModule {
+
+    override fun resumers(): List<ContinuationResumer<*>> = listOf(
+        resumer(TriggerModalModeSelectionContinuation::class, ::resumeModeSelection),
+        resumer(TriggerModalTargetSelectionContinuation::class, ::resumeTargetSelection)
+    )
+
+    private fun resumeModeSelection(
+        state: GameState,
+        continuation: TriggerModalModeSelectionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option response for modal trigger mode selection")
+        }
+
+        val totalOptions = continuation.offeredIndices.size + (if (continuation.doneOptionOffered) 1 else 0)
+        if (response.optionIndex < 0 || response.optionIndex >= totalOptions) {
+            return ExecutionResult.error(state, "Invalid mode option index: ${response.optionIndex}")
+        }
+
+        val chooseDone = continuation.doneOptionOffered &&
+            response.optionIndex == continuation.offeredIndices.size
+        val chosenIndex = if (chooseDone) null else continuation.offeredIndices[response.optionIndex]
+        val newSelected = continuation.selectedModeIndices + listOfNotNull(chosenIndex)
+
+        if (!chooseDone && newSelected.size < continuation.chooseCount) {
+            // Another pick to make. Narrow the remaining pool unless modes may repeat.
+            val nextAvailable = if (continuation.allowRepeat) null else {
+                (continuation.availableIndices ?: continuation.modes.indices.toList())
+                    .filter { it != chosenIndex }
+            }
+            return services.triggerProcessor.presentTriggerModalModeDecision(
+                state = state,
+                ability = continuation.ability,
+                outerTargets = continuation.outerTargets,
+                outerTargetRequirements = continuation.outerTargetRequirements,
+                modal = ModalEffect(
+                    modes = continuation.modes,
+                    chooseCount = continuation.chooseCount,
+                    minChooseCount = continuation.minChooseCount,
+                    allowRepeat = continuation.allowRepeat
+                ),
+                selectedModeIndices = newSelected,
+                availableIndices = nextAvailable,
+                causedByAttack = continuation.causedByAttack
+            ).thenCheckForMore(checkForMore)
+        }
+
+        return services.triggerProcessor.presentTriggerModalTargetDecision(
+            state = state,
+            ability = continuation.ability,
+            outerTargets = continuation.outerTargets,
+            outerTargetRequirements = continuation.outerTargetRequirements,
+            modes = continuation.modes,
+            chosenModeIndices = newSelected,
+            resolvedModeTargets = emptyList(),
+            currentOrdinal = 0,
+            causedByAttack = continuation.causedByAttack
+        ).thenCheckForMore(checkForMore)
+    }
+
+    private fun resumeTargetSelection(
+        state: GameState,
+        continuation: TriggerModalTargetSelectionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is TargetsResponse) {
+            return ExecutionResult.error(state, "Expected targets response for modal trigger target selection")
+        }
+
+        // Keep per-requirement order so buildNamedTargets maps each target to its own slot.
+        val chosenTargets = response.selectedTargets.entries
+            .sortedBy { it.key }
+            .flatMap { (_, ids) -> ids.map { entityIdToChosenTarget(state, it) } }
+
+        return services.triggerProcessor.presentTriggerModalTargetDecision(
+            state = state,
+            ability = continuation.ability,
+            outerTargets = continuation.outerTargets,
+            outerTargetRequirements = continuation.outerTargetRequirements,
+            modes = continuation.modes,
+            chosenModeIndices = continuation.chosenModeIndices,
+            resolvedModeTargets = continuation.resolvedModeTargets + listOf(chosenTargets),
+            currentOrdinal = continuation.currentOrdinal + 1,
+            causedByAttack = continuation.causedByAttack
+        ).thenCheckForMore(checkForMore)
+    }
+
+    /**
+     * Once the ability is finally on the stack (or fizzled for lack of legal modes), let the
+     * continuation chain drain — sibling triggers queued behind this one still need placing.
+     */
+    private fun ExecutionResult.thenCheckForMore(checkForMore: CheckForMore): ExecutionResult =
+        if (isSuccess) checkForMore(state, events) else this
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -206,7 +206,7 @@ class WardCounterEffectExecutor(
 
             // Can't possibly pay → counter immediately.
             if (validPermanents.size < count) {
-                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId)
             }
 
             val fodderLabel = filter.description
@@ -277,7 +277,7 @@ class WardCounterEffectExecutor(
                 }
             }
             if (eligibleCount < count) {
-                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId)
             }
 
             val cardsLabel = if (filter != null) {
@@ -360,7 +360,7 @@ class WardCounterEffectExecutor(
                 manaSolver.canPay(state, payingPlayerId, manaCost)
             }
             if (!affordable) {
-                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId)
             }
 
             val sources = manaSolver.findAvailableManaSources(state, payingPlayerId)
@@ -448,7 +448,7 @@ class WardCounterEffectExecutor(
             val currentLife = state.lifeTotal(payingPlayerId) // CR 810.9a — team's shared total
             if (currentLife < lifeCost) {
                 // Can't pay — counter immediately.
-                return counterSpellOrAbility(state, cardRegistry, spellEntityId, container)
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId)
             }
 
             val decisionId = java.util.UUID.randomUUID().toString()
@@ -508,15 +508,9 @@ class WardCounterEffectExecutor(
         private fun counterSpellOrAbility(
             state: GameState,
             cardRegistry: CardRegistry,
-            entityId: EntityId,
-            container: ComponentContainer
-        ): EffectResult {
-            val resolver = StackResolver(cardRegistry = cardRegistry)
-            return EffectResult.from(if (container.has<SpellOnStackComponent>()) {
-                resolver.counterSpell(state, entityId)
-            } else {
-                resolver.counterAbility(state, entityId)
-            })
-        }
+            entityId: EntityId
+        ): EffectResult = EffectResult.from(
+            StackResolver(cardRegistry = cardRegistry).counterSpellOrAbility(state, entityId)
+        )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2388,6 +2388,22 @@ class StackResolver(
     // =========================================================================
 
     /**
+     * Counter whatever stack object [entityId] is, spell or ability.
+     *
+     * A countered spell goes to its owner's graveyard; a countered ability simply ceases to
+     * exist. "Counter it unless you pay …" effects — ward above all — can end up pointed at
+     * either kind, so they route through here instead of assuming a spell: [counterSpell] on a
+     * triggered ability finds no card/spell component and errors out, leaving the ability on the
+     * stack to resolve as though the cost had been paid.
+     */
+    fun counterSpellOrAbility(state: GameState, entityId: EntityId): ExecutionResult {
+        val container = state.getEntity(entityId)
+            ?: return ExecutionResult.error(state, "Stack object not found: $entityId")
+        return if (container.has<SpellOnStackComponent>()) counterSpell(state, entityId)
+        else counterAbility(state, entityId)
+    }
+
+    /**
      * Counter a spell on the stack.
      */
     fun counterSpell(state: GameState, spellId: EntityId): ExecutionResult {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FangkeepersFamiliarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FangkeepersFamiliarScenarioTest.kt
@@ -50,6 +50,10 @@ class FangkeepersFamiliarScenarioTest : ScenarioTestBase() {
                     ?: error("expected a ChooseOptionDecision for the ETB trigger; got ${game.state.pendingDecision}")
                 game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
 
+                // The mode is picked as the trigger goes on the stack (CR 603.3c); the chosen
+                // mode's effect runs when the ability itself resolves.
+                game.resolveStack()
+
                 // Mode 0 = gain 3 life and surveil 3 → a card selection over the top three cards.
                 val surveil = game.getPendingDecision()
                 withClue("Surveil 3 should pause for a library look") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HullbreakerHorrorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HullbreakerHorrorScenarioTest.kt
@@ -56,8 +56,10 @@ class HullbreakerHorrorScenarioTest : ScenarioTestBase() {
                 game.resolveStack()
                 val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
                     ?: error("Expected a ChooseOptionDecision; got ${game.getPendingDecision()}")
-                withClue("both bounce modes plus a decline option are offered") {
-                    modeDecision.options.size shouldBe 3
+                withClue("the permanent-bounce mode plus a decline option are offered — the only spell " +
+                    "on the stack is your own Bolt, so 'target spell you don't control' has no legal " +
+                    "target and can't be chosen (CR 603.3c)") {
+                    modeDecision.options.size shouldBe 2
                 }
                 val bounceModeIndex = modeDecision.options.indexOfFirst { it.contains("nonland permanent") }
                 withClue("the 'return target nonland permanent' mode is offered") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OltecMatterweaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OltecMatterweaverScenarioTest.kt
@@ -39,8 +39,9 @@ class OltecMatterweaverScenarioTest : ScenarioTestBase() {
             // Resolve it first → mode choice.
             game.resolveStack()
             val modeDecision = game.getPendingDecision() as ChooseOptionDecision
-            withClue("two modes are offered") {
-                modeDecision.options.size shouldBe 2
+            withClue("only the token-making mode is offered — you control no artifact token, so the " +
+                "copy mode has no legal target and can't be chosen (CR 603.3c)") {
+                modeDecision.options.size shouldBe 1
             }
             game.submitDecision(OptionChosenResponse(modeDecision.id, 0))
             game.resolveStack()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardModalTriggeredAbilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardModalTriggeredAbilityTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ward (CR 702.21) must fire when a **modal triggered ability** targets the warded permanent.
+ *
+ * CR 603.3c: the controller of a triggered ability chooses its modes *and* its targets as the
+ * ability is put onto the stack — not while it resolves. Choosing them at resolution time means
+ * the target never "becomes the target" of anything on the stack, so ward never triggers and the
+ * controller gets the mode for free.
+ *
+ * Regression scenario: Downwind Ambusher's ETB ("choose one — target creature an opponent
+ * controls gets -1/-1; or destroy target creature an opponent controls that was dealt damage
+ * this turn") pointed at Long River Lurker (ward {1}).
+ */
+class WardModalTriggeredAbilityTest : ScenarioTestBase() {
+
+    init {
+        context("ward vs. a modal triggered ability") {
+
+            test("ward triggers when the -1/-1 mode targets the warded creature") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Downwind Ambusher")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardOnBattlefield(2, "Long River Lurker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurker = game.findPermanent("Long River Lurker")!!
+
+                val cast = game.castSpell(1, "Downwind Ambusher")
+                withClue("Downwind Ambusher should cast: ${cast.error}") { cast.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // Mode + targets are chosen as the trigger goes on the stack (CR 603.3c).
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the mode; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(lurker))))
+
+                // Ward {1} triggered — resolving it asks the ability's controller to pay.
+                game.resolveStack()
+                val wardDecision = game.state.pendingDecision as? SelectManaSourcesDecision
+                    ?: error("expected ward's SelectManaSourcesDecision; got ${game.state.pendingDecision}")
+                withClue("ward's cost is asked of the ability's controller") {
+                    wardDecision.playerId shouldBe game.player1Id
+                    wardDecision.requiredCost shouldBe "{1}"
+                    wardDecision.canDecline shouldBe true
+                }
+            }
+
+            test("declining the ward cost counters the modal ability, so -1/-1 never applies") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Downwind Ambusher")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardOnBattlefield(2, "Long River Lurker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurker = game.findPermanent("Long River Lurker")!!
+
+                game.castSpell(1, "Downwind Ambusher")
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(lurker))))
+
+                game.resolveStack()
+                game.state.pendingDecision.shouldBeSelectManaSources()
+                // Decline the ward payment — the modal ability is countered.
+                game.submitManaSourcesDecision()
+                game.resolveStack()
+
+                withClue("countered ability never applied -1/-1; the 2/3 Lurker is untouched") {
+                    game.state.projectedState.getPower(lurker) shouldBe 2
+                    game.state.projectedState.getToughness(lurker) shouldBe 3
+                }
+            }
+
+            test("paying the ward cost lets the destroy mode resolve") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Downwind Ambusher")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardOnBattlefield(2, "Long River Lurker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurker = game.findPermanent("Long River Lurker")!!
+
+                // Damage the 2/3 Lurker so the destroy mode has a legal target (it survives Shock).
+                game.castSpell(1, "Shock", lurker)
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                // Shock also targets, so its own ward trigger has to be paid first.
+                if (game.state.pendingDecision is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+                withClue("Shock's 2 damage doesn't kill the 2/3") {
+                    game.findPermanent("Long River Lurker") shouldNotBe null
+                }
+
+                game.castSpell(1, "Downwind Ambusher")
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(lurker))))
+
+                game.resolveStack()
+                game.state.pendingDecision.shouldBeSelectManaSources()
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("ward paid, so the destroy mode resolves") {
+                    game.findPermanent("Long River Lurker") shouldBe null
+                }
+            }
+
+            test("declining ward counters a plain targeted trigger too, not just spells") {
+                // Ward's "counter it unless…" has always been able to point at an ability, but the
+                // decline path only knew how to counter *spells*: countering a triggered ability
+                // errored out and left it on the stack to resolve for free.
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Flametongue Kavu")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Long River Lurker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lurker = game.findPermanent("Long River Lurker")!!
+
+                game.castSpell(1, "Flametongue Kavu")
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the ETB; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(lurker))))
+
+                game.resolveStack()
+                game.state.pendingDecision.shouldBeSelectManaSources()
+                game.submitManaSourcesDecision()
+                game.resolveStack()
+
+                withClue("countered trigger deals no damage; the 2/3 survives") {
+                    game.findPermanent("Long River Lurker") shouldNotBe null
+                }
+            }
+        }
+    }
+}
+
+private fun Any?.shouldBeSelectManaSources() {
+    if (this !is SelectManaSourcesDecision) error("expected ward's SelectManaSourcesDecision; got $this")
+}


### PR DESCRIPTION
## The bug

> Opponent has a creature with ward. Downwind Ambusher targets it with destroy. Owner of Downwind Ambusher doesn't have to pay the ward cost.

A modal *triggered* ability picked its mode and its targets while it **resolved**. So the targeted creature never "became the target" of anything on the stack — and ward (CR 702.21a), "whenever this becomes the target of a spell or ability", and shroud/hexproof all keyed on an event that was never emitted.

## The fix

CR 603.3c: *"If a triggered ability is modal, its controller announces the mode choice when putting the ability on the stack. If one of the modes would be illegal (due to an inability to choose legal targets, for example), that mode can't be chosen. If no mode is chosen, the ability is removed from the stack."*

Modal triggers with at least one **targeting** mode now do exactly that: `TriggerProcessor.putTriggerOnStack` pauses for mode selection, then per-mode target selection, via two new continuation frames mirroring the cast-time `CastModal*` flow. The ability then reaches the stack with `chosenModes` / `modeTargetsOrdered` populated — the resolution-time `ModalEffectExecutor` already understood pre-chosen modes (that's how trigger copies work), so no resolution-side change was needed. `StackResolver.putTriggeredAbility` emits the `BecomesTargetEvent`s, and ward fires.

Modal triggers whose modes never target keep the simpler resolution-time pick, as do `chooseUpToDynamic` (cap needs resolving state) and `chooseOneNotYetChosen` (per-source mode memory).

### Two follow-on bugs the first ward test surfaced

- **Declining a "counter it unless you pay" cost never countered an *ability*.** The decline path called `counterSpell`, which finds no card/spell component on a triggered ability and errors out — leaving it on the stack to resolve as though the cost had been paid. Added `StackResolver.counterSpellOrAbility` and routed the nine decline sites through it. This was broken for ward on *any* targeted trigger, modal or not.
- **`entityIdToChosenTarget` mapped a card outside battlefield/graveyard to `ChosenTarget.Permanent`.** An exile-zone target (Blade of the Swarm's warp mode) then failed resolution-time re-validation as "not on the battlefield" and fizzled. It now searches every card zone.

## Tests

New `WardModalTriggeredAbilityTest` (written first, all four failed before the fix):
- ward triggers when the −1/−1 mode targets a warded creature, and asks the *ability's controller*
- declining the ward counters the modal ability, so −1/−1 never lands
- paying the ward lets the destroy mode resolve
- declining ward counters a plain targeted trigger too (Flametongue Kavu), pinning the `counterSpellOrAbility` fix

Three existing scenario tests changed with the timing, all in the rules-correct direction:
- **Oltec Matterweaver** / **Hullbreaker Horror** — the mode with no legal target is no longer offered (you control no artifact token; the only spell on the stack is your own)
- **Fangkeeper's Familiar** — needs a `resolveStack()` between picking the mode and the mode's effect running

`just build` and `just test` green.

Rule numbers verified against the Comprehensive Rules text (603.3c, 601.2b, 608.2b, 702.21a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)