### PR TITLE
Add three Foundations cards (Loot, Nullpriest, Bloodtithe Collector)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BloodtitheCollectorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BloodtitheCollectorReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodtithe Collector reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in MID's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row.
+ */
+val BloodtitheCollectorReprint = Printing(
+    oracleId = "93088b0c-d158-473a-9c06-aa2f344a9868",
+    name = "Bloodtithe Collector",
+    setCode = "FDN",
+    collectorNumber = "751",
+    scryfallId = "37931135-100d-4a23-a6e3-baf90fb259ee",
+    artist = "Maria Zolotukhina",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37931135-100d-4a23-a6e3-baf90fb259ee.jpg?1783903950",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LootExuberantExplorer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LootExuberantExplorer.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Loot, Exuberant Explorer
+ * {2}{G}
+ * Legendary Creature — Beast Noble
+ * 1/4
+ *
+ * You may play an additional land on each of your turns.
+ * {4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with
+ *   mana value less than or equal to the number of lands you control from among them and put it
+ *   onto the battlefield. Put the rest on the bottom in a random order.
+ *
+ * - The extra land drop is a static [GrantAdditionalLandDrop] (cumulative with other such effects).
+ * - The activated ability is an atomic Gather → Select → Move pipeline: look at the top six
+ *   (GatherCards), the controller may keep at most one creature card whose mana value is at most
+ *   the number of lands they control (SelectUpTo(1) filtered by [ManaValueAtMostDynamic] over
+ *   [DynamicAmounts.landsYouControl] — evaluated live), that card is put onto the battlefield, and
+ *   every remaining looked-at card goes to the bottom of the library in a random order. Declining /
+ *   no eligible creature simply keeps nothing and bottoms all six.
+ */
+val LootExuberantExplorer = card("Loot, Exuberant Explorer") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Beast Noble"
+    power = 1
+    toughness = 4
+    oracleText = "You may play an additional land on each of your turns.\n" +
+        "{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card " +
+        "with mana value less than or equal to the number of lands you control from among them and " +
+        "put it onto the battlefield. Put the rest on the bottom in a random order."
+
+    // You may play an additional land on each of your turns.
+    staticAbility {
+        ability = GrantAdditionalLandDrop(count = 1)
+    }
+
+    // {4}{G}{G}, {T}: Look at the top six ... put a creature (MV <= lands) onto the battlefield;
+    // rest on the bottom in a random order.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{4}{G}{G}"),
+            Costs.Tap,
+        )
+        effect = Effects.Composite(
+            // Look at the top six cards of your library.
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(6)),
+                storeAs = "lootLooked",
+            ),
+            // You may reveal a creature card with mana value <= the number of lands you control.
+            SelectFromCollectionEffect(
+                from = "lootLooked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Creature.manaValueAtMostDynamic(
+                    DynamicAmounts.landsYouControl(),
+                ),
+                storeSelected = "lootKept",
+                storeRemainder = "lootRest",
+                prompt = "You may put a creature card with mana value ≤ lands you control " +
+                    "onto the battlefield",
+                showAllCards = true,
+            ),
+            // ... and put it onto the battlefield (revealed as it goes).
+            MoveCollectionEffect(
+                from = "lootKept",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                revealed = true,
+            ),
+            // Put the rest on the bottom in a random order.
+            MoveCollectionEffect(
+                from = "lootRest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "106"
+        artist = "Arif Wijaya"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg?1783909097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NullpriestOfOblivionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NullpriestOfOblivionReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nullpriest of Oblivion reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in ZNR's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row.
+ */
+val NullpriestOfOblivionReprint = Printing(
+    oracleId = "c1111228-ef88-4b64-91e0-66ee32a1f5e4",
+    name = "Nullpriest of Oblivion",
+    setCode = "FDN",
+    collectorNumber = "611",
+    scryfallId = "b2c7613c-38fc-49c3-93ee-1df93136455a",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2c7613c-38fc-49c3-93ee-1df93136455a.jpg?1783908928",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BloodtitheCollector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BloodtitheCollector.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodtithe Collector
+ * {4}{B}
+ * Creature — Vampire Noble
+ * 3/4
+ *
+ * Flying
+ * When this creature enters, if an opponent lost life this turn, each opponent discards a card.
+ *
+ * The ETB discard is gated by an intervening "if" ([Conditions.OpponentLostLifeThisTurn], CR 603.4):
+ * the trigger only goes on the stack — and only checked again on resolution — when an opponent has
+ * lost life this turn. [Effects.EachOpponentDiscards] handles the per-opponent discard.
+ *
+ * Canonical printing lives here (Innistrad: Midnight Hunt, the earliest real printing); Foundations
+ * reprints it (see the FDN `Printing` row).
+ */
+val BloodtitheCollector = card("Bloodtithe Collector") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Noble"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, if an opponent lost life this turn, each opponent discards a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.OpponentLostLifeThisTurn
+        effect = Effects.EachOpponentDiscards(1)
+        description = "When this creature enters, if an opponent lost life this turn, each opponent " +
+            "discards a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Maria Zolotukhina"
+        flavorText = "For the more refined vampire, breaking a victim's will is far more satisfying " +
+            "than simply taking their blood."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg?1783925623"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/NullpriestOfOblivion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/NullpriestOfOblivion.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Nullpriest of Oblivion
+ * {1}{B}
+ * Creature — Vampire Cleric
+ * 2/1
+ *
+ * Kicker {3}{B}
+ * Lifelink
+ * Menace
+ * When this creature enters, if it was kicked, return target creature card from your graveyard to
+ *   the battlefield.
+ *
+ * - Kicker is the [KeywordAbility.kicker] alternative additional cost; the ETB reanimation is gated
+ *   by an intervening "if" ([Conditions.WasKicked], CR 603.4) so the trigger only goes on the stack
+ *   — and only asks for a graveyard target — when the spell was actually kicked.
+ * - The reanimation is a plain graveyard-targeted [Effects.PutOntoBattlefield].
+ *
+ * Canonical printing lives here (Zendikar Rising, the earliest real printing); Foundations reprints
+ * it (see the FDN `Printing` row).
+ */
+val NullpriestOfOblivion = card("Nullpriest of Oblivion") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\n" +
+        "Lifelink\n" +
+        "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "When this creature enters, if it was kicked, return target creature card from your " +
+        "graveyard to the battlefield."
+
+    keywords(Keyword.LIFELINK, Keyword.MENACE)
+    keywordAbility(KeywordAbility.kicker("{3}{B}"))
+
+    // When this creature enters, if it was kicked, return target creature card from your graveyard
+    // to the battlefield.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasKicked
+        val t = target(
+            "target creature card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.PutOntoBattlefield(t)
+        description = "When this creature enters, if it was kicked, return target creature card " +
+            "from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "118"
+        artist = "Yongjae Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg?1783929369"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -4566,6 +4566,113 @@
     "colorIdentityOverride": []
 }
 
+// Loot, Exuberant Explorer
+{
+    "name": "Loot, Exuberant Explorer",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Beast Noble",
+    "oracleText": "You may play an additional land on each of your turns.\n{4}{G}{G}, {T}: Look at the top six cards of your library. You may reveal a creature card with mana value less than or equal to the number of lands you control from among them and put it onto the battlefield. Put the rest on the bottom in a random order.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "lootLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "lootLooked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "ManaValueAtMostDynamic",
+                                        "amount": {
+                                            "type": "AggregateBattlefield",
+                                            "player": "You",
+                                            "filter": "land"
+                                        }
+                                    }
+                                ]
+                            },
+                            "storeSelected": "lootKept",
+                            "storeRemainder": "lootRest",
+                            "prompt": "You may put a creature card with mana value ≤ lands you control onto the battlefield",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "lootKept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "lootRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            "GrantAdditionalLandDrop"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "RARE",
+        "artist": "Arif Wijaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09980ce6-425b-4e03-94d0-0f02043cb361.jpg?1783909097"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Luminous Rebuke
 {
     "name": "Luminous Rebuke",

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -127,6 +127,97 @@
     ]
 }
 
