### PR TITLE
Add three Foundations cards: Time Stop, Deadly Brew, Rite of Replication

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/TimeStopReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/TimeStopReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Time Stop reprint in Tenth Edition (10E). Canonical CardDefinition lives in Champions of
+ * Kamigawa (CHK), its earliest printing; this file contributes only presentation data.
+ */
+val TimeStopReprint = Printing(
+    oracleId = "55bc6a7e-2356-48f0-a93a-8bf19044ee4b",
+    name = "Time Stop",
+    setCode = "10E",
+    collectorNumber = "117",
+    scryfallId = "521d1b29-c25b-443b-ae5f-07c11786947e",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/521d1b29-c25b-443b-ae5f-07c11786947e.jpg?1783943046",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/RiteOfReplicationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/RiteOfReplicationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rite of Replication reprint in Commander 2014 (C14). Canonical CardDefinition lives in
+ * Zendikar (ZEN), its earliest printing; this file contributes only presentation data.
+ */
+val RiteOfReplicationReprint = Printing(
+    oracleId = "fb60739e-1dc3-481d-a056-ad72e665c680",
+    name = "Rite of Replication",
+    setCode = "C14",
+    collectorNumber = "122",
+    scryfallId = "863c3968-d23d-4bf3-97ab-fbf2f6015a70",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/863c3968-d23d-4bf3-97ab-fbf2f6015a70.jpg?1783938847",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/RiteOfReplicationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/RiteOfReplicationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rite of Replication reprint in Commander 2015 (C15). Canonical CardDefinition lives in
+ * Zendikar (ZEN), its earliest printing; this file contributes only presentation data.
+ */
+val RiteOfReplicationReprint = Printing(
+    oracleId = "fb60739e-1dc3-481d-a056-ad72e665c680",
+    name = "Rite of Replication",
+    setCode = "C15",
+    collectorNumber = "105",
+    scryfallId = "67432030-2ff6-4926-8320-3d813ed5888a",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67432030-2ff6-4926-8320-3d813ed5888a.jpg?1783938090",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TimeStop.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/TimeStop.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Time Stop
+ * {4}{U}{U}
+ * Instant
+ *
+ * End the turn. (Exile all spells and abilities, including this spell. The player whose
+ * turn it is discards down to their maximum hand size. Damage heals and "this turn" and
+ * "until end of turn" effects end.)
+ *
+ * Takes no target — [Effects.EndTheTurn] always ends the active player's turn (CR 720).
+ * When it resolves the whole stack is exiled (including this spell and any triggers the
+ * resolution queued, even uncounterable ones), creatures leave combat, and the game skips
+ * straight to the cleanup step before the next turn begins.
+ */
+val TimeStop = card("Time Stop") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "End the turn. (Exile all spells and abilities, including this spell. " +
+        "The player whose turn it is discards down to their maximum hand size. Damage " +
+        "heals and \"this turn\" and \"until end of turn\" effects end.)"
+
+    spell {
+        effect = Effects.EndTheTurn
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "97"
+        artist = "Scott M. Fischer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg?1783944320"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeadlyBrewReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeadlyBrewReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Brew reprint in FDN. Canonical CardDefinition lives in Strixhaven (STX), its
+ * earliest printing; this file contributes only presentation data.
+ */
+val DeadlyBrewReprint = Printing(
+    oracleId = "b831d3f8-07ce-4172-ba29-213cac414c9a",
+    name = "Deadly Brew",
+    setCode = "FDN",
+    collectorNumber = "654",
+    scryfallId = "4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4cd4d5a4-4342-49fb-b1e4-7d08e6cf5376.jpg?1783908912",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiteOfReplicationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiteOfReplicationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rite of Replication reprint in FDN. Canonical CardDefinition lives in Zendikar (ZEN),
+ * its earliest printing; this file contributes only presentation data.
+ */
+val RiteOfReplicationReprint = Printing(
+    oracleId = "fb60739e-1dc3-481d-a056-ad72e665c680",
+    name = "Rite of Replication",
+    setCode = "FDN",
+    collectorNumber = "711",
+    scryfallId = "fe98958d-30ee-4a47-aacc-064e02d109b3",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe98958d-30ee-4a47-aacc-064e02d109b3.jpg?1783908893",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TimeStopReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TimeStopReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Time Stop reprint in FDN. Canonical CardDefinition lives in Champions of Kamigawa (CHK),
+ * its earliest printing; this file contributes only presentation data.
+ */
+val TimeStopReprint = Printing(
+    oracleId = "55bc6a7e-2356-48f0-a93a-8bf19044ee4b",
+    name = "Time Stop",
+    setCode = "FDN",
+    collectorNumber = "166",
+    scryfallId = "d938603b-0f1e-44c4-b86e-38e15f4a0d27",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d938603b-0f1e-44c4-b86e-38e15f4a0d27.jpg?1783909077",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DeadlyBrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DeadlyBrew.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Deadly Brew
+ * {B}{G}
+ * Sorcery
+ *
+ * Each player sacrifices a creature or planeswalker of their choice. If you sacrificed a
+ * permanent this way, you may return another permanent card from your graveyard to your
+ * hand.
+ *
+ * Same shape as Rise of the Witch-king, with two differences: the edict filter is
+ * creature-or-planeswalker (not just creature), and the reanimation half returns the
+ * chosen card to hand rather than the battlefield.
+ *
+ * The oracle text does not say "target" — the return is a *resolution-time* choice, not a
+ * cast-time target, so the spell has no targets and always resolves.
+ *
+ * Composition:
+ *  - `Effects.Sacrifice(CreatureOrPlaneswalker, count=1, target=Player.Each)` — each player
+ *    auto-sacrifices a sole eligible permanent or chooses among multiples. The snapshots
+ *    flow into `EffectContext.sacrificedPermanents` so the rider can read them.
+ *  - The rider is a `ConditionalEffect` gated on `YouSacrificedThisWay`.
+ *  - The recursion half is the standard Gather → Select(`ChooseUpTo(1)`) → Move pipeline
+ *    against your graveyard. `excludeSacrificedThisWay = true` keeps the permanent you just
+ *    sacrificed (now in your graveyard) out of the "another permanent card" choice.
+ */
+val DeadlyBrew = card("Deadly Brew") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Sorcery"
+    oracleText = "Each player sacrifices a creature or planeswalker of their choice. " +
+        "If you sacrificed a permanent this way, you may return another permanent card " +
+        "from your graveyard to your hand."
+
+    spell {
+        effect = Effects.Sacrifice(
+            GameObjectFilter.CreatureOrPlaneswalker,
+            count = 1,
+            target = EffectTarget.PlayerRef(Player.Each)
+        ).then(
+            ConditionalEffect(
+                condition = Conditions.YouSacrificedThisWay,
+                effect = Effects.Composite(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(
+                                Zone.GRAVEYARD,
+                                Player.You,
+                                GameObjectFilter.Permanent,
+                                // "return ANOTHER permanent card" — the permanent you just
+                                // sacrificed sits in your graveyard but is not a legal choice.
+                                excludeSacrificedThisWay = true
+                            ),
+                            storeAs = "eligible"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "eligible",
+                            selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                            storeSelected = "chosen",
+                            prompt = "Choose a permanent card to return to your hand"
+                        ),
+                        MoveCollectionEffect(
+                            from = "chosen",
+                            destination = CardDestination.ToZone(Zone.HAND)
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "176"
+        artist = "Randy Vargas"
+        flavorText = "\"No one ever asked what was in Dina's concoctions, so long as they worked.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg?1783927318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/RiteOfReplication.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/RiteOfReplication.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rite of Replication
+ * {2}{U}{U}
+ * Sorcery
+ *
+ * Kicker {5} (You may pay an additional {5} as you cast this spell.)
+ * Create a token that's a copy of target creature. If this spell was kicked, create five
+ * of those tokens instead.
+ *
+ * "Create five … instead" is a mutually-exclusive branch, not additive: a kicked cast
+ * makes five copies *and no more* (not five + the base one). Modeled as a
+ * [ConditionalEffect] on [Conditions.WasKicked] — the kicked branch creates five copies,
+ * the else branch creates one. Each token is a copy of the resolved target creature via
+ * `Effects.CreateTokenCopyOfTarget` (copiable characteristics per Rule 707); the copies'
+ * own enters-the-battlefield triggers fire as they are created.
+ */
+val RiteOfReplication = card("Rite of Replication") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Kicker {5} (You may pay an additional {5} as you cast this spell.)\n" +
+        "Create a token that's a copy of target creature. If this spell was kicked, " +
+        "create five of those tokens instead."
+
+    keywordAbility(KeywordAbility.kicker("{5}"))
+
+    spell {
+        val t = target("target", TargetCreature())
+        effect = ConditionalEffect(
+            condition = Conditions.WasKicked,
+            effect = Effects.CreateTokenCopyOfTarget(t, count = 5),
+            elseEffect = Effects.CreateTokenCopyOfTarget(t, count = 1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "61"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg?1783942162"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -2664,6 +2664,26 @@
     ]
 }
 
+// Time Stop
+{
+    "name": "Time Stop",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "End the turn. (Exile all spells and abilities, including this spell. The player whose turn it is discards down to their maximum hand size. Damage heals and \"this turn\" and \"until end of turn\" effects end.)",
+    "script": {
+        "spellEffect": "EndTheTurn"
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f968c5e9-12a8-4542-90b4-84e0238fa375.jpg?1783944320"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Time of Need
 {
     "name": "Time of Need",

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -124,6 +124,83 @@
     "colorIdentityOverride": []
 }
 
+// Deadly Brew
+{
+    "name": "Deadly Brew",
+    "manaCost": "{B}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player sacrifices a creature or planeswalker of their choice. If you sacrificed a permanent this way, you may return another permanent card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "creature|planeswalker",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "YouSacrificedPermanentThisWay"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "filter": "permanent",
+                                    "excludeSacrificedThisWay": true
+                                },
+                                "storeAs": "eligible"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "eligible",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "chosen",
+                                "prompt": "Choose a permanent card to return to your hand"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "chosen",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "flavorText": "\"No one ever asked what was in Dina's concoctions, so long as they worked.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87d33e48-90fc-4aac-b09a-68050bc053b5.jpg?1783927318"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Flamescroll Celebrant
 {
     "name": "Flamescroll Celebrant",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -615,6 +615,65 @@
     ]
 }
 
+// Rite of Replication
+{
+    "name": "Rite of Replication",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a token that's a copy of target creature. If this spell was kicked, create five of those tokens instead.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{5}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": "WasKicked"
+            },
+            "then": {
+                "type": "CreateTokenCopyOfTarget",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                },
+                "count": {
+                    "type": "Fixed",
+                    "amount": 5
+                }
+            },
+            "otherwise": {
+                "type": "CreateTokenCopyOfTarget",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/4530fe45-8a3d-48e9-a7a5-abf8fb1485e3.jpg?1783942162"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vampire Nighthawk
 {
     "name": "Vampire Nighthawk",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeadlyBrewScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeadlyBrewScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.stx.cards.DeadlyBrew
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Engine coverage for Deadly Brew (STX #176; reprinted in Foundations #654).
+ *
+ * "Each player sacrifices a creature or planeswalker of their choice. If you sacrificed a
+ * permanent this way, you may return another permanent card from your graveyard to your
+ * hand."
+ *
+ * Same shape as Rise of the Witch-king; the two behaviours worth pinning are the ones this
+ * card changes: the edict hits creatures *or* planeswalkers, and the recursion returns the
+ * chosen card to hand (guarded by the intervening "if you sacrificed" clause).
+ */
+class DeadlyBrewScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + DeadlyBrew)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.handNames(playerId: com.wingedsheep.sdk.model.EntityId): List<String> =
+        getHand(playerId).mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    test("each player sacrifices; you may return another permanent card to your hand") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        // Both players control exactly one creature, so each edict auto-sacrifices it.
+        driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        driver.putCreatureOnBattlefield(p2, "Centaur Courser")
+        // A distinct permanent card already in p1's graveyard, eligible to return.
+        val savannah = driver.putCardInGraveyard(p1, "Savannah Lions")
+
+        val brew = driver.putCardInHand(p1, "Deadly Brew")
+        driver.giveMana(p1, Color.BLACK, 1)
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.castSpell(p1, brew)
+        driver.bothPass() // resolve: both auto-sacrifice, then pause for the optional return
+
+        // Both creatures are gone.
+        driver.findPermanent(p1, "Centaur Courser") shouldBe null
+        driver.findPermanent(p2, "Centaur Courser") shouldBe null
+
+        // p1 sacrificed a permanent, so the "you may return" selection is offered.
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe p1
+        driver.submitCardSelection(p1, listOf(savannah))
+
+        // The chosen permanent card moved from graveyard to hand.
+        driver.handNames(p1) shouldContain "Savannah Lions"
+        driver.getGraveyardCardNames(p1) shouldNotContain "Savannah Lions"
+    }
+
+    test("if you sacrificed nothing, you get no return (intervening-if clause)") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        // p1 controls no creature or planeswalker, so p1 sacrifices nothing.
+        driver.putCreatureOnBattlefield(p2, "Centaur Courser")
+        driver.putCardInGraveyard(p1, "Savannah Lions")
+
+        val brew = driver.putCardInHand(p1, "Deadly Brew")
+        driver.giveMana(p1, Color.BLACK, 1)
+        driver.giveMana(p1, Color.GREEN, 1)
+
+        driver.castSpell(p1, brew)
+        driver.bothPass()
+
+        // p2's creature was sacrificed, but p1 sacrificed nothing.
+        driver.findPermanent(p2, "Centaur Courser") shouldBe null
+
+        // No return selection is raised, and the graveyard card stays put.
+        driver.pendingDecision shouldBe null
+        driver.getGraveyardCardNames(p1) shouldContain "Savannah Lions"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiteOfReplicationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiteOfReplicationScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.zen.cards.RiteOfReplication
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for Rite of Replication (ZEN #61; reprinted in Foundations #711).
+ *
+ * "Kicker {5}. Create a token that's a copy of target creature. If this spell was kicked,
+ * create five of those tokens instead."
+ *
+ * Pins the mutually-exclusive branch on the kicker: an un-kicked cast makes exactly one
+ * copy, a kicked cast makes exactly five (not six).
+ */
+class RiteOfReplicationScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RiteOfReplication)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.countCreatures(playerId: EntityId, name: String): Int =
+        getCreatures(playerId).count { state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    test("un-kicked, Rite of Replication creates one token copy of the target creature") {
+        val driver = createDriver()
+        val p1 = driver.player1
+
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        val rite = driver.putCardInHand(p1, "Rite of Replication")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.giveColorlessMana(p1, 2)
+
+        driver.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = rite,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        driver.bothPass() // resolve
+
+        // Original + one copy = two.
+        driver.countCreatures(p1, "Centaur Courser") shouldBe 2
+    }
+
+    test("kicked, Rite of Replication creates five token copies instead of one") {
+        val driver = createDriver()
+        val p1 = driver.player1
+
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        val rite = driver.putCardInHand(p1, "Rite of Replication")
+        // Kicked total cost is {7}{U}{U}.
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.giveColorlessMana(p1, 7)
+
+        driver.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = rite,
+                targets = listOf(ChosenTarget.Permanent(courser)),
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        driver.bothPass() // resolve
+
+        // Original + five copies = six.
+        driver.countCreatures(p1, "Centaur Courser") shouldBe 6
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TimeStopScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TimeStopScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.chk.cards.TimeStop
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for Time Stop (CHK #97 — {4}{U}{U} instant, "End the turn.") over the
+ * shared [com.wingedsheep.sdk.dsl.Effects.EndTheTurn] effect (CR 720).
+ *
+ * The card just wires an instant to `EndTheTurn`, so these tests pin the two consequences
+ * players actually see: Time Stop exiles itself with the stack (CR 720.1a) and the turn
+ * ends into the opponent's turn, and any other spell still on the stack is exiled unresolved
+ * (CR 720.1a — "exile all spells and abilities, including this spell").
+ */
+class TimeStopScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + TimeStop)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("Time Stop exiles itself and ends the active player's turn") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val timeStop = driver.putCardInHand(p1, "Time Stop")
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.giveColorlessMana(p1, 4)
+
+        driver.castSpell(p1, timeStop)
+        driver.bothPass() // resolve Time Stop -> end the turn
+
+        // CR 720.1a: Time Stop is exiled with the stack, not put into the graveyard.
+        driver.getExileCardNames(p1) shouldContain "Time Stop"
+        driver.getGraveyardCardNames(p1) shouldNotContain "Time Stop"
+
+        // The turn ended: it is now the opponent's turn.
+        driver.activePlayer shouldBe p2
+    }
+
+    test("Time Stop exiles another spell on the stack, so it never resolves") {
+        val driver = createDriver()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A cheap creature spell to sit under Time Stop on the stack.
+        val lions = driver.putCardInHand(p1, "Savannah Lions")
+        val timeStop = driver.putCardInHand(p1, "Time Stop")
+        driver.giveMana(p1, Color.WHITE, 1)
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.giveColorlessMana(p1, 4)
+
+        // Stack (bottom -> top): Savannah Lions, Time Stop. The caster keeps priority
+        // after each cast, so both go on the stack before anything resolves.
+        driver.castSpell(p1, lions)
+        driver.castSpell(p1, timeStop)
+        driver.bothPass() // resolve Time Stop -> end the turn, exiling the rest of the stack
+
+        // Savannah Lions was exiled with the stack — it never entered the battlefield.
+        driver.findPermanent(p1, "Savannah Lions") shouldBe null
+        driver.getExileCardNames(p1) shouldContain "Savannah Lions"
+    }
+})


### PR DESCRIPTION
Implements three Foundations (FDN) cards, each via the `add-card` workflow. All three are
reprints, so the canonical `CardDefinition` lives in each card's earliest real printing and
Foundations (plus any other scaffolded set that carries the card) gets a `Printing` row.

## Cards

| Card | Canonical set | Printing rows added | Mechanic |
|------|---------------|---------------------|----------|
| **Time Stop** | Champions of Kamigawa (CHK) | 10E, FDN | `{4}{U}{U}` instant → `Effects.EndTheTurn` (CR 720) |
| **Deadly Brew** | Strixhaven (STX) | FDN | `{B}{G}` edict on creature/planeswalker + optional graveyard return to hand |
| **Rite of Replication** | Zendikar (ZEN) | C14, C15, FDN | `{2}{U}{U}` Kicker {5}; copy target creature (five copies if kicked) |

All three compose existing SDK primitives — no new effects, triggers, conditions, or engine
changes — so there is no SDK-reference change.

- **Deadly Brew** mirrors Rise of the Witch-king: `Effects.Sacrifice(CreatureOrPlaneswalker, Player.Each)`
  then a `YouSacrificedThisWay`-gated gather → select(up to 1) → move-to-hand pipeline
  (`excludeSacrificedThisWay` keeps the just-sacrificed card out of the "another permanent" choice).
- **Rite of Replication** uses a `ConditionalEffect` on `Conditions.WasKicked` with mutually
  exclusive branches (five copies vs one) over `Effects.CreateTokenCopyOfTarget`.
- **Time Stop** wires an instant to the already-tested `EndTheTurn` effect.

## Tests

Scenario tests in `rules-engine` (6 tests, all passing):
- Time Stop: self-exile + turn ends; exiles another spell on the stack.
- Deadly Brew: each player sacrifices + optional return-to-hand; intervening-if (no sacrifice → no return).
- Rite of Replication: one copy un-kicked; five copies kicked.

Also verified: `CardDefinitionSnapshotTest` re-blessed (only CHK/STX/ZEN goldens change, pure
additions), `FacadeBoundaryTest`, `CardLintTest`, and `check-card-printing` for all three cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)