### PR TITLE
Add four Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BeanstalkWurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BeanstalkWurm.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PlayAdditionalLandsEffect
+
+/**
+ * Beanstalk Wurm // Plant Beans
+ * {4}{G}
+ * Creature — Plant Wurm
+ * 5/4
+ * Reach
+ *
+ * Adventure: Plant Beans — {1}{G}, Sorcery — Adventure
+ * You may play an additional land this turn.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val BeanstalkWurm = card("Beanstalk Wurm") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wurm"
+    oracleText = "Reach"
+    power = 5
+    toughness = 4
+    keywords(Keyword.REACH)
+
+    adventure("Plant Beans") {
+        manaCost = "{1}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "You may play an additional land this turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = PlayAdditionalLandsEffect(count = 1)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Aldo Domínguez"
+        flavorText = "When Beluna's pets escape Stormkeld, villages fall and new Everstalks rise."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1783915085"
+        ruling(
+            "2023-09-01",
+            "The effect that allows you to play an additional land that turn is cumulative with " +
+                "other effects that do so.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BreakTheSpell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BreakTheSpell.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.MoveType
+
+/**
+ * Break the Spell
+ * {W}
+ * Instant
+ *
+ * Destroy target enchantment. If a permanent you controlled or a token was destroyed this way,
+ * draw a card.
+ *
+ * The conditional draw reads characteristics that are gone by the time the draw would happen:
+ * `ControllerComponent` is stripped when a permanent leaves the battlefield, and a destroyed token
+ * ceases to exist. So the pipeline snapshots the answer *before* the destroy and cross-references
+ * it with what actually died (Builder's Bane shape):
+ *
+ *   1. `gather(ChosenTargets)` — reference the resolved target.
+ *   2. `filterSplit(… you control or a token …)` — evaluated while it is still on the battlefield.
+ *      Only the *rest* slot is used downstream, as the set to subtract in step 4.
+ *   3. `moveTracked(…, MoveType.Destroy)` — the standard destroy path. Indestructible and
+ *      regenerated permanents are skipped by the executor and therefore drop out of the tracked
+ *      "destroyed" slot, which is exactly the "was destroyed this way" gate (first ruling below).
+ *      A permanent whose death is replaced by a move to some other zone still counts as destroyed
+ *      and stays in the slot (second ruling).
+ *   4. `filter(destroyed, ExcludeOtherCollection(rest))` — set difference, i.e. the intersection of
+ *      "actually destroyed" with "was yours or a token". Non-empty ⇒ draw.
+ *
+ * If the enchantment is an illegal target on resolution the spell is countered by the rules and
+ * nothing happens, including the draw.
+ */
+val BreakTheSpell = card("Break the Spell") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target enchantment. If a permanent you controlled or a token was " +
+        "destroyed this way, draw a card."
+
+    spell {
+        target("target enchantment", Targets.Enchantment)
+        effect = Effects.Pipeline(
+            descriptionOverride = "Destroy target enchantment. If a permanent you controlled or " +
+                "a token was destroyed this way, draw a card."
+        ) {
+            val targeted = gather(CardSource.ChosenTargets, name = "breakSpellTarget")
+
+            // "a permanent you controlled or a token" — snapshotted while it is still in play.
+            val (_, neither) = filterSplit(
+                targeted,
+                GameObjectFilter.Any.youControl() or GameObjectFilter.Token,
+                name = "breakSpellYoursOrToken",
+                restName = "breakSpellNeither"
+            )
+
+            // "destroyed this way" — indestructible / regenerated permanents drop out here.
+            val destroyed = moveTracked(
+                targeted,
+                CardDestination.ToZone(Zone.GRAVEYARD),
+                moveType = MoveType.Destroy,
+                name = "breakSpellDestroyed"
+            )
+
+            // destroyed ∖ (neither yours nor a token) = destroyed ∩ (yours or a token)
+            val qualifying = filter(
+                destroyed,
+                CollectionFilter.ExcludeOtherCollection(neither.key),
+                name = "breakSpellQualifyingDestroyed"
+            )
+
+            ifNotEmpty(qualifying) {
+                run(Effects.DrawCards(1))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Miranda Meeks"
+        flavorText = "As Hylda watched Ruby drag Kellan's unconscious form through the cold, " +
+            "Hylda felt something she hadn't felt in a long time: compassion."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg?1783915136"
+
+        ruling(
+            "2023-09-01",
+            "If the enchantment has indestructible, it won't be destroyed. You won't draw a card."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent you controlled or a token is destroyed with Break the Spell but is put " +
+                "into a zone other than a graveyard as a result, you will draw a card."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CoopedUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CoopedUp.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cooped Up
+ * {1}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature can't attack or block.
+ * {2}{W}: Exile enchanted creature.
+ *
+ * "Can't attack or block" is the Pacifism idiom — [CantAttack] + [CantBlock] over the attached
+ * creature. The activated ability reuses [EffectTarget.EnchantedCreature], same shape as
+ * Sigarda's Imprisonment (VOW).
+ */
+val CoopedUp = card("Cooped Up") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature can't attack or block.\n" +
+        "{2}{W}: Exile enchanted creature."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}")
+        effect = Effects.Exile(EffectTarget.EnchantedCreature)
+        description = "{2}{W}: Exile enchanted creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Jodie Muir"
+        flavorText = "\"Cold iron's all you need to hold a faerie. The charms are mostly " +
+            "decorative.\"\n—Eulyn, Edgewall peddler"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg?1783915134"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FeedTheCauldron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FeedTheCauldron.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Feed the Cauldron
+ * {2}{B}
+ * Instant
+ * Destroy target creature with mana value 3 or less. If it's your turn, create a Food token.
+ *
+ * The "if it's your turn" clause is checked on resolution (it is not an intervening-if — the
+ * spell has no trigger condition), so [Conditions.IsYourTurn] gates only the Food half. The
+ * destroy still happens on an opponent's turn; if the only target is illegal on resolution the
+ * whole spell is countered and no Food is created.
+ */
+val FeedTheCauldron = card("Feed the Cauldron") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with mana value 3 or less. If it's your turn, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.manaValueAtMost(3)))
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true) then
+            ConditionalEffect(
+                condition = Conditions.IsYourTurn,
+                effect = Effects.CreateFood()
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Marta Nael"
+        flavorText = "Kellan heard Agatha howl when he slammed into her, heard her scream as she fell into the cauldron, " +
+            "but couldn't afford to think about the implications just yet."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg?1783915107"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,51 @@
     ]
 }
 
+// Beanstalk Wurm
+{
+    "name": "Beanstalk Wurm",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Plant Wurm",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Aldo Domínguez",
+        "flavorText": "When Beluna's pets escape Stormkeld, villages fall and new Everstalks rise.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19f20c0a-22be-4a9c-96ce-4047f7a2d424.jpg?1783915085",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The effect that allows you to play an additional land that turn is cumulative with other effects that do so."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Plant Beans",
+            "manaCost": "{1}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "You may play an additional land this turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "PlayAdditionalLands",
+                    "count": 1
+                }
+            }
+        }
+    ]
+}
+
 // Beluna's Gatekeeper
 {
     "name": "Beluna's Gatekeeper",
@@ -390,6 +435,106 @@
     ]
 }
 
