### PR TITLE
Add four Wilds of Eldraine Adventure cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FrolickingFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FrolickingFamiliar.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frolicking Familiar // Blow Off Steam
+ * {2}{U}
+ * Creature — Otter Wizard
+ * 2/2
+ *
+ * Flying
+ * Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn.
+ *
+ * Adventure: Blow Off Steam — {R}, Instant — Adventure
+ * Blow Off Steam deals 1 damage to any target.
+ *
+ * The pump is a self-targeted [Effects.ModifyStats] (end-of-turn duration) fired by
+ * [Triggers.YouCastInstantOrSorcery]. (CR 715: Adventure cards. Casting the Adventure exiles the
+ * card on resolution and lets the caster cast it as the creature spell while it remains in exile.)
+ */
+val FrolickingFamiliar = card("Frolicking Familiar") {
+    manaCost = "{2}{U}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Otter Wizard"
+    oracleText = "Flying\n" +
+        "Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    adventure("Blow Off Steam") {
+        manaCost = "{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Blow Off Steam deals 1 damage to any target. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Any)
+            effect = Effects.DealDamage(1, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1783915065"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ShroudedShepherd.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ShroudedShepherd.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shrouded Shepherd // Cleave Shadows
+ * {1}{W}
+ * Creature — Spirit Warrior
+ * 2/2
+ *
+ * When this creature enters, target creature you control gets +2/+2 until end of turn.
+ *
+ * Adventure: Cleave Shadows — {1}{B}, Sorcery — Adventure
+ * Creatures your opponents control get -1/-1 until end of turn.
+ *
+ * The Adventure's mass debuff is a resolution-time [Effects.ForEachInGroup] over
+ * [GroupFilter.AllCreaturesOpponentsControl], applying a self-targeted [Effects.ModifyStats] to
+ * each. (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val ShroudedShepherd = card("Shrouded Shepherd") {
+    manaCost = "{1}{W}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Spirit Warrior"
+    oracleText = "When this creature enters, target creature you control gets +2/+2 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    adventure("Cleave Shadows") {
+        manaCost = "{1}{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Creatures your opponents control get -1/-1 until end of turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.ForEachInGroup(
+                GroupFilter.AllCreaturesOpponentsControl,
+                Effects.ModifyStats(-1, -1, EffectTarget.Self)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1783915061"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StormkeldVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StormkeldVanguard.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Stormkeld Vanguard // Bear Down
+ * {4}{G}{G}
+ * Creature — Giant Warrior
+ * 6/7
+ *
+ * This creature can't be blocked by creatures with power 2 or less.
+ *
+ * Adventure: Bear Down — {1}{G}, Sorcery — Adventure
+ * Destroy target artifact or enchantment.
+ *
+ * The evasion is a permanent [CantBeBlockedBy] static keyed on blocker power via
+ * [GameObjectFilter.Creature.powerAtMost]. (CR 715: Adventure cards. Casting the Adventure exiles
+ * the card on resolution and lets the caster cast it as the creature spell while it remains in exile.)
+ */
+val StormkeldVanguard = card("Stormkeld Vanguard") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Giant Warrior"
+    oracleText = "This creature can't be blocked by creatures with power 2 or less."
+    power = 6
+    toughness = 7
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2))
+    }
+
+    adventure("Bear Down") {
+        manaCost = "{1}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Destroy target artifact or enchantment. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.ArtifactOrEnchantment)
+            effect = Effects.Destroy(t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "187"
+        artist = "Aldo Domínguez"
+        flavorText = "He rides like thunder and strikes like lightning."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1783915077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwoHeadedHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwoHeadedHunter.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Two-Headed Hunter // Twice the Rage
+ * {4}{R}
+ * Creature — Giant
+ * 5/4
+ *
+ * Menace
+ *
+ * Adventure: Twice the Rage — {1}{R}, Instant — Adventure
+ * Target creature gains double strike until end of turn.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val TwoHeadedHunter = card("Two-Headed Hunter") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    oracleText = "Menace"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.MENACE)
+
+    adventure("Twice the Rage") {
+        manaCost = "{1}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Target creature gains double strike until end of turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target creature", Targets.Creature)
+            effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Filip Burburan"
+        flavorText = "\"I point, you club!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1783915087"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1918,6 +1918,93 @@
     ]
 }
 
