### PR TITLE
Add four Innistrad Remastered cards: Fiend Hunter, Stitched Mangler, Neonate's Rush, Lightning Axe

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/FiendHunterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/FiendHunterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiend Hunter reprint in DDQ (Duel Decks: Blessed vs. Cursed). Canonical CardDefinition
+ * lives in its earliest set (ISD).
+ */
+val FiendHunterReprint = Printing(
+    oracleId = "cb9d557a-fc06-428c-8be6-7d28add33028",
+    name = "Fiend Hunter",
+    setCode = "DDQ",
+    collectorNumber = "11",
+    scryfallId = "1f8fd6e7-a7d9-433c-9d8c-ec279132af50",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8fd6e7-a7d9-433c-9d8c-ec279132af50.jpg?1783937856",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/FiendHunterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/FiendHunterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiend Hunter reprint in INR. Canonical CardDefinition lives in its earliest set (ISD).
+ */
+val FiendHunterReprint = Printing(
+    oracleId = "cb9d557a-fc06-428c-8be6-7d28add33028",
+    name = "Fiend Hunter",
+    setCode = "INR",
+    collectorNumber = "22",
+    scryfallId = "f606cf4d-e29b-415a-956c-b148045c44e9",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f606cf4d-e29b-415a-956c-b148045c44e9.jpg?1783908182",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LightningAxeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LightningAxeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Axe reprint in INR. Canonical CardDefinition lives in its earliest set (TSP).
+ */
+val LightningAxeReprint = Printing(
+    oracleId = "81b90905-fbc0-426a-a084-c3300533abb4",
+    name = "Lightning Axe",
+    setCode = "INR",
+    collectorNumber = "162",
+    scryfallId = "90911c79-24c3-4566-b72c-02ccde083f1b",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90911c79-24c3-4566-b72c-02ccde083f1b.jpg?1783908116",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/NeonatesRushReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/NeonatesRushReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Neonate's Rush reprint in INR. Canonical CardDefinition lives in its earliest set (MID).
+ */
+val NeonatesRushReprint = Printing(
+    oracleId = "721aeedc-1de5-40d0-a04c-a2ebc056d06a",
+    name = "Neonate's Rush",
+    setCode = "INR",
+    collectorNumber = "166",
+    scryfallId = "1d623e71-05bd-46d6-b831-2c8dcff7ab45",
+    artist = "Justine Cruz",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1d623e71-05bd-46d6-b831-2c8dcff7ab45.jpg?1783908115",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StitchedManglerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StitchedManglerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stitched Mangler reprint in INR. Canonical CardDefinition lives in its earliest set (SOI).
+ */
+val StitchedManglerReprint = Printing(
+    oracleId = "4c502f1b-7361-48c0-8def-0d3b3e9ff628",
+    name = "Stitched Mangler",
+    setCode = "INR",
+    collectorNumber = "87",
+    scryfallId = "e90cb0f1-d6fa-4a73-83bb-8870e59b1d7d",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e90cb0f1-d6fa-4a73-83bb-8870e59b1d7d.jpg?1783908157",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/FiendHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/FiendHunter.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Fiend Hunter
+ * {1}{W}{W}
+ * Creature — Human Cleric
+ * 1/3
+ *
+ * When this creature enters, you may exile another target creature.
+ * When this creature leaves the battlefield, return the exiled card to the battlefield
+ * under its owner's control.
+ *
+ * Unlike "exile until ~ leaves the battlefield" wordings, Fiend Hunter uses two separate
+ * triggers (CR ruling): if it leaves before the exile trigger resolves, the leaves trigger
+ * finds nothing linked and does nothing, then the enter trigger exiles the creature with no
+ * pending return — exiling it indefinitely. Modeled here as [Effects.ExileUntilLeaves] (which
+ * only exiles + links, it does not auto-return) paired with an explicit leaves-battlefield
+ * [Effects.ReturnLinkedExileUnderOwnersControl]. Ordering the leaves trigger before a linked
+ * exile exists naturally reproduces the indefinite-exile interaction.
+ *
+ * "you may exile another target creature" is modeled as an optional target (the player may
+ * choose no target to decline); "another" excludes Fiend Hunter itself via
+ * [TargetFilter.OtherCreature].
+ */
+val FiendHunter = card("Fiend Hunter") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 3
+    oracleText = "When this creature enters, you may exile another target creature.\n" +
+        "When this creature leaves the battlefield, return the exiled card to the battlefield under its owner's control."
+
+    // ETB: you may exile another target creature (until this leaves).
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "another target creature",
+            TargetCreature(filter = TargetFilter.OtherCreature, optional = true)
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+    }
+
+    // LTB: return the exiled card under its owner's control.
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg?1783940994"
+
+        ruling(
+            "2018-12-07",
+            "If Fiend Hunter leaves the battlefield before its first ability has resolved, its second " +
+                "ability will trigger and do nothing. Then its first ability will resolve and exile the " +
+                "target creature indefinitely. This is different from abilities on other cards that exile " +
+                "a permanent \"until\" something happens."
+        )
+        ruling(
+            "2018-12-07",
+            "Once the exiled creature returns, it's considered a new object with no relation to the object " +
+                "that it was. Auras attached to the exiled creature will be put into their owners' graveyards. " +
+                "Equipment attached to the exiled creature will become unattached and remain on the battlefield. " +
+                "Any counters on the exiled creature will cease to exist."
+        )
+        ruling("2018-12-07", "If a token is exiled this way, it won't return to the battlefield.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LightningAxeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LightningAxeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Axe reprint in J22 (Jumpstart 2022). Canonical CardDefinition lives in its
+ * earliest set (TSP).
+ */
+val LightningAxeReprint = Printing(
+    oracleId = "81b90905-fbc0-426a-a084-c3300533abb4",
+    name = "Lightning Axe",
+    setCode = "J22",
+    collectorNumber = "569",
+    scryfallId = "68e43b0f-118c-4abe-a1f2-f3bacbba57c8",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68e43b0f-118c-4abe-a1f2-f3bacbba57c8.jpg?1783918926",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningAxeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningAxeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Axe reprint in JMP (Jumpstart). Canonical CardDefinition lives in its earliest
+ * set (TSP).
+ */
+val LightningAxeReprint = Printing(
+    oracleId = "81b90905-fbc0-426a-a084-c3300533abb4",
+    name = "Lightning Axe",
+    setCode = "JMP",
+    collectorNumber = "341",
+    scryfallId = "f65ea432-9ece-40bf-9cdc-95e01a85b78f",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f65ea432-9ece-40bf-9cdc-95e01a85b78f.jpg?1783930384",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/NeonatesRush.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/NeonatesRush.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Neonate's Rush
+ * {2}{R}
+ * Instant
+ *
+ * This spell costs {1} less to cast if you control a Vampire.
+ * Neonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card.
+ *
+ * Cost reduction is a [ModifySpellCost] self-cast [CostReductionSource.FixedIfControlFilter]
+ * (Venom's Hunger pattern). The two damage clauses share one target: 1 to the creature and 1 to
+ * its controller via [EffectTarget.TargetController] (Judgment Bolt pattern).
+ */
+val NeonatesRush = card("Neonate's Rush") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast if you control a Vampire.\n" +
+        "Neonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfControlFilter(
+                    amount = 1,
+                    filter = GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE)
+                )
+            )
+        )
+    }
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(1, creature)
+            .then(Effects.DealDamage(1, EffectTarget.TargetController))
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Justine Cruz"
+        flavorText = "\"We spend our entire existence pursuing the joy of our first night's feast.\"\n—Anje Falkenrath"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg?1783925594"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/LightningAxeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/LightningAxeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Axe reprint in SOI (Shadows over Innistrad). Canonical CardDefinition lives in
+ * its earliest set (TSP).
+ */
+val LightningAxeReprint = Printing(
+    oracleId = "81b90905-fbc0-426a-a084-c3300533abb4",
+    name = "Lightning Axe",
+    setCode = "SOI",
+    collectorNumber = "170",
+    scryfallId = "97d3105d-4cf9-48bf-8d12-27e856ae7a87",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97d3105d-4cf9-48bf-8d12-27e856ae7a87.jpg?1783937747",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StitchedMangler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StitchedMangler.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stitched Mangler
+ * {2}{U}
+ * Creature — Zombie Horror
+ * 2/3
+ *
+ * This creature enters tapped.
+ * When this creature enters, tap target creature an opponent controls. That creature doesn't
+ * untap during its controller's next untap step.
+ *
+ * "Enters tapped" is the self-replacement [EntersTapped]. The tap + skip-next-untap is the same
+ * construction as Crippling Chill: [Effects.Tap] followed by the [AbilityFlag.DOESNT_UNTAP]
+ * keyword grant with [Duration.UntilAfterAffectedControllersNextUntap].
+ */
+val StitchedMangler = card("Stitched Mangler") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Horror"
+    power = 2
+    toughness = 3
+    oracleText = "This creature enters tapped.\n" +
+        "When this creature enters, tap target creature an opponent controls. That creature doesn't " +
+        "untap during its controller's next untap step."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature) then
+            GrantKeywordEffect(
+                AbilityFlag.DOESNT_UNTAP.name,
+                creature,
+                Duration.UntilAfterAffectedControllersNextUntap
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg?1783937785"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/LightningAxe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/LightningAxe.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning Axe
+ * {R}
+ * Instant
+ *
+ * As an additional cost to cast this spell, discard a card or pay {5}.
+ * Lightning Axe deals 5 damage to target creature.
+ *
+ * The binary additional cost (discard a card OR pay {5}) is modeled with [ModalEffect.chooseOne]
+ * — the same fork Bitter Triumph uses for "discard a card or pay 3 life". Both modes resolve the
+ * same spell effect (5 damage to target creature); they differ only in the additional cost paid
+ * as the spell is cast. `countsAsModalSpell = false` because this is not a "Choose one — •" modal
+ * spell, so "whenever you cast a modal spell" triggers must not see it.
+ */
+val LightningAxe = card("Lightning Axe") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, discard a card or pay {5}.\n" +
+        "Lightning Axe deals 5 damage to target creature."
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            // Discard a card
+            Mode(
+                effect = Effects.DealDamage(5, EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(Targets.Creature),
+                description = "Discard a card — deal 5 damage to target creature",
+                additionalCosts = listOf(Costs.additional.DiscardCards(count = 1))
+            ),
+            // Pay {5}
+            Mode(
+                effect = Effects.DealDamage(5, EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(Targets.Creature),
+                description = "Pay {5} — deal 5 damage to target creature",
+                additionalManaCost = "{5}"
+            ),
+            countsAsModalSpell = false
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"A gargoyle's meat can be carved with an ordinary cleaver, but for its petrous hide . . .\"\n—Asmoranomardicadaistinaculdacar, The Underworld Cookbook"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg?1783943219"
+
+        ruling("2021-03-19", "The mana value of Lightning Axe is 1, no matter which additional cost you paid.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -1261,6 +1261,94 @@
     ]
 }
 
+// Fiend Hunter
+{
+    "name": "Fiend Hunter",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature enters, you may exile another target creature.\nWhen this creature leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1e4c7d8-11a5-40fe-962b-7e938bf08616.jpg?1783940994",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "If Fiend Hunter leaves the battlefield before its first ability has resolved, its second ability will trigger and do nothing. Then its first ability will resolve and exile the target creature indefinitely. This is different from abilities on other cards that exile a permanent \"until\" something happens."
+            },
+            {
+                "date": "2018-12-07",
+                "text": "Once the exiled creature returns, it's considered a new object with no relation to the object that it was. Auras attached to the exiled creature will be put into their owners' graveyards. Equipment attached to the exiled creature will become unattached and remain on the battlefield. Any counters on the exiled creature will cease to exist."
+            },
+            {
+                "date": "2018-12-07",
+                "text": "If a token is exiled this way, it won't return to the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Forbidden Alchemy
 {
     "name": "Forbidden Alchemy",

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -1248,6 +1248,79 @@
     ]
 }
 
+// Neonate's Rush
+{
+    "name": "Neonate's Rush",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast if you control a Vampire.\nNeonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "TargetController"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfControlFilter",
+                        "amount": 1,
+                        "filter": "creature Vampire"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Justine Cruz",
+        "flavorText": "\"We spend our entire existence pursuing the joy of our first night's feast.\"\n—Anje Falkenrath",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/dee17e12-e08f-4449-9f49-05f20e0d1670.jpg?1783925594"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Overgrown Farmland
 {
     "name": "Overgrown Farmland",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1233,6 +1233,68 @@
     ]
 }
 
+// Stitched Mangler
+{
+    "name": "Stitched Mangler",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Zombie Horror",
+    "oracleText": "This creature enters tapped.\nWhen this creature enters, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature an opponent controls"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DOESNT_UNTAP",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature an opponent controls"
+                            },
+                            "duration": "UntilAfterAffectedControllersNextUntap"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature an opponent controls"
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c03c643c-8e4c-4dc9-8756-c253fa057729.jpg?1783937785"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Strength of Arms
 {
     "name": "Strength of Arms",

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -111,6 +111,88 @@
     ]
 }
 
+// Lightning Axe
+{
+    "name": "Lightning Axe",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, discard a card or pay {5}.\nLightning Axe deals 5 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Discard a card — deal 5 damage to target creature",
+                    "additionalCosts": [
+                        {
+                            "type": "AdditionalAtom",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Pay {5} — deal 5 damage to target creature",
+                    "additionalManaCost": "{5}"
+                }
+            ],
+            "countsAsModalSpell": false
+        }
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"A gargoyle's meat can be carved with an ordinary cleaver, but for its petrous hide . . .\"\n—Asmoranomardicadaistinaculdacar, The Underworld Cookbook",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b748290-04b0-48a9-81aa-ab43182cf339.jpg?1783943219",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "The mana value of Lightning Axe is 1, no matter which additional cost you paid."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mystical Teachings
 {
     "name": "Mystical Teachings",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiendHunterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiendHunterScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.InnistradSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fiend Hunter — {1}{W}{W} Creature — Human Cleric 1/3
+ * When this creature enters, you may exile another target creature.
+ * When this creature leaves the battlefield, return the exiled card under its owner's control.
+ */
+class FiendHunterScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + InnistradSet.cards)
+        return d
+    }
+
+    test("exiles a creature on enter and returns it when Fiend Hunter dies") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+
+        val hunter = d.putCardInHand(p1, "Fiend Hunter")
+        d.giveMana(p1, Color.WHITE, 3)
+        d.castSpell(p1, hunter)
+        d.bothPass() // resolve the creature; ETB trigger goes on the stack and asks for a target
+
+        (d.pendingDecision is ChooseTargetsDecision) shouldBe true
+        d.submitTargetSelection(p1, listOf(victim))
+        d.bothPass() // resolve the ETB exile trigger
+
+        // Victim is exiled (under its owner p2's control zone), off the battlefield.
+        d.getExile(p2) shouldContain victim
+        d.state.getBattlefield(p2) shouldNotContain victim
+
+        // Kill Fiend Hunter with a burn spell (3 damage to a 1/3).
+        val bolt = d.putCardInHand(p1, "Lightning Bolt")
+        d.giveMana(p1, Color.RED, 1)
+        d.castSpell(p1, bolt, targets = listOf(hunter))
+        d.bothPass() // resolve bolt -> Fiend Hunter dies -> LTB return trigger goes on stack
+        d.bothPass() // resolve the LTB return trigger
+
+        // Victim returns to the battlefield under its owner's control; exile is empty.
+        d.state.getBattlefield(p2) shouldContain victim
+        d.getExile(p2) shouldNotContain victim
+    }
+
+    test("may decline the exile when a legal target exists") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bystander = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+
+        val hunter = d.putCardInHand(p1, "Fiend Hunter")
+        d.giveMana(p1, Color.WHITE, 3)
+        d.castSpell(p1, hunter)
+        d.bothPass()
+
+        (d.pendingDecision is ChooseTargetsDecision) shouldBe true
+        // Optional "you may" — choose no target.
+        d.submitTargetSelection(p1, emptyList())
+        d.bothPass()
+
+        // Nothing was exiled; the bystander stays on the battlefield.
+        d.getExile(p2) shouldNotContain bystander
+        d.state.getBattlefield(p2) shouldContain bystander
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningAxeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningAxeScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tsp.TimeSpiralSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lightning Axe — {R} Instant
+ * As an additional cost to cast this spell, discard a card or pay {5}.
+ * Lightning Axe deals 5 damage to target creature.
+ *
+ * The binary additional cost is a cast-time [ChooseOptionDecision] between the two modes; both
+ * resolve the same 5-damage effect and differ only in the additional cost paid.
+ */
+class LightningAxeScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + TimeSpiralSet.cards)
+        return d
+    }
+
+    /** Answer the cast-time decisions: pick [modeIndex], target [victim], discard [discardFodder]. */
+    fun GameTestDriver.finishCast(p1: EntityId, modeIndex: Int, victim: EntityId, discardFodder: EntityId?) {
+        var guard = 0
+        while (pendingDecision != null && guard++ < 12) {
+            when (val dec = pendingDecision) {
+                is ChooseOptionDecision -> submitDecision(p1, OptionChosenResponse(dec.id, modeIndex))
+                is ChooseTargetsDecision -> submitTargetSelection(p1, listOf(victim))
+                is SelectCardsDecision -> submitCardSelection(p1, listOf(discardFodder!!))
+                else -> error("unexpected decision ${dec!!::class.simpleName}")
+            }
+        }
+    }
+
+    test("discard mode: discard a card and deal 5 damage to the target creature") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Centaur Courser") // 3/3
+        val axe = d.putCardInHand(p1, "Lightning Axe")
+        val fodder = d.putCardInHand(p1, "Centaur Courser")
+        d.giveMana(p1, Color.RED, 1)
+
+        d.submit(CastSpell(playerId = p1, cardId = axe, paymentStrategy = PaymentStrategy.FromPool))
+            .isPaused shouldBe true
+        d.finishCast(p1, modeIndex = 0, victim = victim, discardFodder = fodder)
+        d.bothPass()
+
+        // 5 damage kills the 3/3; the discarded card and the spent spell are in the graveyard.
+        d.getGraveyard(p2) shouldContain victim
+        d.getGraveyard(p1) shouldContain fodder
+        d.getHand(p1) shouldNotContain fodder
+    }
+
+    test("pay mode: pay {5} and deal 5 damage without discarding") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Centaur Courser") // 3/3
+        val axe = d.putCardInHand(p1, "Lightning Axe")
+        val keeper = d.putCardInHand(p1, "Centaur Courser")
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 5)
+
+        d.submit(CastSpell(playerId = p1, cardId = axe, paymentStrategy = PaymentStrategy.FromPool))
+            .isPaused shouldBe true
+        d.finishCast(p1, modeIndex = 1, victim = victim, discardFodder = null)
+        d.bothPass()
+
+        // Creature dies; no card was discarded (pay mode).
+        d.getGraveyard(p2) shouldContain victim
+        d.getHand(p1) shouldContain keeper
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeonatesRushScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeonatesRushScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mid.InnistradMidnightHuntSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Neonate's Rush — {2}{R} Instant
+ * This spell costs {1} less to cast if you control a Vampire.
+ * Neonate's Rush deals 1 damage to target creature and 1 damage to its controller. Draw a card.
+ */
+class NeonatesRushScenarioTest : FunSpec({
+
+    // A minimal Vampire to switch the cost-reduction static on.
+    val testVampire = card("Test Vampire") {
+        manaCost = "{B}"
+        colorIdentity = "B"
+        typeLine = "Creature — Vampire"
+        power = 1
+        toughness = 1
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + InnistradMidnightHuntSet.cards + testVampire)
+        return d
+    }
+
+    test("deals 1 to a creature and 1 to its controller, then draws a card") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Savannah Lions") // 1/1
+
+        val rush = d.putCardInHand(p1, "Neonate's Rush")
+        val handBefore = d.getHand(p1).size
+        d.giveMana(p1, Color.RED, 3) // no Vampire -> full {2}{R}
+        d.castSpell(p1, rush, targets = listOf(victim)).isSuccess shouldBe true
+        d.bothPass()
+
+        // 1 damage kills the 1/1, and its controller takes 1.
+        d.getGraveyard(p2) shouldContain victim
+        d.getLifeTotal(p2) shouldBe 19
+        // Cast one card (-1) and drew one (+1) -> hand size unchanged.
+        d.getHand(p1).size shouldBe handBefore
+    }
+
+    test("costs {1} less while you control a Vampire") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(p1, "Test Vampire")
+        val victim = d.putCreatureOnBattlefield(p2, "Savannah Lions")
+
+        val rush = d.putCardInHand(p1, "Neonate's Rush")
+        // Only {1}{R} available — enough only if the Vampire discount applied.
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 1)
+        d.castSpell(p1, rush, targets = listOf(victim)).isSuccess shouldBe true
+        d.bothPass()
+
+        // The reduced cast still resolved: victim died and its controller took 1.
+        d.getGraveyard(p2) shouldContain victim
+        d.getLifeTotal(p2) shouldBe 19
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchedManglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchedManglerScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stitched Mangler — {2}{U} Creature — Zombie Horror 2/3
+ * This creature enters tapped.
+ * When this creature enters, tap target creature an opponent controls. That creature doesn't
+ * untap during its controller's next untap step.
+ */
+class StitchedManglerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ShadowsOverInnistradSet.cards)
+        return d
+    }
+
+    test("enters tapped, taps an opponent's creature, and keeps it tapped through its next untap") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        d.removeSummoningSickness(victim)
+
+        val mangler = d.putCardInHand(p1, "Stitched Mangler")
+        d.giveMana(p1, Color.BLUE, 3)
+        d.castSpell(p1, mangler)
+        d.bothPass() // resolve the creature; it enters tapped and its ETB trigger asks for a target
+
+        // Stitched Mangler entered tapped.
+        d.isTapped(mangler) shouldBe true
+
+        (d.pendingDecision is ChooseTargetsDecision) shouldBe true
+        d.submitTargetSelection(p1, listOf(victim))
+        d.bothPass() // resolve the ETB tap trigger
+
+        d.isTapped(victim) shouldBe true
+
+        // Advance to p2's untap step — the victim must stay tapped (doesn't untap).
+        d.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        d.activePlayer shouldBe p2
+        d.isTapped(victim) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements a handful of Innistrad Remastered (INR) cards. INR is a remaster set, so every card is a reprint — each canonical `CardDefinition` is placed in its **earliest real printing** and INR (plus any other scaffolded set that reprints it) gets a `Printing` row.

