### PR TITLE
Add the LCI god cycle (Ojer ×4 + Aclazotz) + Rebound, SetMinimumDamage,
  MultiplyTokenCreation

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 257 / 286
+**Implemented:** 258 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -168,7 +168,7 @@
 - [x] Nicanzil, Current Conductor
 - [x] Nurturing Bristleback
 - [x] Oaken Siren
-- [ ] Ojer Axonil, Deepest Might
+- [x] Ojer Axonil, Deepest Might
 - [x] Ojer Kaslem, Deepest Growth
 - [ ] Ojer Pakpatiq, Deepest Epoch
 - [x] Ojer Taq, Deepest Foundation

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 256 / 286
+**Implemented:** 257 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -171,7 +171,7 @@
 - [ ] Ojer Axonil, Deepest Might
 - [x] Ojer Kaslem, Deepest Growth
 - [ ] Ojer Pakpatiq, Deepest Epoch
-- [ ] Ojer Taq, Deepest Foundation
+- [x] Ojer Taq, Deepest Foundation
 - [x] Oltec Archaeologists
 - [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,12 +2,12 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 258 / 286
+**Implemented:** 259 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
 - [x] Abyssal Gorestalker
-- [ ] Aclazotz, Deepest Betrayal
+- [x] Aclazotz, Deepest Betrayal
 - [x] Acolyte of Aclazotz
 - [x] Acrobatic Leap
 - [x] Adaptive Gemguard

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 259 / 286
+**Implemented:** 260 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -170,7 +170,7 @@
 - [x] Oaken Siren
 - [x] Ojer Axonil, Deepest Might
 - [x] Ojer Kaslem, Deepest Growth
-- [ ] Ojer Pakpatiq, Deepest Epoch
+- [x] Ojer Pakpatiq, Deepest Epoch
 - [x] Ojer Taq, Deepest Foundation
 - [x] Oltec Archaeologists
 - [x] Oltec Cloud Guard

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 255 / 286
+**Implemented:** 256 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -169,7 +169,7 @@
 - [x] Nurturing Bristleback
 - [x] Oaken Siren
 - [ ] Ojer Axonil, Deepest Might
-- [ ] Ojer Kaslem, Deepest Growth
+- [x] Ojer Kaslem, Deepest Growth
 - [ ] Ojer Pakpatiq, Deepest Epoch
 - [ ] Ojer Taq, Deepest Foundation
 - [x] Oltec Archaeologists

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -708,7 +708,7 @@ sealed interface ReplacementEffect {
 }
 
 // Doubling Season: double token creation
-data class DoubleTokenCreation(
+data class MultiplyTokenCreation(
     override val appliesTo: EventPattern = EventPattern.TokenCreationEvent()
 ) : ReplacementEffect
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5465,6 +5465,10 @@ default to "you" so card authors don't need to pass it explicitly.
   `DynamicAmounts.permanentsSacrificedThisTurn()` amount for "that much" damage (Sawblade Skinripper:
   "At the beginning of your end step, if you sacrificed one or more permanents this turn, this creature
   deals that much damage to any target").
+- `YouDealtRedNoncombatDamageThisTurn(atLeast = 1)` — red sources you controlled dealt at least
+  `atLeast` noncombat damage this turn. `Compare(TurnTracking(Player.You, TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT),
+  GTE, Fixed(atLeast))`, backed by the per-player `RedNoncombatDamageDealtThisTurnComponent`. Gates
+  Temple of Power's transform-back (back of Ojer Axonil, Deepest Might).
 - `GraveyardContains(filter)` — "there is at least one card matching `filter` in your graveyard"
   (`Exists(Player.You, Zone.GRAVEYARD, filter)`). Compose with `Conditions.All`/`Any` for multi-type
   checks, e.g. `All(GraveyardContains(Filters.Instant), GraveyardContains(Filters.Sorcery))` =
@@ -6161,6 +6165,11 @@ this turn").
   counter (which sums every player's sacrifices). Backs `Conditions.YouSacrificedPermanentsThisTurn(atLeast)`
   and `DynamicAmounts.permanentsSacrificedThisTurn(player)` — e.g. Sawblade Skinripper's "if you sacrificed
   one or more permanents this turn, ... deals that much damage".
+- `RED_NONCOMBAT_DAMAGE_DEALT` — total noncombat damage red sources a player controlled dealt this turn
+  (controller-scoped). Backed by the per-player `RedNoncombatDamageDealtThisTurnComponent`, incremented in
+  `DamageUtils.dealDamageToTarget` on the source's controller whenever a red source deals positive noncombat
+  damage, and reset to 0 at end of turn. Backs `Conditions.YouDealtRedNoncombatDamageThisTurn(atLeast)` —
+  Temple of Power's transform gate (back of Ojer Axonil, Deepest Might).
 
 `SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity?)` /
 `DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` —
@@ -6403,6 +6412,14 @@ replacementEffect {
   "as long as …, prevent …" statics (Spirit of Resistance: a five-distinct-colors `Compare` gate).
 - `CapDamage(maxAmount, appliesTo)` — clamp matching damage to `maxAmount` (a *replacement* distinct
   from prevent/modify; applied after all amplification). Divine Presence: `CapDamage(3, DamageEvent(recipient = Any))`.
+- `SetMinimumDamage(minAmount = 0, dynamicMinimum?, appliesTo)` — the **floor** mirror of `CapDamage`:
+  raise matching damage *up to* a minimum (larger amounts unchanged; a zero would-be amount is not
+  raised — a source only "deals damage" once it deals a positive amount). `dynamicMinimum` (a
+  `DynamicAmount`, else the flat `minAmount`) is evaluated against the **replacement's source**
+  permanent, like `ModifyDamageAmount.dynamicModifier`. Applied after all amplification/capping. Ojer
+  Axonil, Deepest Might: `SetMinimumDamage(dynamicMinimum = DynamicAmounts.sourcePower(), appliesTo =
+  DamageEvent(recipient = Opponent, source = SourceFilter.Matching(GameObjectFilter.Any.withColor(RED).youControl()),
+  damageType = NonCombat))`.
 - `DoubleDamage(restrictions?, appliesTo)` — double matching damage (Gratuitous Violence, Furnace of
   Rath). `restrictions: List<Condition>` (default empty) gates the doubling on extra conditions
   evaluated against the source's controller — the same pattern as `PreventDamage.restrictions`. The

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6570,6 +6570,17 @@ replacementEffect {
   `Effects.GrantCounterPlacementModifier(...)` (§4 Counters) instead — it records a controller-scoped
   modifier in a turn-scoped game-state store consulted from the same counter-placement chokepoint,
   and expires at end of turn.
+- `MultiplyTokenCreation(factor = 2, appliesTo)` / `ModifyTokenCount(modifier, appliesTo)` —
+  **static** token-count replacements living on a battlefield permanent. `MultiplyTokenCreation`
+  multiplies the number of tokens created by `factor` (Doubling Season / Anointed Procession /
+  Exalted Sunborn — `factor = 2`; **Ojer Taq, Deepest Foundation** — `factor = 3`); several stack
+  multiplicatively. `ModifyTokenCount` shifts the count by a fixed amount. `appliesTo` defaults to
+  `EventPattern.TokenCreationEvent(controller = You)`; the multiplier runs in `CreateTokenExecutor`,
+  the executor for **creature** tokens (it always builds a "… Creature" type line — Treasure/Clue/Map
+  and other predefined tokens go through a separate executor that isn't multiplied), so an
+  unfiltered `MultiplyTokenCreation` scopes to creature tokens in practice. `tokenFilter` on the
+  event is not yet honored by the count path (filtered events are skipped), so express "creature
+  tokens" via the default rather than `tokenFilter = Creature`.
 - `ReplaceTokenCreationWithAttachedCopy(optional, oncePerTurn, attachmentVerb, appliesTo)` —
   "the first time you would create one or more tokens each turn, you may instead create that
   many tokens that are copies of [attached] permanent." Works for both Equipment and Auras —

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4550,6 +4550,19 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > multi-set parameterized keywords (`prowess()`, `rampage(n)`, `keywordAbility(…)`) remain on the core
 > builder. New set mechanics get an extension file in `dsl/mechanics/`.
 
+> **Rebound** (`Keyword.REBOUND`, CR 702.88). "If this spell was cast from your hand, instead of
+> putting it into your graveyard as it resolves, exile it and, at the beginning of your next upkeep,
+> you may cast this card from exile without paying its mana cost." Modeled entirely in the
+> spell-resolution path (`StackResolver.resolveNonPermanentSpell`): a spell whose card def carries the
+> printed keyword **or** that was granted rebound via `GrantKeywordToSpellEffect(Keyword.REBOUND, …)`
+> (stored on `SpellGrantedKeywordsComponent`) and was cast from hand exiles on resolution and schedules
+> a one-shot step-based `DelayedTriggeredAbility` (`fireAtStep = UPKEEP`, `fireOnPlayerId = caster`,
+> `notBeforeTurn = turn + 1`) whose effect is `MayEffect(GatherCards(Self) → CastFromCollectionWithoutPayingCostEffect)`
+> — the same free-cast-from-exile pipeline suspend uses. Casting from exile is not "from hand", so it
+> doesn't rebound again. **Ojer Pakpatiq, Deepest Epoch** grants it to instants you cast from hand via
+> `Triggers.youCastSpell(GameObjectFilter.Instant, requires = setOf(SpellCastPredicate.CastFromZone(Zone.HAND)))`
+> → `GrantKeywordToSpellEffect(Keyword.REBOUND, EffectTarget.TriggeringEntity)`.
+
 > **Enduring** (Duskmourn Glimmer cycle). `card { enduring() }` wires the full mechanic: "When this
 > permanent dies, if it was a creature, return it to the battlefield under its owner's control. It's an
 > enchantment. (It's not a creature.)" Modeled like **Persist** — a synthesized SELF dies-trigger detected

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -603,14 +603,20 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   (the opposite face — front→back), `FRONT` ("return it front face up" — the eikon Saga's final chapter flips
   back to the legend), or `BACK`. The front face's activated ability is sorcery-speed
   (`timing = TimingRule.SorcerySpeed`); Jecht uses it from a "may" combat-damage trigger instead.
-- `ReturnSelfFromGraveyardTransformed()` — "Return this card from your graveyard to the battlefield
-  transformed" (Garland, Knight of Cornelia). Returns the *source card* from the graveyard to the
-  battlefield with its back face up; pair with `activateFromZone = Zone.GRAVEYARD` on the owning
-  activated ability. No transform triggers fire (the card was never turned over on the battlefield);
-  the back face's ETB triggers fire normally. No-ops if the source left the graveyard before
-  resolution, or if it isn't a double-faced card (a single-faced card instructed to enter transformed
-  doesn't move at all). Raw type `ReturnSelfFromZoneTransformedEffect(fromZone)` generalizes to other
-  source zones.
+- `ReturnSelfFromGraveyardTransformed(tapped = false)` — "Return this card from your graveyard to the
+  battlefield transformed" (Garland, Knight of Cornelia). Returns the *source card* from the graveyard
+  to the battlefield with its back face up; pair with `activateFromZone = Zone.GRAVEYARD` on the owning
+  activated ability, **or wire it to `Triggers.Dies`** for the "when this dies, return it transformed"
+  templating (LCI god cycle — Ojer Axonil/Kaslem/Pakpatiq/Taq // Temples, Aclazotz). No transform
+  triggers fire (the card was never turned over on the battlefield); the back face's ETB triggers fire
+  normally. No-ops if the source left the graveyard before resolution, or if it isn't a double-faced
+  card (a single-faced card instructed to enter transformed doesn't move at all). Pass `tapped = true`
+  to return the back-face permanent **tapped** ("...return it to the battlefield tapped and
+  transformed"). Because the graveyard→battlefield move preserves the entity id, "...with N counters
+  on it" (Ojer Pakpatiq's three time counters) composes as `Composite(ReturnSelfFromGraveyardTransformed(
+  tapped = true), AddCounters(counter, n, EffectTarget.Self))` — the following `Self` still resolves to
+  the returned permanent. Raw type `ReturnSelfFromZoneTransformedEffect(fromZone, tapped)` generalizes
+  to other source zones.
 - `ReturnCreaturesPutInGraveyardThisTurn(player)` — Patriarch's Bidding shape.
 - `ReturnSameNamedFromGraveyard(target = ContextTarget(0))` — return the target graveyard card and
   **every other card with the same name** in the controller's graveyard to the battlefield **tapped**

--- a/manual-scenarios/sets/lci/god-cycle.json
+++ b/manual-scenarios/sets/lci/god-cycle.json
@@ -1,0 +1,71 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Ojer Kaslem, Deepest Growth",
+      "Ojer Taq, Deepest Foundation",
+      "Ojer Axonil, Deepest Might",
+      "Aclazotz, Deepest Betrayal",
+      "Ojer Pakpatiq, Deepest Epoch",
+      "Lathril, Blade of the Elves",
+      "Shock"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Shock", "Shock", "Forest", "Island", "Forest", "Island", "Forest", "Grizzly Bears", "Forest", "Island", "Forest", "Island", "Forest", "Island", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Forest", "Mountain", "Hero's Downfall", "Hero's Downfall"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Hill Giant"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Swamp", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -465,7 +465,18 @@ enum class Keyword(val displayName: String) {
      * Wired via the `increment()` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder],
      * which attaches this display-only keyword plus the cast-spell triggered ability.
      */
-    INCREMENT("Increment");
+    INCREMENT("Increment"),
+
+    /**
+     * Rebound (CR 702.88). "If this spell was cast from your hand, instead of putting it into
+     * your graveyard as it resolves, exile it and, at the beginning of your next upkeep, you may
+     * cast this card from exile without paying its mana cost." A static ability that functions
+     * while the spell is on the stack (read by the spell-resolution path in `StackResolver`,
+     * which honors both the printed keyword and one granted to the spell via
+     * `GrantKeywordToSpellEffect` — Ojer Pakpatiq, Deepest Epoch grants it to instants you cast
+     * from hand).
+     */
+    REBOUND("Rebound");
 
     companion object {
         fun fromString(value: String): Keyword? =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1291,6 +1291,17 @@ object Conditions {
         )
 
     /**
+     * If red sources you controlled dealt [atLeast] or more noncombat damage this turn
+     * (controller-scoped). Backed by the per-player `RedNoncombatDamageDealtThisTurnComponent`.
+     * Gates Temple of Power's transform-back (back of Ojer Axonil, Deepest Might).
+     */
+    fun YouDealtRedNoncombatDamageThisTurn(atLeast: Int = 1): ConditionInterface =
+        trackerAtLeast(
+            com.wingedsheep.sdk.scripting.values.TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT,
+            atLeast = atLeast,
+        )
+
+    /**
      * If a permanent of the given card type entered the battlefield under the given player's
      * control this turn. The permanent need not still be on the battlefield, still be of that
      * type, or still be under that player's control — only the entry event matters.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -926,11 +926,15 @@ object Effects {
     /**
      * Return the source card from your graveyard to the battlefield with its back face up —
      * "Return this card from your graveyard to the battlefield transformed" (Garland, Knight
-     * of Cornelia). Pair with `activateFromZone = Zone.GRAVEYARD` on the owning ability. No-ops
-     * if the source left the graveyard before resolution or is not a double-faced card.
+     * of Cornelia). Pair with `activateFromZone = Zone.GRAVEYARD` on the owning ability, or wire
+     * it to `Triggers.Dies` for the LCI "god cycle" dies-and-return templating. No-ops if the
+     * source left the graveyard before resolution or is not a double-faced card.
+     *
+     * @param tapped return the back-face permanent tapped ("...return it to the battlefield
+     *   **tapped** and transformed", Ojer Axonil/Kaslem/Pakpatiq/Taq // Temples, Aclazotz).
      */
-    fun ReturnSelfFromGraveyardTransformed(): Effect =
-        ReturnSelfFromZoneTransformedEffect(Zone.GRAVEYARD)
+    fun ReturnSelfFromGraveyardTransformed(tapped: Boolean = false): Effect =
+        ReturnSelfFromZoneTransformedEffect(Zone.GRAVEYARD, tapped = tapped)
 
     /**
      * Exile a double-faced permanent, then return it to the battlefield as a new object on the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -678,6 +678,43 @@ data class CapDamage(
     }
 }
 
+/**
+ * Raise damage to a minimum amount — the floor mirror of [CapDamage]. If a matching source
+ * would deal **less than** the minimum, it deals exactly the minimum instead (larger amounts
+ * are unchanged, and a zero would-be amount is not raised — the source only "deals damage" once
+ * it deals a positive amount). Distinct from [ModifyDamageAmount] (which adds unconditionally):
+ * this clamps to a lower bound.
+ *
+ * The minimum is [minAmount], or — when [dynamicMinimum] is non-null — an amount evaluated at
+ * damage time against the **replacement's source** permanent (as with [ModifyDamageAmount]'s
+ * `dynamicModifier`). Ojer Axonil, Deepest Might: "If a red source you control would deal an
+ * amount of noncombat damage less than Ojer Axonil's power to an opponent, that source deals
+ * damage equal to Ojer Axonil's power instead." →
+ * `SetMinimumDamage(dynamicMinimum = DynamicAmount.SourcePower, appliesTo = DamageEvent(
+ *   recipient = Opponent, source = SourceFilter.Matching(red you-control), damageType = NonCombat))`.
+ */
+@SerialName("SetMinimumDamage")
+@Serializable
+data class SetMinimumDamage(
+    val minAmount: Int = 0,
+    val dynamicMinimum: DynamicAmount? = null,
+    override val appliesTo: EventPattern
+) : ReplacementEffect {
+    override val description: String
+        get() {
+            val floor = dynamicMinimum?.description ?: "$minAmount"
+            return "If ${appliesTo.description}, it deals $floor damage instead"
+        }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newDynamic = dynamicMinimum?.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo || newDynamic !== dynamicMinimum)
+            copy(appliesTo = newAppliesTo, dynamicMinimum = newDynamic)
+        else this
+    }
+}
+
 // =============================================================================
 // Draw Replacement Effects
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -27,8 +27,8 @@ import kotlinx.serialization.Serializable
  *
  * Examples:
  * ```kotlin
- * // Doubling Season (tokens)
- * DoubleTokenCreation(
+ * // Doubling Season (tokens) — factor defaults to 2; Ojer Taq passes factor = 3
+ * MultiplyTokenCreation(
  *     appliesTo = EventPattern.TokenCreationEvent(controller = ControllerFilter.You)
  * )
  *
@@ -74,13 +74,21 @@ sealed interface ReplacementEffect : TextReplaceable<ReplacementEffect> {
  * Double the number of tokens created.
  * Example: Doubling Season, Parallel Lives, Anointed Procession
  */
-@SerialName("DoubleTokenCreation")
+@SerialName("MultiplyTokenCreation")
 @Serializable
-data class DoubleTokenCreation(
+data class MultiplyTokenCreation(
+    val factor: Int = 2,
     override val appliesTo: EventPattern = EventPattern.TokenCreationEvent()
 ) : ReplacementEffect {
-    override val description: String =
-        "If ${appliesTo.description}, create twice that many of those tokens instead"
+    override val description: String
+        get() {
+            val times = when (factor) {
+                2 -> "twice"
+                3 -> "three times"
+                else -> "$factor times"
+            }
+            return "If ${appliesTo.description}, create $times that many of those tokens instead"
+        }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
@@ -98,12 +98,20 @@ data object ReturnSelfFromExileTransformedEffect : Effect {
  * put a card that isn't a double-faced card onto the battlefield transformed, it will not enter
  * at all"), the executor no-ops when the source is not a double-faced card, and it also no-ops
  * if the source has already left [fromZone] by the time the ability resolves.
+ *
+ * [tapped] returns the back-face permanent tapped — the templating used by the LCI "god cycle"
+ * dies-triggers ("When Ojer X dies, return it to the battlefield **tapped** and transformed").
+ * Because the graveyard→battlefield move preserves the entity id, a card that enters with
+ * counters ("...with three time counters on it", Ojer Pakpatiq) composes this effect with a
+ * following `AddCounters(..., EffectTarget.Self)` — no dedicated counter parameter is needed.
  */
 @SerialName("ReturnSelfFromZoneTransformed")
 @Serializable
 data class ReturnSelfFromZoneTransformedEffect(
     val fromZone: Zone = Zone.GRAVEYARD,
+    val tapped: Boolean = false,
 ) : Effect {
     override val description: String =
-        "Return this card from your ${fromZone.displayName.lowercase()} to the battlefield transformed"
+        "Return this card from your ${fromZone.displayName.lowercase()} to the battlefield transformed" +
+            if (tapped) " tapped" else ""
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -104,6 +104,13 @@ enum class TurnTracker {
      */
     PERMANENTS_SACRIFICED,
     /**
+     * Total noncombat damage red sources this player controlled have dealt this turn
+     * (controller-scoped). Backed by `RedNoncombatDamageDealtThisTurnComponent`, reset to 0 for
+     * every player at end of turn. Powers Temple of Power's transform gate ("red sources you
+     * controlled dealt 4 or more noncombat damage this turn", back of Ojer Axonil, Deepest Might).
+     */
+    RED_NONCOMBAT_DAMAGE_DEALT,
+    /**
      * Number of *distinct* elemental bending keyword actions ([com.wingedsheep.sdk.core.BendType]:
      * waterbend, earthbend, firebend, airbend) the player has performed this turn — 0 through 4.
      * Backed by `BendsThisTurnComponent`, reset to empty for every player at the start of each
@@ -135,6 +142,7 @@ enum class TurnTracker {
         CARDS_DRAWN -> "the number of cards ${player.description} have drawn this turn"
         CARDS_PUT_INTO_EXILE -> "the number of cards put into exile this turn"
         PERMANENTS_SACRIFICED -> "the number of permanents ${player.description} sacrificed this turn"
+        RED_NONCOMBAT_DAMAGE_DEALT -> "the noncombat damage red sources ${player.description} controlled dealt this turn"
         DISTINCT_BENDS -> "the number of different ways ${player.description} bent this turn"
     }
 }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
@@ -741,7 +741,7 @@ class CardDslTest : DescribeSpec({
 
         it("should have compositional ReplacementEffect types available") {
             // Test that replacement effect types are properly defined with compositional filters
-            val tokenDoubler = DoubleTokenCreation()
+            val tokenDoubler = MultiplyTokenCreation()
             tokenDoubler.appliesTo.shouldBeInstanceOf<EventPattern.TokenCreationEvent>()
 
             // Hardened Scales - +1 counter when +1/+1 counters placed on creatures you control

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
@@ -327,12 +327,12 @@ class CardSerializationRoundTripTest : DescribeSpec({
             val card = card("Doubling Season") {
                 manaCost = "{4}{G}"
                 typeLine = "Enchantment"
-                replacementEffect(DoubleTokenCreation())
+                replacementEffect(MultiplyTokenCreation())
                 replacementEffect(DoubleCounterPlacement())
             }
 
             val serialized = CardLoader.toJson(card)
-            serialized shouldContain "DoubleTokenCreation"
+            serialized shouldContain "MultiplyTokenCreation"
             serialized shouldContain "DoubleCounterPlacement"
 
             val deserialized = CardLoader.fromJson(serialized)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ExaltedSunborn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/ExaltedSunborn.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.eoe.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.DoubleTokenCreation
+import com.wingedsheep.sdk.scripting.MultiplyTokenCreation
 
 /**
  * Exalted Sunborn
@@ -30,7 +30,7 @@ val ExaltedSunborn = card("Exalted Sunborn") {
 
     // Doubling Season-style token replacement. The engine resolves the count
     // multiplier in CreateTokenExecutor before any per-token replacements run.
-    replacementEffect(DoubleTokenCreation())
+    replacementEffect(MultiplyTokenCreation())
 
     warp = "{1}{W}"
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AclazotzDeepestBetrayal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AclazotzDeepestBetrayal.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aclazotz, Deepest Betrayal // Temple of the Dead (The Lost Caverns of Ixalan)
+ * {3}{B}{B}
+ * Legendary Creature — Bat God // Land
+ *
+ * Front — Aclazotz, Deepest Betrayal (4/4, Flying, lifelink)
+ *   Whenever Aclazotz attacks, each opponent discards a card. For each opponent who can't, you
+ *   draw a card.
+ *   Whenever an opponent discards a land card, create a 1/1 black Bat creature token with flying.
+ *   When Aclazotz dies, return it to the battlefield tapped and transformed under its owner's
+ *   control.
+ *
+ * Back — Temple of the Dead (Land)
+ *   {T}: Add {B}.
+ *   {2}{B}, {T}: Transform this land. Activate only if a player has one or fewer cards in hand
+ *   and only as a sorcery.
+ *
+ * Implementation:
+ *  - The attack trigger draws for each opponent who can't discard (an empty-handed opponent)
+ *    via [DynamicAmount.CountPlayersWith]`(EachOpponent, hand <= 0)` — the Bandit's Talent idiom —
+ *    then makes each opponent discard via [Effects.EachOpponentDiscards]. The count is snapshotted
+ *    before the discards (an opponent's own draw can't change another player's hand), so
+ *    draw-before-discard is outcome-equivalent to the printed discard-then-draw order.
+ *  - The Bat trigger fires per land an opponent discards ([Triggers.discards]`(EachOpponent, Land)`).
+ *  - Dies-return uses the shared [Effects.ReturnSelfFromGraveyardTransformed]`(tapped = true)`.
+ *  - Back land: `{T}: Add {B}` + a `{2}{B}, {T}` sorcery-speed [TransformEffect] gated on at least
+ *    one player (any) having one or fewer cards in hand.
+ */
+
+private val AclazotzDeepestBetrayalFront = card("Aclazotz, Deepest Betrayal") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Bat God"
+    power = 4
+    toughness = 4
+    oracleText = "Flying, lifelink\n" +
+        "Whenever Aclazotz attacks, each opponent discards a card. For each opponent who can't, " +
+        "you draw a card.\n" +
+        "Whenever an opponent discards a land card, create a 1/1 black Bat creature token with " +
+        "flying.\n" +
+        "When Aclazotz dies, return it to the battlefield tapped and transformed under its " +
+        "owner's control."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            // Draw for each opponent who can't discard (empty hand), snapshotted before the discards.
+            Effects.DrawCards(
+                DynamicAmount.CountPlayersWith(
+                    scope = Player.EachOpponent,
+                    condition = Compare(
+                        left = DynamicAmount.Count(Player.You, Zone.HAND),
+                        operator = ComparisonOperator.LTE,
+                        right = DynamicAmount.Fixed(0),
+                    ),
+                )
+            ),
+            Effects.EachOpponentDiscards(1),
+        )
+        description = "Whenever Aclazotz attacks, each opponent discards a card. For each " +
+            "opponent who can't, you draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.discards(player = Player.EachOpponent, cardFilter = GameObjectFilter.Land)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Bat"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg?1721425184",
+        )
+        description = "Whenever an opponent discards a land card, create a 1/1 black Bat creature " +
+            "token with flying."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.ReturnSelfFromGraveyardTransformed(tapped = true)
+        description = "When Aclazotz dies, return it to the battlefield tapped and transformed " +
+            "under its owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "88"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1782694541"
+    }
+}
+
+private val TempleOfTheDead = card("Temple of the Dead") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Land"
+    oracleText = "(Transforms from Aclazotz, Deepest Betrayal.)\n" +
+        "{T}: Add {B}.\n" +
+        "{2}{B}, {T}: Transform this land. Activate only if a player has one or fewer cards in " +
+        "hand and only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                // At least one player (any) has one or fewer cards in hand.
+                Conditions.CompareAmounts(
+                    DynamicAmount.CountPlayersWith(
+                        scope = Player.Each,
+                        condition = Compare(
+                            left = DynamicAmount.Count(Player.You, Zone.HAND),
+                            operator = ComparisonOperator.LTE,
+                            right = DynamicAmount.Fixed(1),
+                        ),
+                    ),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(1),
+                )
+            )
+        )
+        description = "Transform this land. Activate only if a player has one or fewer cards in " +
+            "hand and only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "88"
+        artist = "Steve Prescott"
+        flavorText = "Chimil gave the Oltec peace in death. Aclazotz ripped it away."
+        imageUri = "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1782694541"
+    }
+}
+
+val AclazotzDeepestBetrayal: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = AclazotzDeepestBetrayalFront,
+    backFace = TempleOfTheDead,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerAxonilDeepestMight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerAxonilDeepestMight.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SetMinimumDamage
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ojer Axonil, Deepest Might // Temple of Power (The Lost Caverns of Ixalan)
+ * {2}{R}{R}
+ * Legendary Creature — God // Land
+ *
+ * Front — Ojer Axonil, Deepest Might (4/4, Trample)
+ *   If a red source you control would deal an amount of noncombat damage less than Ojer Axonil's
+ *   power to an opponent, that source deals damage equal to Ojer Axonil's power instead.
+ *   When Ojer Axonil dies, return it to the battlefield tapped and transformed under its owner's
+ *   control.
+ *
+ * Back — Temple of Power (Land)
+ *   {T}: Add {R}.
+ *   {2}{R}, {T}: Transform this land. Activate only if red sources you controlled dealt 4 or more
+ *   noncombat damage this turn and only as a sorcery.
+ *
+ * Implementation:
+ *  - The damage floor is [SetMinimumDamage] with `dynamicMinimum = DynamicAmounts.sourcePower()`
+ *    (evaluated against the replacement's source — Ojer Axonil), gated to noncombat damage from a
+ *    red source you control to an opponent player. It raises the would-be amount up to Axonil's
+ *    power; larger amounts are untouched.
+ *  - Dies-return uses the shared [Effects.ReturnSelfFromGraveyardTransformed]`(tapped = true)`
+ *    wired to [Triggers.Dies].
+ *  - Back land: `{T}: Add {R}` mana ability + a `{2}{R}, {T}` sorcery-speed [TransformEffect]
+ *    gated on [Conditions.YouDealtRedNoncombatDamageThisTurn]`(4)` (backed by the per-player
+ *    RED_NONCOMBAT_DAMAGE_DEALT tracker).
+ */
+
+private val OjerAxonilDeepestMightFront = card("Ojer Axonil, Deepest Might") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — God"
+    power = 4
+    toughness = 4
+    oracleText = "Trample\n" +
+        "If a red source you control would deal an amount of noncombat damage less than Ojer " +
+        "Axonil's power to an opponent, that source deals damage equal to Ojer Axonil's power " +
+        "instead.\n" +
+        "When Ojer Axonil dies, return it to the battlefield tapped and transformed under its " +
+        "owner's control."
+
+    keywords(Keyword.TRAMPLE)
+
+    replacementEffect(
+        SetMinimumDamage(
+            dynamicMinimum = DynamicAmounts.sourcePower(),
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Opponent,
+                source = SourceFilter.Matching(GameObjectFilter.Any.withColor(Color.RED).youControl()),
+                damageType = DamageType.NonCombat,
+            ),
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.ReturnSelfFromGraveyardTransformed(tapped = true)
+        description = "When Ojer Axonil dies, return it to the battlefield tapped and transformed " +
+            "under its owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "158"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1782694483"
+    }
+}
+
+private val TempleOfPower = card("Temple of Power") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "(Transforms from Ojer Axonil, Deepest Might.)\n" +
+        "{T}: Add {R}.\n" +
+        "{2}{R}, {T}: Transform this land. Activate only if red sources you controlled dealt 4 " +
+        "or more noncombat damage this turn and only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouDealtRedNoncombatDamageThisTurn(4)
+            )
+        )
+        description = "Transform this land. Activate only if red sources you controlled dealt 4 " +
+            "or more noncombat damage this turn and only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "158"
+        artist = "Victor Adame Minguez"
+        flavorText = "Chimil gave the Oltec passion. Ojer Axonil challenged them to harness it."
+        imageUri = "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1782694483"
+    }
+}
+
+val OjerAxonilDeepestMight: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OjerAxonilDeepestMightFront,
+    backFace = TempleOfPower,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerKaslemDeepestGrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerKaslemDeepestGrowth.kt
@@ -1,0 +1,184 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ojer Kaslem, Deepest Growth // Temple of Cultivation (The Lost Caverns of Ixalan)
+ * {3}{G}{G}
+ * Legendary Creature — God // Land
+ *
+ * Front — Ojer Kaslem, Deepest Growth (6/5, Trample)
+ *   Whenever Ojer Kaslem deals combat damage to a player, reveal that many cards from the top
+ *   of your library. You may put a creature card and/or a land card from among them onto the
+ *   battlefield. Put the rest on the bottom of your library in a random order.
+ *   When Ojer Kaslem dies, return it to the battlefield tapped and transformed under its
+ *   owner's control.
+ *
+ * Back — Temple of Cultivation (Land)
+ *   {T}: Add {G}.
+ *   {2}{G}, {T}: Transform this land. Activate only if you control ten or more permanents and
+ *   only as a sorcery.
+ *
+ * Implementation:
+ *  - Combat-damage reveal reuses the Gishath, Sun's Avatar pipeline: [GatherCardsEffect] from the
+ *    top of the library (N = [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT], revealed) → two
+ *    [SelectionMode.ChooseUpTo]`(1)` selects, one filtered to [GameObjectFilter.Creature] and one
+ *    to [GameObjectFilter.Land] chained on the first select's remainder (the "and/or" — up to one
+ *    of each, and a creature-land picked as the creature can't be double-counted) → [MoveCollectionEffect]s
+ *    put the picks onto the battlefield and bottom the rest in a random order.
+ *  - Dies-return uses the shared [Effects.ReturnSelfFromGraveyardTransformed]`(tapped = true)`
+ *    wired to [Triggers.Dies]: the God dies to the graveyard and the trigger returns it to the
+ *    battlefield tapped, back face up (Temple of Cultivation).
+ *  - Back land: `{T}: Add {G}` mana ability + a `{2}{G}, {T}` sorcery-speed [TransformEffect]
+ *    gated on [Conditions.YouControlAtLeast]`(10, Permanent)`.
+ */
+
+private val OjerKaslemDeepestGrowthFront = card("Ojer Kaslem, Deepest Growth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — God"
+    power = 6
+    toughness = 5
+    oracleText = "Trample\n" +
+        "Whenever Ojer Kaslem deals combat damage to a player, reveal that many cards from the " +
+        "top of your library. You may put a creature card and/or a land card from among them " +
+        "onto the battlefield. Put the rest on the bottom of your library in a random order.\n" +
+        "When Ojer Kaslem dies, return it to the battlefield tapped and transformed under its " +
+        "owner's control."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val damageDealt = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = damageDealt, player = Player.You),
+                    storeAs = "kaslem_revealed",
+                    revealed = true,
+                ),
+                SelectFromCollectionEffect(
+                    from = "kaslem_revealed",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Creature,
+                    showAllCards = true,
+                    storeSelected = "kaslem_creature",
+                    storeRemainder = "kaslem_afterCreature",
+                    prompt = "You may put a creature card onto the battlefield",
+                    selectedLabel = "Put onto the battlefield",
+                ),
+                SelectFromCollectionEffect(
+                    from = "kaslem_afterCreature",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Land,
+                    showAllCards = true,
+                    storeSelected = "kaslem_land",
+                    storeRemainder = "kaslem_toBottom",
+                    prompt = "You may put a land card onto the battlefield",
+                    selectedLabel = "Put onto the battlefield",
+                    remainderLabel = "Put on the bottom of your library",
+                ),
+                MoveCollectionEffect(
+                    from = "kaslem_creature",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You),
+                ),
+                MoveCollectionEffect(
+                    from = "kaslem_land",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You),
+                ),
+                MoveCollectionEffect(
+                    from = "kaslem_toBottom",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Bottom),
+                    order = CardOrder.Random,
+                ),
+            )
+        )
+        description = "Whenever Ojer Kaslem deals combat damage to a player, reveal that many " +
+            "cards from the top of your library. You may put a creature card and/or a land card " +
+            "from among them onto the battlefield. Put the rest on the bottom of your library in " +
+            "a random order."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.ReturnSelfFromGraveyardTransformed(tapped = true)
+        description = "When Ojer Kaslem dies, return it to the battlefield tapped and transformed " +
+            "under its owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "204"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1782694445"
+    }
+}
+
+private val TempleOfCultivation = card("Temple of Cultivation") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Land"
+    oracleText = "(Transforms from Ojer Kaslem, Deepest Growth.)\n" +
+        "{T}: Add {G}.\n" +
+        "{2}{G}, {T}: Transform this land. Activate only if you control ten or more permanents " +
+        "and only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouControlAtLeast(10, GameObjectFilter.Permanent)
+            )
+        )
+        description = "Transform this land. Activate only if you control ten or more permanents " +
+            "and only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "204"
+        artist = "Ryan Pancoast"
+        flavorText = "Chimil gave the Oltec sacred lands. Ojer Kaslem brought them to life."
+        imageUri = "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1782694445"
+    }
+}
+
+val OjerKaslemDeepestGrowth: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OjerKaslemDeepestGrowthFront,
+    backFace = TempleOfCultivation,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerPakpatiqDeepestEpoch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerPakpatiqDeepestEpoch.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordToSpellEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time (The Lost Caverns of Ixalan)
+ * {2}{U}{U}
+ * Legendary Creature — God // Land
+ *
+ * Front — Ojer Pakpatiq, Deepest Epoch (4/3, Flying)
+ *   Whenever you cast an instant spell from your hand, it gains rebound.
+ *   When Ojer Pakpatiq dies, return it to the battlefield tapped and transformed under its
+ *   owner's control with three time counters on it.
+ *
+ * Back — Temple of Cyclical Time (Land)
+ *   {T}: Add {U}. Remove a time counter from this land.
+ *   {2}{U}, {T}: Transform this land. Activate only if it has no time counters on it and only as
+ *   a sorcery.
+ *
+ * Implementation:
+ *  - The grant is a [Triggers.youCastSpell]`(Instant, CastFromZone(HAND))` trigger whose effect is
+ *    [GrantKeywordToSpellEffect]`(Keyword.REBOUND, TriggeringEntity)` — it stamps the just-cast
+ *    spell with rebound, which the spell-resolution path (CR 702.88) honors by exiling the spell
+ *    and arming a next-upkeep free recast.
+ *  - Dies-return uses the shared [Effects.ReturnSelfFromGraveyardTransformed]`(tapped = true)`;
+ *    because the graveyard→battlefield move preserves the entity id, the "with three time counters"
+ *    clause composes as a following [Effects.AddCounters]`(TIME, 3, Self)`.
+ *  - Back land: a `{T}: Add {U}` mana ability that also removes a time counter (a legal rider —
+ *    no targets/choices, CR 605.1a) + a `{2}{U}, {T}` sorcery-speed [TransformEffect] gated on the
+ *    land having no time counters.
+ */
+
+private val OjerPakpatiqDeepestEpochFront = card("Ojer Pakpatiq, Deepest Epoch") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — God"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever you cast an instant spell from your hand, it gains rebound. (Exile it as it " +
+        "resolves. At the beginning of your next upkeep, you may cast it from exile without " +
+        "paying its mana cost.)\n" +
+        "When Ojer Pakpatiq dies, return it to the battlefield tapped and transformed under its " +
+        "owner's control with three time counters on it."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Instant,
+            requires = setOf(SpellCastPredicate.CastFromZone(Zone.HAND)),
+        )
+        effect = GrantKeywordToSpellEffect(Keyword.REBOUND, EffectTarget.TriggeringEntity)
+        description = "Whenever you cast an instant spell from your hand, it gains rebound."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Composite(
+            Effects.ReturnSelfFromGraveyardTransformed(tapped = true),
+            Effects.AddCounters(Counters.TIME, 3, EffectTarget.Self),
+        )
+        description = "When Ojer Pakpatiq dies, return it to the battlefield tapped and " +
+            "transformed under its owner's control with three time counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "67"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1782694556"
+    }
+}
+
+private val TempleOfCyclicalTime = card("Temple of Cyclical Time") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Land"
+    oracleText = "(Transforms from Ojer Pakpatiq, Deepest Epoch.)\n" +
+        "{T}: Add {U}. Remove a time counter from this land.\n" +
+        "{2}{U}, {T}: Transform this land. Activate only if it has no time counters on it and " +
+        "only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLUE, 1),
+            Effects.RemoveCounters(Counters.TIME, 1, EffectTarget.Self),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.Not(Conditions.SourceCounterCountAtLeast(Counters.TIME, 1))
+            )
+        )
+        description = "Transform this land. Activate only if it has no time counters on it and " +
+            "only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "67"
+        artist = "Chris Rahn"
+        flavorText = "Chimil gave the Oltec time. Ojer Pakpatiq gave them the tools to learn its lessons."
+        imageUri = "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1782694556"
+    }
+}
+
+val OjerPakpatiqDeepestEpoch: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OjerPakpatiqDeepestEpochFront,
+    backFace = TempleOfCyclicalTime,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerTaqDeepestFoundation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OjerTaqDeepestFoundation.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MultiplyTokenCreation
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ojer Taq, Deepest Foundation // Temple of Civilization (The Lost Caverns of Ixalan)
+ * {4}{W}{W}
+ * Legendary Creature — God // Land
+ *
+ * Front — Ojer Taq, Deepest Foundation (6/6, Vigilance)
+ *   If one or more creature tokens would be created under your control, three times that many
+ *   of those tokens are created instead.
+ *   When Ojer Taq dies, return it to the battlefield tapped and transformed under its owner's
+ *   control.
+ *
+ * Back — Temple of Civilization (Land)
+ *   {T}: Add {W}.
+ *   {2}{W}, {T}: Transform this land. Activate only if you attacked with three or more creatures
+ *   this turn and only as a sorcery.
+ *
+ * Implementation:
+ *  - Token tripling is [MultiplyTokenCreation]`(factor = 3)` — the Doubling Season replacement
+ *    generalized to any factor. Its `appliesTo` defaults to `TokenCreationEvent(controller = You)`;
+ *    the count multiplier runs in `CreateTokenExecutor`, which is the executor for *creature*
+ *    tokens (it always builds a "… Creature" type line — Treasure/Clue/Map and other predefined
+ *    tokens use a different executor that isn't multiplied), so the effect's scope coincides with
+ *    the oracle's "creature tokens".
+ *  - Dies-return uses the shared [Effects.ReturnSelfFromGraveyardTransformed]`(tapped = true)`
+ *    wired to [Triggers.Dies].
+ *  - Back land: `{T}: Add {W}` mana ability + a `{2}{W}, {T}` sorcery-speed [TransformEffect]
+ *    gated on [Conditions.YouAttackedWithCreaturesThisTurn]`(Creature, 3)`.
+ */
+
+private val OjerTaqDeepestFoundationFront = card("Ojer Taq, Deepest Foundation") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — God"
+    power = 6
+    toughness = 6
+    oracleText = "Vigilance\n" +
+        "If one or more creature tokens would be created under your control, three times that " +
+        "many of those tokens are created instead.\n" +
+        "When Ojer Taq dies, return it to the battlefield tapped and transformed under its " +
+        "owner's control."
+
+    keywords(Keyword.VIGILANCE)
+
+    replacementEffect(MultiplyTokenCreation(factor = 3))
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.ReturnSelfFromGraveyardTransformed(tapped = true)
+        description = "When Ojer Taq dies, return it to the battlefield tapped and transformed " +
+            "under its owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "26"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1782694591"
+    }
+}
+
+private val TempleOfCivilization = card("Temple of Civilization") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "(Transforms from Ojer Taq, Deepest Foundation.)\n" +
+        "{T}: Add {W}.\n" +
+        "{2}{W}, {T}: Transform this land. Activate only if you attacked with three or more " +
+        "creatures this turn and only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouAttackedWithCreaturesThisTurn(GameObjectFilter.Creature, 3)
+            )
+        )
+        description = "Transform this land. Activate only if you attacked with three or more " +
+            "creatures this turn and only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "26"
+        artist = "Cristi Balanescu"
+        flavorText = "Chimil gave the Oltec life. Ojer Taq taught them how to live together."
+        imageUri = "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1782694591"
+    }
+}
+
+val OjerTaqDeepestFoundation: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OjerTaqDeepestFoundationFront,
+    backFace = TempleOfCivilization,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ElspethStormSlayer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ElspethStormSlayer.kt
@@ -8,7 +8,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.DoubleTokenCreation
+import com.wingedsheep.sdk.scripting.MultiplyTokenCreation
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
@@ -40,7 +40,7 @@ val ElspethStormSlayer = card("Elspeth, Storm Slayer") {
         "−3: Destroy target creature an opponent controls with mana value 3 or greater."
 
     // If one or more tokens would be created under your control, twice that many instead.
-    replacementEffect(DoubleTokenCreation())
+    replacementEffect(MultiplyTokenCreation())
 
     // +1: Create a 1/1 white Soldier creature token.
     loyaltyAbility(+1) {

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -4922,7 +4922,7 @@
     ],
     "script": {
         "replacementEffects": [
-            "DoubleTokenCreation"
+            "MultiplyTokenCreation"
         ]
     },
     "metadata": {

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10379,6 +10379,133 @@
     ]
 }
 
