### PR TITLE
Add four Wilds of Eldraine cards (Roles, adventurer graveyard tally, Adventure)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2242,6 +2242,13 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `Filters.PlainsCard` / `IslandCard` / `SwampCard` / `MountainCard` / `ForestCard` — specific basics.
 - `Filters.Instant` — instant card.
 - `Filters.Sorcery` — sorcery card.
+- `Filters.HasAdventure` — card that has an Adventure (adventurer card), regardless of which face it
+  currently shows (`CardPredicate.HasAdventure`, backed by `CardComponent.hasAdventure`). A static,
+  whole-card characteristic evaluated the same way in every zone.
+- `Filters.InstantSorceryOrAdventure` (= `GameObjectFilter.InstantSorceryOrAdventure`) — instant,
+  sorcery, or a card that has an Adventure. Backs Frantic Firebolt's "cards in your graveyard that
+  are instant cards, sorcery cards, and/or have an Adventure" tally (a single membership test, so a
+  card that satisfies more than one clause is counted once).
 - `Filters.Permanent` — permanent card.
 - `Filters.NonlandPermanent` — nonland permanent.
 - `Filters.WithSubtype(subtype)` — card of a given subtype.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -458,6 +458,9 @@ class ScenarioBuilderService(
                 // craft material filter). Omitting them made scenario permanents look ability-less.
                 hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
                 hasActivatedAbility = cardDef.hasActivatedAbility,
+                // Mirror CardEntityFactory so CardPredicate.HasAdventure (Frantic Firebolt's
+                // graveyard tally) sees adventurer cards created in dev scenarios.
+                hasAdventure = cardDef.isAdventure,
             )
 
             var container = ComponentContainer.of(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.core.Zone
@@ -83,6 +84,16 @@ object Filters {
      * Sorcery card.
      */
     val Sorcery: GameObjectFilter = GameObjectFilter.Sorcery
+
+    /**
+     * Card that has an Adventure (adventurer card), regardless of which face it shows.
+     */
+    val HasAdventure: GameObjectFilter = GameObjectFilter.Any.withCardPredicate(CardPredicate.HasAdventure)
+
+    /**
+     * Instant card, sorcery card, or a card that has an Adventure — Frantic Firebolt's graveyard tally.
+     */
+    val InstantSorceryOrAdventure: GameObjectFilter = GameObjectFilter.InstantSorceryOrAdventure
 
     /**
      * Permanent card.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -131,6 +131,15 @@ data class GameObjectFilter(
                 CardPredicate.Or(listOf(CardPredicate.IsInstant, CardPredicate.IsSorcery))
             )
         )
+
+        /** Instant, sorcery, or a card with an Adventure — Frantic Firebolt's graveyard tally. */
+        val InstantSorceryOrAdventure = GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.Or(
+                    listOf(CardPredicate.IsInstant, CardPredicate.IsSorcery, CardPredicate.HasAdventure)
+                )
+            )
+        )
         val CreatureOrPlaneswalker = GameObjectFilter(
             cardPredicates = listOf(
                 CardPredicate.Or(listOf(CardPredicate.IsCreature, CardPredicate.IsPlaneswalker))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -68,6 +68,18 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "sorcery"
     }
 
+    /**
+     * The card has an Adventure ([com.wingedsheep.sdk.model.CardLayout.ADVENTURE]) — i.e. it is an
+     * adventurer card, regardless of which face it currently shows. Matches the whole card in any
+     * zone (Frantic Firebolt counts adventurer cards in your graveyard). Tokens and non-adventure
+     * cards never match.
+     */
+    @SerialName("HasAdventure")
+    @Serializable
+    data object HasAdventure : CardPredicate {
+        override val description: String = "has an Adventure"
+    }
+
     @SerialName("IsBasicLand")
     @Serializable
     data object IsBasicLand : CardPredicate {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EmberethVeteran.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EmberethVeteran.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Embereth Veteran
+ * {R}
+ * Creature — Human Knight (2/1)
+ * {1}, Sacrifice this creature: Create a Young Hero Role token attached to another target creature.
+ * (If you control another Role on it, put that one into the graveyard. Enchanted creature has
+ * "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.")
+ *
+ * The Young Hero Role token carries the granted attack trigger; this card just pays {1} + sacrifices
+ * itself to create it on another target creature (any controller, so it can buff an ally or bait a
+ * gift onto an opponent's small creature).
+ */
+val EmberethVeteran = card("Embereth Veteran") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "{1}, Sacrifice this creature: Create a Young Hero Role token attached to another " +
+        "target creature. (If you control another Role on it, put that one into the graveyard. " +
+        "Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, " +
+        "put a +1/+1 counter on it.\")"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreature))
+        effect = Effects.CreateRoleToken("Young Hero Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Andreia Ugrai"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg?1783915096"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EriettesWhisper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EriettesWhisper.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Eriette's Whisper
+ * {3}{B}
+ * Sorcery
+ * Target opponent discards two cards. Create a Wicked Role token attached to up to one target
+ * creature you control. (If you control another Role on it, put that one into the graveyard.
+ * Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)
+ *
+ * Two independent targets: the opponent who discards, and the optional ("up to one") creature that
+ * gains the Wicked Role. Role replacement (an existing Role you control on that creature is put into
+ * the graveyard first) is handled by the CreateRoleToken executor; the Wicked Role token itself
+ * carries the +1/+1 buff and the graveyard-drain trigger.
+ */
+val EriettesWhisper = card("Eriette's Whisper") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent discards two cards. Create a Wicked Role token attached to up to " +
+        "one target creature you control. (If you control another Role on it, put that one into the " +
+        "graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each " +
+        "opponent loses 1 life.)"
+
+    spell {
+        val opponent = target("opponent", Targets.Opponent)
+        val creature = target(
+            "creature",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.Composite(
+            Effects.Discard(2, opponent),
+            Effects.CreateRoleToken("Wicked Role", creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Quintin Gleim"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg?1783915109"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FranticFirebolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FranticFirebolt.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Frantic Firebolt
+ * {2}{R}
+ * Instant
+ * Frantic Firebolt deals X damage to target creature, where X is 2 plus the number of cards in your
+ * graveyard that are instant cards, sorcery cards, and/or have an Adventure.
+ *
+ * X is counted at resolution (CR 608.2) from the current graveyard contents. A card is counted once
+ * even if it satisfies more than one clause (instant *and* has an Adventure), because the tally is a
+ * single [Filters.InstantSorceryOrAdventure] membership test rather than three separate counts.
+ */
+val FranticFirebolt = card("Frantic Firebolt") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Frantic Firebolt deals X damage to target creature, where X is 2 plus the number " +
+        "of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(
+            DynamicAmount.Add(
+                DynamicAmount.Fixed(2),
+                DynamicAmount.Count(Player.You, Zone.GRAVEYARD, Filters.InstantSorceryOrAdventure)
+            ),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Olivier Bernard"
+        flavorText = "Johann's conjecture about draconic fire dispelling rainwater elementals proved " +
+            "to be correct. Now he just needed a way to dispel draconic fire."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg?1783915094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GrabbyGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GrabbyGiant.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Grabby Giant // That's Mine
+ * {3}{R}
+ * Creature — Giant (4/3)
+ * Reach
+ * {2}{R}, Sacrifice an artifact or land: Draw a card.
+ *
+ * Adventure: That's Mine — {1}{R}, Instant — Adventure
+ * Create a Treasure token.
+ *
+ * (CR 715: casting the Adventure exiles the card on resolution and lets the caster cast the creature
+ * from exile later. The front's own draw ability feeds on the Treasure the Adventure leaves behind.)
+ */
+val GrabbyGiant = card("Grabby Giant") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    oracleText = "Reach\n{2}{R}, Sacrifice an artifact or land: Draw a card."
+    power = 4
+    toughness = 3
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Sacrifice(GameObjectFilter.ArtifactOrLand))
+        effect = Effects.DrawCards(1)
+    }
+
+    adventure("That's Mine") {
+        manaCost = "{1}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a Treasure token. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.CreateTreasure(1)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1783915094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.tokens
 
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
@@ -23,6 +24,7 @@ import com.wingedsheep.sdk.scripting.GrantWard
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
 import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
@@ -409,6 +411,66 @@ object PredefinedTokens {
     }
 
     /**
+     * Wicked Role — Enchantment — Aura Role token (Wilds of Eldraine).
+     * "Enchanted creature gets +1/+1. When this Role is put into a graveyard, each opponent loses 1 life."
+     */
+    val WickedRole = card("Wicked Role") {
+        typeLine = "Enchantment — Aura Role"
+        oracleText = "Enchant creature\nEnchanted creature gets +1/+1.\n" +
+            "When this Role is put into a graveyard, each opponent loses 1 life."
+
+        auraTarget = Targets.Creature
+
+        staticAbility {
+            ability = ModifyStats(+1, +1, Filters.EnchantedCreature)
+        }
+
+        // The Role leaving the battlefield for the graveyard — destroyed, sacrificed, replaced by
+        // another Role, or falling off as its creature leaves — drains each opponent for 1.
+        triggeredAbility {
+            trigger = Triggers.PutIntoGraveyardFromBattlefield
+            effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        }
+
+        metadata {
+            // "Wicked // Cursed" flip token: Wicked is the upright (front) face — no rotation.
+            imageUri = "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1782732081"
+            artist = "Rovina Cai"
+        }
+    }
+
+    /**
+     * Young Hero Role — Enchantment — Aura Role token (Wilds of Eldraine).
+     * "Enchanted creature has 'Whenever this creature attacks, if its toughness is 3 or less,
+     *  put a +1/+1 counter on it.'"
+     */
+    val YoungHeroRole = card("Young Hero Role") {
+        typeLine = "Enchantment — Aura Role"
+        oracleText = "Enchant creature\nEnchanted creature has \"Whenever this creature attacks, " +
+            "if its toughness is 3 or less, put a +1/+1 counter on it.\""
+
+        auraTarget = Targets.Creature
+
+        // The granted ability is modeled as an ATTACHED-bound trigger on the Role watching its
+        // enchanted creature attack; the intervening-if re-checks the toughness at resolution (CR 603.4).
+        triggeredAbility {
+            trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+            triggerCondition = Conditions.EntityMatches(
+                EffectTarget.EnchantedCreature,
+                GameObjectFilter.Creature.toughnessAtMost(3)
+            )
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.EnchantedCreature)
+        }
+
+        metadata {
+            // "Royal // Young Hero" flip token: Young Hero is the bottom face — rotate 180°.
+            imageUri = "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1783914992"
+            imageRotation = 180
+            artist = "Rovina Cai"
+        }
+    }
+
+    /**
      * Phyrexian — back face of the Incubator token.
      * Colorless 0/0 Phyrexian artifact creature.
      */
@@ -610,6 +672,8 @@ object PredefinedTokens {
         MonsterRole,
         RoyalRole,
         CursedRole,
+        WickedRole,
+        YoungHeroRole,
         Incubator,
         Drone,
         Everywhere,

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1110,6 +1110,65 @@
     ]
 }
 
+// Embereth Veteran
+{
+    "name": "Embereth Veteran",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "{1}, Sacrifice this creature: Create a Young Hero Role token attached to another target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Young Hero Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature",
+                            "excludeSelf": true
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Andreia Ugrai",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc7130b8-3168-421f-912a-46ed5b769807.jpg?1783915096"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Eriette's Tempting Apple
 {
     "name": "Eriette's Tempting Apple",
@@ -1230,6 +1289,95 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b61711f-8982-4ff0-86ba-01e0125cd705.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Eriette's Whisper
+{
+    "name": "Eriette's Whisper",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent discards two cards. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 2 cards to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "opponent"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Quintin Gleim",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfed2acf-9ac8-447b-94f5-7db3a713c991.jpg?1783915109"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Faerie Dreamthief
@@ -1587,6 +1735,65 @@
     ]
 }
 
+// Frantic Firebolt
+{
+    "name": "Frantic Firebolt",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Frantic Firebolt deals X damage to target creature, where X is 2 plus the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Add",
+                "left": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "right": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery",
+                                    "HasAdventure"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Olivier Bernard",
+        "flavorText": "Johann's conjecture about draconic fire dispelling rainwater elementals proved to be correct. Now he just needed a way to dispel draconic fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efd85f5a-258b-4ced-bf9e-3abe7fe72395.jpg?1783915094"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Freeze in Place
 {
     "name": "Freeze in Place",
@@ -1766,6 +1973,77 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Grabby Giant
+{
+    "name": "Grabby Giant",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Reach\n{2}{R}, Sacrifice an artifact or land: Draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact|land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Johann Bodin",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fab7646a-61e8-446b-9dba-ac6e0db82f10.jpg?1783915094"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "That's Mine",
+            "manaCost": "{1}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a Treasure token. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
@@ -91,6 +91,7 @@ object CardEntityFactory {
                 hasActivatedAbility = cardDef.hasActivatedAbility,
                 // Original-printing set (canonical, not the pinned printing) — "originally printed in X".
                 originalSetCode = cardDef.setCode,
+                hasAdventure = cardDef.isAdventure,
             ),
             OwnerComponent(ownerId),
             ControllerComponent(ownerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -243,6 +243,9 @@ class PredicateEvaluator {
             CardPredicate.IsPlaneswalker -> "PLANESWALKER" in types
             CardPredicate.IsInstant -> "INSTANT" in types
             CardPredicate.IsSorcery -> "SORCERY" in types
+            // Adventure-ness is a static characteristic of the whole card (not a projected type),
+            // read straight off the CardComponent flag stamped at entity creation.
+            CardPredicate.HasAdventure -> card.hasAdventure
             CardPredicate.IsBasicLand -> "LAND" in types && card.typeLine.supertypes.any { it.name == "BASIC" }
             CardPredicate.IsPermanent -> types.any { it in setOf("CREATURE", "LAND", "ARTIFACT", "ENCHANTMENT", "PLANESWALKER") }
             CardPredicate.IsNonland -> "LAND" !in types
@@ -1273,6 +1276,10 @@ class PredicateEvaluator {
             CardPredicate.IsPlaneswalker -> com.wingedsheep.sdk.core.CardType.PLANESWALKER in typeLine.cardTypes
             CardPredicate.IsInstant -> typeLine.isInstant
             CardPredicate.IsSorcery -> typeLine.isSorcery
+            // A cast-spell record stores only the resolved characteristics, not the card's layout,
+            // so adventure-ness can't be recovered here. No in-scope card queries it against cast
+            // history; fall through to the safe default.
+            CardPredicate.HasAdventure -> false
             CardPredicate.IsBasicLand -> typeLine.isBasicLand
             CardPredicate.IsPermanent -> typeLine.isPermanent
             CardPredicate.IsNonland -> !typeLine.isLand

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -607,6 +607,8 @@ internal class AffectsFilterResolver {
         CardPredicate.IsPlaneswalker -> "PLANESWALKER" in types
         CardPredicate.IsInstant -> "INSTANT" in types
         CardPredicate.IsSorcery -> "SORCERY" in types
+        // Adventure-ness is a static whole-card characteristic, not a projected type.
+        CardPredicate.HasAdventure -> card.hasAdventure
         CardPredicate.IsPermanent -> types.any { it in setOf("CREATURE", "LAND", "ARTIFACT", "ENCHANTMENT", "PLANESWALKER") }
         CardPredicate.IsNonland -> "LAND" !in types
         CardPredicate.IsNoncreature -> "CREATURE" !in types

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -898,6 +898,7 @@ class CostCalculator(
             CardPredicate.IsPlaneswalker -> CardType.PLANESWALKER in typeLine.cardTypes
             CardPredicate.IsInstant -> typeLine.isInstant
             CardPredicate.IsSorcery -> typeLine.isSorcery
+            CardPredicate.HasAdventure -> cardDef.isAdventure
             CardPredicate.IsBasicLand -> typeLine.isBasicLand
             CardPredicate.IsPermanent -> typeLine.isPermanent
             CardPredicate.IsNonland -> !typeLine.isLand

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
@@ -53,6 +53,13 @@ data class CardComponent(
      * Null for tokens and any card whose definition carries no set code.
      */
     val originalSetCode: String? = null,
+    /**
+     * Precomputed from the card definition: does this card have an Adventure
+     * ([com.wingedsheep.sdk.model.CardLayout.ADVENTURE])? A static, copyable-independent
+     * characteristic of the whole card in any zone — read by `CardPredicate.HasAdventure`
+     * (Frantic Firebolt tallies adventurer cards in the graveyard). False for tokens.
+     */
+    val hasAdventure: Boolean = false,
 ) : Component {
     // Convenience accessors
     val isCreature: Boolean get() = typeLine.isCreature

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmberethVeteranScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmberethVeteranScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Embereth Veteran (WOE #127) — {R} 2/1 Human Knight.
+ *
+ * "{1}, Sacrifice this creature: Create a Young Hero Role token attached to another target creature."
+ *
+ * Exercises the new Young Hero Role token, whose granted ability puts a +1/+1 counter on the
+ * enchanted creature when it attacks *if its toughness is 3 or less* (an intervening-if gate).
+ */
+class EmberethVeteranScenarioTest : ScenarioTestBase() {
+
+    private fun emberethAbilityId() =
+        cardRegistry.getCard("Embereth Veteran")!!.activatedAbilities.first().id
+
+    init {
+        context("Embereth Veteran") {
+
+            test("activating {1}, Sacrifice creates a Young Hero Role on another creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Embereth Veteran")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Embereth Veteran")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = veteran,
+                        abilityId = emberethAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Embereth Veteran was sacrificed as a cost") {
+                    game.findPermanent("Embereth Veteran") shouldBe null
+                }
+                withClue("A Young Hero Role enters attached to Grizzly Bears") {
+                    game.findPermanent("Young Hero Role") shouldNotBe null
+                }
+            }
+
+            test("enchanted creature with toughness 3 or less gets a +1/+1 counter when it attacks") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Embereth Veteran")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 — toughness ≤ 3
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Embereth Veteran")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = veteran,
+                        abilityId = emberethAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                val projector = StateProjector()
+                withClue("2/2 (toughness ≤ 3) attacking gains a +1/+1 counter → 3/3") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 3
+                    projector.getProjectedToughness(game.state, bears) shouldBe 3
+                }
+            }
+
+            test("enchanted creature with toughness greater than 3 gets no counter when it attacks") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Embereth Veteran")
+                    .withCardOnBattlefield(1, "Archive Dragon") // 4/6 — toughness > 3
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val veteran = game.findPermanent("Embereth Veteran")!!
+                val dragon = game.findPermanent("Archive Dragon")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = veteran,
+                        abilityId = emberethAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(dragon))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Archive Dragon" to 2)).error shouldBe null
+                game.resolveStack()
+
+                val projector = StateProjector()
+                withClue("toughness 6 > 3, so the intervening-if fails and no counter is added") {
+                    projector.getProjectedPower(game.state, dragon) shouldBe 4
+                    projector.getProjectedToughness(game.state, dragon) shouldBe 6
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EriettesWhisperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EriettesWhisperScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/** Find a card by name in a player's hand — Eriette's Whisper needs a manual multi-target cast. */
+private fun ScenarioTestBase.TestGame.handCardId(playerNumber: Int, name: String): EntityId {
+    val playerId = if (playerNumber == 1) player1Id else player2Id
+    return state.getHand(playerId).first {
+        state.getEntity(it)?.get<CardComponent>()?.name == name
+    }
+}
+
+/**
+ * Resolve the spell, answering the opponent's "discard two cards" selection (the discarding player
+ * picks the cards, so resolution pauses on a SelectCardsDecision). Player 2 holds exactly two cards,
+ * so we discard the whole hand.
+ */
+private fun ScenarioTestBase.TestGame.resolveWithDiscard(opponentNumber: Int) {
+    val opponentId = if (opponentNumber == 1) player1Id else player2Id
+    resolveStack()
+    if (state.pendingDecision != null) {
+        selectCards(state.getHand(opponentId))
+        resolveStack()
+    }
+}
+
+/**
+ * Scenario tests for Eriette's Whisper (WOE #88) — {3}{B} Sorcery.
+ *
+ * "Target opponent discards two cards. Create a Wicked Role token attached to up to one target
+ *  creature you control."
+ *
+ * Exercises the new Wicked Role token: the +1/+1 buff and its "when this Role is put into a
+ * graveyard, each opponent loses 1 life" drain trigger.
+ */
+class EriettesWhisperScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Eriette's Whisper") {
+
+            test("opponent discards two cards and your creature gains the Wicked Role (+1/+1)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Eriette's Whisper")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardInHand(2, "Forest")
+                    .withCardInHand(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.handCardId(1, "Eriette's Whisper"),
+                        listOf(ChosenTarget.Player(game.player2Id), ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveWithDiscard(2)
+
+                val projector = StateProjector()
+                withClue("Player 2 discards its whole two-card hand") {
+                    game.state.getHand(game.player2Id).size shouldBe 0
+                }
+                withClue("Wicked Role enters attached to Grizzly Bears, buffing it to 3/3") {
+                    game.findPermanent("Wicked Role") shouldNotBe null
+                    projector.getProjectedPower(game.state, bears) shouldBe 3
+                    projector.getProjectedToughness(game.state, bears) shouldBe 3
+                }
+            }
+
+            test("each opponent loses 1 life when the Wicked Role is put into the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Eriette's Whisper")
+                    .withCardInHand(1, "Frantic Firebolt")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Savannah Lions") // 1/1 → 2/2 with the Role
+                    .withCardInHand(2, "Forest")
+                    .withCardInHand(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lions = game.findPermanent("Savannah Lions")!!
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        game.handCardId(1, "Eriette's Whisper"),
+                        listOf(ChosenTarget.Player(game.player2Id), ChosenTarget.Permanent(lions))
+                    )
+                ).error shouldBe null
+                game.resolveWithDiscard(2)
+
+                val lifeBefore = game.state.getEntity(game.player2Id)!!.get<LifeTotalComponent>()!!.life
+
+                // Kill the 2/2 (Lions + Wicked Role) with our own Frantic Firebolt; the Role falls off
+                // into the graveyard, firing its drain.
+                game.castSpell(1, "Frantic Firebolt", lions).error shouldBe null
+                game.resolveStack()
+
+                withClue("Savannah Lions died, so the Wicked Role went to the graveyard and drained the opponent") {
+                    game.findPermanent("Savannah Lions") shouldBe null
+                    game.findPermanent("Wicked Role") shouldBe null
+                    game.state.getEntity(game.player2Id)!!.get<LifeTotalComponent>()!!.life shouldBe lifeBefore - 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FranticFireboltScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FranticFireboltScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Frantic Firebolt (WOE #130) — {2}{R} Instant.
+ *
+ * "Frantic Firebolt deals X damage to target creature, where X is 2 plus the number of cards in
+ *  your graveyard that are instant cards, sorcery cards, and/or have an Adventure."
+ *
+ * Exercises the new `CardPredicate.HasAdventure` (adventurer cards count) and the
+ * `Filters.InstantSorceryOrAdventure` graveyard tally that backs the dynamic X.
+ */
+class FranticFireboltScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Frantic Firebolt") {
+
+            test("X = 2 + instant + sorcery + adventurer, ignoring an unrelated enchantment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Frantic Firebolt")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    // Graveyard tally: 1 instant + 1 sorcery + 1 adventurer card = 3 → X = 5.
+                    .withCardInGraveyard(1, "Feed the Cauldron")   // Instant
+                    .withCardInGraveyard(1, "Ego Drain")           // Sorcery
+                    .withCardInGraveyard(1, "Besotted Knight")     // Creature that has an Adventure
+                    .withCardInGraveyard(1, "Hopeless Nightmare")  // Enchantment — must NOT count
+                    .withCardOnBattlefield(2, "Wall of Stone")    // 0/8, survives 5 damage
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wall = game.findPermanent("Wall of Stone")!!
+                game.castSpell(1, "Frantic Firebolt", wall).error shouldBe null
+                game.resolveStack()
+
+                withClue("2 base + (instant + sorcery + adventurer) = 5 damage; the enchantment is excluded") {
+                    game.findPermanent("Wall of Stone") shouldNotBe null
+                    game.state.getEntity(wall)?.get<DamageComponent>()?.amount shouldBe 5
+                }
+            }
+
+            test("with an empty graveyard X is just the base 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Frantic Firebolt")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Wall of Stone") // 0/8
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wall = game.findPermanent("Wall of Stone")!!
+                game.castSpell(1, "Frantic Firebolt", wall).error shouldBe null
+                game.resolveStack()
+
+                withClue("no graveyard cards → X = 2") {
+                    game.state.getEntity(wall)?.get<DamageComponent>()?.amount shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -447,6 +447,7 @@ abstract class ScenarioTestBase : FunSpec() {
                 imageUri = cardDef.metadata.imageUri,
                 hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
                 originalSetCode = cardDef.setCode,
+                hasAdventure = cardDef.isAdventure,
             )
 
             var container = ComponentContainer.of(


### PR DESCRIPTION
## Summary

Implements four Wilds of Eldraine cards, along with the shared SDK/engine support they need. All four are WOE-only printings, so each is canonical in WOE.

| Card | Cost | What it does |
|------|------|--------------|
| **Frantic Firebolt** | {2}{R} instant | Deals 2 + (instant/sorcery/adventurer cards in your graveyard) damage to target creature |
| **Eriette's Whisper** | {3}{B} sorcery | Target opponent discards two; create a **Wicked Role** on up to one of your creatures |
| **Embereth Veteran** | {R} 2/1 | `{1}, Sacrifice: ` create a **Young Hero Role** on another target creature |
| **Grabby Giant // That's Mine** | {3}{R} // {1}{R} | Reach + sac-an-artifact-or-land draw; the Adventure makes a Treasure |

## New SDK / engine building blocks

- **`CardPredicate.HasAdventure`** — a static, whole-card characteristic (adventurer card in any zone), backed by a new **`CardComponent.hasAdventure`** flag stamped from `CardDefinition.isAdventure` in `CardEntityFactory`. Exposed via **`Filters.HasAdventure`** and **`GameObjectFilter.InstantSorceryOrAdventure`** (Frantic Firebolt's graveyard tally — a single membership test, so a card counts once even if it satisfies more than one clause). The predicate is wired through every exhaustive `CardPredicate` site (`PredicateEvaluator`, `CostCalculator`, `AffectsFilterResolver`).
- **Wicked Role** and **Young Hero Role** predefined tokens (flip partners of the existing Cursed / Royal roles). Young Hero's granted ability uses an ATTACHED-bound attack trigger with a `toughness <= 3` intervening-"if" (CR 603.4); Wicked's drain is a `PutIntoGraveyardFromBattlefield` → each opponent loses 1 life.
- Both scenario-test fixtures (`ScenarioTestBase`, game-server `ScenarioBuilderService`) now mirror `CardEntityFactory`'s `hasAdventure` so scenario-created cards carry the characteristic.

## Testing

- New Kotest scenario tests for the three cards that introduced mechanics (Frantic Firebolt ×2, Eriette's Whisper ×2 including the Wicked Role drain, Embereth Veteran ×3 including the Young Hero intervening-if gate). Grabby Giant is composed entirely from existing, tested primitives (Adventure, Reach, sacrifice cost, Draw, Treasure) so needs no new-mechanic test.
- `CardDefinitionSnapshotTest` golden re-blessed (only the four new WOE cards added; no other card changed).
- `docs/card-sdk-language-reference.md` updated for the new filter/predicate.
- **Full `just build` (all modules + entire JVM test suite) passes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)