## Cards

| Card | Canonical set | Mechanic |
|------|---------------|----------|
| **Fiend Hunter** `{1}{W}{W}` | ISD | ETB "you may exile another target creature" (optional target) + LTB return. Modeled as `ExileUntilLeaves` + explicit `ReturnLinkedExileUnderOwnersControl`, which reproduces the classic two-trigger indefinite-exile interaction (per the CR ruling). |
| **Stitched Mangler** `{2}{U}` | SOI | Enters tapped (`EntersTapped`) + ETB tap target opponent creature that doesn't untap next untap step (`DOESNT_UNTAP` grant, `UntilAfterAffectedControllersNextUntap`). |
| **Neonate's Rush** `{2}{R}` | MID | Costs `{1}` less if you control a Vampire (`ModifySpellCost` / `FixedIfControlFilter`); deals 1 to a creature and 1 to its controller (`TargetController`); draw a card. |
| **Lightning Axe** `{R}` | TSP | "Discard a card or pay `{5}`" binary additional cost as a `ModalEffect.chooseOne` (discard mode vs per-mode `additionalManaCost`); 5 damage to target creature. |

## Reprint rows
- Fiend Hunter → DDQ, INR
- Stitched Mangler → INR
- Neonate's Rush → INR
- Lightning Axe → SOI, JMP, J22, INR

## Notes
- **No new SDK types** — all four compose existing effects/patterns (`add-card` scope only).
- Adds a scenario test per card (7 tests, all passing), covering exile+return, the optional "may" decline, enters-tapped + freeze-through-untap, split damage + draw, Vampire cost reduction, and both Lightning Axe additional-cost modes.
- Re-blessed the ISD/SOI/MID/TSP card snapshots (additions only; no unrelated card moved). `CardLintTest` and `check-card-printing` pass for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)