### PR TITLE
Support multi-layer single static abilities (CR 613.6)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3781,6 +3781,19 @@ staticAbility {
   "Enchanted creature ... is a Citizen with base power and toughness 1/1 and '{T}: Add {C}' named Humble Merchant."
 - `ConditionalStaticAbility` — static gated by a runtime `Condition`. A conditional wrapping a *multi-effect* ability
   (e.g. `TransformPermanent`) lowers through the plural converter and gates every resulting effect on the condition.
+- `CompositeStaticAbility(abilities)` — bundles several component static abilities into **one** printed static ability
+  whose single continuous effect spans multiple Rule 613 layers (CR 613.6). Use it when one printed ability grants a
+  *combination* of type/subtype/color/keyword/P/T changes to the same objects — e.g. Bello, Bard of the Brambles: "each
+  ... permanent ... is a 4/4 Elemental creature in addition to its other types and has indestructible [and] haste."
+  Authoring those as separate `staticAbility { }` blocks is wrong per CR 613.6: each block becomes an *independent*
+  effect that re-resolves its own affected set per layer (so the set can drift between layers) and drops its later-layer
+  parts if the source loses the ability in Layer 6. Bundling them tags the parts as one group so the engine locks the
+  affected-object set once (when the effect first starts to apply) and keeps applying every layer to that same set, even
+  if the ability is removed mid-sequence. The engine assigns every multi-effect ability (this, `AnimateLandGroup`,
+  `TransformPermanent`, Blood Moon's type+ability pair, ...) a shared `ContinuousEffectData.groupId` automatically; see
+  `StateProjector`'s group locking. Only layer-projected grants belong inside — abilities routed to other subsystems
+  (e.g. `GrantTriggeredAbility`, read by `TriggerDetector`) stay in their own top-level block. Gate the whole bundle by
+  wrapping it in a `ConditionalStaticAbility` (or setting `condition` on the `staticAbility { }` block).
 - `CantBeTurnedFaceUp(filter)` — matching permanents can't be turned face up (Layer 6; projects a
   `cantBeTurnedFaceUp` flag read by the turn-face-up handler/enumerator). Only meaningful while the
   permanent is face down (a face-up permanent can't be "turned face up"), so it's applied

--- a/docs/continuous-effect-dependency-system.md
+++ b/docs/continuous-effect-dependency-system.md
@@ -235,3 +235,38 @@ class StateProjector(val state: GameState) {
 
 This effectively solves the hardest logic problem in the engine while keeping the core `GameAction` logic pure and
 simple.
+
+## 6. Cross-Layer Grouping (Rule 613.6)
+
+Dependencies (613.8) order effects *within* a layer. Rule **613.6** governs a different problem: a *single* continuous
+effect that applies in **several** layers.
+
+> 613.6. If an effect should be applied in different layers and/or sublayers, the parts of the effect each apply in
+> their appropriate ones. If an effect starts to apply in one layer and/or sublayer, it will continue to be applied to
+> the **same set of objects** in each other applicable layer and/or sublayer, **even if the ability generating the
+> effect is removed during this process.**
+
+The canonical example: *"All noncreature artifacts become 2/2 artifact creatures."* The type change (Layer 4) is applied
+to the set of noncreature artifacts; the P/T set (Layer 7b) is applied to **those same permanents**, even though they
+are no longer noncreature artifacts by then. Bello, Bard of the Brambles is the same shape (Layer 4 type/subtype, Layer
+6 keywords, Layer 7b P/T), and additionally exercises the "even if the ability is removed" clause — if Bello loses all
+abilities in Layer 6, the animation it started in Layer 4 still sets the 4/4 in Layer 7b.
+
+### Implementation: effect groups
+
+A single static ability that lowers to more than one `ContinuousEffectData` (an `AnimateLandGroup`, a
+`TransformPermanent`, a `CompositeStaticAbility`, Blood Moon's type + ability pair, ...) is one continuous effect
+spanning multiple layers. `StaticAbilityHandler.toGroupedEffectData` stamps every such ability's effects with a shared
+`ContinuousEffectData.groupId` (unique per source permanent; single-layer abilities keep `groupId = null`). The
+`StateProjector` then enforces 613.6 for each group, keyed by `(sourceId, groupId)`:
+
+* **Same set of objects** — `lockAffected` records the affected-object set the *first* time a group is resolved. Because
+  the projector processes effects in ascending layer order, that's the group's earliest applicable layer. Every later
+  layer reuses the frozen set instead of re-resolving its filter (which could otherwise drift — a "noncreature artifact"
+  filter matches nothing once Layer 4 has made the artifacts creatures).
+* **Survives ability removal** — the Layer-7 "source lost all abilities" suppression (which correctly kills a standalone
+  lord anthem removed by Humility) is *skipped* for a group whose earliest layer is before Layer 6 (ABILITY). Such a
+  group "started to apply" before the removal, so per 613.6 its later-layer parts keep applying.
+
+This is orthogonal to 613.8: grouping decides *which set* a multi-layer effect uses across layers; dependency sorting
+decides the *order* of effects within a layer.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -46,6 +46,44 @@ data class ConditionalStaticAbility(
 }
 
 /**
+ * A single static ability whose one continuous effect spans multiple Rule 613 layers, expressed
+ * as a bundle of component static abilities that share one identity (CR 613.6).
+ *
+ * Per CR 613.6, when an effect applies in several layers/sublayers, the set of objects it affects
+ * is locked in as it *first* starts to apply and reused in every later applicable layer — and the
+ * effect keeps being applied even if the ability generating it is removed partway through the
+ * layer sequence. Authoring such an effect as separate `staticAbility { }` blocks makes the engine
+ * treat each layer as an independent effect: it re-resolves its own affected set per layer (so the
+ * set can drift between layers) and drops the later-layer parts if the source loses the ability in
+ * Layer 6. Bundling the parts here tags them as one grouped effect, so the engine locks the
+ * affected set once at the first layer and keeps applying every layer to that same set.
+ *
+ * Used for Bello, Bard of the Brambles: "each ... permanent ... is a 4/4 Elemental creature in
+ * addition to its other types and has indestructible [and] haste" — one printed ability touching
+ * Layer 4 (type/subtype), Layer 6 (keywords), and Layer 7b (base P/T).
+ *
+ * The component abilities are the ordinary grant primitives (GrantCardType, GrantSubtype,
+ * SetBasePowerToughnessStatic, GrantKeyword, ...), each carrying the shared filter. Only abilities
+ * projected through the layer system belong here; abilities handled by other subsystems (e.g.
+ * GrantTriggeredAbility, read by TriggerDetector) are not layer effects and stay in their own
+ * top-level block. Wrap the whole bundle in a `ConditionalStaticAbility` (or set a `condition` on
+ * the `staticAbility { }` block) to gate every layer on the same condition.
+ *
+ * @property abilities The component static abilities forming this one multi-layer ability.
+ */
+@SerialName("CompositeStaticAbility")
+@Serializable
+data class CompositeStaticAbility(
+    val abilities: List<StaticAbility>
+) : StaticAbility {
+    override val description: String = abilities.joinToString("; ") { it.description }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newAbilities = abilities.map { it.applyTextReplacement(replacer) }
+        return if (newAbilities != abilities) copy(abilities = newAbilities) else this
+    }
+}
+
+/**
  * Whenever enchanted land is tapped for mana, its controller adds additional mana.
  * Used for auras like Elvish Guidance: "Whenever enchanted land is tapped for mana,
  * its controller adds an additional {G} for each Elf on the battlefield."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BelloBardOfTheBrambles.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BelloBardOfTheBrambles.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantCardType
 import com.wingedsheep.sdk.scripting.GrantKeyword
@@ -26,11 +27,14 @@ import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
  * types and has indestructible, haste, and "Whenever this creature deals combat
  * damage to a player, draw a card."
  *
- * Implementation: each layer of the animation (add type, add subtype, set P/T,
- * grant indestructible, grant haste) is a separate `ConditionalStaticAbility` gated
- * by `IsYourTurn`. The combat-damage trigger is granted unconditionally — it can
- * only fire when the source is a creature in combat, which only happens on Bello's
- * controller's turn (when the gating condition adds the creature type).
+ * Implementation: the animation is one printed static ability whose single continuous effect
+ * spans Layer 4 (add creature type + Elemental subtype), Layer 6 (grant indestructible + haste),
+ * and Layer 7b (set base 4/4). Per CR 613.6 those parts must affect the *same* locked-in set of
+ * objects and keep applying even if Bello loses the ability mid-layer-sequence, so they are bundled
+ * into one [CompositeStaticAbility] (gated by `IsYourTurn`) rather than separate `staticAbility`
+ * blocks. The combat-damage trigger is granted separately — it is detected by TriggerDetector, not
+ * projected through the layer system, and it can only fire when the source is a creature in combat,
+ * which only happens on Bello's controller's turn (when the gating condition adds the creature type).
  */
 val BelloBardOfTheBrambles = card("Bello, Bard of the Brambles") {
     manaCost = "{1}{R}{G}"
@@ -47,25 +51,19 @@ val BelloBardOfTheBrambles = card("Bello, Bard of the Brambles") {
             .youControl()
     )
 
+    // One multi-layer static ability (CR 613.6): the type/subtype/keyword/P/T grants share a
+    // single locked-in affected set and all persist even if Bello loses this ability in Layer 6.
     staticAbility {
-        ability = GrantCardType("CREATURE", animatedFilter)
         condition = Conditions.IsYourTurn
-    }
-    staticAbility {
-        ability = GrantSubtype("Elemental", animatedFilter)
-        condition = Conditions.IsYourTurn
-    }
-    staticAbility {
-        ability = SetBasePowerToughnessStatic(4, 4, animatedFilter)
-        condition = Conditions.IsYourTurn
-    }
-    staticAbility {
-        ability = GrantKeyword(Keyword.INDESTRUCTIBLE, animatedFilter)
-        condition = Conditions.IsYourTurn
-    }
-    staticAbility {
-        ability = GrantKeyword(Keyword.HASTE, animatedFilter)
-        condition = Conditions.IsYourTurn
+        ability = CompositeStaticAbility(
+            listOf(
+                GrantCardType("CREATURE", animatedFilter),
+                GrantSubtype("Elemental", animatedFilter),
+                SetBasePowerToughnessStatic(4, 4, animatedFilter),
+                GrantKeyword(Keyword.INDESTRUCTIBLE, animatedFilter),
+                GrantKeyword(Keyword.HASTE, animatedFilter),
+            )
+        )
     }
     staticAbility {
         ability = GrantTriggeredAbility(

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -296,221 +296,210 @@
             {
                 "type": "ConditionalStaticAbility",
                 "ability": {
-                    "type": "GrantCardType",
-                    "cardType": "CREATURE",
-                    "filter": {
-                        "baseFilter": {
-                            "cardPredicates": [
-                                {
-                                    "type": "Or",
-                                    "predicates": [
+                    "type": "CompositeStaticAbility",
+                    "abilities": [
+                        {
+                            "type": "GrantCardType",
+                            "cardType": "CREATURE",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
                                         {
-                                            "type": "And",
+                                            "type": "Or",
                                             "predicates": [
-                                                "IsArtifact",
                                                 {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Equipment"
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Equipment"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Aura"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
                                         {
-                                            "type": "And",
-                                            "predicates": [
-                                                "IsEnchantment",
-                                                {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Aura"
-                                                }
-                                            ]
+                                            "type": "ManaValueAtLeast",
+                                            "min": 4
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ManaValueAtLeast",
-                                    "min": 4
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
                                 }
-                            ],
-                            "controllerPredicate": "ControlledByYou"
-                        }
-                    }
-                },
-                "condition": "IsYourTurn"
-            },
-            {
-                "type": "ConditionalStaticAbility",
-                "ability": {
-                    "type": "GrantSubtype",
-                    "subtype": "Elemental",
-                    "filter": {
-                        "baseFilter": {
-                            "cardPredicates": [
-                                {
-                                    "type": "Or",
-                                    "predicates": [
+                            }
+                        },
+                        {
+                            "type": "GrantSubtype",
+                            "subtype": "Elemental",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
                                         {
-                                            "type": "And",
+                                            "type": "Or",
                                             "predicates": [
-                                                "IsArtifact",
                                                 {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Equipment"
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Equipment"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Aura"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
                                         {
-                                            "type": "And",
-                                            "predicates": [
-                                                "IsEnchantment",
-                                                {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Aura"
-                                                }
-                                            ]
+                                            "type": "ManaValueAtLeast",
+                                            "min": 4
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ManaValueAtLeast",
-                                    "min": 4
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
                                 }
-                            ],
-                            "controllerPredicate": "ControlledByYou"
-                        }
-                    }
-                },
-                "condition": "IsYourTurn"
-            },
-            {
-                "type": "ConditionalStaticAbility",
-                "ability": {
-                    "type": "SetBasePowerToughnessStatic",
-                    "power": 4,
-                    "toughness": 4,
-                    "filter": {
-                        "baseFilter": {
-                            "cardPredicates": [
-                                {
-                                    "type": "Or",
-                                    "predicates": [
+                            }
+                        },
+                        {
+                            "type": "SetBasePowerToughnessStatic",
+                            "power": 4,
+                            "toughness": 4,
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
                                         {
-                                            "type": "And",
+                                            "type": "Or",
                                             "predicates": [
-                                                "IsArtifact",
                                                 {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Equipment"
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Equipment"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Aura"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
                                         {
-                                            "type": "And",
-                                            "predicates": [
-                                                "IsEnchantment",
-                                                {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Aura"
-                                                }
-                                            ]
+                                            "type": "ManaValueAtLeast",
+                                            "min": 4
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ManaValueAtLeast",
-                                    "min": 4
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
                                 }
-                            ],
-                            "controllerPredicate": "ControlledByYou"
-                        }
-                    }
-                },
-                "condition": "IsYourTurn"
-            },
-            {
-                "type": "ConditionalStaticAbility",
-                "ability": {
-                    "type": "GrantKeyword",
-                    "keyword": "INDESTRUCTIBLE",
-                    "filter": {
-                        "baseFilter": {
-                            "cardPredicates": [
-                                {
-                                    "type": "Or",
-                                    "predicates": [
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
                                         {
-                                            "type": "And",
+                                            "type": "Or",
                                             "predicates": [
-                                                "IsArtifact",
                                                 {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Equipment"
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Equipment"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Aura"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
                                         {
-                                            "type": "And",
-                                            "predicates": [
-                                                "IsEnchantment",
-                                                {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Aura"
-                                                }
-                                            ]
+                                            "type": "ManaValueAtLeast",
+                                            "min": 4
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ManaValueAtLeast",
-                                    "min": 4
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
                                 }
-                            ],
-                            "controllerPredicate": "ControlledByYou"
-                        }
-                    }
-                },
-                "condition": "IsYourTurn"
-            },
-            {
-                "type": "ConditionalStaticAbility",
-                "ability": {
-                    "type": "GrantKeyword",
-                    "keyword": "HASTE",
-                    "filter": {
-                        "baseFilter": {
-                            "cardPredicates": [
-                                {
-                                    "type": "Or",
-                                    "predicates": [
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
                                         {
-                                            "type": "And",
+                                            "type": "Or",
                                             "predicates": [
-                                                "IsArtifact",
                                                 {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Equipment"
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Equipment"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsEnchantment",
+                                                        {
+                                                            "type": "NotSubtype",
+                                                            "subtype": "Aura"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
                                         {
-                                            "type": "And",
-                                            "predicates": [
-                                                "IsEnchantment",
-                                                {
-                                                    "type": "NotSubtype",
-                                                    "subtype": "Aura"
-                                                }
-                                            ]
+                                            "type": "ManaValueAtLeast",
+                                            "min": 4
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ManaValueAtLeast",
-                                    "min": 4
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
                                 }
-                            ],
-                            "controllerPredicate": "ControlledByYou"
+                            }
                         }
-                    }
+                    ]
                 },
                 "condition": "IsYourTurn"
             },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -30,7 +30,17 @@ data class ContinuousEffectSourceComponent(
 data class ContinuousEffectData(
     val modification: Modification,
     val affectsFilter: AffectsFilter? = null,
-    val sourceCondition: Condition? = null
+    val sourceCondition: Condition? = null,
+    /**
+     * Identifies the single multi-layer static ability this modification belongs to (CR 613.6).
+     * Non-null and shared across every [ContinuousEffectData] a single static ability lowers to
+     * when that ability touches more than one layer (e.g. an animate/transform ability, or a
+     * [com.wingedsheep.sdk.scripting.CompositeStaticAbility]). Effects sharing a groupId (within
+     * one source permanent) resolve their affected-object set once — when the group first starts
+     * to apply — and reuse it in every later layer, and keep applying even if the source loses the
+     * generating ability in Layer 6. Null for single-layer abilities, which need no grouping.
+     */
+    val groupId: String? = null
 ) {
     val layer: Layer get() = modification.layer
     val sublayer: Sublayer? get() = modification.sublayer
@@ -193,7 +203,14 @@ data class ContinuousEffect(
      * [EffectContext] after the enchantment has left. Null for static-ability effects, which
      * always resolve their controller from the source permanent on the battlefield.
      */
-    val controllerId: EntityId? = null
+    val controllerId: EntityId? = null,
+    /**
+     * See [ContinuousEffectData.groupId]. Identifies the single multi-layer static ability this
+     * effect belongs to (CR 613.6); shared across the group's per-layer effects from one source.
+     * The lock key is `(sourceId, groupId)`, so the same groupId string on two different source
+     * permanents stays independent. Null for single-layer and floating effects.
+     */
+    val groupId: String? = null
 ) {
     val layer: Layer get() = modification.layer
     val sublayer: Sublayer? get() = modification.sublayer

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -154,21 +154,50 @@ class StateProjector(
         // Sort effects by layer and dependency
         val sortedEffects = effectSorter.sortByLayerAndDependency(effects, state)
 
+        // CR 613.6 group locking. A single multi-layer static ability lowers to several effects
+        // that share a groupId (within one source permanent). Such an effect must affect the *same
+        // set of objects* in every layer it applies in, with that set locked in when it first
+        // starts to apply. [lockAffected] records the affected set the first time a group is
+        // resolved (bands run in ascending layer order, so that's the group's earliest layer) and
+        // returns that frozen set for every later layer, ignoring per-layer re-resolution. Keyed by
+        // (sourceId, groupId) so the same groupId on two permanents never merges. A no-op (returns
+        // the freshly-resolved set) for ungrouped single-layer effects.
+        val lockedGroups = HashMap<Pair<EntityId, String>, Set<EntityId>>()
+        fun lockAffected(effect: ContinuousEffect, resolved: Set<EntityId>): Set<EntityId> {
+            val groupId = effect.groupId ?: return resolved
+            return lockedGroups.getOrPut(effect.sourceId to groupId) { resolved }
+        }
+
+        // Earliest layer each group starts to apply. Per CR 613.6, a group that started applying
+        // before Layer 6 keeps applying its later-layer parts "even if the ability generating the
+        // effect is removed during this process" — used below to exempt such groups from the
+        // Layer-7 lose-all-abilities suppression.
+        val groupFirstLayer = HashMap<Pair<EntityId, String>, Layer>()
+        for (effect in sortedEffects) {
+            val groupId = effect.groupId ?: continue
+            val key = effect.sourceId to groupId
+            val existing = groupFirstLayer[key]
+            if (existing == null || effect.layer.ordinal < existing.ordinal) {
+                groupFirstLayer[key] = effect.layer
+            }
+        }
+
         // === Layer 2 (Control) ===
         val controlEffects = sortedEffects.filter { it.layer == Layer.CONTROL }
         for (effect in controlEffects) {
-            effectApplicator.applyEffect(effect, state, projectedValues)
+            effectApplicator.applyEffect(effect.copy(affectedEntities = lockAffected(effect, effect.affectedEntities)), state, projectedValues)
         }
 
         // Re-resolve controller-dependent filters for layers 3-6 now that control is established
         val nonControlNonPTEffects = sortedEffects.filter { it.layer != Layer.CONTROL && it.layer != Layer.POWER_TOUGHNESS }
             .map { effect -> applyControllerGate(effect, projectedValues) }
             .map { effect ->
-                if (effect.affectsFilter != null && filterResolver.isControllerDependentFilter(effect.affectsFilter)) {
-                    effect.copy(affectedEntities = filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues))
+                val resolved = if (effect.affectsFilter != null && filterResolver.isControllerDependentFilter(effect.affectsFilter)) {
+                    filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues)
                 } else {
-                    effect
+                    effect.affectedEntities
                 }
+                effect.copy(affectedEntities = lockAffected(effect, resolved))
             }
 
         // === Layers 3-4 (Text + Type) ===
@@ -193,14 +222,17 @@ class StateProjector(
             }
         }
 
-        // Re-resolve creature-dependent filters for layers 5-6 now that type changes are applied
+        // Re-resolve creature-dependent filters for layers 5-6 now that type changes are applied.
+        // A grouped effect keeps its locked set (CR 613.6) — [lockAffected] ignores this re-resolve
+        // for any group already frozen at an earlier layer.
         val postTypeEffects = nonControlNonPTEffects.filter { it.layer != Layer.TEXT && it.layer != Layer.TYPE }
             .map { effect ->
-                if (effect.affectsFilter != null && filterResolver.isCreatureDependentFilter(effect.affectsFilter)) {
-                    effect.copy(affectedEntities = filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues))
+                val resolved = if (effect.affectsFilter != null && filterResolver.isCreatureDependentFilter(effect.affectsFilter)) {
+                    filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues)
                 } else {
-                    effect
+                    effect.affectedEntities
                 }
+                effect.copy(affectedEntities = lockAffected(effect, resolved))
             }
 
         // === Layers 5-6 (Color + Ability) ===
@@ -251,22 +283,33 @@ class StateProjector(
             val effect = applyControllerGate(rawEffect, projectedValues)
             if (effect.layer != Layer.POWER_TOUGHNESS) return@mapNotNull effect
 
+            // CR 613.6: a grouped effect that started applying before Layer 6 keeps applying its
+            // Layer-7 part "even if the ability generating the effect is removed during this
+            // process" (e.g. Bello's 4/4 set survives Bello losing all abilities). Only such
+            // groups are exempt — a standalone P/T static (a lord anthem removed by Humility) has
+            // no earlier-layer part and is still suppressed below.
+            val startedBeforeAbility = effect.groupId?.let { groupId ->
+                (groupFirstLayer[effect.sourceId to groupId]?.ordinal ?: Int.MAX_VALUE) < Layer.ABILITY.ordinal
+            } ?: false
+
             // Suppress effects from sources that lost all abilities (e.g., a lord under Humility),
-            // but NOT from sources that are themselves the source of a RemoveAllAbilities effect.
+            // but NOT from sources that are themselves the source of a RemoveAllAbilities effect,
+            // nor from a multi-layer group that already started applying before Layer 6.
             val sourceProjected = projectedValues[effect.sourceId]
             if (sourceProjected != null && sourceProjected.lostAllAbilities &&
-                effect.sourceId !in removeAllAbilitiesSources) {
+                effect.sourceId !in removeAllAbilitiesSources && !startedBeforeAbility) {
                 return@mapNotNull null
             }
 
-            if (effect.affectsFilter != null &&
+            val resolved = if (effect.affectsFilter != null &&
                 (filterResolver.isSubtypeDependentFilter(effect.affectsFilter) ||
                     filterResolver.isControllerDependentFilter(effect.affectsFilter) ||
                     filterResolver.isCreatureDependentFilter(effect.affectsFilter))) {
-                effect.copy(affectedEntities = filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues))
+                filterResolver.resolveAffectedEntities(state, effect.sourceId, effect.affectsFilter, projectedValues)
             } else {
-                effect
+                effect.affectedEntities
             }
+            effect.copy(affectedEntities = lockAffected(effect, resolved))
         }
 
         // Apply layer 7 continuous effects
@@ -486,7 +529,8 @@ class StateProjector(
                         modification = effect.modification,
                         affectedEntities = filterResolver.resolveAffectedEntities(state, entityId, effectiveFilter, projectedValues),
                         sourceCondition = effect.sourceCondition,
-                        affectsFilter = effectiveFilter
+                        affectsFilter = effectiveFilter,
+                        groupId = effect.groupId
                     )
                 })
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.sdk.scripting.MustBeBlocked
 import com.wingedsheep.sdk.scripting.MustBlock
 import com.wingedsheep.sdk.scripting.MustAttack
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
 import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
@@ -225,10 +226,9 @@ class StaticAbilityHandler(
         // unlocked; the component is re-baked on later unlocks by RoomDoorUnlocker.
         val allStaticAbilities = RoomFaceStatics.activeStaticAbilities(container, cardDefinition)
 
-        // Convert static abilities to continuous effect data
-        val effectsData = allStaticAbilities.flatMap { ability ->
-            convertStaticAbilities(ability)
-        }
+        // Convert static abilities to continuous effect data, tagging each ability's effects with
+        // a shared group id when it touches more than one layer (CR 613.6 — see toGroupedEffectData).
+        val effectsData = allStaticAbilities.toGroupedEffectData()
 
         if (effectsData.isNotEmpty()) {
             result = result.with(ContinuousEffectSourceComponent(effectsData))
@@ -308,12 +308,29 @@ class StaticAbilityHandler(
         container: ComponentContainer,
         staticAbilities: List<StaticAbility>
     ): ComponentContainer {
-        val effectsData = staticAbilities.flatMap { ability ->
-            convertStaticAbilities(ability)
-        }
+        val effectsData = staticAbilities.toGroupedEffectData()
         return if (effectsData.isNotEmpty()) container.with(ContinuousEffectSourceComponent(effectsData))
         else container
     }
+
+    /**
+     * Lower a list of static abilities to [ContinuousEffectData], stamping every effect that comes
+     * from the *same* multi-layer ability with a shared [ContinuousEffectData.groupId] (CR 613.6).
+     *
+     * An ability that lowers to more than one effect (an animate/transform ability, a
+     * [com.wingedsheep.sdk.scripting.CompositeStaticAbility], Blood Moon's type+ability pair, ...)
+     * is one continuous effect spanning multiple layers: its affected-object set must be locked in
+     * at the first layer and reused in the rest, and it keeps applying even if the ability is
+     * removed mid-sequence. The shared groupId lets [StateProjector] enforce that. Single-effect
+     * abilities need no grouping and keep a null groupId. The id is the ability's index in this
+     * list — stable and unique per source permanent (the lock key also includes the source id, so
+     * ids never collide across permanents).
+     */
+    private fun List<StaticAbility>.toGroupedEffectData(): List<ContinuousEffectData> =
+        flatMapIndexed { index, ability ->
+            val effects = convertStaticAbilities(ability)
+            if (effects.size > 1) effects.map { it.copy(groupId = "g$index") } else effects
+        }
 
     /**
      * Convert a static ability to a list of ContinuousEffectData.
@@ -325,6 +342,10 @@ class StaticAbilityHandler(
             is GrantAdditionalTypesToGroup -> convertGrantAdditionalTypesToGroup(ability)
             is SetLandTypesForGroup -> convertSetLandTypesForGroup(ability)
             is TransformPermanent -> convertTransformPermanent(ability)
+            // A CompositeStaticAbility is one printed ability whose single effect spans several
+            // layers (CR 613.6): flatten its component abilities. The shared groupId is stamped by
+            // toGroupedEffectData at the call site, so the whole bundle locks one affected set.
+            is CompositeStaticAbility -> ability.abilities.flatMap { convertStaticAbilities(it) }
             // A ConditionalStaticAbility wrapping a multi-effect ability (e.g. TransformPermanent)
             // must lower through the plural converter too, then gate every resulting effect on the
             // condition — otherwise the singular path returns null and the whole gated ability is
@@ -782,6 +803,7 @@ class StaticAbilityHandler(
             is GrantAdditionalTypesToGroup,
             is SetLandTypesForGroup,
             is TransformPermanent,
+            is CompositeStaticAbility,
 
             // Trigger system (TriggerDetector / TriggerAbilityResolver / TriggerIndex):
             is AdditionalAttackTriggers,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiLayerStaticAbilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiLayerStaticAbilityTest.kt
@@ -1,0 +1,260 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.AffectsFilter
+import com.wingedsheep.engine.mechanics.layers.ContinuousEffectData
+import com.wingedsheep.engine.mechanics.layers.ContinuousEffectSourceComponent
+import com.wingedsheep.engine.mechanics.layers.Modification
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blc.cards.BelloBardOfTheBrambles
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 613.6 — a single continuous effect that applies in several layers/sublayers affects the
+ * *same* locked-in set of objects in each layer, and keeps applying "even if the ability generating
+ * the effect is removed during this process".
+ *
+ * The engine models such an effect as a group of [ContinuousEffectData] sharing a
+ * [ContinuousEffectData.groupId] (one group per multi-layer static ability). This suite pins the
+ * two behaviours the group machinery must guarantee, both at the raw projection level (direct
+ * effect injection) and end-to-end through Bello, Bard of the Brambles (a
+ * [com.wingedsheep.sdk.scripting.CompositeStaticAbility]).
+ *
+ * Regression coverage for issue #1317.
+ */
+class MultiLayerStaticAbilityTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(vararg extraCards: CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + extraCards.toList())
+        return driver
+    }
+
+    fun GameTestDriver.init() {
+        initMirrorMatch(
+            deck = com.wingedsheep.sdk.model.Deck.of("Plains" to 20, "Forest" to 20),
+            skipMulligans = true
+        )
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun GameTestDriver.addContinuousEffects(entityId: EntityId, effects: List<ContinuousEffectData>) {
+        replaceState(state.updateEntity(entityId) { container ->
+            val existing = container.get<ContinuousEffectSourceComponent>()
+            val merged = if (existing != null) existing.effects + effects else effects
+            container.with(ContinuousEffectSourceComponent(merged))
+        })
+    }
+
+    // A blank enchantment used only as a carrier for injected continuous effects.
+    fun blankEnchantment(name: String) =
+        CardDefinition.enchantment(name, ManaCost.parse("{2}"), script = CardScript())
+
+    // A vanilla artifact with a chosen mana value (no P/T, no abilities of its own).
+    fun blankArtifact(name: String, cost: String) =
+        CardDefinition.artifact(name, ManaCost.parse(cost))
+
+    // "Noncreature artifact you control." Controller-dependent, so Layer 4/7 re-resolve it; and its
+    // membership FLIPS once the object becomes a creature — the exact shape CR 613.6 must lock in.
+    val noncreatureArtifactYouControl = AffectsFilter.Generic(
+        GroupFilter(baseFilter = GameObjectFilter.Artifact.notCreature().youControl())
+    )
+
+    // =========================================================================
+    // Raw projection: the group machinery in isolation.
+    // =========================================================================
+
+    context("CR 613.6 group locking (direct effect injection)") {
+
+        test("same set of objects: a grouped animate keeps setting P/T on the now-creature it made") {
+            // "Each noncreature artifact you control is a 2/2 creature" — Layer 4 makes it a
+            // creature, Layer 7b sets its P/T to those SAME objects (CR 613.6's noncreature-
+            // artifact example). Because the two parts share a groupId, the affected set is locked
+            // in at Layer 4 and reused in Layer 7b even though the artifact is no longer a
+            // "noncreature artifact" by then.
+            val driver = createDriver(blankEnchantment("Animus"), blankArtifact("Idol", "{4}"))
+            driver.init()
+            val p = driver.activePlayer!!
+
+            val source = driver.putPermanentOnBattlefield(p, "Animus")
+            val idol = driver.putPermanentOnBattlefield(p, "Idol")
+            driver.addContinuousEffects(source, listOf(
+                ContinuousEffectData(Modification.AddType("CREATURE"), noncreatureArtifactYouControl, groupId = "g0"),
+                ContinuousEffectData(Modification.SetPowerToughness(2, 2), noncreatureArtifactYouControl, groupId = "g0"),
+            ))
+
+            val projected = projector.project(driver.state)
+
+            projected.isCreature(idol) shouldBe true
+            projected.getPower(idol) shouldBe 2
+            projected.getToughness(idol) shouldBe 2
+        }
+
+        test("ungrouped contrast: the Layer 7b part is lost because the filter re-resolves per layer") {
+            // The SAME two effects WITHOUT a shared groupId: each layer re-resolves the filter
+            // independently, so by Layer 7b the artifact is a creature and drops out of
+            // "noncreature artifact" — its P/T is never set. This documents the bug that grouping
+            // (CompositeStaticAbility / groupId) fixes.
+            val driver = createDriver(blankEnchantment("Animus"), blankArtifact("Idol", "{4}"))
+            driver.init()
+            val p = driver.activePlayer!!
+
+            val source = driver.putPermanentOnBattlefield(p, "Animus")
+            val idol = driver.putPermanentOnBattlefield(p, "Idol")
+            driver.addContinuousEffects(source, listOf(
+                ContinuousEffectData(Modification.AddType("CREATURE"), noncreatureArtifactYouControl),
+                ContinuousEffectData(Modification.SetPowerToughness(2, 2), noncreatureArtifactYouControl),
+            ))
+
+            val projected = projector.project(driver.state)
+
+            projected.isCreature(idol) shouldBe true
+            // Layer 7b dropped it — no P/T set.
+            projected.getPower(idol) shouldBe null
+            projected.getToughness(idol) shouldBe null
+        }
+
+        test("removed mid-sequence: a grouped effect that started before Layer 6 still applies Layer 7") {
+            // The animate source loses all abilities (Layer 6). Per CR 613.6, because the animate
+            // effect already started applying in Layer 4, it keeps applying its Layer 7b P/T set to
+            // the locked-in objects even though the ability generating it was removed.
+            val driver = createDriver(
+                blankEnchantment("Animus"), blankEnchantment("Silencer"), blankArtifact("Idol", "{4}")
+            )
+            driver.init()
+            val p = driver.activePlayer!!
+
+            val source = driver.putPermanentOnBattlefield(p, "Animus")
+            val idol = driver.putPermanentOnBattlefield(p, "Idol")
+            val silencer = driver.putPermanentOnBattlefield(p, "Silencer")
+            driver.addContinuousEffects(source, listOf(
+                ContinuousEffectData(Modification.AddType("CREATURE"), noncreatureArtifactYouControl, groupId = "g0"),
+                ContinuousEffectData(Modification.SetPowerToughness(2, 2), noncreatureArtifactYouControl, groupId = "g0"),
+            ))
+            // Silencer removes all abilities from the animate source (the ability generating the effect).
+            driver.addContinuousEffects(silencer, listOf(
+                ContinuousEffectData(Modification.RemoveAllAbilities, AffectsFilter.SpecificEntities(setOf(source))),
+            ))
+
+            val projected = projector.project(driver.state)
+
+            projected.hasLostAllAbilities(source) shouldBe true
+            projected.isCreature(idol) shouldBe true
+            projected.getPower(idol) shouldBe 2
+            projected.getToughness(idol) shouldBe 2
+        }
+
+        test("ungrouped contrast: losing the ability suppresses the standalone Layer 7 P/T set") {
+            // Without grouping, the Layer 7 part is a standalone effect from a source that lost all
+            // abilities, so it IS suppressed — the artifact becomes a 0/0-ish creature with no P/T.
+            val driver = createDriver(
+                blankEnchantment("Animus"), blankEnchantment("Silencer"), blankArtifact("Idol", "{4}")
+            )
+            driver.init()
+            val p = driver.activePlayer!!
+
+            val source = driver.putPermanentOnBattlefield(p, "Animus")
+            val idol = driver.putPermanentOnBattlefield(p, "Idol")
+            val silencer = driver.putPermanentOnBattlefield(p, "Silencer")
+            driver.addContinuousEffects(source, listOf(
+                ContinuousEffectData(Modification.AddType("CREATURE"), noncreatureArtifactYouControl),
+                ContinuousEffectData(Modification.SetPowerToughness(2, 2), noncreatureArtifactYouControl),
+            ))
+            driver.addContinuousEffects(silencer, listOf(
+                ContinuousEffectData(Modification.RemoveAllAbilities, AffectsFilter.SpecificEntities(setOf(source))),
+            ))
+
+            val projected = projector.project(driver.state)
+
+            projected.getPower(idol) shouldBe null
+            projected.getToughness(idol) shouldBe null
+        }
+    }
+
+    // =========================================================================
+    // End-to-end: Bello, Bard of the Brambles (CompositeStaticAbility).
+    // =========================================================================
+
+    context("Bello, Bard of the Brambles") {
+
+        test("animates a qualifying artifact across layers 4/6/7 on your turn") {
+            val driver = createDriver(
+                BelloBardOfTheBrambles, blankArtifact("Big Idol", "{4}")
+            )
+            driver.init()
+            val p = driver.activePlayer!!
+
+            driver.putPermanentOnBattlefield(p, "Bello, Bard of the Brambles")
+            val idol = driver.putPermanentOnBattlefield(p, "Big Idol")
+
+            val projected = projector.project(driver.state)
+
+            // Layer 4: a 4/4 Elemental creature in addition to its other types (still an artifact).
+            projected.isCreature(idol) shouldBe true
+            projected.hasSubtype(idol, "Elemental") shouldBe true
+            projected.getTypes(idol).contains("ARTIFACT") shouldBe true
+            // Layer 7b: base 4/4.
+            projected.getPower(idol) shouldBe 4
+            projected.getToughness(idol) shouldBe 4
+            // Layer 6: indestructible and haste.
+            projected.hasKeyword(idol, Keyword.INDESTRUCTIBLE) shouldBe true
+            projected.hasKeyword(idol, Keyword.HASTE) shouldBe true
+        }
+
+        test("does not animate an artifact with mana value below 4, nor Equipment") {
+            val driver = createDriver(
+                BelloBardOfTheBrambles,
+                blankArtifact("Small Idol", "{3}"),
+                CardDefinition.equipment("Big Boots", ManaCost.parse("{4}"), equipCost = ManaCost.parse("{2}")),
+            )
+            driver.init()
+            val p = driver.activePlayer!!
+
+            driver.putPermanentOnBattlefield(p, "Bello, Bard of the Brambles")
+            val smallIdol = driver.putPermanentOnBattlefield(p, "Small Idol")
+            val boots = driver.putPermanentOnBattlefield(p, "Big Boots")
+
+            val projected = projector.project(driver.state)
+
+            projected.isCreature(smallIdol) shouldBe false
+            projected.isCreature(boots) shouldBe false
+        }
+
+        test("keeps the animation when Bello loses all abilities (CR 613.6)") {
+            // Bello's animate ability is removed in Layer 6, but it already started applying in
+            // Layer 4, so the whole effect — including the Layer 7b 4/4 — keeps applying.
+            val driver = createDriver(
+                BelloBardOfTheBrambles, blankEnchantment("Silencer"), blankArtifact("Big Idol", "{4}")
+            )
+            driver.init()
+            val p = driver.activePlayer!!
+
+            val bello = driver.putPermanentOnBattlefield(p, "Bello, Bard of the Brambles")
+            val idol = driver.putPermanentOnBattlefield(p, "Big Idol")
+            val silencer = driver.putPermanentOnBattlefield(p, "Silencer")
+            driver.addContinuousEffects(silencer, listOf(
+                ContinuousEffectData(Modification.RemoveAllAbilities, AffectsFilter.SpecificEntities(setOf(bello))),
+            ))
+
+            val projected = projector.project(driver.state)
+
+            projected.hasLostAllAbilities(bello) shouldBe true
+            // The animated artifact still projects as a 4/4 creature.
+            projected.isCreature(idol) shouldBe true
+            projected.getPower(idol) shouldBe 4
+            projected.getToughness(idol) shouldBe 4
+        }
+    }
+})


### PR DESCRIPTION
Fixes #1317.

## Problem

A static ability whose single continuous effect spans several Rule 613 layers — Bello, Bard of the Brambles being the motivating card (Layer 4 type/subtype, Layer 6 keywords, Layer 7b P/T) — was authored as separate `staticAbility { }` blocks. The engine therefore treated each layer as an **independent** effect, violating **CR 613.6** two ways:

> 613.6. … If an effect starts to apply in one layer and/or sublayer, it will continue to be applied to the **same set of objects** in each other applicable layer and/or sublayer, **even if the ability generating the effect is removed during this process.**

1. **Same set of objects** — each layer re-resolved its own filter, so the affected set could drift between layers (the canonical "all noncreature artifacts become 2/2 creatures" case: the Layer-7b P/T must apply to the objects the Layer-4 type change selected, even though they're no longer noncreature artifacts).
2. **Survives ability removal** — the Layer-7 "source lost all abilities" suppression dropped the P/T part if the source lost the ability in Layer 6, even though the effect had already started applying in Layer 4.

## Approach

Model a single multi-layer ability as one **group**:

- `ContinuousEffectData` / `ContinuousEffect` carry a `groupId`, shared across every effect a single multi-layer ability lowers to. `StaticAbilityHandler.toGroupedEffectData` assigns it (per source permanent) to `AnimateLandGroup`, `TransformPermanent`, `SetLandTypesForGroup`/Blood Moon, and the new `CompositeStaticAbility`.
- `StateProjector` enforces CR 613.6 per `(sourceId, groupId)`: **locks** the affected-object set the first time the group applies (its earliest layer) and reuses it in every later layer, and **exempts** a group that started before Layer 6 from the Layer-7 lose-all-abilities suppression.
- New SDK `CompositeStaticAbility(abilities)` — one printed ability bundling composable grant primitives. Bello is rewritten to use it (its combat-damage trigger stays a separate block, as it isn't layer-projected).

Ungrouped single-layer effects keep `groupId = null` and behave exactly as before.

## Checklist (from the issue)

- [x] layered continuous effects can support multiple layers
- [x] removing a multi-layered ability still applies all layers if it started to apply before removal
- [x] multi-layered abilities apply to the same set of objects in each layer

## Tests

`MultiLayerStaticAbilityTest` (rules-engine) pins all three, both via direct effect injection and end-to-end through Bello:
- same-set locking (grouped animate keeps setting P/T on the now-creature it made) + ungrouped contrast that shows the dropped Layer-7 part;
- persistence through ability removal + ungrouped contrast;
- Bello animates a qualifying artifact across layers, ignores mv<4 / Equipment, and keeps the 4/4 when Bello loses all abilities.

`:mtg-sdk:test :rules-engine:test :mtg-sets:test` all green (BLC snapshot re-blessed for Bello's new composite shape). Docs updated: `card-sdk-language-reference.md` (§9) and `continuous-effect-dependency-system.md` (new §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)