### PR TITLE
Add three Foundations cards: Immersturm Predator, Extravagant Replication, Rise of the Dark Realms

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ExtravagantReplicationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ExtravagantReplicationReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Extravagant Replication reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in New
+ * Capenna Commander's `cards/` package. This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ExtravagantReplicationReprint = Printing(
+    oracleId = "3a646245-b8b7-4f91-a312-d5eea9a9e49a",
+    name = "Extravagant Replication",
+    setCode = "FDN",
+    collectorNumber = "154",
+    scryfallId = "6a41dfae-bc7e-4105-8f7e-fd0109197ad8",
+    artist = "Pauline Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a41dfae-bc7e-4105-8f7e-fd0109197ad8.jpg?1783909081",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ImmersturmPredatorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ImmersturmPredatorReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Immersturm Predator reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * Kaldheim's `cards/` package. This file contributes only the FDN-specific presentation
+ * row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ImmersturmPredatorReprint = Printing(
+    oracleId = "fcb6c6d4-ea8d-49cf-b6df-377084bdb757",
+    name = "Immersturm Predator",
+    setCode = "FDN",
+    collectorNumber = "660",
+    scryfallId = "52dfc234-e87a-4594-8dcf-0a2f95eedc97",
+    artist = "Nicholas Gregory",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52dfc234-e87a-4594-8dcf-0a2f95eedc97.jpg?1783908910",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiseOfTheDarkRealmsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiseOfTheDarkRealmsReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rise of the Dark Realms reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (spell script) lives in Magic 2014's
+ * `cards/` package. This file contributes only the FDN-specific presentation row — set,
+ * collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn` and
+ * surfaced via the set's `printings`.
+ */
+val RiseOfTheDarkRealmsReprint = Printing(
+    oracleId = "e5223a09-f732-4747-8914-e6546ab0ef4c",
+    name = "Rise of the Dark Realms",
+    setCode = "FDN",
+    collectorNumber = "183",
+    scryfallId = "8645bf0c-631f-4003-bd24-3e069ae23513",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/8645bf0c-631f-4003-bd24-3e069ae23513.jpg?1783909071",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RiseOfTheDarkRealmsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RiseOfTheDarkRealmsReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rise of the Dark Realms reprint in Jumpstart (JMP).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (spell script) lives in Magic 2014's
+ * `cards/` package. This file contributes only the JMP-specific presentation row — set, collector
+ * number, art — picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the
+ * set's `printings`.
+ */
+val RiseOfTheDarkRealmsReprint = Printing(
+    oracleId = "e5223a09-f732-4747-8914-e6546ab0ef4c",
+    name = "Rise of the Dark Realms",
+    setCode = "JMP",
+    collectorNumber = "271",
+    scryfallId = "7c0e1064-47c3-4f03-a1f2-3bcb356db82b",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c0e1064-47c3-4f03-a1f2-3bcb356db82b.jpg?1783930410",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ImmersturmPredator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/ImmersturmPredator.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Immersturm Predator
+ * {2}{B}{R}
+ * Creature — Vampire Dragon
+ * 3/3
+ *
+ * Flying
+ * Whenever this creature becomes tapped, exile up to one target card from a graveyard and
+ * put a +1/+1 counter on this creature.
+ * Sacrifice another creature: This creature gains indestructible until end of turn. Tap it.
+ *
+ * The "becomes tapped" trigger fires for *any* tapping — attacking, an opponent's tap effect,
+ * or the sacrifice ability's own "Tap it" — so sacrificing a creature both protects Immersturm
+ * Predator and grows it (Rule 603.2 puts the triggered ability on the stack after the ability
+ * that tapped it resolves). The graveyard exile is "up to one target", so it can resolve with
+ * no target chosen; the +1/+1 counter is always placed regardless.
+ */
+val ImmersturmPredator = card("Immersturm Predator") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Vampire Dragon"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever this creature becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on this creature.\n" +
+        "Sacrifice another creature: This creature gains indestructible until end of turn. Tap it."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature becomes tapped, exile up to one target card from a graveyard and
+    // put a +1/+1 counter on this creature.
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        val exiled = target("target card in a graveyard", TargetObject(optional = true, filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Composite(
+            Effects.Move(exiled, Zone.EXILE),
+            Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+        )
+    }
+
+    // Sacrifice another creature: This creature gains indestructible until end of turn. Tap it.
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self),
+            Effects.Tap(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg?1783928197"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RiseOfTheDarkRealms.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RiseOfTheDarkRealms.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Rise of the Dark Realms
+ * {7}{B}{B}
+ * Sorcery
+ *
+ * Put all creature cards from all graveyards onto the battlefield under your control.
+ *
+ * `Player.Each` gathers every player's graveyard at once, so this sweeps up your own dead
+ * as well as your opponents'. The moved cards enter the battlefield under *your* control:
+ * `CardDestination.ToZone` defaults its `player` to [Player.You] (the spell's controller) and
+ * `underOwnersControl` stays false, so the caster — not each card's owner — controls them.
+ */
+val RiseOfTheDarkRealms = card("Rise of the Dark Realms") {
+    manaCost = "{7}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Put all creature cards from all graveyards onto the battlefield under your control."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "creatureCardsInAllGraveyards"
+                ),
+                MoveCollectionEffect(
+                    from = "creatureCardsInAllGraveyards",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "111"
+        artist = "Michael Komarck"
+        flavorText = "\"For every living person there are generations of dead. Which realm would you rather rule?\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg?1783939921"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ExtravagantReplication.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ExtravagantReplication.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Extravagant Replication
+ * {4}{U}
+ * Enchantment
+ *
+ * At the beginning of your upkeep, create a token that's a copy of another target nonland
+ * permanent you control.
+ *
+ * "Another" excludes Extravagant Replication itself (it is a nonland permanent you control);
+ * `TargetFilter.OtherNonlandPermanent.youControl()` restricts to your side and excludes the
+ * source. The copy uses the target's *copiable* characteristics (Rule 707.2), so it carries
+ * over printed abilities but not counters or one-shot effects.
+ */
+val ExtravagantReplication = card("Extravagant Replication") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, create a token that's a copy of another target nonland permanent you control."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val copyTarget = target(
+            "another target nonland permanent you control",
+            TargetObject(filter = TargetFilter.OtherNonlandPermanent.youControl())
+        )
+        effect = Effects.CreateTokenCopyOfTarget(copyTarget)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Pauline Voss"
+        flavorText = "\"Just one aether tiger? What do I look like, a peasant?\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a6f55d7-d689-43eb-a59a-b8be88269ee6.jpg?1783923371"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -243,6 +243,94 @@
     "colorIdentityOverride": []
 }
 
+// Immersturm Predator
+{
+    "name": "Immersturm Predator",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Creature — Vampire Dragon",
+    "oracleText": "Flying\nWhenever this creature becomes tapped, exile up to one target card from a graveyard and put a +1/+1 counter on this creature.\nSacrifice another creature: This creature gains indestructible until end of turn. Tap it.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TapEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card in a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "target card in a graveyard"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d83d2d9-b9d0-47f5-989b-f2c726401ade.jpg?1783928197"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Seize the Spoils
 {
     "name": "Seize the Spoils",

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -232,6 +232,49 @@
     ]
 }
 
+// Rise of the Dark Realms
+{
+    "name": "Rise of the Dark Realms",
+    "manaCost": "{7}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put all creature cards from all graveyards onto the battlefield under your control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "player": "Each",
+                        "filter": "creature"
+                    },
+                    "storeAs": "creatureCardsInAllGraveyards"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "creatureCardsInAllGraveyards",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "MYTHIC",
+        "artist": "Michael Komarck",
+        "flavorText": "\"For every living person there are generations of dead. Which realm would you rather rule?\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/073f81e8-8c0c-4430-bd3e-95ed3625340f.jpg?1783939921"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Sporemound
 {
     "name": "Sporemound",

--- a/mtg-sets/src/test/resources/snapshots/cards/NCC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NCC.json
@@ -1,3 +1,48 @@
+// Extravagant Replication
+{
+    "name": "Extravagant Replication",
+    "manaCost": "{4}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, create a token that's a copy of another target nonland permanent you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target nonland permanent you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target nonland permanent you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Pauline Voss",
+        "flavorText": "\"Just one aether tiger? What do I look like, a peasant?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a6f55d7-d689-43eb-a59a-b8be88269ee6.jpg?1783923371"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Rain of Riches
 {
     "name": "Rain of Riches",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExtravagantReplicationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExtravagantReplicationScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Extravagant Replication (NCC #25; reprinted in Foundations #154).
+ *
+ * At the beginning of your upkeep, create a token that's a copy of another target nonland
+ * permanent you control.
+ *
+ * Covers the your-upkeep trigger and the token copy of a targeted nonland permanent. All
+ * primitives already exist (YourUpkeep trigger, CreateTokenCopyOfTarget, the OtherNonlandPermanent
+ * you-control target filter).
+ */
+class ExtravagantReplicationScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Extravagant Replication") {
+
+            test("your upkeep creates a token copy of another nonland permanent you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Extravagant Replication")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // Start on the opponent's turn so we can pass into our own next upkeep.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Only the original Grizzly Bears exists before the upkeep trigger") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 1
+                }
+
+                val original = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                // The upkeep trigger targets "another target nonland permanent you control".
+                var guard = 0
+                while (guard++ < 12) {
+                    when (game.getPendingDecision()) {
+                        is ChooseTargetsDecision -> game.selectTargets(listOf(original))
+                        null -> if (game.state.stack.isNotEmpty()) game.resolveStack() else break
+                        else -> break
+                    }
+                }
+
+                withClue("A token copy of Grizzly Bears now sits beside the original") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImmersturmPredatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImmersturmPredatorScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Immersturm Predator (KHM #214; reprinted in Foundations #660).
+ *
+ * Flying
+ * Whenever this creature becomes tapped, exile up to one target card from a graveyard and put a
+ * +1/+1 counter on this creature.
+ * Sacrifice another creature: This creature gains indestructible until end of turn. Tap it.
+ *
+ * Covers the "becomes tapped" trigger (fired here by attacking), the optional graveyard exile,
+ * the always-applied +1/+1 counter, and the sacrifice ability whose own "Tap it" re-triggers the
+ * becomes-tapped ability. All primitives already exist (BecomesTapped trigger, Move to exile,
+ * AddCounters, SacrificeAnother cost, GrantKeyword, Tap).
+ */
+class ImmersturmPredatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Immersturm Predator") {
+
+            test("attacking taps it, exiling a graveyard card and adding a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Immersturm Predator", summoningSickness = false)
+                    .withCardInGraveyard(2, "Grizzly Bears") // the graveyard card to exile
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val predator = game.findPermanent("Immersturm Predator")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Immersturm Predator" to 2)).error shouldBe null
+
+                // The becomes-tapped trigger wants "up to one target card from a graveyard".
+                val graveyardCard = game.findCardsInGraveyard(2, "Grizzly Bears").first()
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(graveyardCard))
+                }
+                game.resolveStack()
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(graveyardCard))
+                    game.resolveStack()
+                }
+
+                withClue("The targeted graveyard card is exiled") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+                withClue("A +1/+1 counter grew the 3/3 into a 4/4") {
+                    game.state.projectedState.getPower(predator) shouldBe 4
+                    game.state.projectedState.getToughness(predator) shouldBe 4
+                }
+            }
+
+            test("the counter is still placed when no graveyard card is chosen") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Immersturm Predator", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val predator = game.findPermanent("Immersturm Predator")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Immersturm Predator" to 2)).error shouldBe null
+
+                // "Up to one" — decline the exile by choosing no target.
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.skipTargets()
+                }
+                game.resolveStack()
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.skipTargets()
+                    game.resolveStack()
+                }
+
+                withClue("The +1/+1 counter is placed regardless of the optional exile") {
+                    game.state.projectedState.getPower(predator) shouldBe 4
+                    game.state.projectedState.getToughness(predator) shouldBe 4
+                }
+            }
+
+            test("sacrificing a creature grants indestructible until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Immersturm Predator", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // fodder to sacrifice
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val predator = game.findPermanent("Immersturm Predator")!!
+                val ability = cardRegistry.requireCard("Immersturm Predator").activatedAbilities.first()
+
+                game.execute(
+                    com.wingedsheep.engine.core.ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = predator,
+                        abilityId = ability.id
+                    )
+                ).error shouldBe null
+
+                // The sacrifice cost may ask which creature to sacrifice; the "Tap it" effect then
+                // re-triggers the becomes-tapped ability, which may offer a graveyard target.
+                var guard = 0
+                while (guard++ < 15) {
+                    when (val decision = game.getPendingDecision()) {
+                        is ChooseTargetsDecision -> game.skipTargets()
+                        is SelectCardsDecision -> game.selectCards(decision.options.take(decision.minSelections))
+                        is YesNoDecision -> game.answerYesNo(false)
+                        null -> if (game.state.stack.isNotEmpty()) game.resolveStack() else break
+                        else -> break
+                    }
+                }
+
+                withClue("Immersturm Predator gains indestructible until end of turn") {
+                    game.state.projectedState.hasKeyword(predator, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+                withClue("The fodder creature was sacrificed") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfTheDarkRealmsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfTheDarkRealmsScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rise of the Dark Realms (M14 #111; reprinted in Foundations #183).
+ *
+ * Put all creature cards from all graveyards onto the battlefield under your control.
+ *
+ * Covers the sweep of every player's graveyard (Player.Each), the creature-only filter, and the
+ * "under your control" placement. All primitives already exist (GatherCards from graveyards +
+ * MoveCollection to the battlefield under the caster's control).
+ */
+class RiseOfTheDarkRealmsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rise of the Dark Realms") {
+
+            test("reanimates every creature card from all graveyards under your control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rise of the Dark Realms")
+                    .withCardInGraveyard(1, "Grizzly Bears")   // your creature
+                    .withCardInGraveyard(2, "Craw Wurm")       // opponent's creature
+                    .withCardInGraveyard(1, "Lightning Bolt")  // non-creature: stays put
+                    .withLandsOnBattlefield(1, "Swamp", 9)     // pays {7}{B}{B}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rise of the Dark Realms").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                val grizzly = game.findPermanent("Grizzly Bears")
+                val crawWurm = game.findPermanent("Craw Wurm")
+
+                withClue("Both creature cards are on the battlefield") {
+                    (grizzly != null) shouldBe true
+                    (crawWurm != null) shouldBe true
+                }
+                withClue("Both are under your (player 1's) control, even the opponent's creature") {
+                    game.state.getEntity(grizzly!!)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                    game.state.getEntity(crawWurm!!)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+                withClue("The non-creature card stays in the graveyard") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a small batch of Foundations (FDN) cards via the `add-card` skill. Each card's
canonical `CardDefinition` lives in its earliest real printing (already scaffolded), with FDN
(and one JMP) `Printing` rows for the reprints. All three compose existing SDK primitives — no
new effects, triggers, or conditions were added.

## Cards

- **Immersturm Predator** — {2}{B}{R} 3/3 Vampire Dragon (canonical **KHM**, FDN reprint)
  - Flying
  - Becomes-tapped trigger: exile up to one target graveyard card + a +1/+1 counter
  - Sacrifice another creature: gains indestructible until EOT and taps itself (which re-triggers
    the becomes-tapped ability)
- **Extravagant Replication** — {4}{U} Enchantment (canonical **NCC**, FDN reprint)
  - At the beginning of your upkeep, create a token copy of another target nonland permanent you control
- **Rise of the Dark Realms** — {7}{B}{B} Sorcery (canonical **M14**, JMP + FDN reprints)
  - Put all creature cards from all graveyards onto the battlefield under your control

## Verification

- New Kotest scenario tests for all three cards (5 tests) — all pass
- `CardDefinitionSnapshotTest` re-blessed; golden diff is **insertion-only** for KHM/M14/NCC (no
  other card touched)
- `CardLintTest` and `FacadeBoundaryTest` pass
- `just check-card-printing` passes for all three (canonical in earliest real set; every scaffolded
  printing has a reprint row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)