### PR TITLE
Add four Foundations cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrypticCavesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrypticCavesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cryptic Caves reprint in FDN. Canonical CardDefinition lives in M20 (earliest real printing).
+ */
+val CrypticCavesReprint = Printing(
+    oracleId = "b2eb7a64-a307-4a78-a25d-63fb3ae1e237",
+    name = "Cryptic Caves",
+    setCode = "FDN",
+    collectorNumber = "771",
+    scryfallId = "9d126c8f-a3df-497c-aad5-a448c55f51cc",
+    artist = "Sung Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d126c8f-a3df-497c-aad5-a448c55f51cc.jpg?1783903941",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DrakusethMawOfFlamesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DrakusethMawOfFlamesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drakuseth, Maw of Flames reprint in FDN. Canonical CardDefinition lives in M20.
+ */
+val DrakusethMawOfFlamesReprint = Printing(
+    oracleId = "060deaff-44d6-4f03-9568-bcb7add80255",
+    name = "Drakuseth, Maw of Flames",
+    setCode = "FDN",
+    collectorNumber = "760",
+    scryfallId = "9e9b40f5-3dd0-4607-a78d-b004d57fa4ea",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e9b40f5-3dd0-4607-a78d-b004d57fa4ea.jpg?1783903947",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SphinxOfTheFinalWordReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SphinxOfTheFinalWordReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sphinx of the Final Word reprint in FDN. Canonical CardDefinition lives in OGW.
+ */
+val SphinxOfTheFinalWordReprint = Printing(
+    oracleId = "d4246e4d-390d-4925-a5a8-89cd096a237c",
+    name = "Sphinx of the Final Word",
+    setCode = "FDN",
+    collectorNumber = "747",
+    scryfallId = "6071239e-0b85-4c54-bef8-d9456eb8d8fc",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/6071239e-0b85-4c54-bef8-d9456eb8d8fc.jpg?1783903951",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VoraciousGreatsharkReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VoraciousGreatsharkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voracious Greatshark reprint in FDN. Canonical CardDefinition lives in IKO.
+ */
+val VoraciousGreatsharkReprint = Printing(
+    oracleId = "5d96840e-f9b3-4c86-8f59-f12e5736318f",
+    name = "Voracious Greatshark",
+    setCode = "FDN",
+    collectorNumber = "600",
+    scryfallId = "c27b40dd-9b2a-4a99-a984-ee9cfdb091a1",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c27b40dd-9b2a-4a99-a984-ee9cfdb091a1.jpg?1783908931",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/VoraciousGreatshark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/VoraciousGreatshark.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Voracious Greatshark
+ * {3}{U}{U}
+ * Creature — Shark
+ * 5/4
+ * Flash
+ * When this creature enters, counter target artifact or creature spell.
+ *
+ * Flash is what makes the enters-trigger usable as a counterspell: the Shark is cast in response
+ * to the spell it will counter, resolves first, and its trigger then goes on the stack above the
+ * still-unresolved artifact/creature spell. The trigger targets on the stack
+ * ([Zone.STACK]); with no legal artifact or creature spell it simply isn't put on the stack.
+ */
+val VoraciousGreatshark = card("Voracious Greatshark") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shark"
+    power = 5
+    toughness = 4
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "When this creature enters, counter target artifact or creature spell."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "target artifact or creature spell",
+            TargetSpell(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact, zone = Zone.STACK))
+        )
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "70"
+        artist = "Mathias Kollros"
+        flavorText = "There is no boat big enough."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg?1783931068"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CrypticCavesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CrypticCavesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cryptic Caves reprint in KHC (Kaldheim Commander). Canonical CardDefinition lives in M20.
+ */
+val CrypticCavesReprint = Printing(
+    oracleId = "b2eb7a64-a307-4a78-a25d-63fb3ae1e237",
+    name = "Cryptic Caves",
+    setCode = "KHC",
+    collectorNumber = "109",
+    scryfallId = "03d864b7-8049-4ef7-ae50-ad28df7d87d9",
+    artist = "Sung Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03d864b7-8049-4ef7-ae50-ad28df7d87d9.jpg?1783928295",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/CrypticCaves.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/CrypticCaves.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Cryptic Caves
+ * Land
+ * {T}: Add {C}.
+ * {1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands.
+ *
+ * The land counts itself towards the five — it is still on the battlefield while the ability's
+ * activation legality is checked (the sacrifice is paid as a cost afterwards), so
+ * [Conditions.YouControlAtLeast] over [GameObjectFilter.Land] is the faithful reading.
+ */
+val CrypticCaves = card("Cryptic Caves") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouControlAtLeast(5, GameObjectFilter.Land)
+            )
+        )
+        effect = Effects.DrawCards(1)
+        description = "{1}, {T}, Sacrifice this land: Draw a card. " +
+            "Activate only if you control five or more lands."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Sung Choi"
+        flavorText = "Only when you've given up the search will the caves yield their secrets."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg?1783932938"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DrakusethMawOfFlames.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DrakusethMawOfFlames.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Drakuseth, Maw of Flames
+ * {4}{R}{R}{R}
+ * Legendary Creature — Dragon
+ * 7/7
+ * Flying
+ * Whenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to two
+ * other targets.
+ *
+ * Three target slots: the 4-damage target (index 0), then an "up to two other targets" slot
+ * wrapped in [TargetOther] so the pair must differ both from each other (enforced within a
+ * requirement by CR 601.2c) and from the 4-damage target (enforced by [TargetOther] against all
+ * prior targets). `minCount = 0` makes the pair genuinely optional; an unchosen slot leaves its
+ * `ContextTarget` unset and the matching [Effects.DealDamage] resolves as a no-op — the same
+ * shape as Trick Shot's optional second target.
+ */
+val DrakusethMawOfFlames = card("Drakuseth, Maw of Flames") {
+    manaCost = "{4}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dragon"
+    power = 7
+    toughness = 7
+    oracleText = "Flying\n" +
+        "Whenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up " +
+        "to two other targets."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        target("any target", AnyTarget())
+        target(
+            "up to two other targets",
+            TargetOther(baseRequirement = AnyTarget(count = 2, minCount = 0))
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.DealDamage(4, EffectTarget.ContextTarget(0)),
+                Effects.DealDamage(3, EffectTarget.ContextTarget(1)),
+                Effects.DealDamage(3, EffectTarget.ContextTarget(2))
+            )
+        )
+        description = "Whenever Drakuseth attacks, it deals 4 damage to any target and 3 damage " +
+            "to each of up to two other targets."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "\"Spread out, you idiots! Spread out!\"\n—Marsden, party leader, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg?1783932980"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/SphinxOfTheFinalWord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/SphinxOfTheFinalWord.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCantBeCountered
+
+/**
+ * Sphinx of the Final Word
+ * {5}{U}{U}
+ * Creature — Sphinx
+ * 5/5
+ * This spell can't be countered.
+ * Flying
+ * Hexproof
+ * Instant and sorcery spells you control can't be countered.
+ *
+ * "This spell can't be countered" is the card-level [cantBeCountered] flag (it applies while the
+ * Sphinx itself is on the stack, before any permanent exists). The last line is a battlefield
+ * static ability; the filter is scoped with `youControl()` so it protects only its controller's
+ * spells — [GrantCantBeCountered] evaluates the filter with the granter's controller as the
+ * predicate context.
+ */
+val SphinxOfTheFinalWord = card("Sphinx of the Final Word") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 5
+    toughness = 5
+    oracleText = "This spell can't be countered.\n" +
+        "Flying\n" +
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\n" +
+        "Instant and sorcery spells you control can't be countered."
+
+    keywords(Keyword.FLYING, Keyword.HEXPROOF)
+
+    cantBeCountered = true
+
+    staticAbility {
+        ability = GrantCantBeCountered(
+            filter = GameObjectFilter.InstantOrSorcery.youControl()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "63"
+        artist = "Lius Lasahido"
+        flavorText = "He answers questions as readily as he asks them, but his answer is always \"no.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg?1783937917"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/IKO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/IKO.json
@@ -17,3 +17,48 @@
         "BLUE"
     ]
 }
+
+// Voracious Greatshark
+{
+    "name": "Voracious Greatshark",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Shark",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, counter target artifact or creature spell.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "Counter",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|artifact",
+                        "zone": "Stack"
+                    },
+                    "id": "target artifact or creature spell"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "RARE",
+        "artist": "Mathias Kollros",
+        "flavorText": "There is no boat big enough.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1400155f-8911-45fd-aab2-998c8a28292c.jpg?1783931068"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -99,6 +99,82 @@
     ]
 }
 
