### PR TITLE
Add three Wilds of Eldraine cards (Merry Bards, Barrow Naughty, Redtooth Vanguard)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BarrowNaughty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BarrowNaughty.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barrow Naughty
+ * {1}{B}
+ * Creature — Faerie
+ * 1/3
+ *
+ * Flying
+ * This creature has lifelink as long as you control another Faerie.
+ * {2}{B}: This creature gets +1/+0 until end of turn.
+ *
+ * The conditional lifelink is a continuous static that grants the keyword to the source only while
+ * you control a *different* Faerie (excludeSelf), mirroring Magitek Infantry's "another artifact"
+ * shape. Pump is a plain self-targeted stat mod (default until-end-of-turn duration).
+ */
+val BarrowNaughty = card("Barrow Naughty") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\nThis creature has lifelink as long as you control another Faerie.\n" +
+        "{2}{B}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.LIFELINK, GroupFilter.source()),
+            condition = Conditions.YouControl(
+                GameObjectFilter.Creature.withSubtype(Subtype.FAERIE),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{2}{B}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Matt Forsyth"
+        flavorText = "\"The difference between mischief and malice? Numbers.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg?1783915111"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MerryBards.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MerryBards.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Merry Bards
+ * {2}{R}
+ * Creature — Human Bard
+ * 3/2
+ *
+ * When this creature enters, you may pay {1}. When you do, create a Young Hero Role token attached
+ * to target creature you control. (If you control another Role on it, put that one into the
+ * graveyard. Enchanted creature has "Whenever this creature attacks, if its toughness is 3 or less,
+ * put a +1/+1 counter on it.")
+ *
+ * Same reflexive "you may pay {1}. When you do" shape as Spellbook Vendor — the target for the Role
+ * token isn't chosen when the ETB triggers, but when the reflexive ability goes on the stack after
+ * the {1} is paid. The Young Hero Role token carries the granted attack trigger.
+ */
+val MerryBards = card("Merry Bards") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Bard"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may pay {1}. When you do, create a Young Hero Role " +
+        "token attached to target creature you control. (If you control another Role on it, put " +
+        "that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if " +
+        "its toughness is 3 or less, put a +1/+1 counter on it.\")"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val targetCreature = target("target creature you control", Targets.CreatureYouControl)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.CreateRoleToken("Young Hero Role", targetCreature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Iris Compiet"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg?1783915092"
+        ruling("2023-09-01", "You don't choose a target for Merry Bards's ability at the time it triggers. Rather, a second reflexive ability triggers when you pay this way. You choose a target for that ability as it goes on the stack.")
+        ruling("2023-09-01", "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedtoothVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedtoothVanguard.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Redtooth Vanguard
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 3/1
+ *
+ * Trample
+ * Whenever an enchantment you control enters, you may pay {2}. If you do, return this card from
+ * your graveyard to your hand.
+ *
+ * The recursion ability functions only while this card is in the graveyard (`triggerZone =
+ * GRAVEYARD`), same shape as Dragon Shadow's graveyard-resident enters trigger. `MayPayManaEffect`
+ * models "you may pay {2}. If you do, ..." and the inner Move returns the source from the graveyard
+ * to its owner's hand.
+ */
+val RedtoothVanguard = card("Redtooth Vanguard") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 3
+    toughness = 1
+    oracleText = "Trample\nWhenever an enchantment you control enters, you may pay {2}. If you do, " +
+        "return this card from your graveyard to your hand."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        triggerZone = Zone.GRAVEYARD
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.GRAVEYARD)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Joshua Cairos"
+        flavorText = "\"I'm just as deadly during the day.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg?1783915079"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,77 @@
     ]
 }
 
+// Barrow Naughty
+{
+    "name": "Barrow Naughty",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\nThis creature has lifelink as long as you control another Faerie.\n{2}{B}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{2}{B}: This creature gets +1/+0 until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Faerie",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Matt Forsyth",
+        "flavorText": "\"The difference between mischief and malice? Numbers.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67da5ad8-4de2-4bd4-8b95-f2657e1fdee5.jpg?1783915111"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Beanstalk Wurm
 {
     "name": "Beanstalk Wurm",
@@ -2509,6 +2580,72 @@
     ]
 }
 
+// Merry Bards
+{
+    "name": "Merry Bards",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Bard",
+    "oracleText": "When this creature enters, you may pay {1}. When you do, create a Young Hero Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateRoleToken",
+                        "roleName": "Young Hero Role",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Iris Compiet",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0058b9b-e919-45eb-9da0-690f62aa252e.jpg?1783915092",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You don't choose a target for Merry Bards's ability at the time it triggers. Rather, a second reflexive ability triggers when you pay this way. You choose a target for that ability as it goes on the stack."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Minecart Daredevil
 {
     "name": "Minecart Daredevil",
@@ -3084,6 +3221,61 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Redtooth Vanguard
+{
+    "name": "Redtooth Vanguard",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Trample\nWhenever an enchantment you control enters, you may pay {2}. If you do, return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "activeZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Cairos",
+        "flavorText": "\"I'm just as deadly during the day.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55271960-b9bd-4bea-93ca-3321bf30be78.jpg?1783915079"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RedtoothVanguardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RedtoothVanguardScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Redtooth Vanguard (WOE #180) — {1}{G} 3/1 Elf Warrior.
+ *
+ * "Trample
+ *  Whenever an enchantment you control enters, you may pay {2}. If you do, return this card from
+ *  your graveyard to your hand."
+ *
+ * Exercises the graveyard-resident enters trigger (`triggerZone = GRAVEYARD`, same mechanism as
+ * Dragon Shadow / Flamewake Phoenix), the optional {2} payment (`MayPayManaEffect`), and the
+ * return-to-hand from the graveyard. All primitives already exist.
+ */
+class RedtoothVanguardScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Redtooth Vanguard") {
+
+            test("enchantment entering + paying {2} returns Redtooth Vanguard from graveyard to hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Redtooth Vanguard")
+                    .withCardInHand(1, "Angelic Shield") // {W}{U} Enchantment
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast the enchantment; pay {W}{U}, resolve it onto the battlefield.
+                game.castSpell(1, "Angelic Shield").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Angelic Shield entered, firing Redtooth's graveyard trigger") {
+                    game.findPermanent("Angelic Shield") shouldNotBe null
+                }
+
+                // The reflexive may-pay is offered by the graveyard-resident trigger.
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(true)
+                game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Redtooth Vanguard is returned to its owner's hand") {
+                    game.isInHand(1, "Redtooth Vanguard") shouldBe true
+                }
+                withClue("Redtooth Vanguard is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Redtooth Vanguard") shouldBe false
+                }
+            }
+
+            test("declining the {2} payment leaves Redtooth Vanguard in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Redtooth Vanguard")
+                    .withCardInHand(1, "Angelic Shield")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Angelic Shield").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining leaves Redtooth Vanguard in the graveyard") {
+                    game.isInGraveyard(1, "Redtooth Vanguard") shouldBe true
+                }
+            }
+
+            test("an opponent's enchantment entering does not trigger Redtooth Vanguard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Redtooth Vanguard")
+                    .withCardInHand(2, "Angelic Shield")
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withLandsOnBattlefield(2, "Island", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Angelic Shield").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("The trigger checks 'an enchantment you control', so an opponent's enchantment is ignored") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe false
+                }
+                withClue("Redtooth Vanguard stays in the graveyard") {
+                    game.isInGraveyard(1, "Redtooth Vanguard") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three more Wilds of Eldraine commons/uncommons, each reusing existing SDK primitives (no new engine features).

## Cards

| Card | Cost | P/T | Mechanic |
|------|------|-----|----------|
| **Merry Bards** | `{2}{R}` | 3/2 | ETB reflexive "you may pay `{1}`. When you do, create a **Young Hero Role** token on target creature you control." Reuses `MayPayManaEffect` + `CreateRoleToken` (same shape as Spellbook Vendor). |
| **Barrow Naughty** | `{1}{B}` | 1/3 | Flying; **lifelink as long as you control another Faerie** via `ConditionalStaticAbility` + `GrantKeyword` gated on `YouControl(another Faerie)`; `{2}{B}`: +1/+0. |
| **Redtooth Vanguard** | `{1}{G}` | 3/1 | Trample; graveyard-resident enters trigger (`triggerZone = GRAVEYARD`) offering "you may pay `{2}`. If you do, return this from your graveyard to your hand." Same mechanism as Dragon Shadow / Flamewake Phoenix. |

## Testing

- `RedtoothVanguardScenarioTest` — covers the graveyard-recursion path most thoroughly: pay `{2}` → returns to hand, decline → stays in graveyard, and an opponent's enchantment entering does **not** trigger (`you control` binding).
- Merry Bards and Barrow Naughty compose already-tested primitives, so no bespoke tests were added.
- Card snapshot golden (`WOE.json`) re-blessed — diff shows only the three new cards.
- `CardLintTest` + `CardDefinitionSnapshotTest` pass; `check-card-printing` confirms all three are canonical in their earliest printing (WOE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)