+// Ojer Axonil, Deepest Might
+{
+    "name": "Ojer Axonil, Deepest Might",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Trample\nIf a red source you control would deal an amount of noncombat damage less than Ojer Axonil's power to an opponent, that source deals damage equal to Ojer Axonil's power instead.\nWhen Ojer Axonil dies, return it to the battlefield tapped and transformed under its owner's control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReturnSelfFromZoneTransformed",
+                    "tapped": true
+                },
+                "descriptionOverride": "When Ojer Axonil dies, return it to the battlefield tapped and transformed under its owner's control."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "SetMinimumDamage",
+                "dynamicMinimum": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": "Power"
+                },
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientOpponent",
+                    "source": {
+                        "type": "SourceMatching",
+                        "filter": "red ctrl:you"
+                    },
+                    "damageType": "DamageNonCombat"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Temple of Power",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Ojer Axonil, Deepest Might.)\n{T}: Add {R}.\n{2}{R}, {T}: Transform this land. Activate only if red sources you controlled dealt 4 or more noncombat damage this turn and only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "RED"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{R}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": "Transform",
+                    "timing": "SorcerySpeed",
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "TurnTracking",
+                                    "player": "You",
+                                    "tracker": "RED_NONCOMBAT_DAMAGE_DEALT"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Transform this land. Activate only if red sources you controlled dealt 4 or more noncombat damage this turn and only as a sorcery."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "158",
+            "rarity": "MYTHIC",
+            "artist": "Victor Adame Minguez",
+            "flavorText": "Chimil gave the Oltec passion. Ojer Axonil challenged them to harness it.",
+            "imageUri": "https://cards.scryfall.io/normal/back/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1782694483"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "MYTHIC",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50f8e2b6-98c7-4f28-bb39-e1fbe841f1ee.jpg?1782694483"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ojer Kaslem, Deepest Growth
 {
     "name": "Ojer Kaslem, Deepest Growth",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10574,6 +10574,112 @@
     ]
 }
 