+// Cryptic Caves
+{
+    "name": "Cryptic Caves",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "land"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 5
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "{1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Sung Choi",
+        "flavorText": "Only when you've given up the search will the caves yield their secrets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fde9e9cb-68ab-4856-8ad6-30f66666dd93.jpg?1783932938"
+    },
+    "colorIdentityOverride": []
+}
+
 // Devout Decree
 {
     "name": "Devout Decree",
@@ -142,6 +218,93 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Drakuseth, Maw of Flames
+{
+    "name": "Drakuseth, Maw of Flames",
+    "manaCost": "{4}{R}{R}{R}",
+    "typeLine": "Legendary Creature — Dragon",
+    "oracleText": "Flying\nWhenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 1
+                            }
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 2
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetOther",
+                        "baseRequirement": {
+                            "type": "AnyTarget",
+                            "count": 2,
+                            "minCount": 0
+                        },
+                        "id": "up to two other targets"
+                    }
+                ],
+                "descriptionOverride": "Whenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to two other targets."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "\"Spread out, you idiots! Spread out!\"\n—Marsden, party leader, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d09af78f-efde-4107-8406-cb12fd11c686.jpg?1783932980"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -97,6 +97,41 @@
     ]
 }
 
+// Sphinx of the Final Word
+{
+    "name": "Sphinx of the Final Word",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "This spell can't be countered.\nFlying\nHexproof (This creature can't be the target of spells or abilities your opponents control.)\nInstant and sorcery spells you control can't be countered.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "HEXPROOF"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantCantBeCountered",
+                "filter": "instant|sorcery ctrl:you"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "MYTHIC",
+        "artist": "Lius Lasahido",
+        "flavorText": "He answers questions as readily as he asks them, but his answer is always \"no.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg?1783937917"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Tajuru Pathwarden
 {
     "name": "Tajuru Pathwarden",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCavesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCavesScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cryptic Caves (M20 #244, reprinted FDN #771).
+ *
+ * "{T}: Add {C}.
+ *  {1}, {T}, Sacrifice this land: Draw a card. Activate only if you control five or more lands."
+ *
+ * Covers the activation restriction in both directions — blocked at four lands, allowed at five
+ * (the Caves counts itself, since it is still on the battlefield when legality is checked).
+ */
+class CrypticCavesScenarioTest : ScenarioTestBase() {
+
+    private val drawAbilityId by lazy {
+        cardRegistry.getCard("Cryptic Caves")!!.script.activatedAbilities[1].id
+    }
+
+    init {
+        context("Cryptic Caves") {
+
+            test("draws a card and sacrifices itself when you control five or more lands") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cryptic Caves")
+                    // Four Forests + the Caves = five lands, and enough mana for the {1}.
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(4) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(4) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val handBefore = game.handSize(1)
+                val librarySizeBefore = game.librarySize(1)
+                val caves = game.findPermanent("Cryptic Caves")!!
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = caves, abilityId = drawAbilityId)
+                )
+                withClue("Activating with five lands should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Cryptic Caves sacrificed itself as part of the cost") {
+                    game.isOnBattlefield("Cryptic Caves") shouldBe false
+                    game.isInGraveyard(1, "Cryptic Caves") shouldBe true
+                }
+                withClue("A card was drawn") {
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.librarySize(1) shouldBe librarySizeBefore - 1
+                }
+            }
+
+            test("cannot be activated while you control only four lands") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cryptic Caves")
+                    // Three Forests + the Caves = four lands — one short.
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(4) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(4) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val handBefore = game.handSize(1)
+                val caves = game.findPermanent("Cryptic Caves")!!
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = caves, abilityId = drawAbilityId)
+                )
+                withClue("Activation should be rejected below five lands") {
+                    (result.error != null) shouldBe true
+                }
+                withClue("Nothing happened — no draw, and the Caves is still on the battlefield") {
+                    game.handSize(1) shouldBe handBefore
+                    game.isOnBattlefield("Cryptic Caves") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DrakusethMawOfFlamesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DrakusethMawOfFlamesScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.m20.cards.DrakusethMawOfFlames
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Drakuseth, Maw of Flames (M20 #136) — {4}{R}{R}{R} Legendary Dragon 7/7, Flying.
+ *
+ *   "Whenever Drakuseth attacks, it deals 4 damage to any target and 3 damage to each of up to
+ *    two other targets."
+ *
+ * Verifies the split damage: the mandatory "any target" (index 0) hits the defending player for 4,
+ * and the "up to two other targets" pair (index 1) each take 3 — enough to kill two 2/2s.
+ */
+class DrakusethMawOfFlamesScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + DrakusethMawOfFlames)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+    }
+
+    test("deals 4 to the defending player and 3 to each of two other creatures") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        val drakuseth = d.putCreatureOnBattlefield(me, "Drakuseth, Maw of Flames")
+        d.removeSummoningSickness(drakuseth)
+        // Two 2/2 blockers on the opponent's side — each dies to 3 damage.
+        val bear1 = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val bear2 = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(drakuseth), opp).error shouldBe null
+
+        // The attack trigger goes on the stack and pauses to choose targets:
+        // requirement 0 = "any target" (hit the opponent), requirement 1 = "up to two other
+        // targets" (the two bears).
+        while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+        (d.pendingDecision as ChooseTargetsDecision)
+        d.submitMultiTargetSelection(
+            me,
+            mapOf(0 to listOf(opp), 1 to listOf(bear1, bear2))
+        ).error shouldBe null
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getLifeTotal(opp) shouldBe 16
+        d.getGraveyard(opp) shouldContain bear1
+        d.getGraveyard(opp) shouldContain bear2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SphinxOfTheFinalWordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SphinxOfTheFinalWordScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sphinx of the Final Word (OGW #63, reprinted FDN #747).
+ *
+ * "This spell can't be countered. Flying. Hexproof.
+ *  Instant and sorcery spells you control can't be countered."
+ *
+ * The interesting half is the static ability's *scope*: `GrantCantBeCountered` is filtered with
+ * `youControl()`, so it protects only the Sphinx controller's instants and sorceries — an
+ * opponent's instant is still counterable while the Sphinx is on the battlefield.
+ */
+class SphinxOfTheFinalWordScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sphinx of the Final Word") {
+
+            test("your instant can't be countered while the Sphinx is on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Sphinx of the Final Word")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(2, "Cancel")
+                    .withLandsOnBattlefield(2, "Island", 3)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 1 (Sphinx controller, active player) casts Shock at the opponent.
+                game.castSpellTargetingPlayer(1, "Shock", 2).error shouldBe null
+                game.passPriority()
+
+                // Player 2 responds with Cancel — legal to cast, but it can't counter Shock.
+                val cancel = game.castSpellTargetingStackSpell(2, "Cancel", "Shock")
+                withClue("Cancel itself is legal to cast — it just won't counter: ${cancel.error}") {
+                    cancel.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Shock resolved despite Cancel — 2 damage dealt") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Both spells left the stack") {
+                    game.isInGraveyard(1, "Shock") shouldBe true
+                    game.isInGraveyard(2, "Cancel") shouldBe true
+                }
+            }
+
+            test("does not protect an opponent's instant") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Sphinx of the Final Word")
+                    .withCardInHand(1, "Cancel")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2 (the opponent, active player) casts Shock at the Sphinx's controller.
+                game.castSpellTargetingPlayer(2, "Shock", 1).error shouldBe null
+                game.passPriority()
+
+                // Player 1 counters it — the Sphinx's `youControl()` scope does NOT protect the
+                // opponent's Shock, so Cancel resolves and counters it.
+                game.castSpellTargetingStackSpell(1, "Cancel", "Shock").error shouldBe null
+                game.resolveStack()
+
+                withClue("The opponent's Shock is not covered by the Sphinx's `youControl()` scope") {
+                    game.getLifeTotal(1) shouldBe 20
+                    game.isInGraveyard(2, "Shock") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoraciousGreatsharkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoraciousGreatsharkScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.iko.cards.VoraciousGreatshark
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Voracious Greatshark (IKO #70) — {3}{U}{U} Shark 5/4, Flash.
+ *
+ *   "When this creature enters, counter target artifact or creature spell."
+ *
+ * Flash lets the Shark be cast in response to a creature spell; its ETB trigger then goes on the
+ * stack above the still-unresolved spell and counters it. Verifies the creature spell is countered
+ * (moves to its controller's graveyard) and the Shark stays on the battlefield.
+ */
+class VoraciousGreatsharkScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + VoraciousGreatshark)
+        initMirrorMatch(deck = Deck.of("Island" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("counters a creature spell cast by the opponent") {
+        val d = driver()
+        // The active player casts a creature at sorcery speed on their own main phase; the
+        // responder flashes the Shark in response to counter it.
+        val caster = d.activePlayer!!
+        val responder = d.getOpponent(caster)
+
+        val oppCreature = d.putCardInHand(caster, "Grizzly Bears")
+        d.giveMana(caster, Color.GREEN, 2)
+        d.castSpell(caster, oppCreature).error shouldBe null
+        d.passPriority(caster)
+
+        // Responder flashes in Voracious Greatshark in response.
+        val shark = d.putCardInHand(responder, "Voracious Greatshark")
+        d.giveMana(responder, Color.BLUE, 5)
+        d.castSpell(responder, shark).error shouldBe null
+
+        // Resolve the Shark; its ETB pauses to choose the spell to counter.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        (d.pendingDecision as ChooseTargetsDecision)
+        d.submitTargetSelection(responder, listOf(oppCreature))
+
+        // Resolve the ETB counter.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getGraveyard(caster) shouldContain oppCreature
+        d.getPermanents(responder) shouldContain shark
+    }
+})


### PR DESCRIPTION
## Summary

Implements four Foundations (FDN) cards using the `add-card` skill. Each card's canonical `CardDefinition` lives in its **earliest real printing** (per the reprint convention), with an FDN `Printing` row — plus rows for any other scaffolded set that reprints it.

| Card | Canonical set | Reprint rows added | Mechanic |
|------|---------------|--------------------|----------|
| **Cryptic Caves** | M20 | KHC, FDN | `{T}: Add {C}` + `{1},{T},Sac: Draw`, gated on controlling ≥5 lands |
| **Sphinx of the Final Word** | OGW | FDN | Flying, hexproof, uncounterable; your instants/sorceries can't be countered |
| **Voracious Greatshark** | IKO | FDN | Flash; ETB counters target artifact or creature spell |
| **Drakuseth, Maw of Flames** | M20 | FDN | Attack trigger: 4 to any target and 3 to each of up to two other targets |

## Implementation notes

- **No engine/SDK changes** — all four compose existing primitives:
  - Cryptic Caves: `ActivationRestriction.OnlyIfCondition(YouControlAtLeast(5, Land))` + `Costs.SacrificeSelf`.
  - Sphinx: card-level `cantBeCountered` for the spell itself + `GrantCantBeCountered(InstantOrSorcery.youControl())` so the static protects only its controller's spells.
  - Greatshark: ETB `Triggers.EntersBattlefield` targeting a `CreatureOrArtifact` spell on the stack + `Effects.CounterSpell()`.
  - Drakuseth: two target slots — a mandatory `AnyTarget()` and an `TargetOther(AnyTarget(count=2, minCount=0))` pair — over a `Composite` of three `DealDamage` effects.

## Testing

- Four rules-engine scenario tests, one per card, covering the key interactions:
  - Cryptic Caves: draws + sacrifices at 5 lands; **rejected** at 4 lands.
  - Sphinx: your instant survives Cancel; an **opponent's** instant is still counterable (scope check).
  - Greatshark: flashed in response to a creature spell, ETB counters it.
  - Drakuseth: 4 damage to the defending player + 3 to each of two 2/2s (both die).
- `just build` green (compile + all tests, incl. snapshot / lint / printing-consistency / coverage).
- Card snapshots re-blessed for IKO / M20 / OGW (additions only; no unrelated cards moved).
- `just check-card-printing` clean for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)