### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CharmingScoundrel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CharmingScoundrel.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Charming Scoundrel
+ * {1}{R}
+ * Creature — Human Rogue (1/1)
+ *
+ * Haste
+ * When this creature enters, choose one —
+ * • Discard a card, then draw a card.
+ * • Create a Treasure token.
+ * • Create a Wicked Role token attached to target creature you control.
+ *
+ * A three-mode ETB via [ModalEffect.chooseOne]. Only the third mode targets, so it uses
+ * [Mode.withTarget]; the loot and Treasure modes are [Mode.noTarget]. The loot mode is discard-then-
+ * draw (order matters — discard resolves before the draw). The Wicked Role token carries the +1/+1
+ * buff and the "put into a graveyard, each opponent loses 1 life" trigger; [Effects.CreateRoleToken]
+ * handles replacing an existing Role you control on that creature.
+ */
+val CharmingScoundrel = card("Charming Scoundrel") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "When this creature enters, choose one —\n" +
+        "• Discard a card, then draw a card.\n" +
+        "• Create a Treasure token.\n" +
+        "• Create a Wicked Role token attached to target creature you control."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.Discard(1).then(Effects.DrawCards(1)),
+                "Discard a card, then draw a card."
+            ),
+            Mode.noTarget(
+                Effects.CreateTreasure(),
+                "Create a Treasure token."
+            ),
+            Mode.withTarget(
+                Effects.CreateRoleToken("Wicked Role", EffectTarget.ContextTarget(0)),
+                TargetCreature(filter = TargetFilter.CreatureYouControl),
+                "Create a Wicked Role token attached to target creature you control."
+            )
+        )
+        description = "When this creature enters, choose one."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Caroline Gariba"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1783915097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CutIn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CutIn.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Cut In
+ * {3}{R}
+ * Sorcery
+ *
+ * Cut In deals 4 damage to target creature.
+ * Create a Young Hero Role token attached to up to one target creature you control.
+ *
+ * Two independent targets: the mandatory "target creature" that takes 4 damage (any creature), and
+ * the optional ("up to one") creature you control that gains the Young Hero Role. The Young Hero
+ * Role token carries the attack trigger ("Whenever this creature attacks, if its toughness is 3 or
+ * less, put a +1/+1 counter on it."); [Effects.CreateRoleToken] handles the "replace an existing
+ * Role" rule. Same optional-role shape as Eriette's Whisper.
+ */
+val CutIn = card("Cut In") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Cut In deals 4 damage to target creature.\n" +
+        "Create a Young Hero Role token attached to up to one target creature you control. " +
+        "(If you control another Role on it, put that one into the graveyard. Enchanted creature has " +
+        "\"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")"
+
+    spell {
+        val damaged = target("target creature", TargetCreature())
+        val roleTarget = target(
+            "creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.Composite(
+            Effects.DealDamage(4, damaged),
+            Effects.CreateRoleToken("Young Hero Role", roleTarget)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg?1783915097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ScreamPuff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ScreamPuff.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scream Puff
+ * {4}{B}
+ * Creature — Horror (4/5)
+ *
+ * Deathtouch
+ * Whenever this creature deals combat damage to a player, create a Food token.
+ *
+ * Straight composition: the [Keyword.DEATHTOUCH] keyword plus a [Triggers.DealsCombatDamageToPlayer]
+ * (SELF-bound) trigger that creates a Food token via [Effects.CreateFood]. Food is the shared
+ * Wilds of Eldraine artifact token ("{2}, {T}, Sacrifice this token: You gain 3 life.").
+ */
+val ScreamPuff = card("Scream Puff") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 4
+    toughness = 5
+    oracleText = "Deathtouch\n" +
+        "Whenever this creature deals combat damage to a player, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateFood()
+        description = "Whenever this creature deals combat damage to a player, create a Food token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Nicholas Gregory"
+        flavorText = "Too much sugar is bad for your health."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg?1783915103"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WaterWings.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WaterWings.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Water Wings
+ * {1}{U}
+ * Instant
+ *
+ * Until end of turn, target creature you control has base power and toughness 4/4 and gains flying
+ * and hexproof.
+ *
+ * [Effects.SetBasePowerAndToughness] sets base P/T to 4/4 in Layer 7b (so later +N/+N counters and
+ * pumps still apply on top), and two [Effects.GrantKeyword] grants confer flying and hexproof. All
+ * three effects default to [com.wingedsheep.sdk.scripting.Duration.EndOfTurn], matching the oracle
+ * "until end of turn".
+ */
+val WaterWings = card("Water Wings") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature you control has base power and toughness 4/4 " +
+        "and gains flying and hexproof. (It can't be the target of spells or abilities your " +
+        "opponents control.)"
+
+    spell {
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.SetBasePowerAndToughness(4, 4, creature)
+            .then(Effects.GrantKeyword(Keyword.FLYING, creature))
+            .then(Effects.GrantKeyword(Keyword.HEXPROOF, creature))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Arash Radkia"
+        flavorText = "Luckily for the plummeting Johann, the hydroloft spell was one he had actually mastered."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg?1783915113"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WerefoxBodyguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WerefoxBodyguard.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Werefox Bodyguard
+ * {1}{W}{W}
+ * Creature — Elf Fox Knight (2/2)
+ *
+ * Flash
+ * When this creature enters, exile up to one other target non-Fox creature until this creature
+ * leaves the battlefield.
+ * {1}{W}, Sacrifice this creature: You gain 2 life.
+ *
+ * O-Ring-style linked exile: the ETB exiles the target ("up to one" → optional) via
+ * [Effects.ExileUntilLeaves], and a companion [Triggers.LeavesBattlefield] trigger returns the
+ * exiled card with [Effects.ReturnLinkedExileUnderOwnersControl]. The target filter is
+ * `Creature.notSubtype(Fox)` with `excludeSelf` (Werefox is itself a Fox, and the oracle says
+ * "other"). The sacrifice ability lets its owner cash it in for 2 life before an opponent can
+ * remove it to free the exiled creature.
+ */
+val WerefoxBodyguard = card("Werefox Bodyguard") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elf Fox Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\n" +
+        "When this creature enters, exile up to one other target non-Fox creature until this " +
+        "creature leaves the battlefield.\n" +
+        "{1}{W}, Sacrifice this creature: You gain 2 life."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "other target non-Fox creature",
+            TargetCreature(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.notSubtype(Subtype("Fox")),
+                    excludeSelf = true
+                )
+            )
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+        description = "When this creature enters, exile up to one other target non-Fox creature " +
+            "until this creature leaves the battlefield."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.SacrificeSelf)
+        effect = Effects.GainLife(2)
+        description = "{1}{W}, Sacrifice this creature: You gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg?1783915124"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -730,6 +730,113 @@
     "colorIdentityOverride": []
 }
 