+// Bloodtithe Collector
+{
+    "name": "Bloodtithe Collector",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire Noble",
+    "oracleText": "Flying\nWhen this creature enters, if an opponent lost life this turn, each opponent discards a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "EachOpponent",
+                        "tracker": "LIFE_LOST"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, if an opponent lost life this turn, each opponent discards a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Maria Zolotukhina",
+        "flavorText": "For the more refined vampire, breaking a victim's will is far more satisfying than simply taking their blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57d5e536-7774-4949-8127-727ae4d8fc80.jpg?1783925623"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cathar Commando
 {
     "name": "Cathar Commando",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -178,6 +178,66 @@
     ]
 }
 
+// Nullpriest of Oblivion
+{
+    "name": "Nullpriest of Oblivion",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Kicker {3}{B} (You may pay an additional {3}{B} as you cast this spell.)\nLifelink\nMenace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, if it was kicked, return target creature card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK",
+        "MENACE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{3}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                },
+                "triggerCondition": "WasKicked",
+                "descriptionOverride": "When this creature enters, if it was kicked, return target creature card from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "RARE",
+        "artist": "Yongjae Choi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/086fc7fb-efcf-4676-8455-39b63edaec6a.jpg?1783929369"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spitfire Lagac
 {
     "name": "Spitfire Lagac",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodtitheCollectorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodtitheCollectorScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bloodtithe Collector (MID #90, reprinted in FDN #751) — {4}{B} 3/4 flyer whose ETB reads
+ * "if an opponent lost life this turn, each opponent discards a card."
+ *
+ * Proves the intervening "if" (CR 603.4): the discard only happens when an opponent has already
+ * lost life this turn. A Lightning Bolt to the opponent's face satisfies the condition; without it,
+ * the trigger does nothing.
+ */
+class BloodtitheCollectorScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 30))
+        return d
+    }
+
+    /** Resolve the stack, answering any forced discard the opponent is handed along the way. */
+    fun GameTestDriver.settle(maxSteps: Int = 20) {
+        var guard = 0
+        while ((stackSize > 0 || state.pendingDecision != null) && guard++ < maxSteps) {
+            when (val pending = state.pendingDecision) {
+                is SelectCardsDecision -> submitCardSelection(pending.playerId, pending.options.take(1))
+                else -> bothPass()
+            }
+        }
+    }
+
+    test("each opponent discards when an opponent lost life this turn") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Bolt the opponent so they lose life this turn (does not touch their hand).
+        val bolt = d.putCardInHand(you, "Lightning Bolt")
+        d.giveMana(you, Color.RED, 1)
+        d.castSpell(you, bolt, listOf(opp)).isSuccess shouldBe true
+        d.bothPass()
+
+        // Cast Bloodtithe Collector ({4}{B}); its ETB sees the life loss → opponent discards one.
+        val handBefore = d.getHandSize(opp)
+        val collector = d.putCardInHand(you, "Bloodtithe Collector")
+        d.giveMana(you, Color.BLACK, 5)
+        d.castSpell(you, collector).isSuccess shouldBe true
+        d.settle()
+
+        d.getHandSize(opp) shouldBe handBefore - 1
+    }
+
+    test("no discard when no opponent has lost life this turn") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.player2
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val handBefore = d.getHandSize(opp)
+        val collector = d.putCardInHand(you, "Bloodtithe Collector")
+        d.giveMana(you, Color.BLACK, 5)
+        d.castSpell(you, collector).isSuccess shouldBe true
+        d.settle()
+
+        d.getHandSize(opp) shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LootExuberantExplorerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LootExuberantExplorerScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.LootExuberantExplorer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Loot, Exuberant Explorer (FDN #106) — "{4}{G}{G}, {T}: Look at the top six cards of your library.
+ * You may reveal a creature card with mana value less than or equal to the number of lands you
+ * control from among them and put it onto the battlefield. Put the rest on the bottom in a random
+ * order."
+ *
+ * Proves the dynamic mana-value cap is read live off the number of lands the controller has:
+ *   - With 3 lands, a mana-value-3 creature (Centaur Courser) is eligible → it can be put onto the
+ *     battlefield.
+ *   - With 2 lands, the same creature is over the cap (3 > 2) → it is not even offered as a choice.
+ */
+class LootExuberantExplorerScenarioTest : FunSpec({
+
+    val activateAbilityId = LootExuberantExplorer.activatedAbilities.first().id
+
+    fun setup(lands: Int): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val loot = driver.putPermanentOnBattlefield(player, "Loot, Exuberant Explorer")
+        driver.removeSummoningSickness(loot)
+        repeat(lands) { driver.putLandOnBattlefield(player, "Forest") }
+
+        // Centaur Courser is a {2}{G} 3/3 — mana value 3.
+        val courser = driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+
+        // {4}{G}{G} — six green mana covers the two {G} pips and the four generic.
+        driver.giveMana(player, Color.GREEN, 6)
+        return Triple(driver, loot, courser)
+    }
+
+    test("puts a creature with mana value <= lands you control onto the battlefield") {
+        val (driver, loot, courser) = setup(lands = 3)
+        val player = driver.activePlayer!!
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = loot, abilityId = activateAbilityId)
+        ).isSuccess shouldBe true
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.options shouldContain courser
+        driver.submitDecision(player, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(courser)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.getPermanents(player) shouldContain courser
+    }
+
+    test("does not offer a creature whose mana value exceeds the number of lands you control") {
+        val (driver, loot, courser) = setup(lands = 2)
+        val player = driver.activePlayer!!
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = loot, abilityId = activateAbilityId)
+        ).isSuccess shouldBe true
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The "look at" pipeline still pauses (showAllCards), but the over-cap creature is not a
+        // legal choice, so it is absent from the selectable options.
+        if (driver.isPaused) {
+            val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            pick.options shouldNotContain courser
+            driver.submitDecision(player, CardsSelectedResponse(decisionId = pick.id, selectedCards = emptyList()))
+            while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+        }
+
+        driver.getPermanents(player) shouldNotContain courser
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NullpriestOfOblivionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NullpriestOfOblivionScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nullpriest of Oblivion (ZNR #118, reprinted in FDN #611) — {1}{B} 2/1 Vampire Cleric with
+ * Kicker {3}{B}, Lifelink, Menace, and "When this creature enters, if it was kicked, return target
+ * creature card from your graveyard to the battlefield."
+ *
+ * Proves the intervening "if" (CR 603.4): the ETB reanimation only happens when the spell was
+ * kicked. Kicked → a graveyard creature is returned to the battlefield; not kicked → no trigger, so
+ * no target is even requested and the graveyard is untouched.
+ */
+class NullpriestOfOblivionScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 30))
+        return d
+    }
+
+    test("kicked: the ETB returns a creature card from your graveyard to the battlefield") {
+        val d = driver()
+        val you = d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardInGraveyard(you, "Centaur Courser")
+        val nullpriest = d.putCardInHand(you, "Nullpriest of Oblivion")
+        // {1}{B} + kicker {3}{B} = {4}{B}{B} → six Swamps cover it.
+        repeat(6) { d.putLandOnBattlefield(you, "Swamp") }
+
+        d.submit(
+            CastSpell(
+                playerId = you,
+                cardId = nullpriest,
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            ),
+        ).isSuccess shouldBe true
+        d.bothPass() // resolve the creature; the kicked ETB trigger goes on the stack and wants a target
+
+        val courser = d.getGraveyard(you).first {
+            d.state.getEntity(it)?.get<CardComponent>()?.name == "Centaur Courser"
+        }
+        d.pendingDecision.shouldNotBeNull()
+        d.submitTargetSelection(you, listOf(courser))
+        while (d.stackSize > 0) d.bothPass()
+
+        d.findPermanent(you, "Centaur Courser").shouldNotBeNull()
+    }
+
+    test("not kicked: no ETB trigger fires and the graveyard creature stays put") {
+        val d = driver()
+        val you = d.player1
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardInGraveyard(you, "Centaur Courser")
+        val nullpriest = d.putCardInHand(you, "Nullpriest of Oblivion")
+        // Base cost {1}{B} only.
+        repeat(2) { d.putLandOnBattlefield(you, "Swamp") }
+
+        d.submit(
+            CastSpell(
+                playerId = you,
+                cardId = nullpriest,
+                wasKicked = false,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            ),
+        ).isSuccess shouldBe true
+        d.bothPass() // resolve the creature; the intervening "if" is false, so nothing triggers
+
+        d.pendingDecision.shouldBeNull()
+        d.findPermanent(you, "Centaur Courser").shouldBeNull()
+    }
+})


