### PR TITLE
Add four Foundations reprints and fix GrantSubtype filter on Auras

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3737,7 +3737,10 @@ staticAbility {
   remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
 - `GrantSubtype(subtype, filter)` — Layer 4 type-changing static that adds a **fixed** creature subtype to the group,
-  in addition to their other types ("is a Knight in addition to its other types"). (Dub)
+  in addition to their other types ("is a Knight in addition to its other types"). (Dub, Angelic Destiny)
+  **`filter` defaults to the source, not the attached creature** — unlike `ModifyStats` / `GrantKeyword`, which
+  default to `attachedCreature()`. An Aura must pass `Filters.EnchantedCreature` explicitly or it silently makes
+  *itself* the Knight and leaves the enchanted creature alone.
 - `GrantChosenSubtype(filter, includeControlledSpells = false, includeOwnedCardsOutsideBattlefield = false)` — Layer 4
   type-changing static that adds the creature type **chosen as the source entered** (read from the source's
   `CastChoicesComponent`) to the group, in addition to their other types. Chosen-value counterpart to `GrantSubtype`,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -7,13 +7,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Grants a creature subtype to the target (typically the enchanted creature for Auras).
+ * Grants a creature subtype to a group of permanents.
  * Used for Dub: "Enchanted creature is a Knight in addition to its other types."
  *
  * This is a Layer 4 (type-changing) continuous effect that adds a subtype.
  *
+ * NOTE: [filter] defaults to the **source**, unlike [ModifyStats] and [GrantKeyword], which
+ * default to the attached creature. An Aura granting a subtype to the creature it enchants
+ * MUST pass `Filters.EnchantedCreature` explicitly, or it will silently grant the subtype to
+ * itself and leave the enchanted creature untouched — the failure is invisible without a
+ * scenario test that asserts the subtype on the *host*.
+ *
  * @property subtype The creature subtype to add (e.g., "Knight")
- * @property filter What this ability applies to (typically SourceCreature for Auras → enchanted creature)
+ * @property filter What this ability applies to; defaults to the source, NOT the enchanted creature
  */
 @SerialName("GrantSubtype")
 @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/Dub.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/Dub.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
@@ -32,7 +33,9 @@ val Dub = card("Dub") {
     }
 
     staticAbility {
-        ability = GrantSubtype("Knight")
+        // GrantSubtype defaults its filter to the source, unlike ModifyStats/GrantKeyword
+        // (which default to the attached creature) — an Aura must say so explicitly.
+        ability = GrantSubtype("Knight", Filters.EnchantedCreature)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelicDestinyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelicDestinyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Destiny reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2012 (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val AngelicDestinyReprint = Printing(
+    oracleId = "8ba36878-0816-44c7-b543-8ebfc28c2ecd",
+    name = "Angelic Destiny",
+    setCode = "FDN",
+    collectorNumber = "565",
+    scryfallId = "066d73fa-369b-44a3-b1a9-d22176ac3566",
+    artist = "Jana Schirmer & Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/066d73fa-369b-44a3-b1a9-d22176ac3566.jpg?1783908943",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FynnTheFangbearerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FynnTheFangbearerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fynn, the Fangbearer reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Kaldheim (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val FynnTheFangbearerReprint = Printing(
+    oracleId = "c0b1fba1-4338-4671-934b-098689ad2085",
+    name = "Fynn, the Fangbearer",
+    setCode = "FDN",
+    collectorNumber = "637",
+    scryfallId = "699efb9e-2649-432b-8b2d-10775114c314",
+    artist = "Lie Setiawan",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/699efb9e-2649-432b-8b2d-10775114c314.jpg?1783908919",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NewHorizonsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NewHorizonsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * New Horizons reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val NewHorizonsReprint = Printing(
+    oracleId = "8834d3c9-cdb5-423b-bc78-94a94add5e74",
+    name = "New Horizons",
+    setCode = "FDN",
+    collectorNumber = "557",
+    scryfallId = "86b3923c-c35c-4eb2-9dd3-b15c13778ecf",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86b3923c-c35c-4eb2-9dd3-b15c13778ecf.jpg?1783908946",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WildwoodScourgeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WildwoodScourgeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildwood Scourge reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Core Set 2021 (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val WildwoodScourgeReprint = Printing(
+    oracleId = "b9dec104-c636-4770-a7fc-7a3331face15",
+    name = "Wildwood Scourge",
+    setCode = "FDN",
+    collectorNumber = "236",
+    scryfallId = "36359fb6-fb8c-4382-8555-e348422f116c",
+    artist = "Bryan Sola",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36359fb6-fb8c-4382-8555-e348422f116c.jpg?1783909054",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NewHorizonsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NewHorizonsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * New Horizons reprint in JMP. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan (its earliest printing);
+ * this file contributes only the JMP presentation row.
+ */
+val NewHorizonsReprint = Printing(
+    oracleId = "8834d3c9-cdb5-423b-bc78-94a94add5e74",
+    name = "New Horizons",
+    setCode = "JMP",
+    collectorNumber = "414",
+    scryfallId = "f7df29a3-c40f-4cd8-a6fe-c1b95085cfed",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7df29a3-c40f-4cd8-a6fe-c1b95085cfed.jpg?1783930359",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FynnTheFangbearer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/FynnTheFangbearer.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fynn, the Fangbearer
+ * {1}{G}
+ * Legendary Creature — Human Warrior
+ * 1/3
+ * Deathtouch
+ * Whenever a creature you control with deathtouch deals combat damage to a player, that
+ * player gets two poison counters.
+ *
+ * The source filter reads deathtouch off projected state, so creatures that *gain*
+ * deathtouch (auras, granted keywords, deathtouch counters) count — Fynn itself included.
+ */
+val FynnTheFangbearer = card("Fynn, the Fangbearer") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 1
+    toughness = 3
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n" +
+        "Whenever a creature you control with deathtouch deals combat damage to a player, that player " +
+        "gets two poison counters. (A player with ten or more poison counters loses the game.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().withKeyword(Keyword.DEATHTOUCH),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(
+            counterType = Counters.POISON,
+            count = 2,
+            target = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Lie Setiawan"
+        flavorText = "\"Come, Koma, and reclaim what you lost! Or does the great serpent fear a rematch?\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg?1783928214"
+        ruling(
+            "2021-02-05",
+            "Losing the game because a player (preferably an opponent) has ten or more poison counters " +
+                "is a rule of the game. Fynn doesn't have to still be on the battlefield when someone " +
+                "(preferably an opponent) gets their tenth poison counter."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AngelicDestiny.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AngelicDestiny.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Angelic Destiny
+ * {2}{W}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition
+ * to its other types.
+ * When enchanted creature dies, return this card to its owner's hand.
+ *
+ * The return clause moves *this Aura* (not the dead creature) — by the time the trigger
+ * resolves the Aura has already been put into its owner's graveyard as a state-based action,
+ * so [EffectTarget.Self] picks it up there (same shape as Spine of Ish Sah).
+ */
+val AngelicDestiny = card("Angelic Destiny") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\n" +
+        "When enchanted creature dies, return this card to its owner's hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(4, 4)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    staticAbility {
+        // GrantSubtype defaults its filter to the source, unlike ModifyStats/GrantKeyword
+        // (which default to the attached creature) — an Aura must say so explicitly.
+        ability = GrantSubtype("Angel", Filters.EnchantedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(to = Zone.GRAVEYARD, binding = TriggerBinding.ATTACHED)
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "3"
+        artist = "Jana Schirmer & Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg?1783941107"
+        ruling(
+            "2011-09-22",
+            "If the creature dies before the Angelic Destiny spell resolves, Angelic Destiny will go " +
+                "to its owner's graveyard. It won't return to its owner's hand."
+        )
+        ruling(
+            "2011-09-22",
+            "If Angelic Destiny is no longer in a graveyard when its triggered ability resolves, " +
+                "it won't be returned to its owner's hand."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WildwoodScourge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WildwoodScourge.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wildwood Scourge
+ * {X}{G}
+ * Creature — Hydra
+ * 0/0
+ * This creature enters with X +1/+1 counters on it.
+ * Whenever one or more +1/+1 counters are put on another non-Hydra creature you control,
+ * put a +1/+1 counter on this creature.
+ *
+ * `firstTimeEachTurn = false` — the ability watches every counter placement, not just the
+ * first on a given creature each turn. Per the Scryfall ruling the Scourge gets exactly one
+ * counter per event batch no matter how many counters landed, which is what
+ * `countersPlacedOn` (a per-batch watcher) delivers.
+ */
+val WildwoodScourge = card("Wildwood Scourge") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Hydra"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with X +1/+1 counters on it.\n" +
+        "Whenever one or more +1/+1 counters are put on another non-Hydra creature you control, " +
+        "put a +1/+1 counter on this creature."
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = DynamicAmount.XValue
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Creature.youControl().notSubtype(Subtype.HYDRA),
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            firstTimeEachTurn = false,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.AddCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = EffectTarget.Self
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg?1783930664"
+        ruling(
+            "2024-11-08",
+            "Abilities that trigger when counters are put on a creature trigger when a creature " +
+                "enters with counters and when a player puts counters on a creature."
+        )
+        ruling(
+            "2024-11-08",
+            "Wildwood Scourge gets just one +1/+1 counter when its last ability resolves, no matter " +
+                "how many counters were put on the non-Hydra creature."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/NewHorizonsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/NewHorizonsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * New Horizons reprint in WAR. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan (its earliest printing);
+ * this file contributes only the WAR presentation row.
+ */
+val NewHorizonsReprint = Printing(
+    oracleId = "8834d3c9-cdb5-423b-bc78-94a94add5e74",
+    name = "New Horizons",
+    setCode = "WAR",
+    collectorNumber = "168",
+    scryfallId = "02c521da-677e-43b9-b5fe-c84dc64e66ec",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02c521da-677e-43b9-b5fe-c84dc64e66ec.jpg?1783933410",
+    releaseDate = "2019-05-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/NewHorizons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/NewHorizons.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+
+/**
+ * New Horizons
+ * {2}{G}
+ * Enchantment — Aura
+ * Enchant land
+ * When this Aura enters, put a +1/+1 counter on target creature you control.
+ * Enchanted land has "{T}: Add two mana of any one color."
+ *
+ * The granted ability is a *separate* mana ability on the land (it doesn't replace or
+ * augment the land's own tap-for-mana), so it is modelled as [GrantActivatedAbility]
+ * rather than the `AdditionalManaOnTap` (Fertile Ground) shape.
+ */
+val NewHorizons = card("New Horizons") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant land\n" +
+        "When this Aura enters, put a +1/+1 counter on target creature you control.\n" +
+        "Enchanted land has \"{T}: Add two mana of any one color.\""
+
+    auraTarget = Targets.Land
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = creature
+        )
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddAnyColorMana(2)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Noah Bradley"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg?1783935723"
+        ruling("2019-05-03", "You can cast New Horizons even if you control no creatures.")
+        ruling(
+            "2019-05-03",
+            "If the land this Aura would enchant is an illegal target by the time New Horizons resolves, " +
+                "the entire spell doesn't resolve. It won't enter the battlefield, so its ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -3270,7 +3270,11 @@
             },
             {
                 "type": "GrantSubtype",
-                "subtype": "Knight"
+                "subtype": "Knight",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
             }
         ],
         "auraTarget": {

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -120,6 +120,60 @@
     ]
 }
 
+// Fynn, the Fangbearer
+{
+    "name": "Fynn, the Fangbearer",
+    "manaCost": "{1}{G}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever a creature you control with deathtouch deals combat damage to a player, that player gets two poison counters. (A player with ten or more poison counters loses the game.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "creature kw:deathtouch ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "poison",
+                    "count": 2,
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "UNCOMMON",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"Come, Koma, and reclaim what you lost! Or does the great serpent fear a rematch?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d7a8a90-13c1-4b0c-ab2e-fc8d91ccefd9.jpg?1783928214",
+        "rulings": [
+            {
+                "date": "2021-02-05",
+                "text": "Losing the game because a player (preferably an opponent) has ten or more poison counters is a rule of the game. Fynn doesn't have to still be on the battlefield when someone (preferably an opponent) gets their tenth poison counter."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Goldvein Pick
 {
     "name": "Goldvein Pick",

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -39,6 +39,80 @@
     "colorIdentityOverride": []
 }
 
+// Angelic Destiny
+{
+    "name": "Angelic Destiny",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition to its other types.\nWhen enchanted creature dies, return this card to its owner's hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 4,
+                "toughnessBonus": 4
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Angel",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "MYTHIC",
+        "artist": "Jana Schirmer & Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0cd7438-fde2-4e26-9c34-52c476a971e9.jpg?1783941107",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "If the creature dies before the Angelic Destiny spell resolves, Angelic Destiny will go to its owner's graveyard. It won't return to its owner's hand."
+            },
+            {
+                "date": "2011-09-22",
+                "text": "If Angelic Destiny is no longer in a graveyard when its triggered ability resolves, it won't be returned to its owner's hand."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Grand Abolisher
 {
     "name": "Grand Abolisher",

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -343,3 +343,68 @@
         "BLACK"
     ]
 }
+
+// Wildwood Scourge
+{
+    "name": "Wildwood Scourge",
+    "manaCost": "{X}{G}",
+    "typeLine": "Creature — Hydra",
+    "oracleText": "This creature enters with X +1/+1 counters on it.\nWhenever one or more +1/+1 counters are put on another non-Hydra creature you control, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "+1/+1",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Hydra"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46ff0b33-d153-4b0e-ac48-7e5ed70dea09.jpg?1783930664",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Abilities that trigger when counters are put on a creature trigger when a creature enters with counters and when a player puts counters on a creature."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Wildwood Scourge gets just one +1/+1 counter when its last ability resolves, no matter how many counters were put on the non-Hydra creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -498,6 +498,81 @@
     ]
 }
 
+// New Horizons
+{
+    "name": "New Horizons",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant land\nWhen this Aura enters, put a +1/+1 counter on target creature you control.\nEnchanted land has \"{T}: Add two mana of any one color.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddManaOfChoice",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "land"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Noah Bradley",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15b12c75-1248-4c81-90cf-28e341a885cf.jpg?1783935723",
+        "rulings": [
+            {
+                "date": "2019-05-03",
+                "text": "You can cast New Horizons even if you control no creatures."
+            },
+            {
+                "date": "2019-05-03",
+                "text": "If the land this Aura would enchant is an illegal target by the time New Horizons resolves, the entire spell doesn't resolve. It won't enter the battlefield, so its ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pirate's Cutlass
 {
     "name": "Pirate's Cutlass",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelicDestinyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelicDestinyScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Angelic Destiny (M12 #3, reprinted as FDN #565) — {2}{W}{W} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  Enchanted creature gets +4/+4, has flying and first strike, and is an Angel in addition
+ *  to its other types.
+ *  When enchanted creature dies, return this card to its owner's hand."
+ *
+ * Pins both halves: the four-part continuous grant (stats, two keywords, the added Angel
+ * subtype) and the recursion trigger — which must return *the Aura itself* from the
+ * graveyard it was put into by state-based actions, not the dead creature.
+ */
+class AngelicDestinyScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Angelic Destiny") {
+
+            test("grants +4/+4, flying, first strike, and the Angel type") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Angelic Destiny", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = projector.project(game.state)
+
+                withClue("2/2 base plus +4/+4") {
+                    projected.getPower(bears) shouldBe 6
+                    projected.getToughness(bears) shouldBe 6
+                }
+                projected.hasKeyword(bears, Keyword.FLYING) shouldBe true
+                projected.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                withClue("Angel is added, the printed Bear type is kept") {
+                    projected.hasSubtype(bears, "Angel") shouldBe true
+                    projected.hasSubtype(bears, "Bear") shouldBe true
+                }
+            }
+
+            test("returns itself to its owner's hand when the enchanted creature dies") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Angelic Destiny", "Grizzly Bears")
+                    .withCardInHand(2, "Doom Blade")
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(2, "Doom Blade", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the enchanted creature died") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("the Aura went to the graveyard as an SBA, then its trigger recurred it") {
+                    game.isInHand(1, "Angelic Destiny") shouldBe true
+                    game.isInGraveyard(1, "Angelic Destiny") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DubScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DubScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dub (DOM #15) — {2}{W} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  Enchanted creature gets +2/+2, has first strike, and is a Knight in addition to its
+ *  other types."
+ *
+ * Pins the whole continuous grant, in particular the added Knight subtype: `GrantSubtype`
+ * defaults its filter to the *source*, so an Aura that omits the filter silently makes
+ * itself the Knight instead of the creature it enchants.
+ */
+class DubScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Dub") {
+
+            test("grants +2/+2, first strike, and the Knight type to the enchanted creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Dub", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val dub = game.findPermanent("Dub")!!
+                val projected = projector.project(game.state)
+
+                withClue("2/2 base plus +2/+2") {
+                    projected.getPower(bears) shouldBe 4
+                    projected.getToughness(bears) shouldBe 4
+                }
+                projected.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                withClue("Knight is added, the printed Bear type is kept") {
+                    projected.hasSubtype(bears, "Knight") shouldBe true
+                    projected.hasSubtype(bears, "Bear") shouldBe true
+                }
+                withClue("the Aura itself does not become the Knight") {
+                    projected.hasSubtype(dub, "Knight") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FynnTheFangbearerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FynnTheFangbearerScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fynn, the Fangbearer (KHM #170, reprinted as FDN #637) — {1}{G} 1/3 Legendary Creature.
+ *
+ * "Deathtouch
+ *  Whenever a creature you control with deathtouch deals combat damage to a player, that
+ *  player gets two poison counters."
+ *
+ * Pins the trigger's source filter: it fires for Fynn itself (which has printed
+ * deathtouch), for another deathtouch creature you control, and *not* for a creature
+ * without deathtouch.
+ */
+class FynnTheFangbearerScenarioTest : ScenarioTestBase() {
+
+    private fun poisonCounters(playerNumber: Int, game: TestGame): Int {
+        val playerId = EntityId.of("player-$playerNumber")
+        return game.state.getEntity(playerId)?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0
+    }
+
+    init {
+        context("Fynn, the Fangbearer") {
+
+            test("Fynn's own combat damage gives the defending player two poison counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Fynn, the Fangbearer")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                poisonCounters(2, game) shouldBe 0
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Fynn, the Fangbearer" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Fynn has deathtouch, so his own combat damage triggers his ability") {
+                    poisonCounters(2, game) shouldBe 2
+                }
+                game.getLifeTotal(2) shouldBe 19
+            }
+
+            test("another deathtouch creature you control also triggers it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Fynn, the Fangbearer")
+                    .withCardOnBattlefield(1, "Typhoid Rats") // 1/1 deathtouch
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Typhoid Rats" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("the Rats have deathtouch and are controlled by Fynn's controller") {
+                    poisonCounters(2, game) shouldBe 2
+                }
+            }
+
+            test("a creature without deathtouch does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Fynn, the Fangbearer")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("the Bears have no deathtouch, so no poison is dealt") {
+                    poisonCounters(2, game) shouldBe 0
+                }
+                game.getLifeTotal(2) shouldBe 18
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NewHorizonsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NewHorizonsScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * New Horizons (XLN #198, reprinted as FDN #557) — {2}{G} Enchantment — Aura.
+ *
+ * "Enchant land
+ *  When this Aura enters, put a +1/+1 counter on target creature you control.
+ *  Enchanted land has \"{T}: Add two mana of any one color.\""
+ *
+ * Pins the ETB counter trigger and the granted mana ability. The granted ability is a
+ * *second* mana ability on the land — it does not replace the land's own tap-for-mana —
+ * so the enchanted Forest surfaces two distinct activations.
+ */
+class NewHorizonsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("New Horizons") {
+
+            test("its enters trigger puts a +1/+1 counter on a target creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInHand(1, "New Horizons")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "New Horizons", forest).error shouldBe null
+                // The Aura resolves and enters; its ETB trigger then asks for a target — object
+                // targets are never auto-chosen, even when only one is legal.
+                game.resolveStack()
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Aura's enters trigger targets the only creature its controller has") {
+                    game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+
+            test("the enchanted land gains a second tap-for-mana ability") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                val before = game.getLegalActions(1)
+                    .count { (it.action as? ActivateAbility)?.sourceId == forest }
+
+                val enchanted = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardAttachedTo(1, "New Horizons", "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantedForest = enchanted.findPermanent("Forest")!!
+                val after = enchanted.getLegalActions(1)
+                    .count { (it.action as? ActivateAbility)?.sourceId == enchantedForest }
+
+                withClue("New Horizons adds an activation the bare Forest doesn't have") {
+                    after shouldBe before + 1
+                }
+                enchanted.findPermanent("New Horizons") shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildwoodScourgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildwoodScourgeScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wildwood Scourge (M21 #214, reprinted as FDN #236) — {X}{G} 0/0 Creature — Hydra.
+ *
+ * "This creature enters with X +1/+1 counters on it.
+ *  Whenever one or more +1/+1 counters are put on another non-Hydra creature you control,
+ *  put a +1/+1 counter on this creature."
+ *
+ * Pins the X-scaled entry and the counter-watcher's filter: it grows off a non-Hydra
+ * creature you control, but not off another Hydra.
+ */
+class WildwoodScourgeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOnes(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Wildwood Scourge") {
+
+            test("enters with X +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInHand(1, "Wildwood Scourge")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "Wildwood Scourge", xValue = 4).error shouldBe null
+                game.resolveStack()
+
+                val scourge = game.findPermanent("Wildwood Scourge")!!
+                withClue("X = 4 means four +1/+1 counters") {
+                    plusOnes(game, scourge) shouldBe 4
+                }
+            }
+
+            test("grows when +1/+1 counters land on another non-Hydra creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInHand(1, "Wildwood Scourge")
+                    .withCardInHand(1, "New Horizons")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // The Scourge is a printed 0/0, so it has to be cast for X — dropping a
+                // counterless copy straight onto the battlefield just feeds it to SBAs.
+                game.castXSpell(1, "Wildwood Scourge", xValue = 1).error shouldBe null
+                game.resolveStack()
+
+                val scourge = game.findPermanent("Wildwood Scourge")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                plusOnes(game, scourge) shouldBe 1
+
+                // New Horizons' enters trigger puts a +1/+1 counter on the Bears.
+                game.castSpell(1, "New Horizons", game.findPermanent("Forest")!!).error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                plusOnes(game, bears) shouldBe 1
+                withClue("the Bears are a non-Hydra creature you control, so the Scourge grows") {
+                    plusOnes(game, scourge) shouldBe 2
+                }
+            }
+
+            test("does not grow off counters on another Hydra you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withCardInHand(1, "Wildwood Scourge")
+                    .withCardInHand(1, "Wildwood Scourge")
+                    .withCardInHand(1, "New Horizons")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                repeat(2) {
+                    game.castXSpell(1, "Wildwood Scourge", xValue = 1).error shouldBe null
+                    game.resolveStack()
+                }
+
+                val hydras = game.findAllPermanents("Wildwood Scourge")
+                hydras.size shouldBe 2
+
+                game.castSpell(1, "New Horizons", game.findPermanent("Forest")!!).error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(hydras.first())).error shouldBe null
+                game.resolveStack()
+
+                plusOnes(game, hydras.first()) shouldBe 2
+                withClue("the other Hydra is excluded by the filter, so it doesn't grow") {
+                    plusOnes(game, hydras.last()) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Cards

Implements four cards reprinted in Foundations. Each canonical `cardDef` lives in the card's **earliest real printing**, with `Printing(...)` rows for the later sets:

| Card | Canonical | Reprint rows |
|---|---|---|
| Angelic Destiny | M12 | FDN |
| Fynn, the Fangbearer | KHM | FDN |
| New Horizons | XLN | WAR, JMP, FDN |
| Wildwood Scourge | M21 | FDN |

`just check-card-printing` reports `ok` for all four.

## Bug fix: `GrantSubtype` on Auras

`GrantSubtype` defaults its `filter` to `GroupFilter.source()`, while `ModifyStats` and `GrantKeyword` default to `GroupFilter.attachedCreature()`. An Aura that omits the filter therefore grants the subtype **to itself** and leaves the enchanted creature untouched.

This bit Angelic Destiny during implementation (stats and keywords applied to the enchanted creature; the Angel type didn't), and the same latent bug was already sitting in **Dub** (DOM) — it made itself a Knight. Dub had no scenario test, which is why it went unnoticed.

Both cards now pass `Filters.EnchantedCreature` explicitly. Dub gains the scenario test whose absence let the bug through, including an assertion that the Aura itself does *not* gain the subtype.

The trap is documented in the `GrantSubtype` KDoc and in `docs/card-sdk-language-reference.md` (the old KDoc actively claimed the default was the enchanted creature).

### Follow-up not taken here

The tidier fix is to flip `GrantSubtype`'s default to `attachedCreature()` in `TypeStaticAbilities.kt`, which would make both card-level filters redundant. Dub and Angelic Destiny were the only two cards relying on the current default and both want the attached creature, so it's safe today — but it's an SDK behavior change and belongs in its own `add-feature` pass.

## Testing

- 11 scenario tests pass (Angelic Destiny 2, Fynn 3, New Horizons 2, Wildwood Scourge 3, Dub 1)
- `:mtg-sets:test` and `:rules-engine:test` full suites pass
- Snapshots re-blessed: DOM (the Dub filter, a 5-line diff) and KHM/M12/M21/XLN (the new cards, pure additions). No other card trees changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)