+// Ojer Taq, Deepest Foundation
+{
+    "name": "Ojer Taq, Deepest Foundation",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Vigilance\nIf one or more creature tokens would be created under your control, three times that many of those tokens are created instead.\nWhen Ojer Taq dies, return it to the battlefield tapped and transformed under its owner's control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReturnSelfFromZoneTransformed",
+                    "tapped": true
+                },
+                "descriptionOverride": "When Ojer Taq dies, return it to the battlefield tapped and transformed under its owner's control."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "MultiplyTokenCreation",
+                "factor": 3
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Temple of Civilization",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Ojer Taq, Deepest Foundation.)\n{T}: Add {W}.\n{2}{W}, {T}: Transform this land. Activate only if you attacked with three or more creatures this turn and only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "WHITE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{W}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": "Transform",
+                    "timing": "SorcerySpeed",
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "PlayerAttackedWithCreaturesThisTurn",
+                                "filter": "creature",
+                                "atLeast": 3
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Transform this land. Activate only if you attacked with three or more creatures this turn and only as a sorcery."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "26",
+            "rarity": "MYTHIC",
+            "artist": "Cristi Balanescu",
+            "flavorText": "Chimil gave the Oltec life. Ojer Taq taught them how to live together.",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1782694591"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "MYTHIC",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1ca79dd4-67fc-496c-96fc-489b039c4932.jpg?1782694591"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Oltec Archaeologists
 {
     "name": "Oltec Archaeologists",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -227,6 +227,223 @@
     ]
 }
 