+// Frolicking Familiar
+{
+    "name": "Frolicking Familiar",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Otter Wizard",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64c432d5-4f5b-44ac-9d61-891e78460d58.jpg?1783915065"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Blow Off Steam",
+            "manaCost": "{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Blow Off Steam deals 1 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Frostbridge Guard
 {
     "name": "Frostbridge Guard",
@@ -3534,6 +3621,93 @@
     "colorIdentityOverride": []
 }
 
+// Shrouded Shepherd
+{
+    "name": "Shrouded Shepherd",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Warrior",
+    "oracleText": "When this creature enters, target creature you control gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab03c342-2bf4-41bf-8bb8-472d978d238a.jpg?1783915061"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Cleave Shadows",
+            "manaCost": "{1}{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Creatures your opponents control get -1/-1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        }
+    ]
+}
+
 // Skewer Slinger
 {
     "name": "Skewer Slinger",
@@ -4016,6 +4190,73 @@
     ]
 }
 
+// Stormkeld Vanguard
+{
+    "name": "Stormkeld Vanguard",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "This creature can't be blocked by creatures with power 2 or less.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtMost",
+                            "max": 2
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "UNCOMMON",
+        "artist": "Aldo Domínguez",
+        "flavorText": "He rides like thunder and strikes like lightning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bacb1fe5-0adf-461f-b698-9d09a8728c63.jpg?1783915077"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Bear Down",
+            "manaCost": "{1}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Destroy target artifact or enchantment. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Stroke of Midnight
 {
     "name": "Stroke of Midnight",
@@ -4333,6 +4574,59 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Two-Headed Hunter
+{
+    "name": "Two-Headed Hunter",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Menace",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "\"I point, you club!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70c12e75-7e65-4706-b976-e47835910928.jpg?1783915087"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Twice the Rage",
+            "manaCost": "{1}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Target creature gains double strike until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Implements four **Wilds of Eldraine** Adventure creatures via the `add-card` workflow. Each composes existing SDK primitives — **no new engine mechanics**, no scenario tests required (matching the convention of existing pure-composition adventures like Besotted Knight / Cheeky House-Mouse).

## Cards

| Card | Cost | Creature face | Adventure |
|------|------|---------------|-----------|
| **Stormkeld Vanguard // Bear Down** | {4}{G}{G} · 6/7 | Can't be blocked by creatures with power 2 or less (`CantBeBlockedBy` + `powerAtMost(2)`) | {1}{G} Sorcery — Destroy target artifact or enchantment |
| **Frolicking Familiar // Blow Off Steam** | {2}{U} · 2/2 | Flying; whenever you cast an instant or sorcery, +1/+1 until EOT (`YouCastInstantOrSorcery` → `ModifyStats`) | {R} Instant — 1 damage to any target |
| **Two-Headed Hunter // Twice the Rage** | {4}{R} · 5/4 | Menace | {1}{R} Instant — Target creature gains double strike until EOT |
| **Shrouded Shepherd // Cleave Shadows** | {1}{W} · 2/2 | ETB: target creature you control gets +2/+2 until EOT | {1}{B} Sorcery — Creatures opponents control get -1/-1 until EOT (`ForEachInGroup`) |

## Verification
- ✅ `:mtg-sets:test` — full suite passes (`CardDefinitionSnapshotTest`, `CardLintTest`, discovery, legality)
- ✅ WOE snapshot golden reblessed; diff scoped to only these 4 cards (both faces each)
- ✅ `just check-card-printing` — all four canonical in WOE (earliest real printing)
- ✅ Every field re-checked against Scryfall (mana cost, P/T, type line, oracle text, color identity incl. off-color adventure faces UR / WB, art, artist, collector number)
- ✅ Image URIs verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)