### PR TITLE
Add four Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MonstrousRage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MonstrousRage.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Monstrous Rage
+ * {R}
+ * Instant
+ *
+ * Target creature gets +2/+0 until end of turn. Create a Monster Role token attached to it.
+ * (If you control another Role on it, put that one into the graveyard. Enchanted creature gets
+ * +1/+1 and has trample.)
+ *
+ * The +2/+0 comes from the spell; the +1/+1 and trample come from the Monster Role token itself,
+ * so the spell only pumps and creates the Role (Role replacement is handled by the executor).
+ */
+val MonstrousRage = card("Monstrous Rage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+0 until end of turn. Create a Monster Role token attached to it. " +
+        "(If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(+2, 0, t),
+            Effects.CreateRoleToken("Monster Role", t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg?1783915091"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RegalBunnicorn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RegalBunnicorn.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Regal Bunnicorn
+ * {1}{W}
+ * Creature — Rabbit Unicorn
+ * *|*
+ *
+ * Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.
+ *
+ * A characteristic-defining ability (CR 604.3): the P/T is set to the count of nonland permanents
+ * you control in every zone, so it includes Regal Bunnicorn itself while on the battlefield.
+ */
+val RegalBunnicorn = card("Regal Bunnicorn") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rabbit Unicorn"
+    oracleText = "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control."
+
+    dynamicStats(DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, Filters.NonlandPermanent))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Ilse Gort"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg?1783915128"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SkewerSlinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SkewerSlinger.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skewer Slinger
+ * {1}{R}
+ * Creature — Dwarf Knight
+ * 1/3
+ *
+ * Reach
+ * Whenever this creature blocks or becomes blocked by a creature, this creature deals 1 damage to that creature.
+ *
+ * The single trigger covers both halves of "blocks or becomes blocked": [Triggers.BlocksOrBecomesBlockedBy]
+ * exposes the combat partner (the blocked attacker, or the creature blocking it) as
+ * [EffectTarget.TriggeringEntity]. "That creature" is not a target — it's the combat partner.
+ */
+val SkewerSlinger = card("Skewer Slinger") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Knight"
+    power = 1
+    toughness = 3
+    oracleText = "Reach\nWhenever this creature blocks or becomes blocked by a creature, this creature deals 1 damage to that creature."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.BlocksOrBecomesBlockedBy(Filters.Creature)
+        effect = Effects.DealDamage(1, EffectTarget.TriggeringEntity, damageSource = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg?1783915089"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StormkeldProwler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StormkeldProwler.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stormkeld Prowler
+ * {1}{U}
+ * Creature — Human Rogue
+ * 2/1
+ *
+ * Whenever you cast a spell with mana value 5 or greater, put two +1/+1 counters on this creature.
+ */
+val StormkeldProwler = card("Stormkeld Prowler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast a spell with mana value 5 or greater, put two +1/+1 counters on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Any.manaValueAtLeast(5))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Zara Alfonso"
+        flavorText = "To the giants, it was one little gem among thousands. But to Kylene, it was a haul that would feed her family for years."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg?1783915114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -337,6 +337,31 @@ object PredefinedTokens {
     }
 
     /**
+     * Monster Role — Enchantment — Aura Role token (Wilds of Eldraine).
+     * "Enchanted creature gets +1/+1 and has trample."
+     */
+    val MonsterRole = card("Monster Role") {
+        typeLine = "Enchantment — Aura Role"
+        oracleText = "Enchant creature\nEnchanted creature gets +1/+1 and has trample."
+
+        auraTarget = Targets.Creature
+
+        staticAbility {
+            ability = ModifyStats(+1, +1, Filters.EnchantedCreature)
+        }
+
+        staticAbility {
+            ability = GrantKeyword(Keyword.TRAMPLE, Filters.EnchantedCreature)
+        }
+
+        metadata {
+            // "Monster // Sorcerer" flip token: Monster is the upright (front) face — no rotation.
+            imageUri = "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1694737457"
+            artist = "Rovina Cai"
+        }
+    }
+
+    /**
      * Royal Role — Enchantment — Aura Role token (Wilds of Eldraine).
      * "Enchanted creature gets +1/+1 and has ward {1}."
      */
@@ -582,6 +607,7 @@ object PredefinedTokens {
         Cragflame,
         Mutavault,
         SorcererRole,
+        MonsterRole,
         RoyalRole,
         CursedRole,
         Incubator,

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2198,6 +2198,62 @@
     ]
 }
 
+// Monstrous Rage
+{
+    "name": "Monstrous Rage",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+0 until end of turn. Create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Monster Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eef5a0ae-5907-42c9-a097-3f973737e392.jpg?1783915091"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Moonshaker Cavalry
 {
     "name": "Moonshaker Cavalry",
@@ -2432,6 +2488,43 @@
     ]
 }
 
+// Regal Bunnicorn
+{
+    "name": "Regal Bunnicorn",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Rabbit Unicorn",
+    "oracleText": "Regal Bunnicorn's power and toughness are each equal to the number of nonland permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Battlefield",
+                "filter": "nonland permanent"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Battlefield",
+                "filter": "nonland permanent"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Ilse Gort",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03c7d409-90e7-44d7-a8c6-4eda35fbcc83.jpg?1783915128"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Rimefur Reindeer
 {
     "name": "Rimefur Reindeer",
@@ -2648,6 +2741,53 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/d/3dc08461-bec6-4a18-b782-da4c92abb789.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Skewer Slinger
+{
+    "name": "Skewer Slinger",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dwarf Knight",
+    "oracleText": "Reach\nWhenever this creature blocks or becomes blocked by a creature, this creature deals 1 damage to that creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BlocksOrBecomesBlockedByEvent",
+                    "partnerFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "TriggeringEntity",
+                    "damageSource": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e78e50ca-d27b-45db-91fa-7fef3cad16d0.jpg?1783915089"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Sleep-Cursed Faerie
@@ -2906,6 +3046,52 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Stormkeld Prowler
+{
+    "name": "Stormkeld Prowler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Whenever you cast a spell with mana value 5 or greater, put two +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtLeast",
+                                "min": 5
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Zara Alfonso",
+        "flavorText": "To the giants, it was one little gem among thousands. But to Kylene, it was a haul that would feed her family for years.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff065dbf-77e3-45a8-bcca-aff9eaeb151f.jpg?1783915114"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeHandfulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeHandfulScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for a handful of Wilds of Eldraine cards implemented together:
+ *
+ *  - Regal Bunnicorn ({1}{W}) — CDA P/T = number of nonland permanents you control.
+ *  - Skewer Slinger ({1}{R} 1/3, Reach) — pings the combat partner for 1 when it blocks or
+ *    becomes blocked.
+ *  - Monstrous Rage ({R} instant) — +2/+0 to a creature and creates a Monster Role token
+ *    (which itself grants +1/+1 and trample).
+ *  - Stormkeld Prowler ({1}{U} 2/1) — two +1/+1 counters whenever you cast a spell with mana
+ *    value 5 or greater.
+ */
+class WoeHandfulScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Regal Bunnicorn — CDA counts nonland permanents you control") {
+            test("power and toughness equal the number of nonland permanents you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Regal Bunnicorn", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bunnicorn = game.findPermanent("Regal Bunnicorn")!!
+
+                withClue("3 nonland permanents you control (Bunnicorn + 2 Bears); lands and the opponent's Bear don't count") {
+                    game.state.projectedState.getPower(bunnicorn) shouldBe 3
+                    game.state.projectedState.getToughness(bunnicorn) shouldBe 3
+                }
+            }
+        }
+
+        context("Monstrous Rage — pump plus a Monster Role token") {
+            test("target gets +2/+0 from the spell and +1/+1 and trample from the Monster Role") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Monstrous Rage")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Monstrous Rage", bear)
+                game.resolveStack()
+
+                withClue("2/2 Bear -> +2/+0 (spell) + +1/+1 (Monster Role) = 5/3") {
+                    game.state.projectedState.getPower(bear) shouldBe 5
+                    game.state.projectedState.getToughness(bear) shouldBe 3
+                }
+                withClue("The Monster Role grants trample") {
+                    game.state.projectedState.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("A Monster Role token was created") {
+                    (game.findPermanent("Monster Role") != null) shouldBe true
+                }
+            }
+        }
+
+        context("Stormkeld Prowler — counters on casting an expensive spell") {
+            test("casting a mana value 5+ spell adds two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stormkeld Prowler", summoningSickness = false)
+                    .withCardInHand(1, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val prowler = game.findPermanent("Stormkeld Prowler")!!
+
+                game.castSpell(1, "Craw Wurm")
+                game.resolveStack()
+
+                withClue("Craw Wurm is mana value 6 (>= 5) -> two +1/+1 counters on the Prowler") {
+                    game.state.getEntity(prowler)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                withClue("2/1 base + two +1/+1 counters = 4/3") {
+                    game.state.projectedState.getPower(prowler) shouldBe 4
+                    game.state.projectedState.getToughness(prowler) shouldBe 3
+                }
+            }
+        }
+
+        context("Skewer Slinger — pings its combat partner") {
+            test("blocking a creature deals it 1 damage on top of combat damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skewer Slinger", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2's 2/2 Bear attacks; Player 1's 1/3 Skewer Slinger blocks it.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Skewer Slinger" to listOf("Grizzly Bears"))).error shouldBe null
+
+                // Pass priority so the "deals 1 damage to that creature" trigger resolves, then
+                // continue through the combat damage step (which deals the remaining combat damage).
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Bear took 1 (trigger) + 1 (Skewer's combat power) = 2 -> dies; without the trigger it would survive") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Skewer Slinger (1/3) survives the Bear's 2 combat damage") {
+                    (game.findPermanent("Skewer Slinger") != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of **Wilds of Eldraine** cards, each using existing SDK infrastructure (no new engine primitives).

## Cards

| Card | Cost | What it does |
|------|------|--------------|
| **Regal Bunnicorn** | `{1}{W}` | CDA — power and toughness each equal to the number of nonland permanents you control (`DynamicAmount.Count`). |
| **Skewer Slinger** | `{1}{R}` 1/3 | Reach; whenever it blocks or becomes blocked by a creature, deals 1 damage to that creature (`Triggers.BlocksOrBecomesBlockedBy` → `DealDamage` to the combat partner). |
| **Monstrous Rage** | `{R}` instant | Target creature gets +2/+0; creates a **Monster Role** token (the token itself grants +1/+1 and trample). |
| **Stormkeld Prowler** | `{1}{U}` 2/1 | Whenever you cast a spell with mana value 5+, put two +1/+1 counters on it (`Triggers.youCastSpell` + mana-value filter). |

## Notes

- Adds the **Monster Role** predefined token (`+1/+1` and trample) alongside the existing Royal / Sorcerer / Cursed Roles. It shares the `Monster // Sorcerer` flip-token art (Monster is the upright face, no rotation).
- The two reprints originally scoped (Titanic Growth, Sleight of Hand) and the mechanic-heavy cards (Torch the Tower needs Bargain, Armory Mice needs a Celebration tracker) were dropped to keep this a content-only PR rather than a feature PR.

## Testing

- `WoeHandfulScenarioTest` — covers all four cards (CDA count, Monster Role pump + trample, cast-trigger counters, and the block ping resolving before combat damage).
- Re-blessed the `WOE` card-definition snapshot; `CardLintTest` passes; diff is limited to the four new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)