+// Aclazotz, Deepest Betrayal
+{
+    "name": "Aclazotz, Deepest Betrayal",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Bat God",
+    "oracleText": "Flying, lifelink\nWhenever Aclazotz attacks, each opponent discards a card. For each opponent who can't, you draw a card.\nWhenever an opponent discards a land card, create a 1/1 black Bat creature token with flying.\nWhen Aclazotz dies, return it to the battlefield tapped and transformed under its owner's control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "CountPlayersWith",
+                                "scope": "EachOpponent",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "Count",
+                                        "player": "You",
+                                        "zone": "Hand"
+                                    },
+                                    "operator": "LTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "EachOpponent"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Aclazotz attacks, each opponent discards a card. For each opponent who can't, you draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "player": "EachOpponent",
+                    "cardFilter": "land"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Bat"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/0/100c0127-49dd-4a78-9c88-1881e7923674.jpg?1721425184"
+                },
+                "descriptionOverride": "Whenever an opponent discards a land card, create a 1/1 black Bat creature token with flying."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReturnSelfFromZoneTransformed",
+                    "tapped": true
+                },
+                "descriptionOverride": "When Aclazotz dies, return it to the battlefield tapped and transformed under its owner's control."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Temple of the Dead",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Aclazotz, Deepest Betrayal.)\n{T}: Add {B}.\n{2}{B}, {T}: Transform this land. Activate only if a player has one or fewer cards in hand and only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_4",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLACK"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_5",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{B}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": "Transform",
+                    "timing": "SorcerySpeed",
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "CountPlayersWith",
+                                    "scope": "Each",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "Count",
+                                            "player": "You",
+                                            "zone": "Hand"
+                                        },
+                                        "operator": "LTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    }
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Transform this land. Activate only if a player has one or fewer cards in hand and only as a sorcery."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "88",
+            "rarity": "MYTHIC",
+            "artist": "Steve Prescott",
+            "flavorText": "Chimil gave the Oltec peace in death. Aclazotz ripped it away.",
+            "imageUri": "https://cards.scryfall.io/normal/back/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1782694541"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "MYTHIC",
+        "artist": "Steve Prescott",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/627c392c-4d18-4eb2-a4e8-c668f61f5487.jpg?1782694541"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Acolyte of Aclazotz
 {
     "name": "Acolyte of Aclazotz",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10918,6 +10918,168 @@
     ]
 }
 
+// Ojer Pakpatiq, Deepest Epoch
+{
+    "name": "Ojer Pakpatiq, Deepest Epoch",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Flying\nWhenever you cast an instant spell from your hand, it gains rebound. (Exile it as it resolves. At the beginning of your next upkeep, you may cast it from exile without paying its mana cost.)\nWhen Ojer Pakpatiq dies, return it to the battlefield tapped and transformed under its owner's control with three time counters on it.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsInstant"
+                        ]
+                    },
+                    "requires": [
+                        {
+                            "type": "SpellCastFromZone",
+                            "zone": "Hand"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeywordToSpell",
+                    "keyword": "REBOUND"
+                },
+                "descriptionOverride": "Whenever you cast an instant spell from your hand, it gains rebound."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ReturnSelfFromZoneTransformed",
+                            "tapped": true
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "time",
+                            "count": 3,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Ojer Pakpatiq dies, return it to the battlefield tapped and transformed under its owner's control with three time counters on it."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Temple of Cyclical Time",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Ojer Pakpatiq, Deepest Epoch.)\n{T}: Add {U}. Remove a time counter from this land.\n{2}{U}, {T}: Transform this land. Activate only if it has no time counters on it and only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddMana",
+                                "color": "BLUE"
+                            },
+                            {
+                                "type": "RemoveCounters",
+                                "counterType": "time",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        ]
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_4",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{U}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": "Transform",
+                    "timing": "SorcerySpeed",
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "Not",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": {
+                                                "type": "Named",
+                                                "name": "time"
+                                            }
+                                        }
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Transform this land. Activate only if it has no time counters on it and only as a sorcery."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "67",
+            "rarity": "MYTHIC",
+            "artist": "Chris Rahn",
+            "flavorText": "Chimil gave the Oltec time. Ojer Pakpatiq gave them the tools to learn its lessons.",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1782694556"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9d71007-bc04-4dff-ad3f-e2c0b5b4400e.jpg?1782694556"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ojer Taq, Deepest Foundation
 {
     "name": "Ojer Taq, Deepest Foundation",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10379,6 +10379,201 @@
     ]
 }
 
