### PR TITLE
Add Knight of Doves and Gnawing Crescendo (Wilds of Eldraine)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GnawingCrescendo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GnawingCrescendo.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gnawing Crescendo
+ * {2}{R}
+ * Instant
+ *
+ * Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature you control dies
+ * this turn, create a 1/1 black Rat creature token with "This token can't block."
+ *
+ * Two clauses composed:
+ *  - The team pump — [Patterns.Group.modifyStatsForAll] over creatures you control (+2/+0, end of
+ *    turn), same shape as Rabbit Response / Valley Rally.
+ *  - A turn-duration event-based delayed trigger ([CreateDelayedTriggerEffect] with
+ *    `expiry = EndOfTurn`, `fireOnce = false`, mirroring Waltz of Rage) that fires once per
+ *    nontoken-creature-you-control death this turn, each firing making the shared [woeRatToken].
+ *    The per-creature `leavesBattlefield` spec (ANY binding, nontoken filter) matches the singular
+ *    "a nontoken creature" wording — a board wipe fires it once per qualifying creature.
+ */
+val GnawingCrescendo = card("Gnawing Crescendo") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature " +
+        "you control dies this turn, create a 1/1 black Rat creature token with \"This token can't block.\""
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            2, 0,
+            GroupFilter(GameObjectFilter.Creature.youControl())
+        ).then(
+            CreateDelayedTriggerEffect(
+                trigger = Triggers.leavesBattlefield(
+                    filter = GameObjectFilter.Creature.youControl().nontoken(),
+                    to = Zone.GRAVEYARD,
+                    binding = TriggerBinding.ANY
+                ),
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+                fireOnce = false,
+                effect = woeRatToken()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Alexey Kruglov"
+        flavorText = "Totentanz's song had no lyrics, but the rats understood it nonetheless. " +
+            "\"You own this land,\" it said. \"You deserve to feast.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg?1783915094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KnightOfDoves.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KnightOfDoves.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Knight of Doves
+ * {2}{W}
+ * Creature — Human Knight
+ * 1/3
+ *
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1
+ * white Bird creature token with flying.
+ *
+ * Same trigger shape as Wicked Visitor: any enchantment you control hitting the graveyard from
+ * the battlefield — destroyed, sacrificed, self-sacrificing (Hopeless Nightmare) or a Role token
+ * falling off when replaced — so it uses the generic `leavesBattlefield` factory with an `ANY`
+ * binding rather than a SELF-bound constant. The payoff is a 1/1 white flying Bird token.
+ */
+val KnightOfDoves = card("Knight of Doves") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 1
+    toughness = 3
+    oracleText = "Whenever an enchantment you control is put into a graveyard from the battlefield, " +
+        "create a 1/1 white Bird creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1783914993"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Volkan Baǵa"
+        flavorText = "So many birds, yet the air was still and empty of song. Part of Syr Damon knew " +
+            "something wasn't right, but it was a far-off worry, unimportant and soon forgotten."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg?1783915132"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1641,6 +1641,78 @@
     ]
 }
 
