### PR TITLE
Add five Foundations cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2599,6 +2599,14 @@ work for abilities-on-stack (which carry no `CardComponent`).
   grant's holder as source (Braided Net's "Its activated abilities can't be activated for as long
   as it remains tapped"). Inert with no source context, and never matches in group-static
   projection (use `GroupFilter.source()` there) or trigger-gating contexts.
+- `Not(IsSource)` (filter builder `notSourceItself()`) — the negation of `sourceItself()`, and the
+  `GameObjectFilter` counterpart of `GroupFilter`/`TargetFilter`'s `excludeSelf`. Use it wherever
+  "other [permanents]" must be expressed as a bare `GameObjectFilter` rather than a group/target
+  filter — notably a `RecipientFilter.Matching` on a damage replacement: Crystal Barricade's
+  "prevent all noncombat damage that would be dealt to *other* creatures you control" is
+  `PreventDamage(amount = null, appliesTo = DamageEvent(recipient =
+  RecipientFilter.Matching(GameObjectFilter.Creature.youControl().notSourceItself()), damageType =
+  DamageType.NonCombat))`.
 - `IsAttachedToSource` (filter builder `attachedToSource()`) — the *mirror* of `IsAttachedToBySource`:
   matches an Aura/Equipment currently attached **to** the effect's source, read from the candidate's
   `AttachedToComponent.targetId == sourceId`. Use it to scope a static ability on the *host* to its own

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -709,6 +709,18 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must NOT be the effect's source permanent — the negation of [sourceItself], and the
+     * [GameObjectFilter] counterpart of `GroupFilter`/`TargetFilter`'s `excludeSelf`. Needed
+     * wherever "other [permanents]" has to be expressed as a bare `GameObjectFilter` rather
+     * than a group/target filter — e.g. a `RecipientFilter.Matching` on a damage replacement
+     * ("prevent all noncombat damage that would be dealt to *other* creatures you control",
+     * Crystal Barricade).
+     */
+    fun notSourceItself() = copy(
+        statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsSource)
+    )
+
+    /**
      * Must BE an Aura/Equipment attached to the effect's source permanent — the mirror of
      * [attachedToBySource]. Source-relative — scopes a static ability on the *host* to its own
      * attachments, e.g. Cloud, Midgar Mercenary's "an Equipment attached to it".

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WildbornPreserver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WildbornPreserver.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayXForEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wildborn Preserver
+ * {1}{G}
+ * Creature — Elf Archer
+ * 2/2
+ * Flash
+ * Reach
+ * Whenever another non-Human creature you control enters, you may pay {X}. When you do, put X
+ * +1/+1 counters on this creature.
+ *
+ * The trigger is an OTHER-bound enters trigger filtered to non-Human creatures you control
+ * (`notSubtype(Human)`), so the Preserver's own arrival doesn't fire it.
+ *
+ * "You may pay {X}. **When you do**, …" is a reflexive triggered ability (CR 603.7): the payment
+ * happens while the first ability resolves, and the counters go on the stack as a *separate*
+ * ability that players may respond to. So the payment gate is [MayPayXForEffect] (a 0..max
+ * number chooser that auto-taps X generic mana) and its post-payment effect is a
+ * [ReflexiveTriggerEffect] with an empty `action` — the "when you do" condition is already the
+ * pay-{X} gate — whose reflexive half reads the X just paid via [DynamicAmount.XValue].
+ * Declining, or paying X = 0, puts no ability on the stack in any observable way.
+ */
+val WildbornPreserver = card("Wildborn Preserver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Archer"
+    power = 2
+    toughness = 2
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Reach (This creature can block creatures with flying.)\n" +
+        "Whenever another non-Human creature you control enters, you may pay {X}. When you do, " +
+        "put X +1/+1 counters on this creature."
+
+    keywords(Keyword.FLASH, Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().notSubtype(Subtype.HUMAN),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = MayPayXForEffect(
+            effect = ReflexiveTriggerEffect(
+                action = Effects.Composite(emptyList()),
+                optional = false,
+                reflexiveEffect = Effects.AddDynamicCounters(
+                    counterType = Counters.PLUS_ONE_PLUS_ONE,
+                    amount = DynamicAmount.XValue,
+                    target = EffectTarget.Self,
+                ),
+                descriptionOverride = "put X +1/+1 counters on this creature",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "182"
+        artist = "Lius Lasahido"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg?1783932600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrystalBarricade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrystalBarricade.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantHexproofToController
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Crystal Barricade
+ * {1}{W}
+ * Artifact Creature — Wall
+ * 0/4
+ * Defender
+ * You have hexproof.
+ * Prevent all noncombat damage that would be dealt to other creatures you control.
+ *
+ * Three printed abilities, each mapped to its own primitive:
+ *  - Defender — plain keyword.
+ *  - "You have hexproof" — the [GrantHexproofToController] static (Shalai, Voice of Plenty's
+ *    player leg); it lives and dies with the Barricade being on the battlefield, so no cleanup.
+ *  - The prevention shield — a continuous [PreventDamage] replacement (`amount = null` = prevent
+ *    all) restricted to `DamageType.NonCombat` and to a recipient filter of creatures you control
+ *    *other than the Barricade itself* (`notSourceItself()`; the Barricade's own damage is not
+ *    prevented, and players aren't creatures so your own life total isn't shielded either). The
+ *    filter is re-evaluated per damage instance against projected state, so creatures that come
+ *    under your control later are covered.
+ */
+val CrystalBarricade = card("Crystal Barricade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "You have hexproof. (You can't be the target of spells or abilities your opponents control.)\n" +
+        "Prevent all noncombat damage that would be dealt to other creatures you control."
+
+    keywords(Keyword.DEFENDER)
+
+    staticAbility {
+        ability = GrantHexproofToController
+    }
+
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Matching(
+                    GameObjectFilter.Creature.youControl().notSourceItself(),
+                ),
+                damageType = DamageType.NonCombat,
+            ),
+        ),
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "7"
+        artist = "Rockey Chen"
+        flavorText = "\"Good as new!\"\n—Krek, daysquad captain"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg?1783909129"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeadlyPlotReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeadlyPlotReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Plot reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Jumpstart 2022 (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val DeadlyPlotReprint = Printing(
+    oracleId = "6178715c-870d-4710-b758-66e080804ee3",
+    name = "Deadly Plot",
+    setCode = "FDN",
+    collectorNumber = "520",
+    scryfallId = "b32fddc3-a38f-4eea-ae01-4158e3cbca6c",
+    artist = "Peter Polach",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b32fddc3-a38f-4eea-ae01-4158e3cbca6c.jpg?1783908959",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/JoragaInvocationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/JoragaInvocationReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Joraga Invocation reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic Origins (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val JoragaInvocationReprint = Printing(
+    oracleId = "216d3eed-cb07-40c5-869a-962e074e757d",
+    name = "Joraga Invocation",
+    setCode = "FDN",
+    collectorNumber = "555",
+    scryfallId = "01ceca57-65f4-4f99-bd14-9fe5f86c1f62",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01ceca57-65f4-4f99-bd14-9fe5f86c1f62.jpg?1783908947",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SanguineIndulgenceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SanguineIndulgenceReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanguine Indulgence reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Core Set 2021 (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val SanguineIndulgenceReprint = Printing(
+    oracleId = "010ec11a-0484-486d-b7c0-de65593bf457",
+    name = "Sanguine Indulgence",
+    setCode = "FDN",
+    collectorNumber = "613",
+    scryfallId = "03a26ca7-b26f-4b86-a060-712f15f4bf7f",
+    artist = "Andrey Kuzinskiy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg?1783908926",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WildbornPreserverReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WildbornPreserverReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildborn Preserver reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Throne of Eldraine (its earliest printing);
+ * this file contributes only the FDN presentation row.
+ */
+val WildbornPreserverReprint = Printing(
+    oracleId = "55cec4bc-3de6-4c0d-a4cc-c5a30849fbda",
+    name = "Wildborn Preserver",
+    setCode = "FDN",
+    collectorNumber = "650",
+    scryfallId = "8a249d1c-a5fe-48e5-bd9b-e50d8eea391b",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a249d1c-a5fe-48e5-bd9b-e50d8eea391b.jpg?1783908914",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeadlyPlot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeadlyPlot.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Deadly Plot
+ * {3}{B}
+ * Instant
+ * Choose one —
+ * • Destroy target creature or planeswalker.
+ * • Return target Zombie creature card from your graveyard to the battlefield tapped.
+ *
+ * A plain choose-one modal spell: each mode carries its own target, so only the chosen mode's
+ * target is announced at cast time (CR 601.2b). The reanimation mode is scoped to Zombie
+ * *creature* cards in your own graveyard and puts the card onto the battlefield tapped.
+ */
+val DeadlyPlot = card("Deadly Plot") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target creature or planeswalker.\n" +
+        "• Return target Zombie creature card from your graveyard to the battlefield tapped."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target creature or planeswalker") {
+                val t = target("creature or planeswalker", Targets.CreatureOrPlaneswalker)
+                effect = Effects.Destroy(t)
+            }
+            mode("Return target Zombie creature card from your graveyard to the battlefield tapped") {
+                val t = target(
+                    "Zombie creature card in your graveyard",
+                    TargetObject(
+                        filter = TargetFilter(
+                            GameObjectFilter(
+                                cardPredicates = listOf(
+                                    CardPredicate.IsCreature,
+                                    CardPredicate.HasSubtype(Subtype.ZOMBIE),
+                                ),
+                                controllerPredicate = ControllerPredicate.OwnedByYou,
+                            ),
+                            zone = Zone.GRAVEYARD,
+                        ),
+                    ),
+                )
+                effect = Effects.PutOntoBattlefield(t, tapped = true)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "22"
+        artist = "Peter Polach"
+        flavorText = "\"Open grave available, only one previous tenant.\"\n—Sign on cemetery gate"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg?1783919187"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WildbornPreserverReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WildbornPreserverReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildborn Preserver reprint in Jumpstart 2022. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Throne of Eldraine (its earliest printing);
+ * this file contributes only the J22 presentation row.
+ */
+val WildbornPreserverReprint = Printing(
+    oracleId = "55cec4bc-3de6-4c0d-a4cc-c5a30849fbda",
+    name = "Wildborn Preserver",
+    setCode = "J22",
+    collectorNumber = "738",
+    scryfallId = "b75ab77b-cd98-4889-afcc-884940999d48",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b75ab77b-cd98-4889-afcc-884940999d48.jpg?1783918828",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SanguineIndulgence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SanguineIndulgence.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sanguine Indulgence
+ * {3}{B}
+ * Sorcery
+ * This spell costs {3} less to cast if you've gained 3 or more life this turn.
+ * Return up to two target creature cards from your graveyard to your hand.
+ *
+ * The discount is a self-cast [ModifySpellCost] gated by [CostGating.OnlyIf] on
+ * [Conditions.YouGainedLifeThisTurnAtLeast] (3), backed by the `LIFE_GAINED` turn tracker —
+ * so it is evaluated as the spell is cast (CR 601.2f) and drops the whole generic component,
+ * leaving {B}.
+ *
+ * "Up to two target" is `TargetObject(count = 2, optional = true)`, so zero, one, or two cards
+ * may be chosen; each chosen card is returned independently via [ForEachTargetEffect] (a card
+ * that left the graveyard in response simply isn't returned, and the spell still resolves for
+ * the remaining legal target).
+ */
+val SanguineIndulgence = card("Sanguine Indulgence") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {3} less to cast if you've gained 3 or more life this turn.\n" +
+        "Return up to two target creature cards from your graveyard to your hand."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(3),
+            gating = CostGating.OnlyIf(Conditions.YouGainedLifeThisTurnAtLeast(3)),
+        )
+    }
+
+    spell {
+        target = TargetObject(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard,
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Drink from the vein? How provincial.\"\n—Lord Duchorvin"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg?1783930700"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JoragaInvocation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/JoragaInvocation.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Joraga Invocation
+ * {4}{G}{G}
+ * Sorcery
+ * Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.
+ *
+ * Both halves are per-creature, so the spell is one [Effects.ForEachInGroup] over the creatures
+ * you control at resolution (creatures that arrive later are unaffected, CR 611.2c): a
+ * `ModifyStats(3, 3)` floating effect plus a floating must-be-blocked requirement
+ * ([MustBeBlockedEffect] with `allCreatures = false` — "must be blocked if able" needs only one
+ * blocker, not the Lure-style every-able-blocker form). Both expire at end of turn.
+ */
+val JoragaInvocation = card("Joraga Invocation") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Each creature you control gets +3/+3 until end of turn and must be blocked " +
+        "this turn if able."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(3, 3, EffectTarget.Self),
+                MustBeBlockedEffect(EffectTarget.Self, allCreatures = false),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Kieran Yanner"
+        flavorText = "\"A single tree does not a forest make. We are stronger when we stand " +
+            "together.\"\n—Numa, Joraga chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg?1783938321"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -454,3 +454,69 @@
         "RED"
     ]
 }
+
+// Wildborn Preserver
+{
+    "name": "Wildborn Preserver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nReach (This creature can block creatures with flying.)\nWhenever another non-Human creature you control enters, you may pay {X}. When you do, put X +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Human"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayPayX",
+                    "then": {
+                        "type": "ReflexiveTrigger",
+                        "action": {
+                            "type": "Composite",
+                            "effects": []
+                        },
+                        "optional": false,
+                        "reflexiveEffect": {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": "XValue",
+                            "target": "Self"
+                        },
+                        "descriptionOverride": "put X +1/+1 counters on this creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "RARE",
+        "artist": "Lius Lasahido",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55f76830-369e-4224-9ded-7d1ce04c87e4.jpg?1783932600"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1462,6 +1462,60 @@
     ]
 }
 
+// Crystal Barricade
+{
+    "name": "Crystal Barricade",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\nYou have hexproof. (You can't be the target of spells or abilities your opponents control.)\nPrevent all noncombat damage that would be dealt to other creatures you control.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "staticAbilities": [
+            "GrantHexproofToController"
+        ],
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                {
+                                    "type": "StateNot",
+                                    "predicate": "IsSource"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    },
+                    "damageType": "DamageNonCombat"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "RARE",
+        "artist": "Rockey Chen",
+        "flavorText": "\"Good as new!\"\n—Krek, daysquad captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/905d3e02-ea06-45e7-9adb-c8e7583323a2.jpg?1783909129"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dauntless Veteran
 {
     "name": "Dauntless Veteran",

--- a/mtg-sets/src/test/resources/snapshots/cards/J22.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/J22.json
@@ -1,3 +1,68 @@
+// Deadly Plot
+{
+    "name": "Deadly Plot",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target creature or planeswalker.\n• Return target Zombie creature card from your graveyard to the battlefield tapped.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature or planeswalker"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "creature or planeswalker"
+                        }
+                    ],
+                    "description": "Destroy target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "Zombie creature card in your graveyard"
+                        },
+                        "destination": "Battlefield",
+                        "placement": "Tapped"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Zombie own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "Zombie creature card in your graveyard"
+                        }
+                    ],
+                    "description": "Return target Zombie creature card from your graveyard to the battlefield tapped"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "UNCOMMON",
+        "artist": "Peter Polach",
+        "flavorText": "\"Open grave available, only one previous tenant.\"\n—Sign on cemetery gate",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c78da23-e7ec-4a3d-9f79-09fb86993b26.jpg?1783919187"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ingenious Leonin
 {
     "name": "Ingenious Leonin",

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -233,6 +233,74 @@
     ]
 }
 
+// Sanguine Indulgence
+{
+    "name": "Sanguine Indulgence",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {3} less to cast if you've gained 3 or more life this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 3
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "LIFE_GAINED"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Drink from the vein? How provincial.\"\n—Lord Duchorvin",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abfcd08a-cfb5-4d34-b950-f57a88c5cb8e.jpg?1783930700"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Shipwreck Dowser
 {
     "name": "Shipwreck Dowser",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -356,6 +356,57 @@
     ]
 }
 
+// Joraga Invocation
+{
+    "name": "Joraga Invocation",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "MustBeBlocked",
+                        "target": "Self",
+                        "allCreatures": false
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"A single tree does not a forest make. We are stronger when we stand together.\"\n—Numa, Joraga chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65c89431-0881-4aa6-ac15-d4c13b075273.jpg?1783938321"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Skyraker Giant
 {
     "name": "Skyraker Giant",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrystalBarricadeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrystalBarricadeScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Crystal Barricade (FDN #7).
+ *
+ * {1}{W} Artifact Creature — Wall 0/4
+ * "Defender
+ *  You have hexproof.
+ *  Prevent all noncombat damage that would be dealt to other creatures you control."
+ *
+ * Covers the prevention shield (applies to *other* creatures you control, not the Barricade
+ * itself, not the opponent's creatures) and the controller-hexproof static.
+ */
+class CrystalBarricadeScenarioTest : ScenarioTestBase() {
+
+    private fun damageOn(game: TestGame, name: String): Int =
+        game.state.getEntity(game.findPermanent(name)!!)?.get<DamageComponent>()?.amount ?: 0
+
+    init {
+        context("Crystal Barricade") {
+
+            test("noncombat damage to another creature you control is fully prevented") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Crystal Barricade")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(2, "Shock", bears).error shouldBe null
+                game.resolveStack()
+
+                // Shock's 2 damage is prevented outright — the 2/2 survives unmarked.
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                damageOn(game, "Grizzly Bears") shouldBe 0
+            }
+
+            test("the Barricade does not prevent damage dealt to itself") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Crystal Barricade")
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val barricade = game.findPermanent("Crystal Barricade")!!
+                game.castSpell(2, "Shock", barricade).error shouldBe null
+                game.resolveStack()
+
+                // "other creatures you control" excludes the Barricade — the 0/4 takes the 2.
+                game.isOnBattlefield("Crystal Barricade") shouldBe true
+                damageOn(game, "Crystal Barricade") shouldBe 2
+            }
+
+            test("creatures the opponent controls are not shielded") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Crystal Barricade")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Shock", bears).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+            }
+
+            test("you have hexproof — an opponent's spell can't target you") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Crystal Barricade")
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shock = game.findCardsInHand(2, "Shock").single()
+                val atYou = game.execute(
+                    CastSpell(
+                        playerId = game.player2Id,
+                        cardId = shock,
+                        targets = listOf(ChosenTarget.Player(game.player1Id)),
+                    )
+                )
+                (atYou.error != null) shouldBe true
+
+                // The Barricade's controller can still target themselves.
+                val atSelf = game.execute(
+                    CastSpell(
+                        playerId = game.player2Id,
+                        cardId = shock,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                )
+                atSelf.error shouldBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeadlyPlotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeadlyPlotScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Deadly Plot (J22 #22).
+ *
+ * {3}{B} Instant
+ * "Choose one —
+ *  • Destroy target creature or planeswalker.
+ *  • Return target Zombie creature card from your graveyard to the battlefield tapped."
+ *
+ * Covers both modes, and that the reanimation mode is scoped to Zombie creature cards in your
+ * own graveyard (a non-Zombie creature card is not a legal target for it).
+ */
+class DeadlyPlotScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Deadly Plot") {
+
+            test("mode 1 destroys the targeted creature") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Deadly Plot")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpellWithMode(1, "Deadly Plot", modeIndex = 0, targetId = bears)
+                    .error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            }
+
+            test("mode 2 returns a Zombie creature card from your graveyard tapped") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Deadly Plot")
+                    .withCardInGraveyard(1, "Zombie Master")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zombie = game.findCardsInGraveyard(1, "Zombie Master").single()
+                val plot = game.findCardsInHand(1, "Deadly Plot").single()
+                val target = listOf(ChosenTarget.Card(zombie, game.player1Id, Zone.GRAVEYARD))
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = plot,
+                        targets = target,
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(target),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Zombie Master") shouldBe true
+                val permanent = game.findPermanent("Zombie Master")!!
+                (game.state.getEntity(permanent)?.get<TappedComponent>() != null) shouldBe true
+            }
+
+            test("mode 2 can't target a non-Zombie creature card in your graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Deadly Plot")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val plot = game.findCardsInHand(1, "Deadly Plot").single()
+                val target = listOf(ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD))
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = plot,
+                        targets = target,
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(target),
+                    )
+                )
+                (result.error != null) shouldBe true
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JoragaInvocationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JoragaInvocationScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Joraga Invocation (ORI #183).
+ *
+ * {4}{G}{G} Sorcery
+ * "Each creature you control gets +3/+3 until end of turn and must be blocked this turn if able."
+ *
+ * Covers both halves of the effect (the pump and the must-be-blocked requirement), that it is
+ * scoped to creatures *you* control, and that only creatures present at resolution are affected
+ * (CR 611.2c).
+ */
+class JoragaInvocationScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("each creature you control gets +3/+3; opponent's creatures are untouched") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val giant = driver.putCreatureOnBattlefield(you, "Hill Giant")
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(you, "Joraga Invocation")
+        driver.giveMana(you, Color.GREEN, 6)
+        driver.castSpell(you, spell).error shouldBe null
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.getPower(bears) shouldBe 5
+        projected.getToughness(bears) shouldBe 5
+        projected.getPower(giant) shouldBe 6
+        projected.getToughness(giant) shouldBe 6
+        // "Each creature you control" — the opponent's copy is unaffected.
+        projected.getPower(theirBears) shouldBe 2
+        projected.getToughness(theirBears) shouldBe 2
+    }
+
+    test("a creature that arrives after resolution gets neither the pump nor the requirement") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val spell = driver.putCardInHand(you, "Joraga Invocation")
+        driver.giveMana(you, Color.GREEN, 6)
+        driver.castSpell(you, spell).error shouldBe null
+        driver.bothPass()
+
+        // Arrives only after the spell has already resolved (CR 611.2c).
+        val latecomer = driver.putCreatureOnBattlefield(you, "Hill Giant")
+
+        val projected = projector.project(driver.state)
+        projected.getPower(latecomer) shouldBe 3
+        projected.getToughness(latecomer) shouldBe 3
+    }
+
+    test("a pumped attacker must be blocked if able — declining to block is illegal") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        driver.removeSummoningSickness(bears)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Hill Giant")
+
+        val spell = driver.putCardInHand(you, "Joraga Invocation")
+        driver.giveMana(you, Color.GREEN, 6)
+        driver.castSpell(you, spell).error shouldBe null
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(bears), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // The Hill Giant is able to block, so "no blockers" violates the requirement.
+        driver.declareNoBlockers(opponent).isSuccess shouldBe false
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(bears))).isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanguineIndulgenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanguineIndulgenceScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sanguine Indulgence (M21 #121).
+ *
+ * {3}{B} Sorcery
+ * "This spell costs {3} less to cast if you've gained 3 or more life this turn.
+ *  Return up to two target creature cards from your graveyard to your hand."
+ *
+ * Covers the life-gain-gated discount (which needs a real life-gain event, not a life-total
+ * poke, since it reads the `LIFE_GAINED` turn tracker) and the "up to two" return.
+ */
+class SanguineIndulgenceScenarioTest : FunSpec({
+
+    // Minimal life-gain spells so the LIFE_GAINED turn tracker is exercised for real.
+    val GainThree = card("Test Gain Three") {
+        manaCost = "{W}"
+        typeLine = "Instant"
+        spell { effect = Effects.GainLife(3) }
+    }
+    val GainTwo = card("Test Gain Two") {
+        manaCost = "{W}"
+        typeLine = "Instant"
+        spell { effect = Effects.GainLife(2) }
+    }
+
+    fun createRegistry(): CardRegistry = CardRegistry().apply {
+        register(TestCards.all)
+        register(GainThree)
+        register(GainTwo)
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GainThree)
+        driver.registerCard(GainTwo)
+        return driver
+    }
+
+    fun gainLife(driver: GameTestDriver, playerId: com.wingedsheep.sdk.model.EntityId, cardName: String) {
+        val spell = driver.putCardInHand(playerId, cardName)
+        driver.giveMana(playerId, Color.WHITE, 1)
+        driver.castSpell(playerId, spell).error shouldBe null
+        driver.bothPass()
+    }
+
+    test("costs {3} less after gaining 3 or more life this turn") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val indulgence = registry.requireCard("Sanguine Indulgence")
+
+        // Before any life gain: full {3}{B}.
+        calculator.calculateEffectiveCost(driver.state, indulgence, you).genericAmount shouldBe 3
+
+        gainLife(driver, you, "Test Gain Three")
+
+        // After gaining 3: the whole generic component is shaved off, leaving {B}.
+        val reduced = calculator.calculateEffectiveCost(driver.state, indulgence, you)
+        reduced.genericAmount shouldBe 0
+        reduced.cmc shouldBe 1
+    }
+
+    test("gaining only 2 life this turn is not enough") {
+        val registry = createRegistry()
+        val calculator = CostCalculator(registry)
+
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        gainLife(driver, you, "Test Gain Two")
+
+        val indulgence = registry.requireCard("Sanguine Indulgence")
+        calculator.calculateEffectiveCost(driver.state, indulgence, you).genericAmount shouldBe 3
+    }
+
+    test("returns both targeted creature cards from your graveyard to your hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCardInGraveyard(you, "Grizzly Bears")
+        val giant = driver.putCardInGraveyard(you, "Hill Giant")
+
+        val spell = driver.putCardInHand(you, "Sanguine Indulgence")
+        driver.giveMana(you, Color.BLACK, 4)
+        driver.castSpellWithTargets(
+            you,
+            spell,
+            targets = listOf(
+                ChosenTarget.Card(bears, you, Zone.GRAVEYARD),
+                ChosenTarget.Card(giant, you, Zone.GRAVEYARD),
+            ),
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.getGraveyardCardNames(you).contains("Grizzly Bears") shouldBe false
+        driver.getGraveyardCardNames(you).contains("Hill Giant") shouldBe false
+        driver.getHand(you).contains(bears) shouldBe true
+        driver.getHand(you).contains(giant) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildbornPreserverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WildbornPreserverScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Wildborn Preserver (ELD #182).
+ *
+ * {1}{G} Creature — Elf Archer 2/2
+ * "Flash, reach
+ *  Whenever another non-Human creature you control enters, you may pay {X}. When you do, put X
+ *  +1/+1 counters on this creature."
+ *
+ * Covers the pay-{X} reflexive payoff, the non-Human filter, and declining the payment.
+ */
+class WildbornPreserverScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame): Int {
+        val preserver = game.findPermanent("Wildborn Preserver")!!
+        return game.state.getEntity(preserver)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Beast",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Beast")),
+                power = 2,
+                toughness = 2
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Villager",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype.HUMAN),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Wildborn Preserver") {
+
+            test("paying {X} puts X +1/+1 counters on the Preserver") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wildborn Preserver")
+                    .withCardInHand(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                (decision is ChooseNumberDecision) shouldBe true
+                game.chooseNumber(3).error shouldBe null
+                game.resolveStack()
+
+                plusOneCounters(game) shouldBe 3
+            }
+
+            test("declining the payment (X = 0) leaves the Preserver untouched") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wildborn Preserver")
+                    .withCardInHand(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+
+                (game.getPendingDecision() is ChooseNumberDecision) shouldBe true
+                game.chooseNumber(0).error shouldBe null
+                game.resolveStack()
+
+                plusOneCounters(game) shouldBe 0
+            }
+
+            test("a Human creature entering does not trigger the ability") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wildborn Preserver")
+                    .withCardInHand(1, "Test Villager")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Villager").error shouldBe null
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+                plusOneCounters(game) shouldBe 0
+            }
+
+            test("a non-Human creature an opponent controls does not trigger the ability") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Wildborn Preserver")
+                    .withCardInHand(2, "Test Beast")
+                    .withLandsOnBattlefield(2, "Forest", 8)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Test Beast").error shouldBe null
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+                plusOneCounters(game) shouldBe 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five Foundations (FDN) cards. Each canonical `CardDefinition` is placed in the card's **earliest real printing** (verified with `just check-card-printing`), with a `Printing` row contributing the FDN presentation data.

| Card | Canonical set | Rows added |
|---|---|---|
| Crystal Barricade | FDN | — |
| Deadly Plot | J22 | FDN |
| Joraga Invocation | ORI | FDN |
| Sanguine Indulgence | M21 | FDN |
| Wildborn Preserver | ELD | J22, FDN |

## How each card is modeled

- **Crystal Barricade** — `Keyword.DEFENDER`, the `GrantHexproofToController` static, and a continuous `PreventDamage` replacement filtered to `DamageType.NonCombat` with a recipient filter of creatures you control *other than the Barricade itself*.
- **Deadly Plot** — plain choose-one `modal(chooseCount = 1)` with per-mode targets; the reanimation mode is scoped to Zombie **creature** cards in your own graveyard and enters tapped.
- **Joraga Invocation** — `ForEachInGroup` over creatures you control at resolution: `ModifyStats(3, 3)` + `MustBeBlockedEffect(allCreatures = false)`. Creatures arriving later are unaffected (CR 611.2c).
- **Sanguine Indulgence** — `ModifySpellCost(SelfCast, ReduceGeneric(3))` gated by `CostGating.OnlyIf(YouGainedLifeThisTurnAtLeast(3))` (backed by the `LIFE_GAINED` turn tracker), plus `TargetObject(count = 2, optional = true)` → `ForEachTargetEffect` return-to-hand.
- **Wildborn Preserver** — OTHER-bound enters trigger filtered by `notSubtype(Human)`. "You may pay {X}. **When you do**, …" is modeled faithfully as `MayPayXForEffect(ReflexiveTriggerEffect(...))` so the counters go on the stack as a separate, respondable ability (CR 603.7).

## SDK change

Adds `ObjectFilter.notSourceItself()` — the `GameObjectFilter` counterpart of `GroupFilter`/`TargetFilter`'s `excludeSelf`, needed because `RecipientFilter.Matching` takes a bare `GameObjectFilter`. Documented in `docs/card-sdk-language-reference.md` alongside `sourceItself()`.

## Testing

17 new scenario tests across five files — all passing:

- both Deadly Plot modes + an illegal non-Zombie target
- Joraga Invocation's pump scoping, the CR 611.2c latecomer case, and an illegal "no blockers" declaration
- Sanguine Indulgence's discount at 3 life gained vs. 2, and the two-card return
- Crystal Barricade's shield exclusions (self, opponent's creatures) and controller hexproof
- Wildborn Preserver's pay-{X} payoff, decline path, Human filter, and opponent-controlled filter

`just build` is green; card snapshot goldens re-blessed (additions only — no unrelated card moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)