### PR TITLE
Add Wilds of Eldraine cards: Gingerbrute and Bellowing Bruiser // Beat a Path

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/Gingerbrute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/Gingerbrute.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gingerbrute
+ * {1}
+ * Artifact Creature — Food Golem
+ * 1/1
+ *
+ * Haste
+ * {1}: This creature can't be blocked this turn except by creatures with haste.
+ * {2}, {T}, Sacrifice this creature: You gain 3 life.
+ *
+ * Canonical earliest real printing is Throne of Eldraine (ELD, 2019); reprinted in Wilds of
+ * Eldraine (WOE) — see GingerbruteReprint in the WOE package.
+ *
+ * The "Food" subtype on the type line makes it a Food artifact for cards that care, in addition
+ * to carrying its own sacrifice-for-life ability (identical to a Food token's).
+ */
+val Gingerbrute = card("Gingerbrute") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Food Golem"
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "{1}: This creature can't be blocked this turn except by creatures with haste.\n" +
+        "{2}, {T}, Sacrifice this creature: You gain 3 life."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.GrantCantBeBlockedExceptBy(
+            EffectTarget.Self,
+            GameObjectFilter.Creature.withKeyword(Keyword.HASTE)
+        )
+        description = "This creature can't be blocked this turn except by creatures with haste."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "219"
+        artist = "Vincent Proce"
+        flavorText = "The unlabeled vial was not vanilla extract after all."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg?1783932587"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GingerbruteReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GingerbruteReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gingerbrute reprint in Jumpstart (JMP). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Throne of Eldraine (ELD) package
+ * (its earliest real printing); this file contributes only JMP presentation data.
+ */
+val GingerbruteReprint = Printing(
+    oracleId = "10b8d4c7-7553-4d76-b643-d98b80701e13",
+    name = "Gingerbrute",
+    setCode = "JMP",
+    collectorNumber = "466",
+    scryfallId = "c1195ec5-979b-4c4a-9c04-62bb53c2b011",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1195ec5-979b-4c4a-9c04-62bb53c2b011.jpg?1783930339",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BellowingBruiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BellowingBruiser.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CantBlockEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bellowing Bruiser // Beat a Path
+ * {4}{R}
+ * Creature — Ogre
+ * 4/4
+ * Haste
+ *
+ * Adventure: Beat a Path — {2}{R}, Sorcery — Adventure
+ * Up to two target creatures can't block this turn.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val BellowingBruiser = card("Bellowing Bruiser") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre"
+    oracleText = "Haste"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.HASTE)
+
+    adventure("Beat a Path") {
+        manaCost = "{2}{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Up to two target creatures can't block this turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            target = TargetCreature(count = 2, optional = true)
+            effect = ForEachTargetEffect(listOf(CantBlockEffect(EffectTarget.ContextTarget(0))))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Kai Carpenter"
+        flavorText = "You can't give an ogre the runaround."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1783915098"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GingerbruteReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GingerbruteReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gingerbrute reprint in Wilds of Eldraine. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the Throne of Eldraine (ELD) package
+ * (its earliest real printing); this file contributes only WOE presentation data.
+ */
+val GingerbruteReprint = Printing(
+    oracleId = "10b8d4c7-7553-4d76-b643-d98b80701e13",
+    name = "Gingerbrute",
+    setCode = "WOE",
+    collectorNumber = "246",
+    scryfallId = "09a4578a-7dc6-4da3-93ee-913b10be5740",
+    artist = "Carlos Palma Cruchaga",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/09a4578a-7dc6-4da3-93ee-913b10be5740.jpg?1783915058",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -135,6 +135,80 @@
     ]
 }
 
+// Gingerbrute
+{
+    "name": "Gingerbrute",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Food Golem",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{1}: This creature can't be blocked this turn except by creatures with haste.\n{2}, {T}, Sacrifice this creature: You gain 3 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantCantBeBlockedExceptBy",
+                    "target": "Self",
+                    "blockerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasKeyword",
+                                "keyword": "HASTE"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "This creature can't be blocked this turn except by creatures with haste."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "artist": "Vincent Proce",
+        "flavorText": "The unlabeled vial was not vanilla extract after all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f55fe038-c903-4d92-b689-72dd6d041a91.jpg?1783932587"
+    },
+    "colorIdentityOverride": []
+}
+
 // Heraldic Banner
 {
     "name": "Heraldic Banner",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -197,6 +197,62 @@
     ]
 }
 
+// Bellowing Bruiser
+{
+    "name": "Bellowing Bruiser",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Ogre",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Kai Carpenter",
+        "flavorText": "You can't give an ogre the runaround.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26ece013-f3ef-4c12-9dea-b2789f61f8a0.jpg?1783915098"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Beat a Path",
+            "manaCost": "{2}{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Up to two target creatures can't block this turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Beluna's Gatekeeper
 {
     "name": "Beluna's Gatekeeper",


### PR DESCRIPTION
Implements a small handful of Wilds of Eldraine cards. Both compose existing SDK primitives only — no engine/SDK changes.

## Cards

### Gingerbrute — `{1}` Artifact Creature — Food Golem, 1/1
- Haste
- `{1}`: This creature can't be blocked this turn except by creatures with haste (`Effects.GrantCantBeBlockedExceptBy` filtered to haste creatures).
- `{2}, {T}, Sacrifice this creature: You gain 3 life` (the standard Food ability).

Gingerbrute's **earliest real printing is Throne of Eldraine (2019)**, so the canonical `CardDefinition` lives in the `eld` package. Jumpstart (`jmp`) and Wilds of Eldraine (`woe`) — both scaffolded — get `Printing` rows. Verified with `just check-card-printing "Gingerbrute"`.

### Bellowing Bruiser // Beat a Path — `{4}{R}` Creature — Ogre, 4/4
- Bruiser: Haste.
- Adventure **Beat a Path** (`{2}{R}` Sorcery): Up to two target creatures can't block this turn. Modeled as `ForEachTarget` + `CantBlock` over an optional count-2 creature target (same shape as Wave of Indifference).

## Notes
- Knight of Doves was originally in this batch but is **already on `main`** (PR #1324), so it was dropped rather than duplicated.
- Card art image URIs verified `HTTP 200`; every field re-checked against Scryfall per-printing data.

## Testing
- `./gradlew :mtg-sets:test` green (snapshot goldens re-blessed for ELD + WOE — additions only, no other card moved; card lint, catalog, and printing-verifier tests pass).
- `just build` compiles all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)