### PR TITLE
Add Foundations cards: Hidetsugu's Second Rite, Koma World-Eater

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HidetsugusSecondRiteReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HidetsugusSecondRiteReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hidetsugu's Second Rite reprint in Foundations. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `sok` (Saviors of Kamigawa) package —
+ * this file contributes only Foundations presentation data.
+ */
+val HidetsugusSecondRiteReprint = Printing(
+    oracleId = "749683c9-8cc0-4e8e-8d90-adda5e5f4e93",
+    name = "Hidetsugu's Second Rite",
+    setCode = "FDN",
+    collectorNumber = "202",
+    scryfallId = "609421da-8d89-4365-b18b-778832d91482",
+    artist = "Ben Hill",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/609421da-8d89-4365-b18b-778832d91482.jpg?1783909065",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KomaWorldEater.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KomaWorldEater.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Koma, World-Eater
+ * {3}{G}{G}{U}{U}
+ * Legendary Creature — Serpent
+ * 8/12
+ * This spell can't be countered.
+ * Trample, ward {4}
+ * Whenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens
+ * named Koma's Coil.
+ *
+ * Pure composition of existing primitives:
+ * - "can't be countered" → the card-level [cantBeCountered] flag.
+ * - Trample → keyword; Ward {4} → [KeywordAbility.Ward] with a [WardCost.Mana] cost.
+ * - The combat-damage trigger fires on [Triggers.DealsCombatDamageToPlayer] and creates four
+ *   specifically-named ("Koma's Coil") 3/3 blue Serpent tokens via [CreateTokenEffect] — the raw
+ *   effect is used directly because the `Effects.CreateToken` facade doesn't expose a token `name`,
+ *   and Koma's Coil's name differs from its Serpent creature type.
+ */
+val KomaWorldEater = card("Koma, World-Eater") {
+    manaCost = "{3}{G}{G}{U}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Serpent"
+    power = 8
+    toughness = 12
+    oracleText = "This spell can't be countered.\n" +
+        "Trample, ward {4}\n" +
+        "Whenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil."
+
+    cantBeCountered = true
+    keywords(Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{4}")))
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = CreateTokenEffect(
+            count = 4,
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Serpent"),
+            name = "Koma's Coil",
+            imageUri = "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg?1783908590",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Mark Zug"
+        flavorText = "The gods imprisoned Koma, fearing he would eventually devour the Cosmos itself."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg?1783909091"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sok/SaviorsOfKamigawaSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sok/SaviorsOfKamigawaSet.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.sok
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Saviors of Kamigawa (2005)
+ *
+ * The final set of the Kamigawa block. Scaffolded here as the canonical home for cards whose
+ * earliest real printing is SOK (e.g. Hidetsugu's Second Rite, reprinted in Foundations).
+ * Intentionally incomplete relative to the official set — only cards relocated here as their
+ * canonical earliest printing live in this package.
+ *
+ * Set Code: SOK
+ * Release Date: 2005-06-03
+ */
+object SaviorsOfKamigawaSet : MtgSet {
+
+    override val code = "SOK"
+    override val displayName = "Saviors of Kamigawa"
+    override val releaseDate = "2005-06-03"
+    override val block = "Kamigawa"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.sok.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sok/cards/HidetsugusSecondRite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sok/cards/HidetsugusSecondRite.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.sok.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hidetsugu's Second Rite
+ * {3}{R}
+ * Instant
+ * If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.
+ *
+ * Not an intervening-if — the spell targets a player at cast time and simply checks their life
+ * total when it resolves. If they aren't at exactly 10, the spell resolves doing nothing (it does
+ * not fizzle for having no legal target). Modeled as a [ConditionalEffect] whose gate compares the
+ * targeted player's current life ([DynamicAmount.LifeTotal] of [Player.ContextPlayer]`(0)` — the
+ * single player target) against 10.
+ *
+ * Canonical earliest printing: Saviors of Kamigawa (2005). Reprinted in Foundations (2024) — see
+ * the `fdn` package's Printing row.
+ */
+val HidetsugusSecondRite = card("Hidetsugu's Second Rite") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player."
+
+    spell {
+        val targetPlayer = target("target player", Targets.Player)
+        effect = ConditionalEffect(
+            condition = Conditions.CompareAmounts(
+                DynamicAmount.LifeTotal(Player.ContextPlayer(0)),
+                ComparisonOperator.EQ,
+                DynamicAmount.Fixed(10),
+            ),
+            effect = Effects.DealDamage(10, targetPlayer),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "102"
+        artist = "Jeff Miracola"
+        flavorText = "Hidetsugu never relinquished a grudge. He let it burn within him, gathering ever greater intensity until the final moment of vengeance."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg?1783944146"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -4402,6 +4402,72 @@
     ]
 }
 
+// Koma, World-Eater
+{
+    "name": "Koma, World-Eater",
+    "manaCost": "{3}{G}{G}{U}{U}",
+    "typeLine": "Legendary Creature — Serpent",
+    "oracleText": "This spell can't be countered.\nTrample, ward {4}\nWhenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens named Koma's Coil.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 12
+    },
+    "keywords": [
+        "TRAMPLE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{4}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Serpent"
+                    ],
+                    "name": "Koma's Coil",
+                    "imageUri": "https://cards.scryfall.io/normal/front/c/e/cef25434-cd23-4dcf-b77e-36e648a8de23.jpg?1783908590"
+                }
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "The gods imprisoned Koma, fearing he would eventually devour the Cosmos itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3b92caa-3401-4b11-9515-152f3e057c05.jpg?1783909091"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Kykar, Zephyr Awakener
 {
     "name": "Kykar, Zephyr Awakener",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOK.json
@@ -1,0 +1,57 @@
+// Hidetsugu's Second Rite
+{
+    "name": "Hidetsugu's Second Rite",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "LifeTotal",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 10
+                    }
+                }
+            },
+            "then": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 10
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target player"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "RARE",
+        "artist": "Jeff Miracola",
+        "flavorText": "Hidetsugu never relinquished a grudge. He let it burn within him, gathering ever greater intensity until the final moment of vengeance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e48eb77-3bd7-444a-9262-799cc706c05a.jpg?1783944146"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HidetsugusSecondRiteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HidetsugusSecondRiteScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hidetsugu's Second Rite (canonical SOK #102, reprinted FDN #202) —
+ * {3}{R} Instant.
+ *
+ * "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player."
+ *
+ * The spell always targets a player; the "exactly 10 life" check is a resolution-time condition
+ * (not an intervening-if that fizzles). The two tests pin both branches: a target at exactly 10
+ * takes 10 (→ 0), and a target at any other life total takes nothing.
+ */
+class HidetsugusSecondRiteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hidetsugu's Second Rite") {
+
+            test("deals 10 damage when the targeted player has exactly 10 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hidetsugu's Second Rite")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 10)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Hidetsugu's Second Rite", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("A player at exactly 10 life takes 10 damage → 0") {
+                    game.getLifeTotal(2) shouldBe 0
+                }
+            }
+
+            test("deals no damage when the targeted player's life is not exactly 10") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hidetsugu's Second Rite")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(2, 11)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Hidetsugu's Second Rite", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("11 life is not exactly 10 — the spell resolves doing nothing") {
+                    game.getLifeTotal(2) shouldBe 11
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KomaWorldEaterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KomaWorldEaterScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Koma, World-Eater (FDN #121) — {3}{G}{G}{U}{U} Legendary Creature — Serpent 8/12.
+ *
+ * "This spell can't be countered."
+ * "Trample, ward {4}"
+ * "Whenever Koma deals combat damage to a player, create four 3/3 blue Serpent creature tokens
+ *  named Koma's Coil."
+ *
+ * The keyword layer (trample/ward) and the can't-be-countered flag are covered by the compiled-card
+ * snapshot; this test exercises the one behavioral ability — the combat-damage-to-a-player trigger
+ * that spawns four Koma's Coil tokens.
+ */
+class KomaWorldEaterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Koma, World-Eater") {
+
+            test("has trample in projected state") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Koma, World-Eater", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val koma = game.findPermanent("Koma, World-Eater")!!
+                withClue("Koma should have trample") {
+                    game.state.projectedState.hasKeyword(koma, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("dealing combat damage to a player creates four Koma's Coil tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Koma, World-Eater", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val attack = game.declareAttackers(mapOf("Koma, World-Eater" to 2))
+                withClue("Koma should be able to attack: ${attack.error}") {
+                    attack.error shouldBe null
+                }
+
+                // Player2 declares no blockers; combat damage auto-resolves and the trigger creates tokens.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Player2 took 8 combat damage from Koma (8/12)") {
+                    game.getLifeTotal(2) shouldBe 12
+                }
+                withClue("Koma's combat damage created four 3/3 Koma's Coil tokens under its controller") {
+                    game.findPermanents("Koma's Coil").size shouldBe 4
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a small handful of Foundations (FDN) cards. Foundations is already 88% complete, so the remaining cards each carry a wrinkle; these two are the cleanest pure-composition picks (no new SDK/engine work). Cards that would have required genuine feature work — Blasphemous Edict (cast-time conditional alternative cost), Banner of Kinship (a new "fellowship" counter type), Infernal Vessel (a self-reanimate-with-counters effect) — were deliberately left out per "fewer if complex."

## Cards

### Hidetsugu's Second Rite — canonical **Saviors of Kamigawa** (SOK), reprinted in FDN
`{3}{R}` Instant — *If target player has exactly 10 life, deals 10 damage to that player.*

- Its earliest real printing is SOK (2005), so the canonical `CardDefinition` lives there and Foundations gets a `Printing` row. This PR **scaffolds the SOK set** (`SaviorsOfKamigawaSet`, auto-discovered by the classpath scan) as the canonical home.
- Modeled as a `ConditionalEffect` whose gate compares the targeted player's current life (`ContextPlayer(0)`) against 10, then deals 10 damage. Not an intervening-if: the spell always targets and simply resolves doing nothing off exactly-10.

### Koma, World-Eater — **Foundations** (FDN-exclusive)
`{3}{G}{G}{U}{U}` Legendary Creature — Serpent, 8/12

- *This spell can't be countered.* — the `cantBeCountered` card flag.
- *Trample, ward {4}* — keyword + `KeywordAbility.Ward(WardCost.Mana("{4}"))`.
- *Whenever Koma deals combat damage to a player, create four 3/3 blue Serpent tokens named Koma's Coil.* — a `DealsCombatDamageToPlayer` trigger + `CreateTokenEffect` (raw, since the token's name differs from its creature type and the facade doesn't expose a name).

## Verification
- **Scenario tests** (rules-engine) — 4 tests, all passing:
  - Hidetsugu: exactly-10 → 10 damage; any other life total → no damage.
  - Koma: trample present in projected state; combat damage to a player creates four Koma's Coil tokens (opponent 20 → 12).
- **Card snapshot** re-blessed — diff is additive only (new `SOK.json` golden; `FDN.json` gains only Koma). No other set's snapshot moved.
- **CardLintTest** passes.
- `just check-card-printing` confirms canonical placement for both (SOK earliest → canonical + FDN reprint row; Koma FDN-canonical).
- No SDK/engine changes, so the SDK reference needs no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)