### PR TITLE
Add five Innistrad Remastered cards + fix host-scoped CantBeBlockedBy

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3845,6 +3845,18 @@ staticAbility {
   (`attachedCreature()`, `source()`) resolve correctly; a `Battlefield`-scope filter matches every
   attacker. No separate "while attacking" gate is needed — must-be-blocked only bites while the
   creature attacks.
+- `CantBeBlockedBy(blockerFilter, filter = GroupFilter.source())` — evasion: the affected creature
+  can't be blocked by creatures matching `blockerFilter` (Juggernaut's "can't be blocked by Walls",
+  Steel Leaf Champion's "power 2 or less"). Resolved by `CantBeBlockedByRule`, which reads three
+  sources: the attacker's own **printed** self-scoped statics, **granted** ones in
+  `GameState.grantedStaticAbilities` (`Effects.GrantStaticAbility`, e.g. Cavern Stomper), and
+  **host-scoped** ones projected from a *different* battlefield permanent through `filter` — an
+  Equipment or Aura whose clause lives on the attachment rather than on the attacker
+  (`GroupFilter.attachedCreature()`; Blazing Torch's "equipped creature can't be blocked by Vampires
+  or Zombies", Artifact Ward's "enchanted creature can't be blocked by artifact creatures"). The
+  host-scoped scan mirrors the `MustBeBlocked` one above: `AttachedTo` resolves to the attachment's
+  host, `Specific` to the bound entity, `Battlefield` matches every attacker, and the attacker must
+  also satisfy the filter's base filter (evaluated with the host as predicate source).
 - `CantBeBlockedByMoreThan(maxBlockers)` — static cap on how many creatures may block the source (CR
   509.1b). For the **turn-scoped, granted** form (Glorfindel, Dauntless Rescuer: "can't be blocked by
   more than one creature each combat this turn"), grant `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE`

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelsTomb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AngelsTomb.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angel's Tomb
+ * {3}
+ * Artifact — Uncommon (AVR #211)
+ *
+ * "Whenever a creature you control enters, you may have this artifact become a 3/3 white Angel
+ * artifact creature with flying until end of turn."
+ *
+ * Implementation notes:
+ *  - The trigger uses [TriggerBinding.ANY] over "creature you control", not the `OtherCreatureEnters`
+ *    sugar: the printed text is "a creature you control", with no "another" clause. The distinction
+ *    is inert in practice (the Tomb is not a creature as it enters) but the ANY binding is what the
+ *    text says.
+ *  - [MayEffect] wraps the animation: the controller is asked each time the trigger resolves, and
+ *    declining leaves the Tomb a plain artifact.
+ *  - [Effects.BecomeCreature] adds CREATURE on top of the printed ARTIFACT type (so it stays an
+ *    *artifact* creature), sets base 3/3, the Angel subtype, white, and flying, all until end of
+ *    turn. Animating an already-animated Tomb just layers a second identical effect — harmless.
+ */
+val AngelsTomb = card("Angel's Tomb") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a creature you control enters, you may have this artifact become a 3/3 " +
+        "white Angel artifact creature with flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = Filters.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayEffect(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 3,
+                toughness = 3,
+                keywords = setOf(Keyword.FLYING),
+                creatureTypes = setOf("Angel"),
+                addTypes = setOf(CardType.CREATURE.name),
+                colors = setOf(Color.WHITE.name),
+                duration = Duration.EndOfTurn
+            ),
+            descriptionOverride = "You may have Angel's Tomb become a 3/3 white Angel artifact " +
+                "creature with flying until end of turn",
+            inlineOnTrigger = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Faith can quicken the stones themselves with life.\"\n—Writings of Mikaeus"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg?1783940655"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrappleWithThePast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrappleWithThePast.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Grapple with the Past
+ * {1}{G}
+ * Instant — Common (EMN #160)
+ *
+ * "Mill three cards, then you may return a creature or land card from your graveyard to your hand."
+ *
+ * Implementation:
+ *  - [Patterns.Library.mill] first, so the three milled cards are already in the graveyard and are
+ *    legal picks for the return step (CR 608.2 — the spell's instructions resolve in printed order).
+ *  - The "you may return a … card" clause is a `chooseUpTo(1)` over the gathered graveyard pool
+ *    rather than a yes/no + forced pick: declining is just choosing zero, and an empty pool
+ *    auto-skips the prompt. Modelling it as "up to one" also keeps the player from being asked to
+ *    confirm before seeing what the mill turned up.
+ *  - The card is not a target ("return a creature or land card", no "target"), so the selection is
+ *    a resolution-time choice, not a `TargetRequirement`.
+ */
+val GrappleWithThePast = card("Grapple with the Past") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Mill three cards, then you may return a creature or land card from your graveyard " +
+        "to your hand. (To mill three cards, put the top three cards of your library into your graveyard.)"
+
+    spell {
+        effect = Effects.Pipeline {
+            // "Mill three cards, ..."
+            run(Patterns.Library.mill(3))
+            // "... then you may return a creature or land card from your graveyard to your hand."
+            val graveyard = gather(
+                CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.CreatureOrLand)
+            )
+            val chosen = chooseUpTo(
+                1,
+                from = graveyard,
+                showAllCards = true,
+                prompt = "You may return a creature or land card from your graveyard to your hand",
+                selectedLabel = "Return to hand",
+                remainderLabel = "Leave in graveyard"
+            )
+            toHand(chosen)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Howard Lyon"
+        flavorText = "Emrakul does not grant wishes. Desires simply align to her will."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg?1783937443"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AngelsTombReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AngelsTombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Tomb reprint in INR. Canonical CardDefinition lives in its earliest set (AVR).
+ */
+val AngelsTombReprint = Printing(
+    oracleId = "de3ed52e-7cc2-49ea-96d9-4254aac46168",
+    name = "Angel's Tomb",
+    setCode = "INR",
+    collectorNumber = "253",
+    scryfallId = "b465d09e-efad-48b6-a89a-f7da0c572991",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b465d09e-efad-48b6-a89a-f7da0c572991.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BlazingTorchReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BlazingTorchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blazing Torch reprint in INR. Canonical CardDefinition lives in its earliest set (ZEN).
+ */
+val BlazingTorchReprint = Printing(
+    oracleId = "cd3d1e5d-db12-4878-92a2-23eb8d23eaf3",
+    name = "Blazing Torch",
+    setCode = "INR",
+    collectorNumber = "254",
+    scryfallId = "ea2d3a1c-287e-4b85-8f3d-25fdcf79f47b",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea2d3a1c-287e-4b85-8f3d-25fdcf79f47b.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EccentricFarmerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EccentricFarmerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eccentric Farmer reprint in INR. Canonical CardDefinition lives in its earliest set (MID).
+ */
+val EccentricFarmerReprint = Printing(
+    oracleId = "b51a852c-ccde-4d23-a3f3-a002f7eacdab",
+    name = "Eccentric Farmer",
+    setCode = "INR",
+    collectorNumber = "194",
+    scryfallId = "fe2a1718-eae1-4330-b494-c3088b992aae",
+    artist = "Tyler Walpole",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe2a1718-eae1-4330-b494-c3088b992aae.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrappleWithThePastReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrappleWithThePastReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grapple with the Past reprint in INR. Canonical CardDefinition lives in its earliest set (EMN).
+ */
+val GrappleWithThePastReprint = Printing(
+    oracleId = "d14c633d-977a-4f78-85c2-88582b3c3670",
+    name = "Grapple with the Past",
+    setCode = "INR",
+    collectorNumber = "199",
+    scryfallId = "06e0c180-2275-461a-86e7-8ccdc5f47938",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06e0c180-2275-461a-86e7-8ccdc5f47938.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SiegeZombieReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SiegeZombieReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Zombie reprint in INR. Canonical CardDefinition lives in its earliest set (MID).
+ */
+val SiegeZombieReprint = Printing(
+    oracleId = "a7756bc2-26ce-4044-a322-a898af8a393d",
+    name = "Siege Zombie",
+    setCode = "INR",
+    collectorNumber = "131",
+    scryfallId = "950e6466-dfd2-4ed6-83ba-be02fe612093",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/950e6466-dfd2-4ed6-83ba-be02fe612093.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/BlazingTorchReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/BlazingTorchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blazing Torch reprint in Innistrad. Canonical CardDefinition lives in ZEN.
+ */
+val BlazingTorchReprint = Printing(
+    oracleId = "cd3d1e5d-db12-4878-92a2-23eb8d23eaf3",
+    name = "Blazing Torch",
+    setCode = "ISD",
+    collectorNumber = "216",
+    scryfallId = "4e14fc60-f300-40f0-b712-4e339dc27929",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e14fc60-f300-40f0-b712-4e339dc27929.jpg",
+    releaseDate = "2011-09-30",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/EccentricFarmer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/EccentricFarmer.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Eccentric Farmer
+ * {2}{G}
+ * Creature — Human Peasant — Common (MID #185)
+ * 2/3
+ *
+ * "When this creature enters, mill three cards, then you may return a land card from your
+ * graveyard to your hand."
+ *
+ * Implementation: the ETB half of the same shape as Grapple with the Past — mill first so the
+ * milled cards are legal picks, then a `chooseUpTo(1)` over the graveyard's land cards. "You may
+ * return a … card" is modelled as "up to one" (declining = choosing zero); an empty pool
+ * auto-skips the prompt. No "target" in the oracle text, so this is a resolution-time choice.
+ */
+val EccentricFarmer = card("Eccentric Farmer") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Peasant"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, mill three cards, then you may return a land card from " +
+        "your graveyard to your hand. (To mill three cards, put the top three cards of your library " +
+        "into your graveyard.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Pipeline {
+            run(Patterns.Library.mill(3))
+            val lands = gather(CardSource.FromZone(Zone.GRAVEYARD, Player.You, Filters.Land))
+            val chosen = chooseUpTo(
+                1,
+                from = lands,
+                showAllCards = true,
+                prompt = "You may return a land card from your graveyard to your hand",
+                selectedLabel = "Return to hand",
+                remainderLabel = "Leave in graveyard"
+            )
+            toHand(chosen)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Tyler Walpole"
+        flavorText = "\"Careful now. Don't want to get the seeds stuck to your feelers like last time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg?1783925579"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SiegeZombie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SiegeZombie.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Siege Zombie
+ * {1}{B}
+ * Creature — Zombie — Common (MID #121)
+ * 2/2
+ *
+ * "Tap three untapped creatures you control: Each opponent loses 1 life."
+ *
+ * Implementation notes:
+ *  - The cost is [Costs.TapPermanents] (3 creatures), **not** `{T}` plus two others: the printed
+ *    cost has no tap symbol, so Siege Zombie may be one of the three tapped creatures and none of
+ *    them need haste (CR 118.3c / 302.6 — the summoning-sickness restriction applies only to the
+ *    `{T}` symbol in an activation cost).
+ *  - "Each opponent loses 1 life" is a life-loss effect (not damage), scoped to
+ *    [Player.EachOpponent] so it hits every opponent in multiplayer.
+ */
+val SiegeZombie = card("Siege Zombie") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "Tap three untapped creatures you control: Each opponent loses 1 life."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(3, Filters.Creature)
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Johann Bodin"
+        flavorText = "A barricade only buys time. So the wealthy buy more barricades."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg?1783925609"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AngelsTombReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AngelsTombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel's Tomb reprint in Magic Origins. Canonical CardDefinition lives in AVR.
+ */
+val AngelsTombReprint = Printing(
+    oracleId = "de3ed52e-7cc2-49ea-96d9-4254aac46168",
+    name = "Angel's Tomb",
+    setCode = "ORI",
+    collectorNumber = "222",
+    scryfallId = "fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/fffaa737-ce46-4f35-aa8c-bd9bb77ed9f6.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/BlazingTorch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/BlazingTorch.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blazing Torch
+ * {1}
+ * Artifact — Equipment — Uncommon (ZEN #197)
+ *
+ * "Equipped creature can't be blocked by Vampires or Zombies.
+ *  Equipped creature has "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
+ *  Equip {1}"
+ *
+ * Implementation notes:
+ *  - The evasion clause is [CantBeBlockedBy] over "creature that is a Vampire or a Zombie"
+ *    ([GameObjectFilter.withAnySubtype]), scoped to [Filters.EquippedCreature].
+ *  - The quoted ability is granted to the bearer via [GrantActivatedAbility] (the Deconstruction
+ *    Hammer idiom): the `{T}` taps *that creature* (CR 113.7 — the granted ability's source is the
+ *    creature, so it is also subject to summoning sickness), and its controller pays the cost.
+ *  - "Sacrifice Blazing Torch" names the specific granting Equipment (CR 201.5a), so the cost is
+ *    [Costs.SacrificeGrantingPermanent] — correct even with a second Blazing Torch in play, and it
+ *    never offers the creature's own controller a choice of which artifact to sacrifice.
+ *  - "**Blazing Torch** deals 2 damage" — the damage source is the Equipment, not the creature, so
+ *    `damageSource = EffectTarget.GrantingSource`. This matters: the Torch has been sacrificed by
+ *    the time the ability resolves (last-known information), it is a colorless artifact source, and
+ *    a lifelinking / deathtouching bearer must not lend those abilities to the damage.
+ */
+val BlazingTorch = card("Blazing Torch") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature can't be blocked by Vampires or Zombies.\n" +
+        "Equipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target.\"\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature can't be blocked by Vampires or Zombies.
+    staticAbility {
+        ability = CantBeBlockedBy(
+            blockerFilter = GameObjectFilter.Creature.withAnySubtype("Vampire", "Zombie"),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    // Equipped creature has "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(
+                    Costs.Tap,
+                    Costs.SacrificeGrantingPermanent
+                ),
+                effect = DealDamageEffect(
+                    amount = 2,
+                    target = EffectTarget.ContextTarget(0),
+                    damageSource = EffectTarget.GrantingSource
+                ),
+                targetRequirements = listOf(Targets.Any),
+                descriptionOverride = "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Vance Kovacs"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg?1783942128"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -48,6 +48,66 @@
     ]
 }
 
+// Angel's Tomb
+{
+    "name": "Angel's Tomb",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a creature you control enters, you may have this artifact become a 3/3 white Angel artifact creature with flying until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayDecide",
+                        "inlineOnTrigger": true
+                    },
+                    "then": {
+                        "type": "BecomeCreature",
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "creatureTypes": [
+                            "Angel"
+                        ],
+                        "addTypes": [
+                            "CREATURE"
+                        ],
+                        "colors": [
+                            "WHITE"
+                        ]
+                    },
+                    "descriptionOverride": "You may have Angel's Tomb become a 3/3 white Angel artifact creature with flying until end of turn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Faith can quicken the stones themselves with life.\"\n—Writings of Mikaeus",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28226303-7e67-4b88-adae-2386aff033ec.jpg?1783940655"
+    },
+    "colorIdentityOverride": []
+}
+
 // Avacyn, Angel of Hope
 {
     "name": "Avacyn, Angel of Hope",

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -609,6 +609,88 @@
     ]
 }
 
+// Grapple with the Past
+{
+    "name": "Grapple with the Past",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Mill three cards, then you may return a creature or land card from your graveyard to your hand. (To mill three cards, put the top three cards of your library into your graveyard.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": "creature|land"
+                    },
+                    "storeAs": "gathered1"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "gathered1",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "selected2",
+                    "prompt": "You may return a creature or land card from your graveyard to your hand",
+                    "selectedLabel": "Return to hand",
+                    "remainderLabel": "Leave in graveyard",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "selected2",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Howard Lyon",
+        "flavorText": "Emrakul does not grant wishes. Desires simply align to her will.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d44a77a6-e8a1-4706-886f-8ab3af56b342.jpg?1783937443"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Guardian of Pilgrims
 {
     "name": "Guardian of Pilgrims",

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -556,6 +556,101 @@
     ]
 }
 
+// Eccentric Farmer
+{
+    "name": "Eccentric Farmer",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "When this creature enters, mill three cards, then you may return a land card from your graveyard to your hand. (To mill three cards, put the top three cards of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "land"
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected2",
+                            "prompt": "You may return a land card from your graveyard to your hand",
+                            "selectedLabel": "Return to hand",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected2",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Tyler Walpole",
+        "flavorText": "\"Careful now. Don't want to get the seeds stuck to your feelers like last time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5339f6e-9ed7-4734-91c9-c2ed59ca1052.jpg?1783925579"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Fading Hope
 {
     "name": "Fading Hope",
@@ -1332,6 +1427,53 @@
     },
     "colorIdentityOverride": [
         "BLUE",
+        "BLACK"
+    ]
+}
+
+// Siege Zombie
+{
+    "name": "Siege Zombie",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Tap three untapped creatures you control: Each opponent loses 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Johann Bodin",
+        "flavorText": "A barricade only buys time. So the wealthy buy more barricades.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d94b5270-840b-4905-815a-057029d7352f.jpg?1783925609"
+    },
+    "colorIdentityOverride": [
         "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -70,6 +70,110 @@
     "colorIdentityOverride": []
 }
 
+// Blazing Torch
+{
+    "name": "Blazing Torch",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature can't be blocked by Vampires or Zombies.\nEquipped creature has \"{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "Or",
+                            "predicates": [
+                                {
+                                    "type": "HasSubtype",
+                                    "subtype": "Vampire"
+                                },
+                                {
+                                    "type": "HasSubtype",
+                                    "subtype": "Zombie"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            "CostTap",
+                            "CostSacrificeGrantingPermanent"
+                        ]
+                    },
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "GrantingSource"
+                    },
+                    "targetRequirements": [
+                        "AnyTarget"
+                    ],
+                    "descriptionOverride": "{T}, Sacrifice Blazing Torch: Blazing Torch deals 2 damage to any target."
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Vance Kovacs",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e9d1ff2-9ce3-4737-af1d-9fc82e4dffe6.jpg?1783942128"
+    },
+    "colorIdentityOverride": []
+}
+
 // Burst Lightning
 {
     "name": "Burst Lightning",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.mechanics.combat.rules
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.core.Color
@@ -14,6 +15,7 @@ import com.wingedsheep.sdk.scripting.CantBeBlockedIfCastSpellType
 import com.wingedsheep.sdk.scripting.CantBeBlockedUnlessDefenderSharesCreatureType
 import com.wingedsheep.sdk.scripting.GrantCantBeBlockedToSmallCreatures
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 
 /**
@@ -166,7 +168,10 @@ class CantBeBlockedByRule(
         // Printed restrictions. cardDef may be null for tokens/copies without a registered
         // definition — the granted form below still applies.
         val cardDef = ctx.cardRegistry.getCard(attackerCard.cardDefinitionId)
-        val printed = cardDef?.staticAbilities?.filterIsInstance<CantBeBlockedBy>().orEmpty()
+        val printed = cardDef?.staticAbilities
+            ?.filterIsInstance<CantBeBlockedBy>()
+            ?.filter { it.filter.scope is Scope.Self }
+            .orEmpty()
         // Granted (floating) restrictions land in state.grantedStaticAbilities keyed to the
         // attacker — e.g. Cavern Stomper's "{3}{G}: this creature can't be blocked by creatures
         // with power 2 or less this turn" grants CantBeBlockedBy to itself via
@@ -175,7 +180,7 @@ class CantBeBlockedByRule(
             .filter { it.entityId == ctx.attackerId }
             .map { it.ability }
             .filterIsInstance<CantBeBlockedBy>()
-        val restrictions = printed + granted
+        val restrictions = printed + granted + hostScopedRestrictions(ctx)
         if (restrictions.isEmpty()) return null
 
         val attackerController = ctx.projected.getController(ctx.attackerId) ?: return null
@@ -191,6 +196,41 @@ class CantBeBlockedByRule(
             }
         }
         return null
+    }
+
+    /**
+     * Restrictions projected onto the attacker by a *different* battlefield permanent through the
+     * static's [com.wingedsheep.sdk.scripting.filters.unified.GroupFilter] — an Equipment or Aura
+     * whose "equipped/enchanted creature can't be blocked by …" clause lives on the attachment, not
+     * on the attacker's own card (Blazing Torch, Artifact Ward). Mirrors the host-scoped
+     * `MustBeBlocked` scan in `BlockPhaseManager`: the filter's scope is resolved relative to the
+     * permanent carrying the static, and the attacker must also satisfy the filter's base filter.
+     */
+    private fun hostScopedRestrictions(ctx: BlockCheckContext): List<CantBeBlockedBy> {
+        val result = mutableListOf<CantBeBlockedBy>()
+        for (hostId in ctx.state.getBattlefield()) {
+            if (hostId == ctx.attackerId) continue
+            val container = ctx.state.getEntity(hostId) ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val hostCard = container.get<CardComponent>() ?: continue
+            val statics = ctx.cardRegistry.getCard(hostCard.cardDefinitionId)?.staticAbilities.orEmpty()
+            for (ability in statics.filterIsInstance<CantBeBlockedBy>()) {
+                val scopeMatches = when (val scope = ability.filter.scope) {
+                    is Scope.AttachedTo -> container.get<AttachedToComponent>()?.targetId == ctx.attackerId
+                    is Scope.Specific -> scope.entityId == ctx.attackerId
+                    is Scope.Battlefield -> true
+                    is Scope.Self -> false // already covered by the attacker's own printed read
+                }
+                if (!scopeMatches) continue
+                val hostController = ctx.projected.getController(hostId) ?: continue
+                val baseMatches = predicateEvaluator.matches(
+                    ctx.state, ctx.projected, ctx.attackerId, ability.filter.baseFilter,
+                    PredicateContext(sourceId = hostId, controllerId = hostController)
+                )
+                if (baseMatches) result.add(ability)
+            }
+        }
+        return result
     }
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InnistradRemasteredBatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InnistradRemasteredBatchScenarioTest.kt
@@ -1,0 +1,311 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.AngelsTomb
+import com.wingedsheep.mtg.sets.definitions.emn.cards.GrappleWithThePast
+import com.wingedsheep.mtg.sets.definitions.mid.cards.EccentricFarmer
+import com.wingedsheep.mtg.sets.definitions.mid.cards.SiegeZombie
+import com.wingedsheep.mtg.sets.definitions.zen.cards.BlazingTorch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the Innistrad Remastered batch: Grapple with the Past (EMN), Eccentric
+ * Farmer (MID), Siege Zombie (MID), Angel's Tomb (AVR) and Blazing Torch (ZEN).
+ *
+ * Every card composes existing SDK primitives, so these tests prove the *composition* — mill
+ * ordering vs the graveyard pick, the optional "you may" declines, the tap-three cost shape, and
+ * the granted-ability / damage-source wiring on the Equipment.
+ */
+class InnistradRemasteredBatchScenarioTest : FunSpec({
+
+    val batch = listOf(GrappleWithThePast, EccentricFarmer, SiegeZombie, AngelsTomb, BlazingTorch)
+    val projector = StateProjector()
+
+    fun setup(deck: Deck = Deck.of("Forest" to 40)): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + batch)
+        initMirrorMatch(deck = deck, startingLife = 20, skipMulligans = true)
+    }
+
+    // ── Grapple with the Past ────────────────────────────────────────────────
+
+    test("Grapple with the Past: mills three, then returns a just-milled creature card to hand") {
+        val d = setup()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed the top three so the mill is deterministic: two creatures and a land.
+        val third = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val second = d.putCardOnTopOfLibrary(you, "Forest")
+        val first = d.putCardOnTopOfLibrary(you, "Hill Giant")
+        val milled = setOf(first, second, third)
+
+        d.giveMana(you, Color.GREEN, 2)
+        val grapple = d.putCardInHand(you, "Grapple with the Past")
+        d.castSpell(you, grapple).error shouldBe null
+        d.bothPass()
+
+        // The three cards are milled *before* the choice, so all three are offered back.
+        val decision = d.pendingDecision as SelectCardsDecision
+        decision.maxSelections shouldBe 1
+        decision.minSelections shouldBe 0
+        milled.forEach { decision.options shouldContain it }
+
+        d.submitCardSelection(you, listOf(first)).error shouldBe null
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        d.getHand(you) shouldContain first
+        d.getGraveyard(you) shouldContain second
+        d.getGraveyard(you) shouldContain third
+    }
+
+    test("Grapple with the Past: declining the return leaves all three milled cards in the graveyard") {
+        val d = setup()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val third = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val second = d.putCardOnTopOfLibrary(you, "Forest")
+        val first = d.putCardOnTopOfLibrary(you, "Hill Giant")
+
+        d.giveMana(you, Color.GREEN, 2)
+        val grapple = d.putCardInHand(you, "Grapple with the Past")
+        val handBefore = d.getHandSize(you)
+        d.castSpell(you, grapple).error shouldBe null
+        d.bothPass()
+
+        // "you may" = choose zero.
+        d.submitCardSelection(you, emptyList()).error shouldBe null
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        // Hand shrank by exactly the Grapple itself; every milled card stayed in the graveyard.
+        d.getHandSize(you) shouldBe handBefore - 1
+        listOf(first, second, third).forEach { d.getGraveyard(you) shouldContain it }
+    }
+
+    // ── Eccentric Farmer ─────────────────────────────────────────────────────
+
+    test("Eccentric Farmer: ETB mills three and offers only land cards from the graveyard") {
+        val d = setup()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creatureOnTop = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val landOnTop = d.putCardOnTopOfLibrary(you, "Forest")
+        val otherCreature = d.putCardOnTopOfLibrary(you, "Hill Giant")
+
+        d.giveMana(you, Color.GREEN, 3)
+        val farmer = d.putCardInHand(you, "Eccentric Farmer")
+        d.castSpell(you, farmer).error shouldBe null
+        d.bothPass() // resolve the creature spell
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        val decision = d.pendingDecision as SelectCardsDecision
+        decision.options shouldContain landOnTop
+        decision.options.contains(creatureOnTop) shouldBe false
+        decision.options.contains(otherCreature) shouldBe false
+
+        d.submitCardSelection(you, listOf(landOnTop)).error shouldBe null
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        d.getHand(you) shouldContain landOnTop
+        d.getGraveyard(you) shouldContain creatureOnTop
+        d.getGraveyard(you) shouldContain otherCreature
+    }
+
+    // ── Siege Zombie ─────────────────────────────────────────────────────────
+
+    test("Siege Zombie: taps three creatures (itself included) and drains each opponent for 1") {
+        val d = setup(Deck.of("Swamp" to 40))
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val zombie = d.putCreatureOnBattlefield(you, "Siege Zombie")
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val giant = d.putCreatureOnBattlefield(you, "Hill Giant")
+        val abilityId = SiegeZombie.activatedAbilities.single().id
+
+        // No `{T}` in the printed cost, so summoning sickness does not gate the tap and the
+        // Zombie may tap itself as one of the three.
+        d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = zombie,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(zombie, bear, giant))
+            )
+        ).isSuccess shouldBe true
+
+        listOf(zombie, bear, giant).forEach { d.isTapped(it) shouldBe true }
+        d.bothPass()
+
+        d.getLifeTotal(opponent) shouldBe 19
+        d.getLifeTotal(you) shouldBe 20
+    }
+
+    test("Siege Zombie: cannot be activated with only two untapped creatures") {
+        val d = setup(Deck.of("Swamp" to 40))
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val zombie = d.putCreatureOnBattlefield(you, "Siege Zombie")
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val abilityId = SiegeZombie.activatedAbilities.single().id
+
+        d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = zombie,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(zombie, bear))
+            )
+        ).isSuccess shouldBe false
+    }
+
+    // ── Angel's Tomb ─────────────────────────────────────────────────────────
+
+    test("Angel's Tomb: accepting the trigger animates it into a 3/3 flying Angel") {
+        val d = setup(Deck.of("Plains" to 40))
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tomb = d.putPermanentOnBattlefield(you, "Angel's Tomb")
+        projector.project(d.state).isCreature(tomb) shouldBe false
+
+        // Casting a creature triggers the Tomb.
+        d.giveMana(you, Color.GREEN, 2)
+        val bears = d.putCardInHand(you, "Grizzly Bears")
+        d.castSpell(you, bears).error shouldBe null
+        d.bothPass() // resolve the creature; the Tomb trigger goes on the stack
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        (d.pendingDecision is YesNoDecision) shouldBe true
+        d.submitYesNo(you, true).error shouldBe null
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        val projected = projector.project(d.state)
+        projected.isCreature(tomb) shouldBe true
+        projected.getPower(tomb) shouldBe 3
+        projected.getToughness(tomb) shouldBe 3
+        projected.hasKeyword(tomb, Keyword.FLYING) shouldBe true
+        // Still an artifact — the animation *adds* the creature type.
+        projected.hasType(tomb, "ARTIFACT") shouldBe true
+    }
+
+    test("Angel's Tomb: declining the trigger leaves it a plain artifact") {
+        val d = setup(Deck.of("Plains" to 40))
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tomb = d.putPermanentOnBattlefield(you, "Angel's Tomb")
+
+        d.giveMana(you, Color.GREEN, 2)
+        val bears = d.putCardInHand(you, "Grizzly Bears")
+        d.castSpell(you, bears).error shouldBe null
+        d.bothPass()
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        (d.pendingDecision is YesNoDecision) shouldBe true
+        d.submitYesNo(you, false).error shouldBe null
+        while (d.pendingDecision == null && d.stackSize > 0) d.bothPass()
+
+        projector.project(d.state).isCreature(tomb) shouldBe false
+    }
+
+    // ── Blazing Torch ────────────────────────────────────────────────────────
+
+    test("Blazing Torch: bearer's granted ability sacrifices the Torch and deals 2 damage") {
+        val d = setup(Deck.of("Mountain" to 40))
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+        val torch = d.putPermanentOnBattlefield(you, "Blazing Torch")
+
+        val equipId = BlazingTorch.activatedAbilities.single { it.isEquipAbility }.id
+        d.giveColorlessMana(you, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = torch,
+                abilityId = equipId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(torch)?.get<AttachedToComponent>()?.targetId shouldBe bear
+
+        // The quoted ability lives on the *creature*, granted by the Equipment.
+        val grantedId = BlazingTorch.staticAbilities
+            .filterIsInstance<GrantActivatedAbility>()
+            .single()
+            .ability
+            .id
+
+        d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = bear,
+                abilityId = grantedId,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+
+        // `{T}` taps the bearer; the Torch is sacrificed as part of the cost, before resolution.
+        d.isTapped(bear) shouldBe true
+        d.findPermanent(you, "Blazing Torch") shouldBe null
+        d.getGraveyard(you) shouldContain torch
+
+        d.bothPass()
+        d.getLifeTotal(opponent) shouldBe 18
+    }
+
+    test("Blazing Torch: equipped creature can't be blocked by a Zombie") {
+        val d = setup(Deck.of("Mountain" to 40))
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+        val torch = d.putPermanentOnBattlefield(you, "Blazing Torch")
+        val zombie = d.putCreatureOnBattlefield(opponent, "Siege Zombie")
+        d.removeSummoningSickness(zombie)
+
+        val equipId = BlazingTorch.activatedAbilities.single { it.isEquipAbility }.id
+        d.giveColorlessMana(you, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = torch,
+                abilityId = equipId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(bear), opponent).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // The Zombie is an otherwise-legal blocker, but the Torch's evasion forbids it.
+        (d.declareBlockers(opponent, mapOf(zombie to listOf(bear))).error != null) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements five Innistrad Remastered cards. Each canonical `CardDefinition` lands in the card's **earliest real printing**, with a `Printing` row in INR (and the ORI / ISD rows `check-card-printing` flagged as missing).

| Card | Canonical set | Oracle |
|---|---|---|
| Grapple with the Past | EMN #160 | Mill three cards, then you may return a creature or land card from your graveyard to your hand |
| Eccentric Farmer | MID #185 | ETB: mill three cards, then you may return a land card from your graveyard to your hand |
| Siege Zombie | MID #121 | Tap three untapped creatures you control: Each opponent loses 1 life |
| Angel's Tomb | AVR #211 | Whenever a creature you control enters, you may have it become a 3/3 white Angel artifact creature with flying until EOT |
| Blazing Torch | ZEN #197 | Equipment: evasion vs Vampires/Zombies + granted "{T}, Sacrifice: 2 damage to any target" |

## Composition — no new SDK types

- **Mill-then-return** (Grapple, Farmer) — `Effects.Pipeline { run(mill) → gather(graveyard) → chooseUpTo(1) → toHand }`. Mill runs first so the milled cards are legal picks; "you may return a card" is modelled as *up to one* (declining = choosing zero), and an empty pool auto-skips the prompt.
- **Siege Zombie** — `Costs.TapPermanents(3, Creature)`. The printed cost has no `{T}` symbol, so the Zombie may tap *itself* and none of the three need haste (CR 302.6 gates only the tap symbol).
- **Angel's Tomb** — `MayEffect(Effects.BecomeCreature(...))`, adding `CREATURE` on top of the printed `ARTIFACT` so it stays an *artifact* creature.
- **Blazing Torch** — the Deconstruction Hammer idiom: `GrantActivatedAbility` scoped to `Filters.EquippedCreature`, with `Costs.SacrificeGrantingPermanent` for "Sacrifice Blazing Torch" (CR 201.5a — the specific granter, correct with a second Torch in play). The oracle says *Blazing Torch* deals the damage, so the effect passes `damageSource = EffectTarget.GrantingSource` rather than attributing it to the bearer — matters for a lifelinking/deathtouching creature and for protection from artifacts.

## Engine fix: host-scoped `CantBeBlockedBy`

Blazing Torch's block test failed on first run and turned up a real gap. `CantBeBlockedByRule` read only (a) the attacker's own printed statics and (b) granted ones in `grantedStaticAbilities` — it never considered a `CantBeBlockedBy` projected onto the attacker by a *different* permanent through `GroupFilter.attachedCreature()`. Added a host-scoped battlefield scan that mirrors the existing `MustBeBlocked` one in `BlockPhaseManager` (`AttachedTo` → the attachment's host, `Specific` → the bound entity, `Battlefield` → every attacker; the attacker must also satisfy the base filter).

This also **fixes Artifact Ward (ATQ)**, whose "enchanted creature can't be blocked by artifact creatures" clause was already authored in exactly this shape and had been silently inert.

## Testing

`InnistradRemasteredBatchScenarioTest` — 9 cases, all passing. Covers the mill-ordering-vs-pick sequencing, both "you may" declines, the tap-three cost (accepted with three, rejected with two), accept/decline of the Tomb animation, the Torch's sacrifice + damage, and the Zombie-can't-block check.

`just build` and `just test` green. Card snapshot goldens re-blessed — the diff is purely additive (388 insertions, 0 deletions), so no other card's tree moved.

`docs/card-sdk-language-reference.md` gains a `CantBeBlockedBy` entry documenting all three resolution sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)