+// Break the Spell
+{
+    "name": "Break the Spell",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target enchantment. If a permanent you controlled or a token was destroyed this way, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "breakSpellTarget"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "breakSpellTarget",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": {
+                            "anyOf": [
+                                {
+                                    "controllerPredicate": "ControlledByYou"
+                                },
+                                {
+                                    "cardPredicates": [
+                                        "IsToken"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "storeMatching": "breakSpellYoursOrToken",
+                    "storeNonMatching": "breakSpellNeither"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "breakSpellTarget",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy",
+                    "storeMovedAs": "breakSpellDestroyed"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "breakSpellDestroyed",
+                    "filter": {
+                        "type": "ExcludeOtherCollection",
+                        "otherCollectionName": "breakSpellNeither"
+                    },
+                    "storeMatching": "breakSpellQualifyingDestroyed"
+                },
+                {
+                    "type": "ConditionalOnCollection",
+                    "collection": "breakSpellQualifyingDestroyed",
+                    "ifNotEmpty": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ],
+            "descriptionOverride": "Destroy target enchantment. If a permanent you controlled or a token was destroyed this way, draw a card."
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "target enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Miranda Meeks",
+        "flavorText": "As Hylda watched Ruby drag Kellan's unconscious form through the cold, Hylda felt something she hadn't felt in a long time: compassion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7094fc0-1d26-429c-9b49-37718c4a5c80.jpg?1783915136",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If the enchantment has indestructible, it won't be destroyed. You won't draw a card."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent you controlled or a token is destroyed with Break the Spell but is put into a zone other than a graveyard as a result, you will draw a card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Candy Trail
 {
     "name": "Candy Trail",
@@ -623,6 +768,65 @@
         "imageUri": "https://cards.scryfall.io/normal/front/9/6/967a4f27-8cd6-437d-8c05-8aedbc7ddc4b.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Cooped Up
+{
+    "name": "Cooped Up",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature can't attack or block.\n{2}{W}: Exile enchanted creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "EnchantedCreature",
+                    "destination": "Exile"
+                },
+                "descriptionOverride": "{2}{W}: Exile enchanted creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "CantBlock",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Jodie Muir",
+        "flavorText": "\"Cold iron's all you need to hold a faerie. The charms are mostly decorative.\"\n—Eulyn, Edgewall peddler",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8acb8758-09c5-4e19-ada1-904e36ece1fc.jpg?1783915134"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Dutiful Griffin
@@ -1107,6 +1311,59 @@
         "artist": "Evyn Fong",
         "flavorText": "Even in the grip of the Wicked Slumber, the High Fae princess Obyra is a blademaster of unrivaled skill.",
         "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bdcaf24-4352-47cf-a043-899be47ab1bb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Feed the Cauldron
+{
+    "name": "Feed the Cauldron",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with mana value 3 or less. If it's your turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "IsYourTurn"
+                    },
+                    "then": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Food"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=3"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Marta Nael",
+        "flavorText": "Kellan heard Agatha howl when he slammed into her, heard her scream as she fell into the cauldron, but couldn't afford to think about the implications just yet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cfd18a5-e06a-4cb5-b78e-de18ec641321.jpg?1783915107"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeanstalkWurmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeanstalkWurmScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.BeanstalkWurm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Beanstalk Wurm // Plant Beans (WOE) — Adventure (CR 715).
+ *
+ * Creature face: {4}{G} 5/4 Plant Wurm with reach.
+ * Adventure face: Plant Beans {1}{G}, Sorcery — Adventure, "You may play an additional land this turn."
+ */
+class BeanstalkWurmScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BeanstalkWurm)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40, "Grizzly Bears" to 20), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("casting Plant Beans grants an extra land drop and exiles the card for later") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val wurm = driver.putCardInHand(player, "Beanstalk Wurm")
+        driver.giveMana(player, Color.GREEN, 2) // {1}{G}
+
+        // Cast the Adventure face (faceIndex = 0), not the creature.
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = wurm,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // Land drops went from 1 to 2 for this turn.
+        driver.state.getEntity(player)?.get<LandDropsComponent>()?.remaining shouldBe 2
+
+        // The card exiled itself on resolution (CR 715.3d) and granted a may-play permission.
+        driver.getExile(player) shouldContain wurm
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldNotContain wurm
+        driver.state.mayPlayPermissions.any { wurm in it.cardIds && it.controllerId == player } shouldBe true
+
+        // Two lands can actually be played this turn.
+        val forest1 = driver.putCardInHand(player, "Forest")
+        val forest2 = driver.putCardInHand(player, "Forest")
+        val forest3 = driver.putCardInHand(player, "Forest")
+        driver.playLand(player, forest1).isSuccess shouldBe true
+        driver.playLand(player, forest2).isSuccess shouldBe true
+        // ...but not a third.
+        driver.submit(PlayLand(player, forest3)).isSuccess shouldBe false
+    }
+
+    test("the creature can be cast from exile afterwards as a 5/4 with reach") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val wurm = driver.putCardInHand(player, "Beanstalk Wurm")
+        driver.giveMana(player, Color.GREEN, 2)
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = wurm,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.getExile(player) shouldContain wurm
+
+        // Cast the creature face from exile — {4}{G}.
+        driver.giveMana(player, Color.GREEN, 5)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = wurm,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getPermanents(player) shouldContain wurm
+        driver.getExile(player) shouldNotContain wurm
+
+        val projected = driver.state.projectedState
+        projected.getPower(wurm) shouldBe 5
+        projected.getToughness(wurm) shouldBe 4
+        projected.hasKeyword(wurm, Keyword.REACH) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakTheSpellScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakTheSpellScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Break the Spell — {W} Instant
+ * "Destroy target enchantment. If a permanent you controlled or a token was destroyed this way,
+ * draw a card."
+ *
+ * Covers all three branches of the conditional draw:
+ *  - an opponent's ordinary enchantment → destroyed, no draw;
+ *  - your own enchantment → destroyed, draw;
+ *  - an opponent's enchantment *token* → destroyed, draw (the token clause is controller-agnostic).
+ *
+ * "Food Fight" is used as the target throughout: a plain WOE enchantment with only a static
+ * ability, so destroying it produces no triggers that could muddy the hand-size assertions.
+ */
+class BreakTheSpellScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("an opponent's ordinary enchantment is destroyed with no draw") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Break the Spell")
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Food Fight")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val enchantment = game.findPermanent("Food Fight")!!
+            game.castSpell(1, "Break the Spell", targetId = enchantment).error shouldBe null
+            game.resolveStack()
+
+            withClue("the enchantment is destroyed regardless of who controlled it") {
+                game.isInGraveyard(2, "Food Fight") shouldBe true
+                game.findPermanent("Food Fight") shouldBe null
+            }
+            withClue("it was neither yours nor a token, so no card is drawn") {
+                game.handSize(1) shouldBe 0
+                game.librarySize(1) shouldBe 1
+            }
+        }
+
+        test("destroying an enchantment you control draws a card") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Break the Spell")
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Food Fight")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val enchantment = game.findPermanent("Food Fight")!!
+            game.castSpell(1, "Break the Spell", targetId = enchantment).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Food Fight") shouldBe true
+            withClue("a permanent you controlled was destroyed this way → draw a card") {
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                game.librarySize(1) shouldBe 0
+            }
+        }
+
+        test("destroying an opponent's enchantment token draws a card") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Break the Spell")
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Food Fight", isToken = true)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val token = game.findPermanent("Food Fight")
+            withClue("the token target should be on the battlefield") { token shouldNotBe null }
+
+            game.castSpell(1, "Break the Spell", targetId = token!!).error shouldBe null
+            game.resolveStack()
+
+            withClue("the destroyed token ceases to exist") {
+                game.findPermanent("Food Fight") shouldBe null
+            }
+            withClue("a token was destroyed this way → draw a card even though it wasn't yours") {
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                game.librarySize(1) shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoopedUpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoopedUpScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cooped Up (WOE #8) — {1}{W} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   Enchanted creature can't attack or block.
+ *   {2}{W}: Exile enchanted creature.
+ */
+class CoopedUpScenarioTest : ScenarioTestBase() {
+
+    private val exileAbilityId =
+        cardRegistry.getCard("Cooped Up")!!.activatedAbilities.first().id
+
+    init {
+        context("Cooped Up") {
+
+            test("enchanted creature can't attack or block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cooped Up")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Cooped Up", targetId = bears)
+                withClue("Casting Cooped Up should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Cooped Up is on the battlefield") {
+                    game.isOnBattlefield("Cooped Up") shouldBe true
+                }
+                withClue("the enchanted creature can't attack") {
+                    game.state.projectedState.cantAttack(bears) shouldBe true
+                }
+                withClue("the enchanted creature can't block") {
+                    game.state.projectedState.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("{2}{W}: exiles the enchanted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cooped Up")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Cooped Up", targetId = bears)
+                game.resolveStack()
+
+                val aura = game.findPermanent("Cooped Up")
+                withClue("Aura should be on the battlefield before activation") {
+                    aura.shouldNotBeNull()
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = aura!!,
+                        abilityId = exileAbilityId,
+                    )
+                )
+                withClue("Activating the exile ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the enchanted creature is exiled") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.state.getExile(game.player2Id).contains(bears) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FeedTheCauldronScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FeedTheCauldronScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Feed the Cauldron — {2}{B} Instant — "Destroy target creature with mana value 3 or less.
+ * If it's your turn, create a Food token."
+ *
+ * Covers the mana-value target restriction and the turn-gated Food half (which is checked on
+ * resolution, so casting on the opponent's turn destroys but makes no Food).
+ */
+class FeedTheCauldronScenarioTest : ScenarioTestBase() {
+
+    private fun game(opponentCreature: String, activePlayer: Int) = scenario()
+        .withPlayers()
+        .withCardInHand(1, "Feed the Cauldron")
+        .withLandsOnBattlefield(1, "Swamp", 3)
+        .withCardOnBattlefield(2, opponentCreature)
+        .withCardInLibrary(1, "Swamp")
+        .withCardInLibrary(2, "Forest")
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .withActivePlayer(activePlayer)
+        .withPriorityPlayer(1)
+        .build()
+
+    init {
+        test("on your turn: destroys a mana value 3 creature and creates a Food") {
+            val g = game("Centaur Courser", activePlayer = 1)
+            val target = g.findPermanent("Centaur Courser")!!
+
+            g.castSpell(1, "Feed the Cauldron", target).error shouldBe null
+            g.resolveStack()
+
+            g.isOnBattlefield("Centaur Courser") shouldBe false
+            g.isInGraveyard(2, "Centaur Courser") shouldBe true
+            g.findPermanents("Food").size shouldBe 1
+        }
+
+        test("on the opponent's turn: destroys the creature but creates no Food") {
+            val g = game("Centaur Courser", activePlayer = 2)
+            val target = g.findPermanent("Centaur Courser")!!
+
+            g.castSpell(1, "Feed the Cauldron", target).error shouldBe null
+            g.resolveStack()
+
+            g.isOnBattlefield("Centaur Courser") shouldBe false
+            g.findPermanents("Food").size shouldBe 0
+        }
+
+        test("cannot target a creature with mana value 4 or greater") {
+            val g = game("Force of Nature", activePlayer = 1) // 5/5 for {3}{G}{G}
+            val target = g.findPermanent("Force of Nature")!!
+
+            g.castSpell(1, "Feed the Cauldron", target).error shouldNotBe null
+
+            g.isOnBattlefield("Force of Nature") shouldBe true
+            g.findPermanents("Food").size shouldBe 0
+        }
+    }
+}


### PR DESCRIPTION
Implements four WOE cards via the `add-card` skill. All four compose from existing SDK primitives — no SDK changes, so no `card-sdk-language-reference.md` update was needed.

| Card | Cost | Notes |
|---|---|---|
| Break the Spell | {W} | Destroy target enchantment; draw if a permanent you controlled or a token was destroyed this way. Pipeline snapshots the target's controller/token status *before* the destroy (`ControllerComponent` is stripped on leaving the battlefield, and a destroyed token ceases to exist), and uses `moveTracked` as the "was actually destroyed" gate so indestructible/regenerated permanents don't draw. |
| Feed the Cauldron | {2}{B} | Destroy creature with mana value 3 or less; Food token if it's your turn (resolution-time check, not intervening-if). |
| Cooped Up | {1}{W} | Aura modeled on Sigarda's Imprisonment: `CantAttack`/`CantBlock` on the attached creature plus a `{2}{W}` exile ability. |
| Beanstalk Wurm // Plant Beans | {4}{G} | 5/4 Reach with a `{1}{G}` Adventure granting an additional land drop, using the existing `CardLayout.ADVENTURE` support. |

## Testing
`just build` is green. Ten new scenario tests across the four cards all pass. The WOE snapshot golden was re-blessed — the diff is additions only (257 lines, no removals).

## Cards considered and dropped
Three candidates were investigated and deliberately not implemented rather than shipped approximately:

- **Eerie Interference** — needs damage prevention scoped to *you and your creatures* from *creature sources*. `PreventAllDamageToGroup` silently drops any `sourceFilter` and can't cover the controller; `PreventionSourceFilter.FromGroup` is combat-damage-only and global. Genuine `add-feature` work.
- **Frantic Firebolt** — counts graveyard cards that "have an Adventure". No card predicate is face-aware, and `HasSubtype("Adventure")` fails because an ADVENTURE-layout card's top-level type line is the creature face. Would have silently under-counted damage.
- **Celebration / Bargain cards** (Armory Mice, Grand Ball Guest, Brave the Wilds, Farsight Ritual) — neither mechanic exists in the SDK; no permanents-entered-this-turn tracker and no bargain keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)