### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/CommuneWithNatureReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/CommuneWithNatureReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Commune with Nature reprint in Tenth Edition. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the card's earliest printing, Champions of
+ * Kamigawa (`definitions/chk/cards/CommuneWithNature.kt`); this file contributes only 10E's
+ * presentation data.
+ */
+val CommuneWithNatureReprint = Printing(
+    oracleId = "d4ed4260-5f38-4b55-ba6e-9f54f04d2360",
+    name = "Commune with Nature",
+    setCode = "10E",
+    collectorNumber = "256",
+    scryfallId = "b760d616-b73a-4c7f-8a38-5606a9a321e3",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b760d616-b73a-4c7f-8a38-5606a9a321e3.jpg?1783943004",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/CommuneWithNature.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/CommuneWithNature.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Commune with Nature
+ * {G}
+ * Sorcery
+ *
+ * Look at the top five cards of your library. You may reveal a creature card from among them and
+ * put it into your hand. Put the rest on the bottom of your library in any order.
+ *
+ * Canonical printing: Champions of Kamigawa (2004). Reprinted in 10E, MM2 and Wilds of Eldraine.
+ *
+ * "You may reveal" → `chooseUpTo(1)`, so declining is legal even with creature cards among the
+ * five. "In any order" → the controller orders the remainder as it goes to the bottom
+ * ([com.wingedsheep.sdk.scripting.effects.CardOrder.ControllerChooses], the `toLibraryBottom`
+ * default), unlike the later "random order" templating on cards such as Memorial to Unity.
+ */
+val CommuneWithNature = card("Commune with Nature") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top five cards of your library. You may reveal a creature card from " +
+        "among them and put it into your hand. Put the rest on the bottom of your library in any order."
+
+    spell {
+        effect = Effects.Pipeline {
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(5)), name = "looked")
+            val (kept, rest) = chooseUpToSplit(
+                1, from = looked,
+                filter = GameObjectFilter.Creature,
+                prompt = "You may reveal a creature card to put into your hand",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Put on bottom",
+                showAllCards = true,
+                name = "kept",
+                remainderName = "rest"
+            )
+            toHand(kept, revealed = true)
+            toLibraryBottom(rest)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "204"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg?1783944291"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CommuneWithNatureReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CommuneWithNatureReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Commune with Nature reprint in Wilds of Eldraine. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the card's earliest printing, Champions of
+ * Kamigawa (`definitions/chk/cards/CommuneWithNature.kt`); this file contributes only WOE's
+ * presentation data.
+ */
+val CommuneWithNatureReprint = Printing(
+    oracleId = "d4ed4260-5f38-4b55-ba6e-9f54f04d2360",
+    name = "Commune with Nature",
+    setCode = "WOE",
+    collectorNumber = "166",
+    scryfallId = "5224eec3-2941-4d16-a713-099e34e93eee",
+    artist = "Jodie Muir",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/5224eec3-2941-4d16-a713-099e34e93eee.jpg?1783915084",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EgoDrain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EgoDrain.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Ego Drain
+ * {B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ * that card. If you don't control a Faerie, exile a card from your hand.
+ *
+ * The Faerie check happens on resolution, after the discard (CR 608.2) — so a Faerie that dies
+ * in response still leaves you paying the exile rider. The rider is not optional: you choose
+ * which card, but you must exile one if you have any.
+ */
+val EgoDrain = card("Ego Drain") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it. " +
+        "That player discards that card. If you don't control a Faerie, exile a card from your hand."
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Pipeline {
+            // 1. Target opponent reveals their hand.
+            run(RevealHandEffect(opponent))
+            // 2. Gather it so you can pick the card to strip.
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "opponentHand")
+            // 3. You choose a nonland card from it.
+            val chosen = chooseExactly(
+                1, from = hand,
+                filter = GameObjectFilter.Nonland,
+                prompt = "Choose a nonland card to discard",
+                alwaysPrompt = true,
+                showAllCards = true,
+                name = "toDiscard"
+            )
+            // 4. That player discards it (MoveType.Discard so discard triggers see it).
+            move(
+                chosen,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard
+            )
+            // 5. The Faerie rider.
+            run(
+                ConditionalEffect(
+                    condition = Conditions.YouControl(
+                        GameObjectFilter.Creature.withSubtype(Subtype.FAERIE),
+                        negate = true
+                    ),
+                    effect = Patterns.Hand.exileFromHand(1, EffectTarget.Controller)
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Valera Lutfullina"
+        flavorText = "\"You've wasted your life. Let's see if I can do any better with it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg?1783915109"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HarriedSpearguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HarriedSpearguard.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harried Spearguard
+ * {R}
+ * Creature — Human Soldier
+ * 1/1
+ *
+ * Haste
+ * When this creature dies, create a 1/1 black Rat creature token with "This token can't block."
+ */
+val HarriedSpearguard = card("Harried Spearguard") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Haste\n" +
+        "When this creature dies, create a 1/1 black Rat creature token with \"This token can't block.\""
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = woeRatToken()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Borja Pindado"
+        flavorText = "\"Why're you vermin so daft? This is a warehouse full of bricks. BRICKS! " +
+            "You can't eat bricks.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg?1783915094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HopelessNightmare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HopelessNightmare.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hopeless Nightmare
+ * {B}
+ * Enchantment
+ *
+ * When this enchantment enters, each opponent discards a card and loses 2 life.
+ * When this enchantment is put into a graveyard from the battlefield, scry 2.
+ * {2}{B}: Sacrifice this enchantment.
+ *
+ * The sacrifice is the *effect* of the activated ability (not part of its cost), so it uses the
+ * stack and can be responded to — and sacrificing this way is what puts the enchantment into the
+ * graveyard, firing the scry trigger.
+ */
+val HopelessNightmare = card("Hopeless Nightmare") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, each opponent discards a card and loses 2 life.\n" +
+        "When this enchantment is put into a graveyard from the battlefield, scry 2.\n" +
+        "{2}{B}: Sacrifice this enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.EachOpponentDiscards(1),
+            Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.PutIntoGraveyardFromBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = SacrificeSelfEffect
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg?1783915106"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WarehouseTabby.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WarehouseTabby.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Warehouse Tabby
+ * {B}
+ * Creature — Cat
+ * 1/1
+ *
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, create a
+ * 1/1 black Rat creature token with "This token can't block."
+ * {1}{B}: This creature gains deathtouch until end of turn.
+ *
+ * The trigger fires on *any* enchantment you control hitting the graveyard from the battlefield
+ * — destroyed, sacrificed, or put there by its own ability (Hopeless Nightmare, the Role tokens
+ * that fall off when replaced) — so it uses the generic `leavesBattlefield` factory with an
+ * `ANY` binding rather than the SELF-bound named constants.
+ */
+val WarehouseTabby = card("Warehouse Tabby") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Cat"
+    oracleText = "Whenever an enchantment you control is put into a graveyard from the battlefield, " +
+        "create a 1/1 black Rat creature token with \"This token can't block.\"\n" +
+        "{1}{B}: This creature gains deathtouch until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = woeRatToken()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "Steve Prescott"
+        flavorText = "For every rat she kills, ten more take its place."
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg?1783915100"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.effects.Effect
+
+/**
+ * Wilds of Eldraine's Rat token: a 1/1 black Rat creature token with "This token can't block."
+ *
+ * The Rat is a type-named token (no printed name beyond its creature type), so it goes through
+ * [Effects.CreateToken] rather than a [com.wingedsheep.mtg.sets.tokens.PredefinedTokens] entry.
+ * Several WOE cards create it (Harried Spearguard, Warehouse Tabby, Rat Out, …), so the shape —
+ * including the token's art — lives here rather than being copied per card.
+ */
+internal fun woeRatToken(): Effect = Effects.CreateToken(
+    power = 1,
+    toughness = 1,
+    colors = setOf(Color.BLACK),
+    creatureTypes = setOf("Rat"),
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+    staticAbilities = listOf(CantBlock())
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -362,6 +362,77 @@
     ]
 }
 
+// Commune with Nature
+{
+    "name": "Commune with Nature",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may reveal a creature card to put into your hand",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "artist": "Edward P. Beard, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce0b706e-017d-4f82-b280-cf9fdf75aef8.jpg?1783944291"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Counsel of the Soratami
 {
     "name": "Counsel of the Soratami",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -683,6 +683,132 @@
     ]
 }
 
+// Ego Drain
+{
+    "name": "Ego Drain",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. If you don't control a Faerie, exile a card from your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RevealHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "opponentHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "opponentHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature Faerie",
+                            "negate": true
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "exiled",
+                                "prompt": "Choose a card to exile"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "flavorText": "\"You've wasted your life. Let's see if I can do any better with it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8faf36da-bbad-4d6e-a530-502d47a2dd23.jpg?1783915109"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Eriette's Tempting Apple
 {
     "name": "Eriette's Tempting Apple",
@@ -1217,6 +1343,57 @@
     ]
 }
 
+// Harried Spearguard
+{
+    "name": "Harried Spearguard",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Haste\nWhen this creature dies, create a 1/1 black Rat creature token with \"This token can't block.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Borja Pindado",
+        "flavorText": "\"Why're you vermin so daft? This is a warehouse full of bricks. BRICKS! You can't eat bricks.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1db79785-4f55-445f-93f2-14c6e4606fc5.jpg?1783915094"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hopeful Vigil
 {
     "name": "Hopeful Vigil",
@@ -1280,6 +1457,115 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Hopeless Nightmare
+{
+    "name": "Hopeless Nightmare",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, each opponent discards a card and loses 2 life.\nWhen this enchantment is put into a graveyard from the battlefield, scry 2.\n{2}{B}: Sacrifice this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "EachOpponent"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": "SacrificeSelf"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c2ee817-9ca9-4f09-bc71-7994c19a9470.jpg?1783915106"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2811,5 +3097,72 @@
                 ]
             }
         }
+    ]
+}
+
+// Warehouse Tabby
+{
+    "name": "Warehouse Tabby",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 black Rat creature token with \"This token can't block.\"\n{1}{B}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Steve Prescott",
+        "flavorText": "For every rat she kills, ten more take its place.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d500ad81-9659-4a00-8f99-8be7c23587e8.jpg?1783915100"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
@@ -1,0 +1,289 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the Wilds of Eldraine batch:
+ *
+ *  - **Hopeless Nightmare** — ETB (each opponent discards + loses 2), the leaves-for-graveyard
+ *    scry trigger, and the `{2}{B}: Sacrifice this enchantment` ability that fires it.
+ *  - **Harried Spearguard** — dies → 1/1 black Rat that can't block.
+ *  - **Warehouse Tabby** — enchantment-you-control hits the graveyard → Rat; `{1}{B}` deathtouch.
+ *  - **Ego Drain** — targeted nonland strip, plus the "if you don't control a Faerie" exile rider
+ *    in both directions.
+ *  - **Commune with Nature** — look at five, take a creature (or decline), rest to the bottom.
+ */
+class WoeCardsScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private val nightmareSacrificeAbility by lazy {
+        cardRegistry.requireCard("Hopeless Nightmare").activatedAbilities[0].id
+    }
+
+    private val tabbyDeathtouchAbility by lazy {
+        cardRegistry.requireCard("Warehouse Tabby").activatedAbilities[0].id
+    }
+
+    init {
+        context("Hopeless Nightmare") {
+
+            test("enters: each opponent discards a card and loses 2 life") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Hopeless Nightmare")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentLife = game.getLifeTotal(2)
+                game.castSpell(1, "Hopeless Nightmare").error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent's only card should have been discarded") {
+                    game.handSize(2) shouldBe 0
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                game.getLifeTotal(2) shouldBe opponentLife - 2
+            }
+
+            test("{2}{B} sacrifices it, and hitting the graveyard scries 2") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Hopeless Nightmare")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Forest")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val nightmare = game.findPermanent("Hopeless Nightmare")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = nightmare,
+                        abilityId = nightmareSacrificeAbility
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the sacrifice is the ability's effect, so it goes to the graveyard") {
+                    game.isInGraveyard(1, "Hopeless Nightmare") shouldBe true
+                }
+                withClue("dying from the battlefield puts the scry-2 trigger on the stack") {
+                    game.hasPendingDecision() shouldBe true
+                }
+            }
+        }
+
+        context("Harried Spearguard") {
+
+            test("dies: creates a 1/1 black Rat that can't block") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Harried Spearguard")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spearguard = game.findPermanent("Harried Spearguard")!!
+                game.castSpell(1, "Shock", targetId = spearguard).error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Harried Spearguard") shouldBe true
+                val rat = game.findPermanent("Rat Token")
+                withClue("the dies trigger should have made a Rat token") { rat shouldNotBe null }
+
+                val projected = projector.project(game.state)
+                projected.getPower(rat!!) shouldBe 1
+                projected.getToughness(rat) shouldBe 1
+                withClue("the token's granted static ability makes it unable to block") {
+                    game.state.projectedState.cantBlock(rat) shouldBe true
+                }
+            }
+        }
+
+        context("Warehouse Tabby") {
+
+            test("an enchantment you control hitting the graveyard makes a Rat") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Warehouse Tabby")
+                    .withCardOnBattlefield(1, "Hopeless Nightmare")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val nightmare = game.findPermanent("Hopeless Nightmare")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = nightmare,
+                        abilityId = nightmareSacrificeAbility
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("sacrificing the enchantment should feed the Tabby's trigger") {
+                    game.findPermanent("Rat Token") shouldNotBe null
+                }
+            }
+
+            test("{1}{B} grants deathtouch until end of turn") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Warehouse Tabby")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tabby = game.findPermanent("Warehouse Tabby")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tabby,
+                        abilityId = tabbyDeathtouchAbility
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                projector.project(game.state).hasKeyword(tabby, Keyword.DEATHTOUCH) shouldBe true
+            }
+        }
+
+        context("Ego Drain") {
+
+            test("strips a nonland card and exiles one of yours when you control no Faerie") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Ego Drain")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Shock")
+                    .withCardInHand(2, "Forest")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Ego Drain", targetPlayerNumber = 2).error shouldBe null
+                game.resolveStack()
+
+                // Choose the opponent's only nonland card — Forest is filtered out of the choice.
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(game.findCardsInHand(2, "Shock")).error shouldBe null
+                game.resolveStack()
+
+                withClue("the chosen nonland card is discarded, the land stays") {
+                    game.isInGraveyard(2, "Shock") shouldBe true
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+
+                // Then the Faerie rider: you control no Faerie, so exile a card from your hand.
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears")).error shouldBe null
+                game.resolveStack()
+
+                withClue("no Faerie → the rider exiles a card from your hand") {
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("controlling a Faerie skips the exile rider") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Ego Drain")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Shock")
+                    .withCardOnBattlefield(1, "Faerie Dreamthief")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Shock")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Ego Drain", targetPlayerNumber = 2).error shouldBe null
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(game.findCardsInHand(2, "Shock")).error shouldBe null
+                game.resolveStack()
+
+                withClue("the strip half still happens") {
+                    game.isInGraveyard(2, "Shock") shouldBe true
+                }
+                withClue("you control a Faerie → your hand is untouched") {
+                    game.hasPendingDecision() shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Grizzly Bears") shouldBe false
+                }
+            }
+        }
+
+        context("Commune with Nature") {
+
+            test("takes a creature from the top five and bottoms the rest") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Commune with Nature")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Swamp")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+                game.castSpell(1, "Commune with Nature").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears")
+                withClue("the only creature among the five should be selectable") {
+                    bears shouldNotBe emptyList<Any>()
+                }
+                game.selectCards(bears).error shouldBe null
+                game.resolveStack()
+
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                withClue("the other four go to the bottom — only the taken card leaves the library") {
+                    game.librarySize(1) shouldBe librarySizeBefore - 1
+                }
+            }
+
+            test("declining leaves all five in the library") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Commune with Nature")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Swamp")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+                game.castSpell(1, "Commune with Nature").error shouldBe null
+                game.resolveStack()
+
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("\"you may reveal\" — declining is legal even with a creature among them") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                    game.librarySize(1) shouldBe librarySizeBefore
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of Wilds of Eldraine cards. No engine or SDK changes — everything composes existing primitives.

