### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/TitanicGrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/TitanicGrowth.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Titanic Growth
+ * {1}{G}
+ * Instant
+ * Target creature gets +4/+4 until end of turn.
+ *
+ * Canonical printing lives in Magic 2012 (M12), the card's earliest real-expansion printing.
+ * Later reprints (e.g. Wilds of Eldraine) contribute only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val TitanicGrowth = card("Titanic Growth") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +4/+4 until end of turn."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(4, 4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Ryan Pancoast"
+        flavorText = "The pup looked over the treetops, eyeing the man who just yesterday had kicked her. " +
+            "Suddenly, her hunger was infused with pure delight."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg?1783941054"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Magic 2013. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "M13",
+    collectorNumber = "195",
+    scryfallId = "5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f1fb9f8-c070-40c9-89cd-c74eb8dbbf1a.jpg?1783940463",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Magic 2015. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "M15",
+    collectorNumber = "203",
+    scryfallId = "b3e511b7-6d41-4aa2-b7bd-d4d6e075a819",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b3e511b7-6d41-4aa2-b7bd-d4d6e075a819.jpg?1783939161",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Core Set 2019. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "M19",
+    collectorNumber = "205",
+    scryfallId = "fe574e49-723a-409b-9222-125eebb620ff",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe574e49-723a-409b-9222-125eebb620ff.jpg?1783934527",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Core Set 2020. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "M20",
+    collectorNumber = "343",
+    scryfallId = "0db41405-87a2-4a91-97f4-a8af2ffe8313",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0db41405-87a2-4a91-97f4-a8af2ffe8313.jpg?1783932899",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Core Set 2021. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "M21",
+    collectorNumber = "210",
+    scryfallId = "6da62557-9783-4e6c-9b5f-2b77dbf96909",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6da62557-9783-4e6c-9b5f-2b77dbf96909.jpg?1783930665",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Phyrexia: All Will Be One. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in M12's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "ONE",
+    collectorNumber = "187",
+    scryfallId = "3583ea03-525f-4c70-9d7e-ccc6002ee9e1",
+    artist = "WolfSkullJack",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/3583ea03-525f-4c70-9d7e-ccc6002ee9e1.jpg?1783918008",
+    releaseDate = "2023-02-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in Magic Origins. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in M12's `cards/` package; this file contributes only presentation data.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "ORI",
+    collectorNumber = "201",
+    scryfallId = "24f80ad0-2420-4de4-886c-1168166c7dae",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24f80ad0-2420-4de4-886c-1168166c7dae.jpg?1783938316",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SleightOfHand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/SleightOfHand.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sleight of Hand
+ * {U}
+ * Sorcery
+ * Look at the top two cards of your library. Put one of them into your hand and the other on
+ * the bottom of your library.
+ *
+ * Canonical printing lives in Portal Second Age (P02), the card's earliest real printing.
+ * Later reprints (e.g. Wilds of Eldraine) contribute only a [com.wingedsheep.sdk.model.Printing] row.
+ *
+ * Modeled with the standard dig recipe [Patterns.Library.lookAtTopAndKeep]: gather the top two,
+ * keep one in hand, the single remaining card goes to the bottom of the library.
+ */
+val SleightOfHand = card("Sleight of Hand") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top two cards of your library. Put one of them into your hand and the " +
+        "other on the bottom of your library."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = DynamicAmount.Fixed(2),
+            keepCount = DynamicAmount.Fixed(1),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Phil Foglio"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg?1783946484"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SleightOfHandReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SleightOfHandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sleight of Hand reprint in Starter 1999. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in P02's `cards/` package; this file contributes only presentation data.
+ */
+val SleightOfHandReprint = Printing(
+    oracleId = "05a039ad-1689-4d13-b393-6c1219583b5d",
+    name = "Sleight of Hand",
+    setCode = "S99",
+    collectorNumber = "51",
+    scryfallId = "bd5768e3-40df-425c-bb1e-c3e67f390e18",
+    artist = "Phil Foglio",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bd5768e3-40df-425c-bb1e-c3e67f390e18.jpg?1783946041",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/Mintstrosity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/Mintstrosity.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mintstrosity
+ * {1}{B}
+ * Creature — Horror
+ * 3/1
+ *
+ * When this creature dies, create a Food token.
+ *
+ * [Triggers.Dies] is the self battlefield→graveyard trigger (CR 700.4); its controller creates a
+ * Food token via [Effects.CreateFood].
+ */
+val Mintstrosity = card("Mintstrosity") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature dies, create a Food token. (It's an artifact with " +
+        "\"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Slawomir Maniak"
+        flavorText = "If the sugary abominations of Sweettooth Village were ever under someone's control, " +
+            "that time is long past."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg?1783915104"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SleightOfHandReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SleightOfHandReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sleight of Hand reprint in WOE.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in P02's
+ * `cards/` package. This file contributes only the WOE-specific presentation row — set,
+ * collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn` and
+ * surfaced via the set's `printings`.
+ */
+val SleightOfHandReprint = Printing(
+    oracleId = "05a039ad-1689-4d13-b393-6c1219583b5d",
+    name = "Sleight of Hand",
+    setCode = "WOE",
+    collectorNumber = "67",
+    scryfallId = "80dea5c0-ada3-488a-9f2b-f895b92c762f",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80dea5c0-ada3-488a-9f2b-f895b92c762f.jpg?1783915115",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpiderFood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpiderFood.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Spider Food
+ * {2}{G}
+ * Sorcery
+ * Destroy up to one target artifact, enchantment, or creature with flying. Create a Food token.
+ *
+ * The target filter is a heterogeneous OR — any artifact, any enchantment, OR a creature that has
+ * flying (the flying restriction binds only to the creature branch). The target is optional
+ * ("up to one"), so the spell still resolves and creates the Food even with no legal/chosen target.
+ */
+val SpiderFood = card("Spider Food") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy up to one target artifact, enchantment, or creature with flying. " +
+        "Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+                )
+            )
+        )
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true) then
+            Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Mila Pesic"
+        flavorText = "To the giant spiders of Dunbarrow, there's little difference between fly and faerie."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg?1783915077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StockpilingCelebrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StockpilingCelebrant.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stockpiling Celebrant
+ * {2}{W}
+ * Creature — Dwarf Knight
+ * 3/2
+ *
+ * When this creature enters, you may return another target nonland permanent you control to its
+ * owner's hand. If you do, scry 2.
+ *
+ * `optional = true` models the "you may" — declining skips the whole effect (no bounce, no scry).
+ * The target is chosen when the trigger goes on the stack; if it becomes illegal before
+ * resolution the ability has no legal target and is removed, so the "if you do" scry never fires.
+ * When the player accepts, [Effects.Move] returns the permanent to its owner's hand and then
+ * [Effects.Scry] follows.
+ */
+val StockpilingCelebrant = card("Stockpiling Celebrant") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Knight"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may return another target nonland permanent you " +
+        "control to its owner's hand. If you do, scry 2."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target(
+            "target",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.NonlandPermanent.youControl(), excludeSelf = true)
+            )
+        )
+        effect = Effects.Move(t, Zone.HAND) then Effects.Scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Raluca Marinescu"
+        flavorText = "\"What? I'm saving it for later.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg?1783915126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TitanicGrowthReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TitanicGrowthReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Titanic Growth reprint in WOE.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in M12's
+ * `cards/` package. This file contributes only the WOE-specific presentation row — set,
+ * collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn` and
+ * surfaced via the set's `printings`.
+ */
+val TitanicGrowthReprint = Printing(
+    oracleId = "61e09dd9-7870-48c2-9177-d6abc3162692",
+    name = "Titanic Growth",
+    setCode = "WOE",
+    collectorNumber = "191",
+    scryfallId = "46917de3-5e98-4dd6-8950-fc10338515df",
+    artist = "Iris Compiet",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46917de3-5e98-4dd6-8950-fc10338515df.jpg?1783915076",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -346,6 +346,49 @@
     "colorIdentityOverride": []
 }
 
+// Titanic Growth
+{
+    "name": "Titanic Growth",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +4/+4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Ryan Pancoast",
+        "flavorText": "The pup looked over the treetops, eyeing the man who just yesterday had kicked her. Suddenly, her hunger was infused with pure delight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db3c8982-e1c2-48be-8094-683d00c2e52b.jpg?1783941054"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Warstorm Surge
 {
     "name": "Warstorm Surge",

--- a/mtg-sets/src/test/resources/snapshots/cards/P02.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/P02.json
@@ -388,6 +388,72 @@
     ]
 }
 
+// Sleight of Hand
+{
+    "name": "Sleight of Hand",
+    "manaCost": "{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Phil Foglio",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3405184-dcda-4bb6-ade6-c2a87bc3296d.jpg?1783946484"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vampiric Spirit
 {
     "name": "Vampiric Spirit",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2564,6 +2564,43 @@
     ]
 }
 
+// Mintstrosity
+{
+    "name": "Mintstrosity",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "When this creature dies, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Slawomir Maniak",
+        "flavorText": "If the sugary abominations of Sweettooth Village were ever under someone's control, that time is long past.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d902f154-6fe8-4b97-aa67-4d4696abf887.jpg?1783915104"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Mocking Sprite
 {
     "name": "Mocking Sprite",
@@ -3552,6 +3589,78 @@
     ]
 }
 
+// Spider Food
+{
+    "name": "Spider Food",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy up to one target artifact, enchantment, or creature with flying. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsArtifact",
+                                            "IsEnchantment"
+                                        ]
+                                    },
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasKeyword",
+                                                "keyword": "FLYING"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Mila Pesic",
+        "flavorText": "To the giant spiders of Dunbarrow, there's little difference between fly and faerie.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9fd720b-e9c2-4e82-917e-bab6c544afb0.jpg?1783915077"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Stingblade Assassin
 {
     "name": "Stingblade Assassin",
@@ -3608,6 +3717,64 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Stockpiling Celebrant
+{
+    "name": "Stockpiling Celebrant",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dwarf Knight",
+    "oracleText": "When this creature enters, you may return another target nonland permanent you control to its owner's hand. If you do, scry 2.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "Scry",
+                            "count": 2
+                        }
+                    ]
+                },
+                "optional": true,
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Raluca Marinescu",
+        "flavorText": "\"What? I'm saving it for later.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0214ebc6-c59f-4170-8dd2-ce07caa6e6ad.jpg?1783915126"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MintstrosityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MintstrosityScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mintstrosity — {1}{B} Creature — Horror 3/1 — "When this creature dies, create a Food token."
+ *
+ * Kills the 3/1 with a Lightning Bolt and confirms the self-dies trigger makes exactly one Food.
+ */
+class MintstrosityScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("creates a Food token when it dies") {
+            val g = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mintstrosity")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .build()
+
+            val mint = g.findPermanent("Mintstrosity")!!
+            g.findPermanents("Food").size shouldBe 0
+
+            g.castSpell(1, "Lightning Bolt", mint).error shouldBe null
+            g.resolveStack() // bolt resolves; state-based death moves Mintstrosity to graveyard
+            g.resolveStack() // dies trigger resolves
+
+            withClue("Mintstrosity died") {
+                g.isOnBattlefield("Mintstrosity") shouldBe false
+                g.isInGraveyard(1, "Mintstrosity") shouldBe true
+            }
+            withClue("dying created one Food") {
+                g.findPermanents("Food").size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SleightOfHandScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SleightOfHandScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sleight of Hand — {U} Sorcery — "Look at the top two cards of your library. Put one of them into
+ * your hand and the other on the bottom of your library."
+ *
+ * Canonical script lives in P02; WOE is a reprint row. The library holds exactly two cards so both
+ * are the "top two"; the chosen card goes to hand and the other stays in the library (net −1).
+ */
+class SleightOfHandScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("keeps one of the top two and bottoms the other") {
+            val g = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Sleight of Hand")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Centaur Courser")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .build()
+
+            g.librarySize(1) shouldBe 2
+            // Capture the ids while both are still in the library; the "look" moves them into a
+            // temporary collection, so we can't re-find them by zone mid-resolution.
+            val bears = g.findCardsInLibrary(1, "Grizzly Bears").first()
+
+            g.castSpell(1, "Sleight of Hand").error shouldBe null
+            g.resolveStack()
+
+            val decision = g.getPendingDecision()
+            withClue("look at the top two: a selection over both cards") {
+                (decision is SelectCardsDecision) shouldBe true
+                (decision as SelectCardsDecision).options.size shouldBe 2
+            }
+
+            g.selectCards(listOf(bears))
+            g.resolveStack()
+
+            withClue("chosen card is in hand") {
+                g.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+            withClue("the other card stayed in the library (bottomed), net −1") {
+                g.librarySize(1) shouldBe 1
+                g.findCardsInLibrary(1, "Centaur Courser").size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderFoodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderFoodScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spider Food — {2}{G} Sorcery — "Destroy up to one target artifact, enchantment, or creature with
+ * flying. Create a Food token."
+ *
+ * Covers the heterogeneous OR target (a creature with flying) plus the always-on Food half, and
+ * the "up to one" optional target (declining still creates the Food).
+ */
+class SpiderFoodScenarioTest : ScenarioTestBase() {
+
+    private fun game(vararg opponentPermanents: String) = scenario()
+        .withPlayers()
+        .withCardInHand(1, "Spider Food")
+        .withLandsOnBattlefield(1, "Forest", 3)
+        .apply { opponentPermanents.forEach { withCardOnBattlefield(2, it) } }
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .build()
+
+    init {
+        test("destroys a creature with flying and creates a Food") {
+            val g = game("Birds of Paradise") // Birds of Paradise has flying
+            val flyer = g.findPermanent("Birds of Paradise")!!
+
+            g.castSpell(1, "Spider Food", flyer).error shouldBe null
+            g.resolveStack()
+
+            g.isOnBattlefield("Birds of Paradise") shouldBe false
+            g.isInGraveyard(2, "Birds of Paradise") shouldBe true
+            g.findPermanents("Food").size shouldBe 1
+        }
+
+        test("with no target chosen it still creates a Food") {
+            val g = game("Centaur Courser")
+
+            g.castSpell(1, "Spider Food").error shouldBe null
+            if (g.getPendingDecision() is ChooseTargetsDecision) {
+                g.skipTargets()
+            }
+            g.resolveStack()
+
+            withClue("no permanent destroyed") {
+                g.isOnBattlefield("Centaur Courser") shouldBe true
+            }
+            withClue("Food still created") {
+                g.findPermanents("Food").size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StockpilingCelebrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StockpilingCelebrantScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stockpiling Celebrant — {2}{W} Creature — Dwarf Knight 3/2 — "When this creature enters, you may
+ * return another target nonland permanent you control to its owner's hand. If you do, scry 2."
+ *
+ * Accepting the "may" bounces the chosen permanent to hand and then scrys 2. Declining does neither.
+ */
+class StockpilingCelebrantScenarioTest : ScenarioTestBase() {
+
+    private fun game() = scenario()
+        .withPlayers()
+        .withCardInHand(1, "Stockpiling Celebrant")
+        .withCardOnBattlefield(1, "Grizzly Bears")
+        .withLandsOnBattlefield(1, "Plains", 3)
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(1, "Forest")
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .build()
+
+    init {
+        test("accepting returns a permanent to hand and scrys 2") {
+            val g = game()
+            val bears = g.findPermanent("Grizzly Bears")!!
+
+            g.castSpell(1, "Stockpiling Celebrant").error shouldBe null
+
+            var sawScry = false
+            var guard = 0
+            g.resolveStack()
+            while (g.getPendingDecision() != null && guard++ < 12) {
+                when (g.getPendingDecision()) {
+                    is YesNoDecision -> g.answerYesNo(true)          // accept the "may"
+                    is ChooseTargetsDecision -> g.selectTargets(listOf(bears))
+                    is SelectCardsDecision -> { sawScry = true; g.skipSelection() } // scry: keep on top
+                    is ReorderLibraryDecision -> g.keepLibraryOrder()
+                    else -> break
+                }
+                g.resolveStack()
+            }
+
+            withClue("Stockpiling Celebrant resolved onto the battlefield") {
+                g.isOnBattlefield("Stockpiling Celebrant") shouldBe true
+            }
+            withClue("the targeted permanent was returned to its owner's hand") {
+                g.isOnBattlefield("Grizzly Bears") shouldBe false
+                g.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+            withClue("scry 2 happened because the permanent was returned") {
+                sawScry shouldBe true
+            }
+        }
+
+        test("declining leaves everything in place") {
+            val g = game()
+
+            g.castSpell(1, "Stockpiling Celebrant").error shouldBe null
+
+            var sawScry = false
+            var guard = 0
+            g.resolveStack()
+            while (g.getPendingDecision() != null && guard++ < 12) {
+                when (g.getPendingDecision()) {
+                    is YesNoDecision -> g.answerYesNo(false)         // decline the "may"
+                    is SelectCardsDecision -> { sawScry = true; g.skipSelection() }
+                    is ReorderLibraryDecision -> g.keepLibraryOrder()
+                    else -> break
+                }
+                g.resolveStack()
+            }
+
+            withClue("declining leaves the creature and skips bounce + scry") {
+                g.isOnBattlefield("Stockpiling Celebrant") shouldBe true
+                g.isOnBattlefield("Grizzly Bears") shouldBe true
+                sawScry shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TitanicGrowthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TitanicGrowthScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Titanic Growth — {1}{G} Instant — "Target creature gets +4/+4 until end of turn."
+ *
+ * Canonical script lives in M12; WOE is a reprint row. Verifies the pump lands on the target and
+ * is a one-turn buff (present in the same-turn projected state).
+ */
+class TitanicGrowthScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("pumps the target creature by +4/+4") {
+            val g = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Titanic Growth")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .build()
+
+            val bears = g.findPermanent("Grizzly Bears")!!
+            g.state.projectedState.getPower(bears) shouldBe 2
+            g.state.projectedState.getToughness(bears) shouldBe 2
+
+            g.castSpell(1, "Titanic Growth", bears).error shouldBe null
+            g.resolveStack()
+
+            g.state.projectedState.getPower(bears) shouldBe 6
+            g.state.projectedState.getToughness(bears) shouldBe 6
+        }
+    }
+}


### PR DESCRIPTION
Implements five Wilds of Eldraine commons, each composed entirely from existing SDK facades — no new engine primitives or SDK reference changes.

## Cards

| Card | Color | Behavior |
|------|-------|----------|
| **Mintstrosity** | B | 3/1; when it dies, create a Food (`Triggers.Dies` → `Effects.CreateFood`). |
| **Spider Food** | G | Destroy **up to one** target artifact, enchantment, or creature with flying (heterogeneous OR filter), then always create a Food. |
| **Stockpiling Celebrant** | W | 3/2; optional ETB "may return another target nonland permanent you control; if you do, scry 2" — the optional trigger gates the whole `Move → Scry` chain. |
| **Titanic Growth** | G | Instant, +4/+4 (reprint — canonical in **M12**). |
| **Sleight of Hand** | U | Sorcery, look at top two, keep one, bottom the other (reprint — canonical in **P02**). |

## Reprint placement

Per the repo convention, the two reprints' canonical `CardDefinition`s live in their earliest real printings (M12, P02). `Printing(...)` rows were added to every scaffolded reprinting set so `check-card-printing` passes:
- Titanic Growth → WOE, M13, M15, ORI, M19, M20, M21, ONE
- Sleight of Hand → WOE, S99

## Testing

- New scenario tests for all five cards (pump, dig-and-bottom, dies→Food, optional-target + Food, and both accept/decline paths of the may-bounce-then-scry) — all pass.
- `CardDefinitionSnapshotTest` goldens re-blessed for M12, P02, WOE (diff contains only the five new card trees).
- `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)