+// Ojer Kaslem, Deepest Growth
+{
+    "name": "Ojer Kaslem, Deepest Growth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Trample\nWhenever Ojer Kaslem deals combat damage to a player, reveal that many cards from the top of your library. You may put a creature card and/or a land card from among them onto the battlefield. Put the rest on the bottom of your library in a random order.\nWhen Ojer Kaslem dies, return it to the battlefield tapped and transformed under its owner's control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            "storeAs": "kaslem_revealed",
+                            "revealed": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "kaslem_revealed",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "kaslem_creature",
+                            "storeRemainder": "kaslem_afterCreature",
+                            "prompt": "You may put a creature card onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "kaslem_afterCreature",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "kaslem_land",
+                            "storeRemainder": "kaslem_toBottom",
+                            "prompt": "You may put a land card onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield",
+                            "remainderLabel": "Put on the bottom of your library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kaslem_creature",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kaslem_land",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kaslem_toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Ojer Kaslem deals combat damage to a player, reveal that many cards from the top of your library. You may put a creature card and/or a land card from among them onto the battlefield. Put the rest on the bottom of your library in a random order."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReturnSelfFromZoneTransformed",
+                    "tapped": true
+                },
+                "descriptionOverride": "When Ojer Kaslem dies, return it to the battlefield tapped and transformed under its owner's control."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Temple of Cultivation",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Ojer Kaslem, Deepest Growth.)\n{T}: Add {G}.\n{2}{G}, {T}: Transform this land. Activate only if you control ten or more permanents and only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "GREEN"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_4",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}{G}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": "Transform",
+                    "timing": "SorcerySpeed",
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": "permanent"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 10
+                                }
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Transform this land. Activate only if you control ten or more permanents and only as a sorcery."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "204",
+            "rarity": "MYTHIC",
+            "artist": "Ryan Pancoast",
+            "flavorText": "Chimil gave the Oltec sacred lands. Ojer Kaslem brought them to life.",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1782694445"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "MYTHIC",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cbc43a3-8cba-4988-9de1-c89aedd79ada.jpg?1782694445"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Oltec Archaeologists
 {
     "name": "Oltec Archaeologists",

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -4834,7 +4834,7 @@
             }
         ],
         "replacementEffects": [
-            "DoubleTokenCreation"
+            "MultiplyTokenCreation"
         ]
     },
     "metadata": {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -66,6 +66,7 @@ import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnCompo
 import com.wingedsheep.engine.state.components.player.NonTokenCreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentLeftBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsSacrificedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.RedNoncombatDamageDealtThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentEnteredFaceDownThisTurnComponent
 import com.wingedsheep.engine.state.components.player.TurnedPermanentFaceUpThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
@@ -641,6 +642,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<PermanentsSacrificedThisTurnComponent>()) {
                     result = result.without<PermanentsSacrificedThisTurnComponent>()
+                }
+                if (result.has<RedNoncombatDamageDealtThisTurnComponent>()) {
+                    result = result.without<RedNoncombatDamageDealtThisTurnComponent>()
                 }
                 if (result.has<PermanentEnteredFaceDownThisTurnComponent>()) {
                     result = result.without<PermanentEnteredFaceDownThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -515,6 +515,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PlayerDescendedThisTurnComponent::class)
         subclass(FlippedCoinsThisTurnComponent::class)
         subclass(PermanentsSacrificedThisTurnComponent::class)
+        subclass(RedNoncombatDamageDealtThisTurnComponent::class)
         subclass(PermanentEnteredFaceDownThisTurnComponent::class)
         subclass(TurnedPermanentFaceUpThisTurnComponent::class)
         subclass(PlayerCitysBlessingComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -511,6 +511,11 @@ class DynamicAmountEvaluator(
                             ?.get<com.wingedsheep.engine.state.components.player.PermanentsSacrificedThisTurnComponent>()
                             ?.count ?: 0
                     }
+                    TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.RedNoncombatDamageDealtThisTurnComponent>()
+                            ?.amount ?: 0
+                    }
                     TurnTracker.DISTINCT_BENDS -> playerIds.sumOf { playerId ->
                         state.getEntity(playerId)
                             ?.get<com.wingedsheep.engine.state.components.player.BendsThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -29,6 +29,8 @@ import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTur
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.player.RedNoncombatDamageDealtThisTurnComponent
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.engine.mechanics.mana.GrantedKeywordResolver
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -359,6 +361,24 @@ object DamageUtils {
         // Read by "damage equal to that creature's toughness" triggers (Taii Wakeen).
         val targetToughnessAtDamage = if (targetWasCreature) projected.getToughness(targetId) else null
         events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, false, sourceName = sourceName, targetName = targetName, targetIsPlayer = targetIsPlayer, targetWasFaceDown = targetIsFaceDown, targetControllerId = targetControllerId, targetWasCreature = targetWasCreature, excessAmount = creatureExcessDamage, targetToughnessAtDamage = targetToughnessAtDamage))
+
+        // Track noncombat damage dealt by red sources, keyed to the source's controller
+        // (Temple of Power's transform gate — TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT). A red
+        // spell/ability carries no ControllerComponent, so fall back to its caster.
+        if (sourceId != null && !isCombatDamage && effectiveAmount > 0) {
+            val sourceIsRed = state.getEntity(sourceId)?.get<CardComponent>()?.colors?.contains(Color.RED) == true
+            if (sourceIsRed) {
+                val sourceControllerId = projected.getController(sourceId)
+                    ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
+                    ?: state.getEntity(sourceId)?.get<SpellOnStackComponent>()?.casterId
+                if (sourceControllerId != null) {
+                    newState = newState.updateEntity(sourceControllerId) { container ->
+                        val prior = container.get<RedNoncombatDamageDealtThisTurnComponent>()?.amount ?: 0
+                        container.with(RedNoncombatDamageDealtThisTurnComponent(prior + effectiveAmount))
+                    }
+                }
+            }
+        }
 
         // Lifelink: if the source has lifelink, its controller gains life equal to the damage dealt
         // (CR 120.3f / 702.15b). The lifelink damage causes a life-gain event, so ModifyLifeGain
