### PR TITLE
Add three Foundations cards: Secluded Courtyard, Angel of Finality, Doubling Season

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/Commander2013Set.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/Commander2013Set.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.c13
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Commander 2013 (2013)
+ *
+ * Scaffolded to hold cards whose canonical earliest printing is C13. Intentionally
+ * incomplete relative to the official set — only cards relocated here as their canonical
+ * earliest printing live in this package.
+ *
+ * Set Code: C13
+ * Release Date: 2013-11-01
+ */
+object Commander2013Set : MtgSet {
+
+    override val code = "C13"
+    override val displayName = "Commander 2013"
+    override val releaseDate = "2013-11-01"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.c13.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AngelOfFinality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AngelOfFinality.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Angel of Finality
+ * {3}{W}
+ * Creature — Angel
+ * Flying
+ * When this creature enters, exile target player's graveyard.
+ *
+ * The whole-graveyard exile is a gather-then-move over the target player's graveyard
+ * (Cranial Archive / Lantern of the Lost shape), so it correctly handles an empty
+ * graveyard and cards owned by any player.
+ */
+val AngelOfFinality = card("Angel of Finality") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 3
+    toughness = 4
+    oracleText =
+        "Flying\n" +
+        "When this creature enters, exile target player's graveyard."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target player", Targets.Player)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.GRAVEYARD, Player.TargetPlayer),
+                storeAs = "targetGraveyard",
+            ),
+            MoveCollectionEffect(
+                from = "targetGraveyard",
+                destination = CardDestination.ToZone(Zone.EXILE),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Howard Lyon"
+        flavorText = "\"Better the dead depart utterly than be enslaved.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd3c34c9-2072-4ebb-93ef-34173015bfb8.jpg?1783939693"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelOfFinalityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelOfFinalityReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Finality reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2013's `cards/`
+ * package (its earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val AngelOfFinalityReprint = Printing(
+    oracleId = "48d14b5c-711a-4f8a-9de5-55415cb7a79a",
+    name = "Angel of Finality",
+    setCode = "FDN",
+    collectorNumber = "136",
+    scryfallId = "baaabd52-3aa9-4e2f-9369-d4db8b405ba8",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/baaabd52-3aa9-4e2f-9369-d4db8b405ba8.jpg?1783909087",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DoublingSeasonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DoublingSeasonReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doubling Season reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Ravnica: City of Guilds'
+ * `cards/` package (its earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DoublingSeasonReprint = Printing(
+    oracleId = "01546b7d-a233-4176-8843-d732074dc5b6",
+    name = "Doubling Season",
+    setCode = "FDN",
+    collectorNumber = "216",
+    scryfallId = "f2c4f80e-84a0-463b-82c3-5c6503809351",
+    artist = "Chuck Lukacs",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2c4f80e-84a0-463b-82c3-5c6503809351.jpg?1783909062",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SecludedCourtyardReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SecludedCourtyardReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Secluded Courtyard reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Kamigawa: Neon Dynasty's
+ * `cards/` package (its earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SecludedCourtyardReprint = Printing(
+    oracleId = "79ba18fd-f184-43c1-86df-56ee18ce806c",
+    name = "Secluded Courtyard",
+    setCode = "FDN",
+    collectorNumber = "267",
+    scryfallId = "d13373d2-139b-48c7-a8c9-828cefc4f150",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d13373d2-139b-48c7-a8c9-828cefc4f150.jpg?1783909044",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/AngelOfFinalityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/AngelOfFinalityReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Finality reprint in Kaldheim Commander (KHC).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2013's `cards/`
+ * package (its earliest real printing). This file contributes only the KHC-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val AngelOfFinalityReprint = Printing(
+    oracleId = "48d14b5c-711a-4f8a-9de5-55415cb7a79a",
+    name = "Angel of Finality",
+    setCode = "KHC",
+    collectorNumber = "17",
+    scryfallId = "fef86cfe-6e4a-4ff7-bb6d-914d8c1e0782",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fef86cfe-6e4a-4ff7-bb6d-914d8c1e0782.jpg?1783928336",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SecludedCourtyard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SecludedCourtyard.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Secluded Courtyard
+ * Land
+ * As this land enters, choose a creature type.
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen
+ * type or activate an ability of a creature source of the chosen type.
+ *
+ * Unclaimed Territory shape (no uncounterable rider), so the restricted mana also covers
+ * activated abilities of sources of the chosen type — `creatureOnly = false` (the facade default).
+ */
+val SecludedCourtyard = card("Secluded Courtyard") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText =
+        "As this land enters, choose a creature type.\n" +
+        "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature source of the chosen type."
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddAnyColorManaSpendOnChosenType()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "275"
+        artist = "Sam Burley"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg?1783923815"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DoublingSeason.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DoublingSeason.kt
@@ -3,8 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.rav.cards
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.DoubleCounterPlacement
-import com.wingedsheep.sdk.scripting.DoubleTokenCreation
 import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.MultiplyTokenCreation
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
 
@@ -30,7 +30,7 @@ val DoublingSeason = card("Doubling Season") {
         "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\n" +
         "If an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead."
 
-    replacementEffect(DoubleTokenCreation())
+    replacementEffect(MultiplyTokenCreation())
 
     replacementEffect(
         DoubleCounterPlacement(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DoublingSeason.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DoublingSeason.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleCounterPlacement
+import com.wingedsheep.sdk.scripting.DoubleTokenCreation
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Doubling Season
+ * {4}{G}
+ * Enchantment
+ * If an effect would create one or more tokens under your control, it creates twice that many
+ * of those tokens instead.
+ * If an effect would put one or more counters on a permanent you control, it puts twice that
+ * many of those counters on that permanent instead.
+ *
+ * Both clauses are static replacement effects. Token doubling uses the default
+ * `TokenCreationEvent(controller = You)`. Counter doubling gates purely on the recipient
+ * ("a permanent you control"), independent of who places the counters — hence
+ * `placedByYou = false` with `RecipientFilter.PermanentYouControl` and any counter type.
+ */
+val DoublingSeason = card("Doubling Season") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText =
+        "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\n" +
+        "If an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead."
+
+    replacementEffect(DoubleTokenCreation())
+
+    replacementEffect(
+        DoubleCounterPlacement(
+            placedByYou = false,
+            appliesTo = EventPattern.CounterPlacementEvent(
+                counterType = CounterTypeFilter.Any,
+                recipient = RecipientFilter.PermanentYouControl,
+            ),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "158"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg?1783943641"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/C13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C13.json
@@ -1,0 +1,61 @@
+// Angel of Finality
+{
+    "name": "Angel of Finality",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nWhen this creature enters, exile target player's graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "TargetPlayer"
+                            },
+                            "storeAs": "targetGraveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "targetGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "\"Better the dead depart utterly than be enslaved.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd3c34c9-2072-4ebb-93ef-34173015bfb8.jpg?1783939693"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/NEO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEO.json
@@ -1,3 +1,48 @@
+// Secluded Courtyard
+{
+    "name": "Secluded Courtyard",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "As this land enters, choose a creature type.\n{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell of the chosen type or activate an ability of a creature source of the chosen type.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddAnyColorManaSpendOnChosenType",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "rarity": "UNCOMMON",
+        "artist": "Sam Burley",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg?1783923815"
+    },
+    "colorIdentityOverride": []
+}
+
 // Uncharted Haven
 {
     "name": "Uncharted Haven",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1229,7 +1229,7 @@
     "oracleText": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
     "script": {
         "replacementEffects": [
-            "DoubleTokenCreation",
+            "MultiplyTokenCreation",
             {
                 "type": "DoubleCounterPlacement",
                 "appliesTo": {

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1221,6 +1221,35 @@
     ]
 }
 
+// Doubling Season
+{
+    "name": "Doubling Season",
+    "manaCost": "{4}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
+    "script": {
+        "replacementEffects": [
+            "DoubleTokenCreation",
+            {
+                "type": "DoubleCounterPlacement",
+                "appliesTo": {
+                    "type": "CounterPlacementEvent",
+                    "recipient": "PermanentYouControl"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7e71299-98f6-494e-b187-8d22ce5f50af.jpg?1783943641"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dowsing Shaman
 {
     "name": "Dowsing Shaman",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelOfFinalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelOfFinalityScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Angel of Finality (C13 #4, reprinted FDN #136) —
+ * {3}{W} Creature — Angel, 3/4, Flying.
+ *
+ * "When this creature enters, exile target player's graveyard." Pins the whole-graveyard
+ * gather-then-move over the targeted player's graveyard, plus the empty-graveyard edge case.
+ */
+class AngelOfFinalityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Angel of Finality") {
+
+            test("ETB exiles the targeted player's graveyard") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Angel of Finality")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("precondition: opponent has two cards in graveyard") {
+                    game.graveyardSize(2) shouldBe 2
+                }
+
+                val cast = game.castSpell(1, "Angel of Finality")
+                withClue("Angel should cast: ${cast.error}") { cast.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the ETB; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(game.player2Id))))
+                game.resolveStack()
+
+                withClue("the targeted player's graveyard is exiled (emptied)") {
+                    game.graveyardSize(2) shouldBe 0
+                }
+                withClue("the Angel resolved onto the battlefield") {
+                    (game.findPermanent("Angel of Finality") != null) shouldBe true
+                }
+            }
+
+            test("ETB resolves cleanly against a player with an empty graveyard") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Angel of Finality")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Angel of Finality")
+                withClue("Angel should cast: ${cast.error}") { cast.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the ETB; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(game.player2Id))))
+                game.resolveStack()
+
+                withClue("no crash; opponent's graveyard stays empty") {
+                    game.graveyardSize(2) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three missing Foundations (FDN) cards, each via the `add-card` workflow. All three are reprints in FDN, so the canonical `CardDefinition` lives in each card's earliest real printing and FDN (plus any other scaffolded set that prints it) gets a `Printing` row. No new SDK/engine capabilities were introduced — every card composes existing building blocks.

## Cards

| Card | Canonical set | Reprint rows | Mechanic |
|------|---------------|--------------|----------|
| **Secluded Courtyard** | NEO (scaffolded) | FDN | Choose-a-creature-type land — `{T}: Add {C}` + `{T}: Add any color`, restricted to spells/abilities of the chosen type (`AddAnyColorManaSpendOnChosenType`, `creatureOnly=false`) |
| **Angel of Finality** | C13 (**newly scaffolded**) | KHC, FDN | `{3}{W}` 3/4 Angel, Flying, ETB exile target player's graveyard (GatherCards → MoveCollection to exile) |
| **Doubling Season** | RAV (scaffolded) | FDN | `{4}{G}` enchantment — `DoubleTokenCreation` + `DoubleCounterPlacement` (any counter on a permanent you control) |

## Notes
- **Commander 2013 (C13)** was scaffolded as a minimal `MtgSet` (auto-discovered via ClassGraph) to hold Angel of Finality as its earliest real printing.
- **Darksteel Colossus** was originally scoped for this batch but dropped: its "shuffle into library instead of graveyard" replacement isn't expressible with existing effects (redirect-to-library defaults to top-of-library, no self-scoped shuffle-instead-of-graveyard variant), so it belongs in an `add-feature` change rather than an easy-cards PR.

## Verification
- `scripts/check-card-printing` clean for all three (canonical in earliest real printing, all scaffolded reprints have rows).
- `CardDefinitionSnapshotTest` reblessed — diff touches only the three new cards (NEO, RAV, new C13 golden).
- `CardLintTest` + `FacadeBoundaryTest` (full `:mtg-sets:test`) pass.
- New `AngelOfFinalityScenarioTest` pins the graveyard-exile, including the empty-graveyard edge case.
- All six card-art image URLs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)