### PR TITLE
Add a handful of Foundations cards (Surrak, Flamewake Phoenix, Crossway Troublemakers, Zul Ashur)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SurrakTheHuntCaller.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/SurrakTheHuntCaller.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Surrak, the Hunt Caller
+ * {2}{G}{G}
+ * Legendary Creature — Human Warrior
+ * 5/4
+ *
+ * Formidable — At the beginning of combat on your turn, if creatures you control have total
+ * power 8 or greater, target creature you control gains haste until end of turn.
+ *
+ * "Formidable" is an ability word (no rules meaning); the intervening-if is a plain total-power
+ * check via [Conditions.CompareAmounts] over `sumPower()`. As an intervening-if (CR 603.4) it is
+ * checked both when the trigger would fire and again on resolution, so losing power in response
+ * fizzles the ability.
+ */
+val SurrakTheHuntCaller = card("Surrak, the Hunt Caller") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Warrior"
+    oracleText = "Formidable — At the beginning of combat on your turn, if creatures you control " +
+        "have total power 8 or greater, target creature you control gains haste until end of turn. " +
+        "(It can attack and {T} no matter when it came under your control.)"
+    power = 5
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).sumPower(),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(8)
+        )
+        val creature = target("target creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.GrantKeyword(Keyword.HASTE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "210"
+        artist = "Wesley Burt"
+        flavorText = "\"The greatest honor is to feed Atarka.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg?1783938575"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrosswayTroublemakersReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrosswayTroublemakersReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crossway Troublemakers reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Innistrad: Crimson Vow Commander's `cards/` package; this file contributes only
+ * presentation data.
+ */
+val CrosswayTroublemakersReprint = Printing(
+    oracleId = "1a362e4d-6c02-4b67-ab63-c6622e505195",
+    name = "Crossway Troublemakers",
+    setCode = "FDN",
+    collectorNumber = "518",
+    scryfallId = "03a5e19c-4cb8-4bd7-923c-4db747dc6ca3",
+    artist = "Aaron J. Riley",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03a5e19c-4cb8-4bd7-923c-4db747dc6ca3.jpg?1783908959",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FlamewakePhoenixReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FlamewakePhoenixReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flamewake Phoenix reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Fate Reforged's `cards/` package; this file contributes only presentation data.
+ */
+val FlamewakePhoenixReprint = Printing(
+    oracleId = "9e43805d-3576-47d4-9331-524869ab99d0",
+    name = "Flamewake Phoenix",
+    setCode = "FDN",
+    collectorNumber = "198",
+    scryfallId = "a94f008e-48a0-406b-83fa-99cd396831f8",
+    artist = "Min Yum",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a94f008e-48a0-406b-83fa-99cd396831f8.jpg?1783909067",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SurrakTheHuntCallerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SurrakTheHuntCallerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Surrak, the Hunt Caller reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Dragons of Tarkir's `cards/` package; this file contributes only presentation data.
+ */
+val SurrakTheHuntCallerReprint = Printing(
+    oracleId = "fa56a5fa-ef96-404c-8fb6-d1f5fcebb52e",
+    name = "Surrak, the Hunt Caller",
+    setCode = "FDN",
+    collectorNumber = "647",
+    scryfallId = "d6a8759d-0dc8-4218-93ac-b1a35088f776",
+    artist = "Wesley Burt",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg?1783908915",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ZulAshurLichLord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ZulAshurLichLord.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Zul Ashur, Lich Lord
+ * {1}{B}
+ * Legendary Creature — Zombie Warlock
+ * 2/2
+ *
+ * Ward—Pay 2 life.
+ * {T}: You may cast target Zombie creature card from your graveyard this turn.
+ *
+ * Implementation:
+ * - Ward is the printed [KeywordAbility.wardLife] (counter unless the targeting opponent pays 2 life).
+ * - The activated ability gathers the chosen Zombie-creature card ([CardSource.ChosenTargets]) and
+ *   grants a may-play-from-graveyard permission ([GrantMayPlayFromExileEffect]) that expires at end
+ *   of turn. The card is not moved out of the graveyard — the cast enumerator already honours a
+ *   `MayPlayPermission` on a graveyard card (Tinybones, the Pickpocket). No `withAnyManaType` and no
+ *   flash grant, so the card is cast for its normal cost following normal timing rules, matching the
+ *   Scryfall ruling ("You pay all costs and follow all normal timing rules for Zombie creature cards
+ *   cast with the permission"). The "may" is the permission itself — the player chooses whether to cast.
+ */
+val ZulAshurLichLord = card("Zul Ashur, Lich Lord") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Zombie Warlock"
+    power = 2
+    toughness = 2
+    oracleText = "Ward—Pay 2 life. (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player pays 2 life.)\n" +
+        "{T}: You may cast target Zombie creature card from your graveyard this turn."
+
+    keywordAbility(KeywordAbility.wardLife(2))
+
+    activatedAbility {
+        cost = Costs.Tap
+        target(
+            "target Zombie creature card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.ChosenTargets,
+                    storeAs = "zulAshurTarget",
+                ),
+                GrantMayPlayFromExileEffect(
+                    from = "zulAshurTarget",
+                    expiry = MayPlayExpiry.EndOfTurn,
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "77"
+        artist = "Raluca Marinescu"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg?1783909107"
+
+        ruling("2024-11-08", "You pay all costs and follow all normal timing rules for Zombie " +
+            "creature cards cast with the permission granted by Zul Ashur's last ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/FlamewakePhoenix.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/FlamewakePhoenix.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MustAttack
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flamewake Phoenix
+ * {1}{R}{R}
+ * Creature — Phoenix
+ * 2/2
+ * Flying, haste
+ * This creature attacks each combat if able.
+ * Ferocious — At the beginning of combat on your turn, if you control a creature with power 4 or
+ * greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield.
+ *
+ * "Ferocious" is an ability word (no rules meaning); the gate is the intervening-if
+ * [Conditions.YouControl] over a power-4+ creature (CR 603.4), checked when the trigger would fire
+ * and again at resolution. The trigger fires while the card is in the graveyard
+ * (`triggerZone = GRAVEYARD`); the optional {R} is modeled as [MayPayManaEffect] whose consequence
+ * moves the card from the graveyard to the battlefield.
+ */
+val FlamewakePhoenix = card("Flamewake Phoenix") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Phoenix"
+    oracleText = "Flying, haste\n" +
+        "This creature attacks each combat if able.\n" +
+        "Ferocious — At the beginning of combat on your turn, if you control a creature with power " +
+        "4 or greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    staticAbility {
+        ability = MustAttack()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerZone = Zone.GRAVEYARD
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{R}"),
+            effect = Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "100"
+        artist = "Min Yum"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg?1783938688"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/InnistradCrimsonVowCommanderSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/InnistradCrimsonVowCommanderSet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.voc
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Innistrad: Crimson Vow Commander (2021)
+ *
+ * Commander preconstructed decks released alongside Innistrad: Crimson Vow. Scaffolded to hold the
+ * canonical [CardDefinition] for cards that first appeared here and are reprinted in later sets
+ * (e.g. Crossway Troublemakers, reprinted in Foundations).
+ *
+ * Set Code: VOC
+ * Release Date: November 19, 2021
+ */
+object InnistradCrimsonVowCommanderSet : MtgSet {
+
+    override val code = "VOC"
+    override val displayName = "Innistrad: Crimson Vow Commander"
+    override val releaseDate = "2021-11-19"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.voc.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/CrosswayTroublemakers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/CrosswayTroublemakers.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Crossway Troublemakers
+ * {5}{B}
+ * Creature — Vampire
+ * 5/5
+ *
+ * Attacking Vampires you control have deathtouch and lifelink.
+ * Whenever a Vampire you control dies, you may pay 2 life. If you do, draw a card.
+ *
+ * The two combat keywords are separate [GrantKeyword] statics over the same filter (attacking
+ * Vampires you control — Crossway itself qualifies while attacking). The death trigger mirrors the
+ * established "pay N life. If you do, draw" shape (Call of the Ring): a [MayEffect] whose
+ * consequence is `LoseLife` + `DrawCards`.
+ */
+val CrosswayTroublemakers = card("Crossway Troublemakers") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    oracleText = "Attacking Vampires you control have deathtouch and lifelink. (Any amount of " +
+        "damage they deal to a creature is enough to destroy it. Damage dealt by those creatures " +
+        "also causes their controller to gain that much life.)\n" +
+        "Whenever a Vampire you control dies, you may pay 2 life. If you do, draw a card."
+    power = 5
+    toughness = 5
+
+    val attackingVampiresYouControl =
+        GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE).attacking().youControl())
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEATHTOUCH, attackingVampiresYouControl)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK, attackingVampiresYouControl)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE).youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayEffect(
+            effect = Effects.Composite(
+                listOf(
+                    Effects.LoseLife(2, EffectTarget.Controller),
+                    Effects.DrawCards(1),
+                )
+            ),
+            descriptionOverride = "You may pay 2 life. If you do, draw a card."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Aaron J. Riley"
+        flavorText = "\"Lady Anje said no violence at the wedding. She never said anything about " +
+            "the journey there!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/431711c5-c04f-4d34-97c9-5199cfbf9da9.jpg?1783925002"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -677,6 +677,70 @@
     ]
 }
 
+// Surrak, the Hunt Caller
+{
+    "name": "Surrak, the Hunt Caller",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Formidable — At the beginning of combat on your turn, if creatures you control have total power 8 or greater, target creature you control gains haste until end of turn. (It can attack and {T} no matter when it came under your control.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "aggregation": "SUM",
+                        "property": "POWER"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "RARE",
+        "artist": "Wesley Burt",
+        "flavorText": "\"The greatest honor is to feed Atarka.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b374446d-44bc-4ac5-9829-8c49f0cca173.jpg?1783938575"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Twin Bolt
 {
     "name": "Twin Bolt",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -7831,3 +7831,74 @@
         "GREEN"
     ]
 }
+
+// Zul Ashur, Lich Lord
+{
+    "name": "Zul Ashur, Lich Lord",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Zombie Warlock",
+    "oracleText": "Ward—Pay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\n{T}: You may cast target Zombie creature card from your graveyard this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 2
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "zulAshurTarget"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "zulAshurTarget"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Zombie own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target Zombie creature card from your graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "RARE",
+        "artist": "Raluca Marinescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34ad4fdb-9805-45b3-ba20-e47a15d6ff38.jpg?1783909107",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "You pay all costs and follow all normal timing rules for Zombie creature cards cast with the permission granted by Zul Ashur's last ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -1,3 +1,65 @@
+// Flamewake Phoenix
+{
+    "name": "Flamewake Phoenix",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Phoenix",
+    "oracleText": "Flying, haste\nThis creature attacks each combat if able.\nFerocious — At the beginning of combat on your turn, if you control a creature with power 4 or greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{R}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Battlefield"
+                    }
+                },
+                "activeZone": "Graveyard",
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ],
+        "staticAbilities": [
+            "MustAttack"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "RARE",
+        "artist": "Min Yum",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fefd5848-9fe1-4129-a5d7-e51606bf76ef.jpg?1783938688"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Noxious Dragon
 {
     "name": "Noxious Dragon",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOC.json
@@ -1,0 +1,76 @@
+// Crossway Troublemakers
+{
+    "name": "Crossway Troublemakers",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Attacking Vampires you control have deathtouch and lifelink. (Any amount of damage they deal to a creature is enough to destroy it. Damage dealt by those creatures also causes their controller to gain that much life.)\nWhenever a Vampire you control dies, you may pay 2 life. If you do, draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Vampire ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may pay 2 life. If you do, draw a card."
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH",
+                "filter": {
+                    "baseFilter": "creature Vampire attacking ctrl:you"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK",
+                "filter": {
+                    "baseFilter": "creature Vampire attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Aaron J. Riley",
+        "flavorText": "\"Lady Anje said no violence at the wedding. She never said anything about the journey there!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/431711c5-c04f-4d34-97c9-5199cfbf9da9.jpg?1783925002"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrosswayTroublemakersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrosswayTroublemakersScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Crossway Troublemakers (VOC #17; reprinted in Foundations).
+ *
+ * Attacking Vampires you control have deathtouch and lifelink.
+ * Whenever a Vampire you control dies, you may pay 2 life. If you do, draw a card.
+ *
+ * Covers the "attacking" gate on the deathtouch/lifelink static and the death trigger's optional
+ * 2-life payment to draw.
+ */
+class CrosswayTroublemakersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Crossway Troublemakers") {
+
+            test("grants deathtouch and lifelink only while a Vampire you control is attacking") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crossway Troublemakers", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crossway = game.findPermanent("Crossway Troublemakers")!!
+
+                withClue("Not attacking yet, so no combat keywords") {
+                    game.state.projectedState.hasKeyword(crossway, Keyword.DEATHTOUCH) shouldBe false
+                    game.state.projectedState.hasKeyword(crossway, Keyword.LIFELINK) shouldBe false
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Crossway Troublemakers" to 2)).error shouldBe null
+
+                withClue("While attacking, this Vampire gains deathtouch and lifelink") {
+                    game.state.projectedState.hasKeyword(crossway, Keyword.DEATHTOUCH) shouldBe true
+                    game.state.projectedState.hasKeyword(crossway, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("a dying Vampire lets you pay 2 life to draw a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crossway Troublemakers", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Indulgent Aristocrat") // a Vampire you control
+                    .withLandsOnBattlefield(1, "Swamp", 3) // pays {1}{B}{B} for Murder
+                    .withCardInHand(1, "Murder")
+                    .withCardInLibrary(1, "Swamp") // something to draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aristocrat = game.findPermanent("Indulgent Aristocrat")!!
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Murder", aristocrat).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("The Vampire's death offers the optional 2-life payment") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                val handBefore = game.handSize(1)
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Paying 2 life then draws a card") {
+                    game.getLifeTotal(1) shouldBe (lifeBefore - 2)
+                    game.handSize(1) shouldBe (handBefore + 1)
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlamewakePhoenixScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlamewakePhoenixScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Flamewake Phoenix (FRF #100; reprinted in Foundations).
+ *
+ * Ferocious — At the beginning of combat on your turn, if you control a creature with power 4 or
+ * greater, you may pay {R}. If you do, return this card from your graveyard to the battlefield.
+ *
+ * Covers the graveyard-zone combat trigger, the Ferocious intervening-if gate, and the optional
+ * {R} payment that returns the phoenix. All primitives already exist (BeginCombat trigger,
+ * YouControl condition, MayPayManaEffect, Move to battlefield).
+ */
+class FlamewakePhoenixScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flamewake Phoenix") {
+
+            test("Ferocious met + paying {R} returns the phoenix from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Flamewake Phoenix")
+                    .withCardOnBattlefield(1, "Craw Wurm") // 6/4 — a creature with power 4 or greater
+                    .withLandsOnBattlefield(1, "Mountain", 1) // pays {R}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                // The begin-combat trigger is queued on the stack; resolve it to surface the may-pay.
+                game.resolveStack()
+
+                withClue("Ferocious trigger offers the optional {R} payment") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Phoenix is returned to the battlefield") {
+                    (game.findPermanent("Flamewake Phoenix") != null) shouldBe true
+                }
+                withClue("Phoenix is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Flamewake Phoenix") shouldBe false
+                }
+            }
+
+            test("declining the payment leaves the phoenix in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Flamewake Phoenix")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Phoenix stays in the graveyard when the payment is declined") {
+                    game.isInGraveyard(1, "Flamewake Phoenix") shouldBe true
+                }
+            }
+
+            test("without a power-4 creature, the Ferocious trigger does not fire") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Flamewake Phoenix")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 — not power 4 or greater
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("No payment prompt because the Ferocious gate is not met") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe false
+                }
+                withClue("Phoenix remains in the graveyard") {
+                    game.isInGraveyard(1, "Flamewake Phoenix") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurrakTheHuntCallerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurrakTheHuntCallerScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Surrak, the Hunt Caller (DTK #210; reprinted in Foundations).
+ *
+ * Formidable — At the beginning of combat on your turn, if creatures you control have total power
+ * 8 or greater, target creature you control gains haste until end of turn.
+ *
+ * These exercise the intervening-if total-power gate (CR 603.4) and the haste grant. The card uses
+ * only existing SDK primitives (BeginCombat trigger, CompareAmounts over sumPower, GrantKeyword).
+ */
+class SurrakTheHuntCallerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Surrak, the Hunt Caller") {
+
+            test("with total power >= 8, grants haste to a chosen creature you control") {
+                // Surrak (5) + two Grizzly Bears (2 each) = 9 total power >= 8.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Surrak, the Hunt Caller", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findAllPermanents("Grizzly Bears").first()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                withClue("Formidable trigger requires a target creature") {
+                    (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("The targeted Grizzly Bears gains haste") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("with total power < 8, the Formidable trigger does not fire") {
+                // Surrak alone = 5 total power < 8, so the intervening-if fails.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Surrak, the Hunt Caller", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                withClue("No target decision because the total-power gate is not met") {
+                    (game.getPendingDecision() is ChooseTargetsDecision) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZulAshurLichLordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZulAshurLichLordScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Zul Ashur, Lich Lord (FDN #77).
+ *
+ * {T}: You may cast target Zombie creature card from your graveyard this turn.
+ *
+ * Covers the activated ability granting a graveyard-cast permission for the targeted Zombie
+ * creature card, paying its normal cost. (Ward is the standard keyword and is exercised elsewhere.)
+ */
+class ZulAshurLichLordScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Zul Ashur, Lich Lord") {
+
+            test("{T} lets you cast the targeted Zombie creature card from your graveyard this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Zul Ashur, Lich Lord", summoningSickness = false)
+                    .withCardInGraveyard(1, "Shepherd of Rot") // a Zombie creature card
+                    .withLandsOnBattlefield(1, "Swamp", 2) // pays {1}{B}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zul = game.findPermanent("Zul Ashur, Lich Lord")!!
+                val zombie = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Shepherd of Rot"
+                }
+                val abilityId = cardRegistry.getCard("Zul Ashur, Lich Lord")!!
+                    .script.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = zul,
+                        abilityId = abilityId,
+                        targets = listOf(entityIdToChosenTarget(game.state, zombie)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Now the Zombie can be cast from the graveyard for its normal cost.
+                game.castSpellFromGraveyard(1, "Shepherd of Rot").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Shepherd of Rot resolves onto the battlefield") {
+                    game.findPermanent("Shepherd of Rot") shouldNotBe null
+                }
+            }
+
+            test("without the ability, the Zombie can't be cast from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Zul Ashur, Lich Lord", summoningSickness = false)
+                    .withCardInGraveyard(1, "Shepherd of Rot")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("No permission granted, so casting from the graveyard is illegal") {
+                    game.castSpellFromGraveyard(1, "Shepherd of Rot").error shouldNotBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Foundations (FDN) cards, each via the `add-card` skill flow, using only existing SDK primitives (no engine changes) plus a proven scenario test.

## Cards

| Card | Canonical set | FDN | Mechanic |
|------|---------------|-----|----------|
| **Surrak, the Hunt Caller** | DTK (reprint row in FDN) | #647 | Formidable: begin-combat trigger gated on total power ≥ 8 (`CompareAmounts` over `sumPower`), grants haste to a target creature you control |
| **Flamewake Phoenix** | FRF (reprint row in FDN) | #198 | Flying/haste, must-attack; Ferocious graveyard-return — begin-combat trigger (`activeZone = GRAVEYARD`) with a "you control a power-4+ creature" intervening-if and an optional `{R}` (`MayPayManaEffect`) to return it |
| **Crossway Troublemakers** | VOC (new set scaffold; reprint row in FDN) | #518 | Attacking Vampires you control have deathtouch + lifelink (`GrantKeyword` statics); "a Vampire you control dies → may pay 2 life, draw" |
| **Zul Ashur, Lich Lord** | FDN original | #77 | Ward—Pay 2 life; `{T}`: grant a zone-agnostic end-of-turn may-play permission over a target Zombie creature card in your graveyard (cast for normal cost) |

## Notes

- **Canonical placement:** reprints keep their canonical `CardDefinition` in the earliest real printing (DTK, FRF, VOC), with only `Printing` rows in FDN. `just check-card-printing` passes for all four.
- **New set scaffold:** Innistrad: Crimson Vow Commander (VOC) is scaffolded (auto-discovered via classpath scan; `sealedSupported = false`) to hold Crossway Troublemakers' canonical definition.
- **No new SDK:** every card composes existing effects/triggers/conditions, so no `card-sdk-language-reference.md` change is needed.

## Tests

- New Kotest scenario tests for all four cards (9 tests) — pass.
- `CardLintTest` passes; `CardDefinitionSnapshotTest` goldens re-blessed (DTK, FRF, FDN updated; VOC added) with diffs limited to the four cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)