+// Gnawing Crescendo
+{
+    "name": "Gnawing Crescendo",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature you control dies this turn, create a 1/1 black Rat creature token with \"This token can't block.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Rat"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                        "staticAbilities": [
+                            "CantBlock"
+                        ]
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "creature nontoken ctrl:you",
+                            "from": "Battlefield",
+                            "to": "Graveyard"
+                        },
+                        "binding": "ANY"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Alexey Kruglov",
+        "flavorText": "Totentanz's song had no lyrics, but the rats understood it nonetheless. \"You own this land,\" it said. \"You deserve to feast.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/254fc64a-9734-44a6-8869-ab03512f1a99.jpg?1783915094"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Harried Spearguard
 {
     "name": "Harried Spearguard",
@@ -1924,6 +1996,57 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Knight of Doves
+{
+    "name": "Knight of Doves",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 white Bird creature token with flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Bird"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1783914993"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "So many birds, yet the air was still and empty of song. Part of Syr Damon knew something wasn't right, but it was a far-off worry, unimportant and soon forgotten.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4f33617-ad19-4d42-ab94-6f21a7fb3dd4.jpg?1783915132"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
@@ -24,6 +24,8 @@ import io.kotest.matchers.shouldNotBe
  *  - **Cursed Courtier** — ETB Cursed Role on itself, dropping it to a 1/1 lifelinker.
  *  - **Voracious Vermin** — ETB Rat, and the "another creature you control dies" +1/+1 counter.
  *  - **Wicked Visitor** — an enchantment you control hitting the graveyard drains each opponent.
+ *  - **Knight of Doves** — an enchantment you control hitting the graveyard makes a 1/1 white flying Bird.
+ *  - **Gnawing Crescendo** — team +2/+0, and a turn-long delayed trigger that Rats each nontoken death.
  */
 class WoeCardsScenarioTest : ScenarioTestBase() {
 
@@ -423,6 +425,93 @@ class WoeCardsScenarioTest : ScenarioTestBase() {
 
                 withClue("sacrificing the enchantment feeds Wicked Visitor's drain") {
                     game.getLifeTotal(2) shouldBe opponentLife - 1
+                }
+            }
+        }
+
+        context("Knight of Doves") {
+
+            test("an enchantment you control hitting the graveyard makes a 1/1 white flying Bird") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Knight of Doves")
+                    .withCardOnBattlefield(1, "Hopeless Nightmare")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val nightmare = game.findPermanent("Hopeless Nightmare")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = nightmare,
+                        abilityId = nightmareSacrificeAbility
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val bird = game.findPermanent("Bird Token")
+                withClue("sacrificing the enchantment should feed the Knight's trigger") {
+                    bird shouldNotBe null
+                }
+                val projected = projector.project(game.state)
+                withClue("the Bird is a 1/1 flier") {
+                    projected.getPower(bird!!) shouldBe 1
+                    projected.getToughness(bird) shouldBe 1
+                    projected.hasKeyword(bird, Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+
+        context("Gnawing Crescendo") {
+
+            test("gives your creatures +2/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Gnawing Crescendo")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gnawing Crescendo").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = projector.project(game.state)
+                withClue("2/2 Grizzly Bears becomes 4/2") {
+                    projected.getPower(bears) shouldBe 4
+                    projected.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("a nontoken creature you control dying this turn creates a Rat that can't block") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Gnawing Crescendo")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gnawing Crescendo").error shouldBe null
+                game.resolveStack()
+
+                withClue("no creature has died yet, so no Rat") {
+                    game.findPermanent("Rat Token") shouldBe null
+                }
+
+                // +2/+0 leaves Grizzly Bears at 4/2, so Shock's 2 damage is still lethal.
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Shock", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the death this turn fires the delayed trigger → a Rat token") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    val rat = game.findPermanent("Rat Token")
+                    rat shouldNotBe null
+                    game.state.projectedState.cantBlock(rat!!) shouldBe true
                 }
             }
         }


### PR DESCRIPTION
Adds two mono-color Wilds of Eldraine cards, both composed entirely from existing SDK primitives — no engine/SDK changes.

## Cards

**Knight of Doves** — `{2}{W}` Creature — Human Knight, 1/3
> Whenever an enchantment you control is put into a graveyard from the battlefield, create a 1/1 white Bird creature token with flying.

Same trigger shape as the already-merged Wicked Visitor: an ANY-binding `leavesBattlefield` (enchantment you control → graveyard). Payoff is a 1/1 white flying Bird token.

**Gnawing Crescendo** — `{2}{R}` Instant
> Creatures you control get +2/+0 until end of turn. Whenever a nontoken creature you control dies this turn, create a 1/1 black Rat creature token with "This token can't block."

Two composed clauses:
- Team pump via `Patterns.Group.modifyStatsForAll` (same as Rabbit Response / Valley Rally).
- A turn-long event-based delayed trigger (`CreateDelayedTriggerEffect`, `EndOfTurn` expiry, `fireOnce = false`, mirroring Waltz of Rage) that makes the shared `woeRatToken()` once per qualifying death.

## Testing
- Scenario tests added to `WoeCardsScenarioTest` — Bird P/T + flying; team +2/+0; and the delayed death → can't-block Rat (with the "no death yet ⇒ no Rat" negative case). All 18 tests in the class pass.
- WOE golden snapshot re-blessed; diff adds only the two new cards' trees.
- `:mtg-sets:test` (lint / facade-boundary / snapshot) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)