+// Charming Scoundrel
+{
+    "name": "Charming Scoundrel",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Haste\nWhen this creature enters, choose one —\n• Discard a card, then draw a card.\n• Create a Treasure token.\n• Create a Wicked Role token attached to target creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    },
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Discard a card, then draw a card."
+                        },
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            },
+                            "description": "Create a Treasure token."
+                        },
+                        {
+                            "effect": {
+                                "type": "CreateRoleToken",
+                                "roleName": "Wicked Role"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "description": "Create a Wicked Role token attached to target creature you control."
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Caroline Gariba",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1783915097"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cheeky House-Mouse
 {
     "name": "Cheeky House-Mouse",
@@ -994,6 +1101,65 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Cut In
+{
+    "name": "Cut In",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Cut In deals 4 damage to target creature.\nCreate a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Young Hero Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ea4d40a-7657-4ff8-9fc2-915b99432275.jpg?1783915097"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3621,6 +3787,47 @@
     "colorIdentityOverride": []
 }
 
+// Scream Puff
+{
+    "name": "Scream Puff",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Deathtouch\nWhenever this creature deals combat damage to a player, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, create a Food token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Too much sugar is bad for your health.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg?1783915103"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Shrouded Shepherd
 {
     "name": "Shrouded Shepherd",
@@ -4885,6 +5092,182 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Water Wings
+{
+    "name": "Water Wings",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature you control has base power and toughness 4/4 and gains flying and hexproof. (It can't be the target of spells or abilities your opponents control.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "SetBaseStats",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Arash Radkia",
+        "flavorText": "Luckily for the plummeting Johann, the hydroloft spell was one he had actually mastered.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ea4993c-d1ba-4b33-955b-e0874fd2132f.jpg?1783915113"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Werefox Bodyguard
+{
+    "name": "Werefox Bodyguard",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Elf Fox Knight",
+    "oracleText": "Flash\nWhen this creature enters, exile up to one other target non-Fox creature until this creature leaves the battlefield.\n{1}{W}, Sacrifice this creature: You gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "other target non-Fox creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "NotSubtype",
+                                    "subtype": "Fox"
+                                }
+                            ]
+                        },
+                        "excludeSelf": true
+                    },
+                    "id": "other target non-Fox creature"
+                },
+                "descriptionOverride": "When this creature enters, exile up to one other target non-Fox creature until this creature leaves the battlefield."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "{1}{W}, Sacrifice this creature: You gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4494dfa1-1343-417e-b0c5-2b096442dd0e.jpg?1783915124"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Implements five commons from **Wilds of Eldraine** (WOE), each composed from existing SDK primitives — **no new engine code, no new effects/triggers/conditions**.

## Cards

| Card | Cost | Type | What it does |
|------|------|------|--------------|
| **Scream Puff** | {4}{B} | Creature — Horror 4/5 | Deathtouch; `DealsCombatDamageToPlayer` → `CreateFood` |
| **Cut In** | {3}{R} | Sorcery | 4 damage to target creature **+** Young Hero Role on up-to-one creature you control (two independent targets) |
| **Water Wings** | {1}{U} | Instant | `SetBasePowerAndToughness` 4/4 + grant flying + hexproof, until end of turn |
| **Charming Scoundrel** | {1}{R} | Creature — Human Rogue 1/1 | Haste; three-mode ETB via `ModalEffect.chooseOne` (loot / Treasure / Wicked Role) |
| **Werefox Bodyguard** | {1}{W}{W} | Creature — Elf Fox Knight 2/2 | Flash; O-Ring-style `ExileUntilLeaves` of an up-to-one *other* non-Fox creature + sacrifice-for-2-life |

Two Celebration cards (Armory Mice, Tuinvale Guide) were considered and **dropped**: Celebration needs a generic "nonland permanents entered under your control this turn" count that the SDK doesn't yet expose (only subtype- and land-specific variants exist). That's an `add-feature` change, out of scope for a card-authoring PR.

## Verification
- `:mtg-sets:test` green — `CardDefinitionSnapshotTest` (WOE golden re-blessed) + `CardLintTest` + discovery.
- Snapshot diff touches **only** `WOE.json`, adding exactly these five cards.
- Every field (mana cost, type line, P/T, oracle text, collector number, artist, image URI) cross-checked against Scryfall; all image URIs return HTTP 200.
- No new effects/triggers/conditions, so per-card scenario tests are not required (skill Step 5); the underlying primitives are already covered by existing scenario tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)