### PR DESCRIPTION
Implements a handful of Foundations (FDN) cards, each via the `add-card` flow. All three compose existing SDK primitives — no new engine features — so they're low-risk additions.

## Cards

| Card | Canonical set | FDN | Summary |
|------|---------------|-----|---------|
| **Loot, Exuberant Explorer** | FDN (original) | #106 | Extra land drop + `{4}{G}{G}, {T}` tutor-to-battlefield (top six → creature with MV ≤ lands you control → rest bottom in a random order) |
| **Nullpriest of Oblivion** | ZNR #118 | #611 (reprint) | Kicker {3}{B}, Lifelink, Menace, kicked-gated ETB reanimation |
| **Bloodtithe Collector** | MID #90 | #751 (reprint) | Flying + ETB "if an opponent lost life this turn, each opponent discards a card" |

The two reprints keep their canonical `CardDefinition` in the earliest real printing (ZNR / MID) and add a `Printing` row in Foundations, per the repo's reprint convention. `check-card-printing` passes for both.

## How they're built (pure composition)
- **Loot** — `GrantAdditionalLandDrop` + a `GatherCards → SelectFromCollection → MoveCollection` pipeline; eligibility uses `CardPredicate.ManaValueAtMostDynamic(DynamicAmounts.landsYouControl())`, evaluated live.
- **Nullpriest** — `KeywordAbility.kicker` + `LIFELINK`/`MENACE` + an ETB `triggeredAbility` with an intervening-if `Conditions.WasKicked` and a graveyard-targeted `Effects.PutOntoBattlefield`.
- **Bloodtithe Collector** — `FLYING` + an ETB `triggeredAbility` gated by `Conditions.OpponentLostLifeThisTurn` running `Effects.EachOpponentDiscards(1)`.

## Tests
- New scenario tests for all three (rules-engine), covering the interesting gating in both directions (MV cap in/out of reach; kicked vs not; opponent-lost-life vs not). All pass.
- `CardDefinitionSnapshotTest` goldens re-blessed for FDN, ZNR, MID (only the three new cards added).
- `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)