## Cards

| Card | Notes |
|---|---|
| **Hopeless Nightmare** (WOE 95) | ETB: each opponent discards a card and loses 2 life. Scry 2 when it's put into a graveyard from the battlefield. `{2}{B}: Sacrifice this enchantment` — the sacrifice is the ability's *effect*, not part of its cost, so it uses the stack and is what fires the scry trigger. |
| **Harried Spearguard** (WOE 135) | Haste; dies → 1/1 black Rat token with "This token can't block." |
| **Warehouse Tabby** (WOE 117) | Whenever an enchantment you control is put into a graveyard from the battlefield → Rat token. `{1}{B}`: deathtouch until end of turn. |
| **Ego Drain** (WOE 86) | Reveal target opponent's hand, choose a nonland card, they discard it. Then, if you don't control a Faerie, exile a card from your hand. |
| **Commune with Nature** | Look at top five, you *may* reveal a creature card and put it into your hand, rest to the bottom in any order. |

## Canonical placement

`Commune with Nature` is a WOE reprint — its canonical `CardDefinition` goes into its earliest real printing, **Champions of Kamigawa**, with `Printing(...)` rows added for the two other scaffolded sets (10E, WOE). `just check-card-printing` is clean for all five cards.

## Shared Rat token

Two cards create the same "1/1 black Rat with can't block" token, so the shape (including its art) lives once in `woe/cards/WoeTokens.kt` rather than being copied per card.

## Testing

- `WoeCardsScenarioTest` — 9 scenario tests covering all five cards, including the Ego Drain Faerie rider in both directions, Commune with Nature's "you may" decline branch, and the Rat token's `cantBlock` projection.
- `just build` green; CHK/WOE card snapshots re-blessed (additions only — no other card's tree moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)