@@ -1605,6 +1625,66 @@ object DamageUtils {
                 if (!recipientMatches) continue
 
                 amplifiedAmount = effect.maxAmount
+            }
+        }
+
+        // Minimum-damage replacements (Ojer Axonil, Deepest Might): raise the would-be amount to
+        // a floor. The floor mirror of CapDamage — applied last, only to a positive would-be
+        // amount (a source dealing 0 isn't dealing damage, so it isn't raised).
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is com.wingedsheep.sdk.scripting.SetMinimumDamage) continue
+                if (amplifiedAmount <= 0) continue
+
+                val floor = effect.dynamicMinimum?.let { dyn ->
+                    dynamicAmountEvaluator.evaluate(
+                        state, dyn,
+                        EffectContext(sourceId = entityId, controllerId = sourceControllerId),
+                        projected
+                    )
+                } ?: effect.minAmount
+                if (amplifiedAmount >= floor) continue
+
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is com.wingedsheep.sdk.scripting.EventPattern.DamageEvent) continue
+
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+                if (!damageEvent.amount.matches(amplifiedAmount)) continue
+
+                val sourceMatches = when (val source = damageEvent.source) {
+                    is SourceFilter.Any -> true
+                    is SourceFilter.Matching -> {
+                        if (sourceId == null) false
+                        else {
+                            val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
+                            predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
+                        }
+                    }
+                    else -> false
+                }
+                if (!sourceMatches) continue
+
+                val recipientMatches = when (val recipient = damageEvent.recipient) {
+                    is RecipientFilter.Any -> true
+                    is RecipientFilter.Opponent -> targetId in state.turnOrder && targetId != sourceControllerId
+                    is RecipientFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
+                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
+                    }
+                    else -> false
+                }
+                if (!recipientMatches) continue
+
+                amplifiedAmount = floor
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -366,7 +366,11 @@ object DamageUtils {
         // (Temple of Power's transform gate — TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT). A red
         // spell/ability carries no ControllerComponent, so fall back to its caster.
         if (sourceId != null && !isCombatDamage && effectiveAmount > 0) {
-            val sourceIsRed = state.getEntity(sourceId)?.get<CardComponent>()?.colors?.contains(Color.RED) == true
+            // Combine projected colors (battlefield permanents, so a granted-red source counts) with
+            // base card colors (spells on the stack, which have no projection).
+            val sourceColors = projected.getColors(sourceId) +
+                (state.getEntity(sourceId)?.get<CardComponent>()?.colors?.map { it.name } ?: emptyList())
+            val sourceIsRed = Color.RED.name in sourceColors
             if (sourceIsRed) {
                 val sourceControllerId = projected.getController(sourceId)
                     ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ExileAndReturnTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ExileAndReturnTransformedExecutor.kt
@@ -78,7 +78,7 @@ class ExileAndReturnTransformedExecutor(
         }
 
         // 2. Flip to the destination face and return it to the battlefield as a new object.
-        val returnTransition = returnDfcFaceFromExile(newState, cardRegistry, targetId, destinationFace)
+        val returnTransition = returnDfcFace(newState, cardRegistry, targetId, destinationFace)
         newState = returnTransition.state
         events.addAll(returnTransition.events)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromExileTransformedExecutor.kt
@@ -54,7 +54,7 @@ class ReturnSelfFromExileTransformedExecutor(
         // Flip to the back face (CR 702.167a always returns transformed) and move EXILE →
         // BATTLEFIELD under owner's control. The shared helper handles the face swap + zone move
         // (it is also used by the FIN Dominant exile-and-return-transformed effect).
-        val transition = returnDfcFaceFromExile(
+        val transition = returnDfcFace(
             state, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK
         )
         var newState = transition.state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
@@ -20,10 +20,10 @@ import kotlin.reflect.KClass
  *     battlefield transformed doesn't move at all (official FIN ruling), so this is a no-op,
  *     not an error.
  *
- * The face flip + zone move is the shared [returnDfcFaceFromExile] helper (its name predates
- * this executor — it flips-then-moves from whatever zone the entity is currently in), always
- * to the back face: a card in a non-battlefield zone is front-face-up by definition, so
- * "transformed" can only mean the back face.
+ * The face flip + zone move is the shared [returnDfcFace] helper (it flips-then-moves from
+ * whatever zone the entity is currently in), always to the back face: a card in a
+ * non-battlefield zone is front-face-up by definition, so "transformed" can only mean the
+ * back face.
  */
 class ReturnSelfFromZoneTransformedExecutor(
     private val cardRegistry: CardRegistry
@@ -72,7 +72,7 @@ class ReturnSelfFromZoneTransformedExecutor(
             }
         }
 
-        val transition = returnDfcFaceFromExile(
+        val transition = returnDfcFace(
             workingState, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK, tapped = effect.tapped
         )
         return EffectResult.success(transition.state, transition.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
@@ -73,7 +73,7 @@ class ReturnSelfFromZoneTransformedExecutor(
         }
 
         val transition = returnDfcFaceFromExile(
-            workingState, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK
+            workingState, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK, tapped = effect.tapped
         )
         return EffectResult.success(transition.state, transition.events)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -148,20 +148,21 @@ internal fun buildCardComponentForDfcFace(
 )
 
 /**
- * Flip a double-faced entity that is currently **in exile** to [destinationFace] and return it to
- * the battlefield as a new object under its owner's control.
+ * Flip a double-faced entity that is currently in a non-battlefield zone (exile or graveyard) to
+ * [destinationFace] and return it to the battlefield as a new object under its owner's control.
  *
- * The face swap is applied while the entity is still in exile so the EXILE → BATTLEFIELD move
+ * The face swap is applied while the entity is still in its source zone so the → BATTLEFIELD move
  * registers the destination face's static abilities and (for a Saga face) the lore-counter entry
  * setup cleanly. Per Rule 712.8a the front face's [CardComponent] is stashed on the
  * [DoubleFacedComponent] when going to the back face, so the restore-on-leave path can swap back
  * without a registry lookup.
  *
  * Shared by [ReturnSelfFromExileTransformedExecutor] (CR 702.167a Craft return — always to the
- * back face) and [ExileAndReturnTransformedExecutor] (FIN Dominant / eikon — either direction).
- * The caller is responsible for having already moved the entity into exile.
+ * back face), [ExileAndReturnTransformedExecutor] (FIN Dominant / eikon — either direction), and
+ * [ReturnSelfFromZoneTransformedExecutor] (graveyard return — LCI god cycle). The caller is
+ * responsible for the entity already being in the zone it is to be returned from.
  */
-internal fun returnDfcFaceFromExile(
+internal fun returnDfcFace(
     state: GameState,
     cardRegistry: CardRegistry,
     entityId: EntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -165,7 +165,8 @@ internal fun returnDfcFaceFromExile(
     state: GameState,
     cardRegistry: CardRegistry,
     entityId: EntityId,
-    destinationFace: DoubleFacedComponent.Face
+    destinationFace: DoubleFacedComponent.Face,
+    tapped: Boolean = false
 ): ZoneTransitionResult {
     val container = state.getEntity(entityId)
         ?: return ZoneTransitionResult(state, emptyList())
@@ -196,6 +197,6 @@ internal fun returnDfcFaceFromExile(
         prepared,
         entityId,
         Zone.BATTLEFIELD,
-        options = ZoneEntryOptions(controllerId = ownerId)
+        options = ZoneEntryOptions(controllerId = ownerId, tapped = tapped)
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -29,7 +29,7 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CreateAdditionalToken
-import com.wingedsheep.sdk.scripting.DoubleTokenCreation
+import com.wingedsheep.sdk.scripting.MultiplyTokenCreation
 import com.wingedsheep.sdk.scripting.EventPattern as SdkGameEvent
 import com.wingedsheep.sdk.scripting.ModifyTokenCount
 import com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy
@@ -47,8 +47,9 @@ object TokenCreationReplacementHelper {
     /**
      * Apply token-count replacement effects whose [SdkGameEvent.TokenCreationEvent] filter
      * matches the player receiving the tokens:
-     * - [DoubleTokenCreation] (Anointed Procession / Exalted Sunborn) multiplies the count
-     *   by 2 per source; stacks multiplicatively when several apply.
+     * - [MultiplyTokenCreation] (Anointed Procession / Exalted Sunborn — factor 2; Ojer Taq —
+     *   factor 3) multiplies the count by its factor per source; stacks multiplicatively when
+     *   several apply.
      * - [ModifyTokenCount] shifts the count by a fixed amount per source (clamped at zero).
      *
      * Dispatch reads `appliesTo.controller`, mirroring [ReplacementEffectUtils.applyCounterPlacementModifiers]:
@@ -68,7 +69,7 @@ object TokenCreationReplacementHelper {
     ): Int {
         if (baseCount <= 0) return baseCount
 
-        var doublings = 0
+        val factors = mutableListOf<Int>()
         var modifier = 0
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
@@ -78,7 +79,7 @@ object TokenCreationReplacementHelper {
             val repl = container.get<ReplacementEffectSourceComponent>() ?: continue
             for (effect in repl.replacementEffects) {
                 val event = when (effect) {
-                    is DoubleTokenCreation -> effect.appliesTo
+                    is MultiplyTokenCreation -> effect.appliesTo
                     is ModifyTokenCount -> effect.appliesTo
                     else -> continue
                 }
@@ -94,7 +95,7 @@ object TokenCreationReplacementHelper {
                 }
                 if (!controllerMatches) continue
                 when (effect) {
-                    is DoubleTokenCreation -> doublings += 1
+                    is MultiplyTokenCreation -> factors += effect.factor
                     is ModifyTokenCount -> modifier += effect.modifier
                 }
             }
@@ -106,7 +107,7 @@ object TokenCreationReplacementHelper {
         // actually allocating entities.
         var count = com.wingedsheep.engine.core.GameLimits.addClamped(baseCount, modifier)
         if (count <= 0) return 0
-        repeat(doublings) { count = com.wingedsheep.engine.core.GameLimits.mulClamped(count, 2) }
+        for (factor in factors) count = com.wingedsheep.engine.core.GameLimits.mulClamped(count, factor)
         return count
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -979,6 +979,7 @@ class StaticAbilityHandler(
             is DoubleDamage,
             is ModifyDamageAmount,
             is com.wingedsheep.sdk.scripting.CapDamage,
+            is com.wingedsheep.sdk.scripting.SetMinimumDamage,
             is com.wingedsheep.sdk.scripting.RedirectDamage,
             is com.wingedsheep.sdk.scripting.DamageCantBePrevented,
             is ReplaceDamageWithCounters,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1014,7 +1014,7 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.ModifyExplore,
             // Token creation:
             is com.wingedsheep.sdk.scripting.ReplaceTokenCreationWithAttachedCopy,
-            is com.wingedsheep.sdk.scripting.DoubleTokenCreation,
+            is com.wingedsheep.sdk.scripting.MultiplyTokenCreation,
             is com.wingedsheep.sdk.scripting.ModifyTokenCount,
             is com.wingedsheep.sdk.scripting.CreateAdditionalToken -> true
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1548,6 +1548,61 @@ class StackResolver(
 
 
     /**
+     * Rebound (CR 702.88): a spell has rebound if the printed keyword is on its card definition
+     * or the keyword was granted to this stack object (Ojer Pakpatiq via GrantKeywordToSpellEffect,
+     * stored on [SpellGrantedKeywordsComponent]). Only matters for a spell cast from hand — the
+     * caller gates on [com.wingedsheep.engine.state.components.stack.SpellOnStackComponent.castFromZone].
+     */
+    private fun spellHasRebound(
+        state: GameState,
+        spellId: EntityId,
+        cardDef: com.wingedsheep.sdk.model.CardDefinition?
+    ): Boolean {
+        if (cardDef?.keywords?.contains(com.wingedsheep.sdk.core.Keyword.REBOUND) == true) return true
+        val granted = state.getEntity(spellId)
+            ?.get<com.wingedsheep.engine.state.components.stack.SpellGrantedKeywordsComponent>()
+        return granted?.keywords?.contains(com.wingedsheep.sdk.core.Keyword.REBOUND.name) == true
+    }
+
+    /**
+     * Schedule rebound's delayed triggered ability (CR 702.88a): at the beginning of the caster's
+     * next upkeep, they may cast the just-exiled card from exile without paying its mana cost.
+     * A one-shot step-based delayed trigger gated to the caster's turn ([fireOnPlayerId]) and to a
+     * later turn ([notBeforeTurn]); it is consumed the first time it fires. The free cast reuses the
+     * suspend/Shiko cast-from-exile pipeline ([CastFromCollectionWithoutPayingCostEffect]).
+     */
+    private fun scheduleReboundRecast(
+        state: GameState,
+        exiledCardId: EntityId,
+        casterId: EntityId,
+        sourceName: String
+    ): GameState = state.addDelayedTrigger(
+        com.wingedsheep.engine.event.DelayedTriggeredAbility(
+            id = java.util.UUID.randomUUID().toString(),
+            effect = com.wingedsheep.sdk.scripting.effects.MayEffect(
+                com.wingedsheep.sdk.scripting.effects.CompositeEffect(
+                    listOf(
+                        com.wingedsheep.sdk.scripting.effects.GatherCardsEffect(
+                            source = com.wingedsheep.sdk.scripting.effects.CardSource.Self,
+                            storeAs = "rebound_recast",
+                        ),
+                        com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect(
+                            from = "rebound_recast",
+                        ),
+                    )
+                ),
+                descriptionOverride = "cast this card from exile without paying its mana cost",
+            ),
+            fireAtStep = com.wingedsheep.sdk.core.Step.UPKEEP,
+            fireOnPlayerId = casterId,
+            notBeforeTurn = state.turnNumber + 1,
+            sourceId = exiledCardId,
+            sourceName = sourceName,
+            controllerId = casterId,
+        )
+    )
+
+    /**
      * Resolve a non-permanent spell - execute effects, put in graveyard.
      */
     private fun resolveNonPermanentSpell(
@@ -1692,8 +1747,10 @@ class StackResolver(
                     spellComponent.faceIndex != null
                 val pausedOmenFaceShuffle = pausedCardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
                     spellComponent.faceIndex != null
+                val pausedReboundExile = spellComponent.castFromZone == Zone.HAND &&
+                    spellHasRebound(effectResult.state, spellId, pausedCardDef)
                 val pausedIntended = when {
-                    pausedSelfExile || pausedFlashbackExile || pausedExileAfterResolve || pausedAdventureFaceExile -> Zone.EXILE
+                    pausedSelfExile || pausedFlashbackExile || pausedExileAfterResolve || pausedAdventureFaceExile || pausedReboundExile -> Zone.EXILE
                     pausedOmenFaceShuffle -> Zone.LIBRARY
                     else -> Zone.GRAVEYARD
                 }
@@ -1716,6 +1773,13 @@ class StackResolver(
                     pausedState = pausedState.updateEntity(spellId) { c ->
                         c.with(com.wingedsheep.engine.state.components.battlefield.ParadigmComponent)
                     }
+                }
+
+                // Rebound: arm the next-upkeep free recast even when the effect paused mid-resolution.
+                if (pausedReboundExile && pausedDestZone == Zone.EXILE) {
+                    pausedState = scheduleReboundRecast(
+                        pausedState, spellId, spellComponent.casterId, cardComponent?.name ?: "Unknown"
+                    )
                 }
 
                 // Link an opponent's resolving spell exiled by a RedirectZoneChange(linkToSource)
@@ -1831,8 +1895,12 @@ class StackResolver(
         // library instead of putting it in the graveyard. No cast-from-exile linkage.
         val omenFaceShuffle = cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.OMEN &&
             spellComponent.faceIndex != null
+        // Rebound (CR 702.88): a spell cast from hand that has rebound (printed or granted) exiles
+        // on resolution instead of going to the graveyard, and arms a next-upkeep free recast.
+        val reboundExile = spellComponent.castFromZone == Zone.HAND &&
+            spellHasRebound(newState, spellId, cardDef)
         val intendedDestination = when {
-            selfExile || flashbackExile || exileAfterResolve || adventureFaceExile -> Zone.EXILE
+            selfExile || flashbackExile || exileAfterResolve || adventureFaceExile || reboundExile -> Zone.EXILE
             omenFaceShuffle -> Zone.LIBRARY
             else -> Zone.GRAVEYARD
         }
@@ -1863,6 +1931,13 @@ class StackResolver(
             newState = newState.updateEntity(spellId) { c ->
                 c.with(com.wingedsheep.engine.state.components.battlefield.ParadigmComponent)
             }
+        }
+
+        // Rebound (CR 702.88a): arm the caster's next-upkeep free recast of the just-exiled card.
+        if (reboundExile && destinationZone == Zone.EXILE) {
+            newState = scheduleReboundRecast(
+                newState, spellId, spellComponent.casterId, cardComponent?.name ?: "Unknown"
+            )
         }
 
         // CR 715.3d — an Adventure card exiled by its own resolution may be cast as the creature

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -53,7 +53,7 @@ import com.wingedsheep.sdk.scripting.effects.WarpExileEffect
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
-import com.wingedsheep.engine.handlers.effects.permanent.types.returnDfcFaceFromExile
+import com.wingedsheep.engine.handlers.effects.permanent.types.returnDfcFace
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
@@ -2044,7 +2044,7 @@ class StackResolver(
      * exile is invisible — no effect keys on it — so the stack → battlefield move is done directly.
      *
      * Per the official ruling, a card that is not double-faced (or whose back face is not a permanent)
-     * "will not enter at all"; [returnDfcFaceFromExile] no-ops in that case and the caller must fall
+     * "will not enter at all"; [returnDfcFace] no-ops in that case and the caller must fall
      * back to the normal graveyard/exile destination.
      */
     private fun resolveSelfToBattlefieldTransformed(
@@ -2075,11 +2075,11 @@ class StackResolver(
 
         // "Exile it, then put it onto the battlefield transformed": the resolving spell was already
         // popped off the stack (it is in no zone), so place it in its owner's exile — the source
-        // zone [returnDfcFaceFromExile] is built to flip-and-return from.
+        // zone [returnDfcFace] is built to flip-and-return from.
         working = working.addToZone(ZoneKey(ownerId, Zone.EXILE), spellId)
 
         // A DFC spell on the stack carries no DoubleFacedComponent yet (it's stamped on ETB); add
-        // one on its front face so returnDfcFaceFromExile can flip it to the back face.
+        // one on its front face so returnDfcFace can flip it to the back face.
         if (working.getEntity(spellId)?.get<DoubleFacedComponent>() == null) {
             working = working.updateEntity(spellId) { c ->
                 c.with(
@@ -2092,7 +2092,7 @@ class StackResolver(
             }
         }
 
-        val transition = returnDfcFaceFromExile(working, cardRegistry, spellId, DoubleFacedComponent.Face.BACK)
+        val transition = returnDfcFace(working, cardRegistry, spellId, DoubleFacedComponent.Face.BACK)
         working = transition.state
         events.addAll(transition.events)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1071,6 +1071,17 @@ data object SacrificedFoodThisTurnComponent : Component
 data class PermanentsSacrificedThisTurnComponent(val count: Int = 0) : Component
 
 /**
+ * Tracks the total noncombat damage red sources this player controlled have dealt this turn
+ * (controller-scoped). Incremented in `DamageUtils.dealDamageToTarget` on the damage source's
+ * controller whenever a red source deals a positive amount of noncombat damage, and cleared at
+ * end of turn by `CleanupPhaseManager`. Backs `TurnTracker.RED_NONCOMBAT_DAMAGE_DEALT` — the
+ * Temple of Power (back of Ojer Axonil, Deepest Might) transform gate ("Activate only if red
+ * sources you controlled dealt 4 or more noncombat damage this turn").
+ */
+@Serializable
+data class RedNoncombatDamageDealtThisTurnComponent(val amount: Int = 0) : Component
+
+/**
  * The set of distinct elemental bending keyword actions ([BendType]: waterbend, earthbend,
  * firebend, airbend) this player has performed this turn (CR 701.65–701.67 / 702.189). Folded in by
  * `BendEvents.record` whenever the player bends, and reset to empty for every player at the start of

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AclazotzDeepestBetrayalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AclazotzDeepestBetrayalScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AclazotzDeepestBetrayal
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Aclazotz, Deepest Betrayal // Temple of the Dead (LCI #88).
+ *
+ *  1. **Attack — discard / draw-for-who-can't** — each opponent discards a card; for each opponent
+ *     with an empty hand (who can't) the controller draws instead.
+ *  2. **Bat on land discard** — an opponent discarding a land card makes a 1/1 black flying Bat.
+ *  3. **Dies → return tapped + transformed** — the shared dies-trigger returns Temple of the Dead.
+ *  4. **Transform-back gate** — Temple of the Dead's transform needs some player at one or fewer
+ *     cards in hand.
+ */
+class AclazotzDeepestBetrayalScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun attack(game: TestGame) {
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Aclazotz, Deepest Betrayal" to 2)).error shouldBe null
+        }
+
+        // Resolve the attack trigger, answering the opponent's discard selection (if any).
+        fun resolveAttackTrigger(game: TestGame) {
+            var guard = 0
+            while (guard++ < 20) {
+                val decision = game.getPendingDecision()
+                if (decision is SelectCardsDecision) {
+                    val pick = decision.options.take(decision.minSelections.coerceAtLeast(1))
+                    game.submitDecision(CardsSelectedResponse(decision.id, pick))
+                } else if (game.state.stack.isNotEmpty()) {
+                    game.resolveStack()
+                } else break
+            }
+        }
+
+        context("Aclazotz, Deepest Betrayal") {
+
+            test("an opponent with cards discards one and the controller draws nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aclazotz, Deepest Betrayal", summoningSickness = false)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withCardInHand(2, "Lightning Bolt") // two non-land cards
+                    .withCardInLibrary(1, "Swamp") // a card to draw if (wrongly) drawn
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                attack(game)
+                resolveAttackTrigger(game)
+
+                withClue("the opponent discarded exactly one card") { game.handSize(2) shouldBe 1 }
+                withClue("the controller drew nothing (opponent could discard)") { game.handSize(1) shouldBe 0 }
+            }
+
+            test("draws a card for an opponent who can't discard (empty hand)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aclazotz, Deepest Betrayal", summoningSickness = false)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                attack(game)
+                resolveAttackTrigger(game)
+
+                withClue("the empty-handed opponent couldn't discard, so the controller drew 1") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("an opponent discarding a land card makes a 1/1 flying Bat") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aclazotz, Deepest Betrayal", summoningSickness = false)
+                    .withCardInHand(2, "Forest") // the opponent's only card is a land
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                attack(game)
+                resolveAttackTrigger(game)
+
+                withClue("the discarded land triggered one Bat token") {
+                    game.findPermanents("Bat Token").size shouldBe 1
+                }
+            }
+
+            test("when it dies it returns tapped as Temple of the Dead") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aclazotz, Deepest Betrayal", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aclazotz = game.findPermanent("Aclazotz, Deepest Betrayal")!!
+
+                repeat(2) {
+                    game.castSpell(1, "Lightning Bolt", targetId = aclazotz).error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+                var guard = 0
+                while (game.findPermanent("Temple of the Dead") == null && guard++ < 10) game.resolveStack()
+
+                withClue("same entity returned as the back face, tapped") {
+                    game.findPermanent("Temple of the Dead") shouldBe aclazotz
+                    game.state.getEntity(aclazotz)!!.get<TappedComponent>() shouldNotBe null
+                }
+            }
+        }
+
+        context("Temple of the Dead — transform-back gate") {
+
+            val transformAbilityId = AclazotzDeepestBetrayal.backFace!!
+                .activatedAbilities.first { !it.isManaAbility }.id
+
+            test("transforms back while a player has one or fewer cards in hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of the Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3) // {2}{B} for the transform
+                    // Player1's hand is empty (0 <= 1), so the gate is satisfied.
+                    .withCardInHand(2, "Forest")
+                    .withCardInHand(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of the Dead")!!
+                game.execute(ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId))
+                    .error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the land flipped to its front face") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Aclazotz, Deepest Betrayal"
+                }
+            }
+
+            test("cannot transform back while every player has two or more cards in hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of the Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(2, "Forest")
+                    .withCardInHand(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of the Dead")!!
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId)
+                )
+
+                withClue("activation is illegal — no player at one or fewer cards") {
+                    result.error shouldNotBe null
+                }
+                withClue("it stays a land") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Temple of the Dead"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElspethStormSlayerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElspethStormSlayerScenarioTest.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.shouldBe
  * Scenario tests for Elspeth, Storm Slayer (TDM #11, {3}{W}{W}, Loyalty 5).
  *
  *   If one or more tokens would be created under your control, twice that many of those tokens
- *   are created instead.  ([com.wingedsheep.sdk.scripting.DoubleTokenCreation])
+ *   are created instead.  ([com.wingedsheep.sdk.scripting.MultiplyTokenCreation])
  *   +1: Create a 1/1 white Soldier creature token.
  *   0: Put a +1/+1 counter on each creature you control. Those creatures gain flying until your
  *      next turn.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerAxonilDeepestMightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerAxonilDeepestMightScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OjerAxonilDeepestMight
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ojer Axonil, Deepest Might // Temple of Power (LCI #158).
+ *
+ *  1. **Damage floor** — [com.wingedsheep.sdk.scripting.SetMinimumDamage] raises noncombat damage
+ *     from a red source you control to an *opponent* up to Ojer Axonil's power; it leaves damage to
+ *     an opponent's creature (recipient is a player) untouched.
+ *  2. **Dies → return tapped + transformed** — the shared dies-trigger returns Temple of Power.
+ *  3. **Transform-back gate** — Temple of Power's transform needs red sources you controlled to
+ *     have dealt 4+ noncombat damage this turn (the RED_NONCOMBAT_DAMAGE_DEALT tracker).
+ */
+class OjerAxonilDeepestMightScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun castBolt(game: TestGame, targetPlayer: Int) {
+            game.castSpellTargetingPlayer(1, "Lightning Bolt", targetPlayer).error shouldBe null
+            if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+        }
+
+        context("Ojer Axonil, Deepest Might") {
+
+            test("floors a red source's noncombat damage to an opponent up to Axonil's power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Axonil, Deepest Might", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                castBolt(game, 2)
+
+                withClue("Bolt's 3 damage floored to Axonil's power (4): 20 - 4 = 16") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+            }
+
+            test("does not floor damage to an opponent's creature (recipient is a player only)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Axonil, Deepest Might", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Craw Wurm") // 6/4
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm")!!
+                game.castSpell(1, "Lightning Bolt", targetId = wurm).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Bolt dealt only 3 (not floored to 4), so the 4-toughness Wurm survives") {
+                    game.findPermanent("Craw Wurm").shouldNotBeNull()
+                }
+            }
+
+            test("when it dies it returns tapped as Temple of Power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Axonil, Deepest Might", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val axonil = game.findPermanent("Ojer Axonil, Deepest Might")!!
+
+                repeat(2) { // 6 damage (bolts to my own creature aren't floored) kills the 4/4
+                    game.castSpell(1, "Lightning Bolt", targetId = axonil).error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+                var guard = 0
+                while (game.findPermanent("Temple of Power") == null && guard++ < 10) game.resolveStack()
+
+                withClue("same entity returned as the back face, tapped") {
+                    game.findPermanent("Temple of Power") shouldBe axonil
+                    game.state.getEntity(axonil)!!.get<TappedComponent>() shouldNotBe null
+                }
+            }
+        }
+
+        context("Temple of Power — transform-back gate") {
+
+            val transformAbilityId = OjerAxonilDeepestMight.backFace!!
+                .activatedAbilities.first { !it.isManaAbility }.id
+
+            test("transforms back after red sources dealt 4+ noncombat damage this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Power")
+                    .withLandsOnBattlefield(1, "Mountain", 5) // 2 Bolts ({R}{R}) + transform ({2}{R})
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Power")!!
+
+                castBolt(game, 2) // 3 red noncombat damage
+                castBolt(game, 2) // 6 total, over the threshold
+
+                game.execute(ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId))
+                    .error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the land flipped to its front face") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Ojer Axonil, Deepest Might"
+                }
+            }
+
+            test("cannot transform back without 4 noncombat damage from red sources") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Power")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Power")!!
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId)
+                )
+
+                withClue("activation is illegal without the red-damage condition") {
+                    result.error shouldNotBe null
+                }
+                withClue("it stays a land") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Temple of Power"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerKaslemDeepestGrowthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerKaslemDeepestGrowthScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OjerKaslemDeepestGrowth
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ojer Kaslem, Deepest Growth // Temple of Cultivation (LCI #204).
+ *
+ * Covers the three behaviours of the card:
+ *  1. **Dies → return tapped + transformed** — the shared
+ *     [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromZoneTransformedEffect]`(tapped = true)`
+ *     wired to [com.wingedsheep.sdk.dsl.Triggers.Dies]. When the God dies, the same entity returns
+ *     to the battlefield **tapped** as its back face, Temple of Cultivation.
+ *  2. **Combat-damage reveal** — deals N combat damage → reveal N → put up to one creature and up
+ *     to one land onto the battlefield (the "and/or") → bottom the rest in a random order.
+ *  3. **Transform-back gate** — the land's `{2}{G}, {T}` transform is only activatable while you
+ *     control ten or more permanents (CR: activate-only-if condition).
+ */
+class OjerKaslemDeepestGrowthScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun optionNamed(game: TestGame, decision: SelectCardsDecision, name: String): EntityId =
+            decision.options.first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+        context("Ojer Kaslem, Deepest Growth") {
+
+            test("when it dies it returns to the battlefield tapped as Temple of Cultivation") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Kaslem, Deepest Growth", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2) // {R}{R} for two Bolts
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaslem = game.findPermanent("Ojer Kaslem, Deepest Growth")!!
+
+                // 6 damage to a 6/5 kills it (SBA). The dies-trigger returns it transformed + tapped.
+                repeat(2) {
+                    game.castSpell(1, "Lightning Bolt", targetId = kaslem).error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                        game.submitManaSourcesAutoPay()
+                    }
+                    game.resolveStack()
+                }
+                var guard = 0
+                while (game.findPermanent("Temple of Cultivation") == null && guard++ < 10) {
+                    game.resolveStack()
+                }
+
+                withClue("same entity returned to the battlefield as the back face") {
+                    game.findPermanent("Temple of Cultivation") shouldBe kaslem
+                    game.state.getEntity(kaslem)!!.get<CardComponent>()!!.name shouldBe "Temple of Cultivation"
+                }
+                withClue("it returned tapped") {
+                    game.state.getEntity(kaslem)!!.get<TappedComponent>() shouldNotBe null
+                }
+            }
+
+            test("combat damage reveals N and puts a creature and a land onto the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Kaslem, Deepest Growth", summoningSickness = false)
+                    // Exactly six cards in library so reveal-6 sees all of them; one creature, one
+                    // land, four non-creature-non-land fillers.
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Ojer Kaslem, Deepest Growth" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+
+                // First select: the creature.
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) game.resolveStack()
+                val creatureDecision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for the creature; got ${game.getPendingDecision()}")
+                game.submitDecision(
+                    CardsSelectedResponse(creatureDecision.id, listOf(optionNamed(game, creatureDecision, "Grizzly Bears")))
+                )
+
+                // Second select: the land.
+                guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) game.resolveStack()
+                val landDecision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision for the land; got ${game.getPendingDecision()}")
+                game.submitDecision(
+                    CardsSelectedResponse(landDecision.id, listOf(optionNamed(game, landDecision, "Forest")))
+                )
+                game.resolveStack()
+
+                withClue("the chosen creature and land entered the battlefield") {
+                    game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                    game.findPermanent("Forest").shouldNotBeNull()
+                }
+                withClue("the remaining four cards were bottomed") {
+                    game.librarySize(1) shouldBe 4
+                }
+            }
+        }
+
+        context("Temple of Cultivation — transform-back gate") {
+
+            val transformAbilityId = OjerKaslemDeepestGrowth.backFace!!
+                .activatedAbilities.first { !it.isManaAbility }.id
+
+            test("cannot transform back while controlling fewer than ten permanents") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Cultivation")
+                    .withLandsOnBattlefield(1, "Forest", 4) // enough mana; only 5 permanents total (<10)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Cultivation")!!
+                val result = game.execute(ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId))
+
+                withClue("activation is illegal under the ten-permanent gate") {
+                    result.error shouldNotBe null
+                }
+                withClue("it stays a land — no transform happened") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Temple of Cultivation"
+                }
+            }
+
+            test("transforms back into Ojer Kaslem while controlling ten or more permanents") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Cultivation")
+                    .withLandsOnBattlefield(1, "Forest", 9) // Temple + 9 Forests = 10 permanents
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Cultivation")!!
+                game.execute(ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId))
+                    .error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the land flipped to its front face") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Ojer Kaslem, Deepest Growth"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerPakpatiqDeepestEpochScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerPakpatiqDeepestEpochScenarioTest.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OjerPakpatiqDeepestEpoch
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time (LCI #67) — the Rebound keyword.
+ *
+ *  1. **Grant + exile-on-resolve** — an instant you cast from hand gains rebound: it deals its
+ *     damage, then is exiled (not put in the graveyard) and a next-upkeep free recast is armed.
+ *  2. **Recast at next upkeep** — at your next upkeep you may cast it from exile for free.
+ *  3. **Dies → return tapped + transformed with three time counters** as Temple of Cyclical Time.
+ *  4. **Back gate** — the mana ability removes a time counter; the transform is only activatable
+ *     once no time counters remain.
+ */
+class OjerPakpatiqDeepestEpochScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun timeCounters(game: TestGame, id: EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.TIME) ?: 0
+
+        fun exileHas(game: TestGame, player: EntityId, name: String): Boolean =
+            game.state.getZone(player, Zone.EXILE).any { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+        fun graveyardHas(game: TestGame, player: EntityId, name: String): Boolean =
+            game.state.getZone(player, Zone.GRAVEYARD).any { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+        context("Ojer Pakpatiq — rebound grant") {
+
+            test("an instant cast from hand is exiled on resolution and arms a next-upkeep recast") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Pakpatiq, Deepest Epoch", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Bolt dealt its 3 damage") { game.getLifeTotal(2) shouldBe 17 }
+                withClue("Bolt was exiled by rebound, not put in the graveyard") {
+                    exileHas(game, game.player1Id, "Lightning Bolt") shouldBe true
+                    graveyardHas(game, game.player1Id, "Lightning Bolt") shouldBe false
+                }
+                withClue("a next-upkeep recast is armed") {
+                    game.state.delayedTriggers.size shouldBe 1
+                }
+            }
+
+            test("at the caster's next upkeep the exiled instant may be recast for free") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Pakpatiq, Deepest Epoch", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(2, 20)
+                    // Library padding so both players survive the draw steps across two turns.
+                    .apply { repeat(6) { withCardInLibrary(1, "Forest"); withCardInLibrary(2, "Forest") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                game.getLifeTotal(2) shouldBe 17
+
+                // Advance to Player1's next upkeep (past Player2's intervening turn).
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)      // Player2 upkeep (turn 2)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // Player2 main
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)      // Player1 upkeep (turn 3) — rebound fires
+                // The delayed trigger is on the stack; resolve it to surface its may-cast.
+                var yesGuard = 0
+                while (game.getPendingDecision() !is YesNoDecision && yesGuard++ < 10) game.resolveStack()
+
+                withClue("the rebound recast offers a may-cast at the caster's upkeep") {
+                    val yesNo = game.getPendingDecision()
+                    (yesNo is YesNoDecision) shouldBe true
+                    game.submitDecision(com.wingedsheep.engine.core.YesNoResponse((yesNo as YesNoDecision).id, true))
+                }
+                // The free cast targets a player — aim it at Player2 again.
+                var guard = 0
+                while (game.getPendingDecision() !is ChooseTargetsDecision && guard++ < 10) game.resolveStack()
+                val td = game.getPendingDecision() as ChooseTargetsDecision
+                game.submitDecision(TargetsResponse(td.id, mapOf(0 to listOf(game.player2Id))))
+                game.resolveStack()
+
+                withClue("the free recast dealt another 3 (17 -> 14)") { game.getLifeTotal(2) shouldBe 14 }
+            }
+        }
+
+        context("Ojer Pakpatiq — dies and back face") {
+
+            test("when it dies it returns tapped as Temple of Cyclical Time with three time counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Pakpatiq, Deepest Epoch", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pakpatiq = game.findPermanent("Ojer Pakpatiq, Deepest Epoch")!!
+
+                repeat(2) { // 6 damage kills the 4/3
+                    game.castSpell(1, "Lightning Bolt", targetId = pakpatiq).error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+                var guard = 0
+                while (game.findPermanent("Temple of Cyclical Time") == null && guard++ < 10) game.resolveStack()
+
+                withClue("same entity returned tapped as the back face") {
+                    game.findPermanent("Temple of Cyclical Time") shouldBe pakpatiq
+                    game.state.getEntity(pakpatiq)!!.get<TappedComponent>() shouldNotBe null
+                }
+                withClue("it entered with three time counters") {
+                    timeCounters(game, pakpatiq) shouldBe 3
+                }
+            }
+
+            test("the mana ability removes a time counter and the transform is gated on none remaining") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Cyclical Time")
+                    .withLandsOnBattlefield(1, "Island", 3) // {2}{U} for the transform
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Cyclical Time")!!
+                // Seed one time counter so we can watch the mana ability remove it.
+                game.state = game.state.updateEntity(temple) {
+                    it.with(CountersComponent(mapOf(CounterType.TIME to 1)))
+                }
+
+                val manaAbilityId = OjerPakpatiqDeepestEpoch.backFace!!
+                    .activatedAbilities.first { it.isManaAbility }.id
+                val transformAbilityId = OjerPakpatiqDeepestEpoch.backFace!!
+                    .activatedAbilities.first { !it.isManaAbility }.id
+
+                // With a time counter present, the transform is illegal.
+                withClue("transform blocked while a time counter remains") {
+                    game.execute(
+                        ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId)
+                    ).error shouldNotBe null
+                }
+
+                // Tapping for mana removes the time counter.
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = manaAbilityId)
+                ).error shouldBe null
+                game.resolveStack()
+                withClue("the mana ability removed the time counter") { timeCounters(game, temple) shouldBe 0 }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerTaqDeepestFoundationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OjerTaqDeepestFoundationScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OjerTaqDeepestFoundation
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ojer Taq, Deepest Foundation // Temple of Civilization (LCI #26).
+ *
+ *  1. **Token tripling** — [com.wingedsheep.sdk.scripting.MultiplyTokenCreation]`(factor = 3)`:
+ *     Dragon Fodder's two Goblin tokens become six under Ojer Taq's control.
+ *  2. **Dies → return tapped + transformed** — the shared dies-trigger returns the God as its
+ *     back face, Temple of Civilization, tapped.
+ *  3. **Transform-back gate** — the land's `{2}{W}, {T}` transform is only activatable once you
+ *     have attacked with three or more creatures this turn.
+ */
+class OjerTaqDeepestFoundationScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ojer Taq, Deepest Foundation") {
+
+            test("triples creature tokens created under your control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Taq, Deepest Foundation", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2) // {1}{R} for Dragon Fodder
+                    .withCardInHand(1, "Dragon Fodder")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dragon Fodder").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("two Goblin tokens tripled to six") {
+                    game.findPermanents("Goblin Token").size shouldBe 6
+                }
+            }
+
+            test("when it dies it returns tapped as Temple of Civilization") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ojer Taq, Deepest Foundation", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val taq = game.findPermanent("Ojer Taq, Deepest Foundation")!!
+
+                repeat(2) { // 6 damage kills the 6/6
+                    game.castSpell(1, "Lightning Bolt", targetId = taq).error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+                var guard = 0
+                while (game.findPermanent("Temple of Civilization") == null && guard++ < 10) game.resolveStack()
+
+                withClue("same entity returned as the back face, tapped") {
+                    game.findPermanent("Temple of Civilization") shouldBe taq
+                    game.state.getEntity(taq)!!.get<TappedComponent>() shouldNotBe null
+                }
+            }
+        }
+
+        context("Temple of Civilization — transform-back gate") {
+
+            val transformAbilityId = OjerTaqDeepestFoundation.backFace!!
+                .activatedAbilities.first { !it.isManaAbility }.id
+
+            test("transforms back after attacking with three or more creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Civilization")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Craw Wurm", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 3) // {2}{W} for the transform (Temple taps for the cost)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Civilization")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 2, "Hill Giant" to 2, "Craw Wurm" to 2)
+                ).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                game.execute(ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId))
+                    .error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the land flipped to its front face") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Ojer Taq, Deepest Foundation"
+                }
+            }
+
+            test("cannot transform back without having attacked with three creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Temple of Civilization")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val temple = game.findPermanent("Temple of Civilization")!!
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = temple, abilityId = transformAbilityId)
+                )
+
+                withClue("activation is illegal without the attack condition") {
+                    result.error shouldNotBe null
+                }
+                withClue("it stays a land") {
+                    game.state.getEntity(temple)!!.get<CardComponent>()!!.name shouldBe "Temple of Civilization"
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -220,6 +220,8 @@ export enum Keyword {
   JOB_SELECT = 'JOB_SELECT',
   // Ability words
   EERIE = 'EERIE',
+  // Instant/sorcery recast next upkeep (Rise of the Eldrazi; granted by Ojer Pakpatiq)
+  REBOUND = 'REBOUND',
 }
 
 export const KeywordDisplayNames: Record<Keyword, string> = {
@@ -286,6 +288,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.TRAINING]: 'Training',
   [Keyword.JOB_SELECT]: 'Job select',
   [Keyword.EERIE]: 'Eerie',
+  [Keyword.REBOUND]: 'Rebound',
 }
 
 /**


### PR DESCRIPTION
## The Lost Caverns of Ixalan — the god cycle (Ojer ×4 + Aclazotz)

Implements the five LCI double-faced gods and the shared engine primitives they need. Each god is a
`{God} // {Temple}` DFC that returns tapped-and-transformed when it dies, and whose land back face
transforms back under a set-specific gate.

### Cards (LCI-original mythics — canonical lives in LCI)

| Card | Front behavior | Back-face transform gate |
|------|----------------|--------------------------|
| **Ojer Taq, Deepest Foundation** // Temple of Civilization | Triples creature tokens created under your control | attacked with 3+ creatures this turn |
| **Ojer Kaslem, Deepest Growth** // Temple of Cultivation | Combat-damage reveal → put a creature and/or land onto the battlefield, bottom the rest | control 10+ permanents |
| **Ojer Axonil, Deepest Might** // Temple of Power | Red noncombat damage to an opponent is floored to Axonil's power | red sources dealt 4+ noncombat damage this turn |
| **Aclazotz, Deepest Betrayal** // Temple of the Dead | Attack: each opponent discards, draw for who can't; Bat on opponent land-discard | a player has ≤1 card in hand |
| **Ojer Pakpatiq, Deepest Epoch** // Temple of Cyclical Time | Grants **rebound** to instants you cast from hand; returns with 3 time counters | land has no time counters |

### Engine primitives added (each parameterized for reuse, not one-off)

- **Rebound keyword** (`Keyword.REBOUND`, CR 702.88) — modeled entirely in the spell-resolution path
  (`StackResolver`). Honors the printed keyword **or** one granted to the stack object via
  `GrantKeywordToSpellEffect` (Ojer Pakpatiq). A from-hand cast exiles on resolution and arms a
  one-shot next-upkeep free recast reusing the suspend cast-from-exile pipeline; casting from exile
  isn't "from hand", so it doesn't re-rebound.
- **`SetMinimumDamage`** — the floor mirror of `CapDamage`; raises a matching source's damage up to a
  (optionally dynamic) minimum. Ojer Axonil uses `dynamicMinimum = sourcePower()`.
- **`MultiplyTokenCreation(factor)`** — generalizes `DoubleTokenCreation` to any factor (2 keeps
  Doubling Season / Elspeth / Exalted Sunborn; 3 for Ojer Taq). Stacks multiplicatively.
- **`ReturnSelfFromGraveyardTransformed(tapped)`** — one bool threaded to `ZoneEntryOptions`, wired to
  `Triggers.Dies` for the whole cycle. Pakpatiq's "with three time counters" composes as
  `Composite(return, AddCounters(TIME, 3, Self))` (entity id preserved).
- **`RED_NONCOMBAT_DAMAGE_DEALT` turn tracker** (`RedNoncombatDamageDealtThisTurnComponent`) — backs
  `Conditions.YouDealtRedNoncombatDamageThisTurn`, cleared at end of turn.

### Tests

- Per-card scenario suites in `rules-engine` (14 tests) covering token tripling, the damage floor
  (incl. that it does *not* apply to a creature recipient), rebound grant + exile + next-upkeep free
  recast across two turns, dies→return-tapped, time counters, and every transform-back gate (both
  directions). All green.
- `mtg-sdk` round-trip + DSL tests and `mtg-sets` `CardDefinitionSnapshotTest` (LCI golden) +
  `CardLintTest` re-blessed and green.

### Review fixes folded in

- The `RED_NONCOMBAT_DAMAGE_DEALT` tracker reads projected colors (a granted-red source counts),
  matching how the `SetMinimumDamage` floor already matches its source.
- Renamed `returnDfcFaceFromExile` → `returnDfcFace` (it returns from the graveyard here, not exile;
  doc corrected).

Docs: `card-sdk-language-reference.md` and `architecture-principles.md` updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
