### PR TITLE
Add cost-vs-cost Choice additional cost + Souls of the Lost (LCI)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 260 / 286
+**Implemented:** 261 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -228,7 +228,7 @@
 - [x] Song of Stupefaction
 - [ ] Sorcerous Spyglass
 - [x] Soulcoil Viper
-- [ ] Souls of the Lost
+- [x] Souls of the Lost
 - [ ] Sovereign Okinec Ahau
 - [x] Spelunking
 - [x] Spring-Loaded Sawblades

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -342,6 +342,23 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   is recovered at payment time from whether the cast action's `additionalCostPayment.sacrificedPermanents`
   is non-empty; the sacrifice path is only offered when you control at least `count` matching
      permanents, so with nothing to sacrifice only the pay path is castable.
+- `Costs.additional.Choice(vararg options)` — **cost-vs-cost**: "as an additional cost to cast this
+  spell, pay exactly one of `options`" (Souls of the Lost: *"discard a card **or** sacrifice a
+  permanent"*). The general, parameterized form of `Forage` — each option is itself an
+  `AdditionalCost` (compose the `Sacrifice` / `Discard` / `ExileFrom` atoms). Distinct from the
+  `*OrPay` family (`SacrificeOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
+  fold a **mana** alternative into the spell's cost, whereas `Choice` is for options that are each
+  independently payable **non-mana** costs (no mana-cost change). The enumerator emits **one cast
+  action per payable option** (`CastSpellEnumerator.expandChoiceAdditionalCosts` +
+  `ChoiceCostResolver`), each carrying that option's existing picker (`SacrificePermanent` /
+  `DiscardCard` / `ExileFromGraveyard`) — so the caster picks the sub-cost by choosing which action to
+  play, with **no new client UI**. The plain (un-expanded) base action is dropped, since a mandatory
+  choice cost can't be skipped. At payment time `CastSpellHandler.reduceChoiceCosts` collapses the
+  `Choice` to the single option the caller populated (or, for a server-initiated free/AI cast with no
+  payment, the first payable option — mirroring `ForageCostResolver`'s engine-direct fallback), so
+  validation, application, and the free-cast selection pause all handle it as a plain atom. Keep the
+  options on **distinct** payment fields (sacrifice vs. discard vs. exile) — two options consuming the
+  same field can't be told apart by the payment alone.
 - `Costs.additional.RemoveCounters(count, counterType = null, filter = Any)` — "as an additional
   cost to cast this spell, remove `count` counters from among permanents matching `filter` you
   control." When `counterType` is set (e.g. `"+1/+1"`), only counters of that type are removed;

--- a/manual-scenarios/cards/s/souls-of-the-lost.json
+++ b/manual-scenarios/cards/s/souls-of-the-lost.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Souls of the Lost", "Deep-Cavern Bat", "Cenote Scout"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Cenote Scout"}
+    ],
+    "graveyard": ["Swamp", "Swamp", "Swamp"],
+    "library": ["Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -414,6 +414,14 @@ object Costs {
         /** Forage (exile three cards from your graveyard or sacrifice a Food). */
         val Forage: AdditionalCost = AdditionalCost.Forage
 
+        /**
+         * Cost-vs-cost — the caster pays exactly one of [options] ("discard a card **or** sacrifice a
+         * permanent"; Souls of the Lost). For options that are each independently payable non-mana
+         * costs; use the `*OrPay` family instead when one branch pays extra *mana*. See
+         * [AdditionalCost.Choice].
+         */
+        fun Choice(vararg options: AdditionalCost): AdditionalCost = AdditionalCost.Choice(options.toList())
+
         /** Blight X — put X -1/-1 counters on a creature you control (X declared at cast time, min [minCount]). */
         fun BlightVariable(minCount: Int = 0): AdditionalCost = AdditionalCost.BlightVariable(minCount)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -134,6 +134,40 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
+     * Cost-vs-cost: the caster chooses **exactly one** of [options] and pays it — "as an additional
+     * cost to cast this spell, discard a card **or** sacrifice a permanent" (Souls of the Lost). Each
+     * option is itself a fully-formed [AdditionalCost] paid through the normal cast machinery, so the
+     * options compose the same atoms every other cost uses (Sacrifice / Discard / ExileFrom / …).
+     *
+     * **Boundary — what this is *not*:** [Choice] is for options that are each *independently payable
+     * non-mana costs*. Options where one branch instead pays *additional mana* ("… or pay {2}") are the
+     * separate `*OrPay` family ([SacrificeOrPay], [ExileFromGraveyardOrPay], [BeholdOrPay],
+     * [BlightOrPay]) — those fold the alternative into the spell's mana cost, which [Choice] never does.
+     * [Forage] (CR 701.61) is the named keyword shortcut for a fixed two-option cost-vs-cost (exile
+     * three from your graveyard / sacrifice a Food); [Choice] is its open, parameterized generalization.
+     *
+     * Each option surfaces as its own cast-time legal action (the same multi-action pattern the OrPay
+     * costs and Forage use), so the caster picks the option by choosing which action to play and the
+     * existing per-cost picker drives the selection — no new client UI. At payment time the chosen
+     * option is recovered from which [AdditionalCostPayment] field the client populated; options that
+     * consume *different* payment fields (sacrifice vs. discard vs. exile) disambiguate cleanly. Two
+     * options that consume the *same* field (e.g. two different Sacrifice filters) are not
+     * distinguishable by payment alone — keep options on distinct fields.
+     */
+    @SerialName("ChoiceCost")
+    @Serializable
+    data class Choice(
+        val options: List<AdditionalCost>
+    ) : AdditionalCost {
+        override val description: String get() = options.joinToString(" or ") { it.description }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
+            val newOptions = options.map { it.applyTextReplacement(replacer) }
+            return if (newOptions.zip(options).any { (a, b) -> a !== b }) copy(options = newOptions) else this
+        }
+    }
+
+    /**
      * Blight X (variable): the caster declares X at cast time, puts X -1/-1
      * counters on a creature they control, and X is exposed to the spell's
      * effects via `DynamicAmount.CastChoice(ChoiceSlot.BLIGHT_AMOUNT)`.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SoulsOfTheLost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SoulsOfTheLost.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Souls of the Lost — {1}{B}
+ * Creature — Spirit
+ * Rare — The Lost Caverns of Ixalan #121
+ * Artist: Nils Hamm
+ *
+ * "As an additional cost to cast this spell, discard a card or sacrifice a permanent.
+ *  Fathomless descent — Souls of the Lost's power is equal to the number of permanent cards in
+ *  your graveyard and its toughness is equal to that number plus 1."
+ *
+ * Two independent mechanics:
+ *  - **Cost-vs-cost additional cost** — the caster pays *either* "discard a card" *or* "sacrifice a
+ *    permanent", modeled with the general `Costs.additional.Choice` primitive
+ *    ([com.wingedsheep.sdk.scripting.AdditionalCost.Choice]). Each option surfaces as its own cast
+ *    action, so the player chooses the sub-cost by choosing which action to play.
+ *  - **Fathomless descent CDA** — a characteristic-defining ability (Layer 7b) setting base power to
+ *    the number of permanent cards in your graveyard and base toughness to that number plus one,
+ *    reusing [DynamicAmount.Count]`(You, GRAVEYARD, Permanent)` (the same count Squirming Emergence /
+ *    Song of Stupefaction read) via the `dynamicStats` DSL with a +1 toughness offset. The printed
+ *    star/star P/T is replaced by these dynamic values.
+ */
+val SoulsOfTheLost = card("Souls of the Lost") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\n" +
+        "Fathomless descent — Souls of the Lost's power is equal to the number of permanent cards " +
+        "in your graveyard and its toughness is equal to that number plus 1."
+
+    dynamicStats(
+        DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent),
+        toughnessOffset = 1
+    )
+
+    additionalCost(
+        Costs.additional.Choice(
+            Costs.additional.DiscardCards(),
+            Costs.additional.SacrificePermanent()
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Nils Hamm"
+        flavorText = "\"Do you remember us?\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg?1782694513"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -14959,6 +14959,62 @@
     ]
 }
 
+// Souls of the Lost
+{
+    "name": "Souls of the Lost",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "As an additional cost to cast this spell, discard a card or sacrifice a permanent.\nFathomless descent — Souls of the Lost's power is equal to the number of permanent cards in your graveyard and its toughness is equal to that number plus 1.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "permanent"
+            }
+        },
+        "toughness": {
+            "type": "DynamicWithOffset",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "permanent"
+            },
+            "offset": 1
+        }
+    },
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "ChoiceCost",
+                "options": [
+                    {
+                        "type": "AdditionalAtom",
+                        "atom": "AtomDiscard"
+                    },
+                    {
+                        "type": "AdditionalAtom",
+                        "atom": "AtomSacrifice"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Do you remember us?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5c6f502-f11f-4e41-beb8-0843432fa431.jpg?1782694513"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spelunking
 {
     "name": "Spelunking",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -904,6 +904,9 @@ class CostHandler {
             }
             is AdditionalCost.Forage ->
                 com.wingedsheep.engine.handlers.costs.ForageCostResolver.canPay(state, controllerId)
+            is AdditionalCost.Choice ->
+                // Cost-vs-cost: payable if at least one option can be paid.
+                cost.options.any { canPayAdditionalCost(state, it, controllerId) }
             is AdditionalCost.Behold -> {
                 // Can behold if matching permanent on battlefield or matching card in hand
                 val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1304,15 +1304,50 @@ class CastSpellHandler(
         return perModeOverrides.flatten()
     }
 
+    /**
+     * Reduce each cost-vs-cost [AdditionalCost.Choice] in [costs] to the single option the caster is
+     * actually paying, so every downstream cost path (validation, application, free-cast selection)
+     * handles it as a plain atom with no [Choice] awareness. The chosen option is:
+     *  1. the option whose [AdditionalCostPayment] field the client populated — a normal cast, where
+     *     each option surfaced as its own legal action so exactly one field is filled; else
+     *  2. the first option payable from the current board — server-initiated free/AI casts arrive with
+     *     no payment (mirrors [ForageCostResolver]'s engine-direct fallback); else
+     *  3. the first option (nothing payable — downstream validation/selection then rejects the cast).
+     */
+    private fun reduceChoiceCosts(
+        costs: List<AdditionalCost>,
+        state: GameState,
+        playerId: EntityId,
+        payment: AdditionalCostPayment?,
+    ): List<AdditionalCost> = costs.map { cost ->
+        if (cost !is AdditionalCost.Choice) cost
+        else cost.options.firstOrNull { optionPaymentSatisfied(it, payment) }
+            ?: cost.options.firstOrNull { costHandler.canPayAdditionalCost(state, it, playerId) }
+            ?: cost.options.first()
+    }
+
+    /** True when [payment] already carries a selection for the field [option]'s atom consumes. */
+    private fun optionPaymentSatisfied(option: AdditionalCost, payment: AdditionalCostPayment?): Boolean {
+        val atom = (option as? AdditionalCost.Atom)?.atom ?: return false
+        val p = payment ?: return false
+        return when (atom) {
+            is CostAtom.Sacrifice -> p.sacrificedPermanents.isNotEmpty()
+            is CostAtom.Discard -> p.discardedCards.isNotEmpty()
+            is CostAtom.ExileFrom -> p.exiledCards.isNotEmpty()
+            is CostAtom.TapPermanents -> p.tappedPermanents.isNotEmpty()
+            is CostAtom.ReturnToHand -> p.bouncedPermanents.isNotEmpty()
+            else -> false
+        }
+    }
+
     private fun validateAdditionalCosts(
         state: GameState,
         additionalCosts: List<AdditionalCost>,
         action: CastSpell
     ): String? {
         val projected = state.projectedState
-        val flattenedCosts = additionalCosts.flatMap {
-            if (it is AdditionalCost.Composite) it.steps else listOf(it)
-        }
+        val flattenedCosts = reduceChoiceCosts(additionalCosts, state, action.playerId, action.additionalCostPayment)
+            .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
         for (additionalCost in flattenedCosts) {
             when (additionalCost) {
                 is AdditionalCost.Atom -> when (val atom = additionalCost.atom) {
@@ -2104,9 +2139,8 @@ class CastSpellHandler(
             linkedGranter?.additionalCost?.let { add(it) }
         }
 
-        val flattenedAllCosts = allAdditionalCosts.flatMap {
-            if (it is AdditionalCost.Composite) it.steps else listOf(it)
-        }
+        val flattenedAllCosts = reduceChoiceCosts(allAdditionalCosts, currentState, action.playerId, action.additionalCostPayment)
+            .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
 
         // Server-initiated free cast: pay the spell's printed additional costs even though the
         // mana cost is waived (CR 601.2f / 118.9). A normal client cast arrives with the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/ChoiceCostResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/ChoiceCostResolver.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.legalactions.AdditionalCostData
+import com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+
+/**
+ * Enumeration helper for the cost-vs-cost [AdditionalCost.Choice] additional cost — the general form
+ * of Forage ("discard a card **or** sacrifice a permanent"; Souls of the Lost).
+ *
+ * A [Choice] surfaces at cast time as **one legal action per payable option** — the same multi-action
+ * pattern [ForageCostResolver] and the `*OrPay` costs use — so the caster picks the option by choosing
+ * which action to play and the existing per-cost picker (SacrificePermanent / DiscardCard /
+ * ExileFromGraveyard) drives the selection with **no new client UI**. This object builds the
+ * [AdditionalCostData] payload for each option; the enumerator's post-process attaches one to each
+ * expanded cast action, and payment is recovered downstream from which field the client populated
+ * (see `CastSpellHandler.reduceChoiceCosts`).
+ *
+ * Only options that map to a client-rendered cost picker are emitted; an option whose atom has no
+ * picker (or which can't currently be paid) is dropped, so a [Choice] with no payable option yields
+ * an empty list and the card is not castable.
+ */
+object ChoiceCostResolver {
+
+    /**
+     * One legal-action cost payload per **payable** option of [choice], in declaration order.
+     * [cardId] is the spell being cast — excluded from its own discard/exile candidate pools.
+     */
+    fun costInfos(
+        state: GameState,
+        playerId: EntityId,
+        choice: AdditionalCost.Choice,
+        costUtils: CostEnumerationUtils,
+        cardId: EntityId,
+    ): List<AdditionalCostData> = choice.options.mapNotNull { optionCostInfo(state, playerId, it, costUtils, cardId) }
+
+    private fun optionCostInfo(
+        state: GameState,
+        playerId: EntityId,
+        option: AdditionalCost,
+        costUtils: CostEnumerationUtils,
+        cardId: EntityId,
+    ): AdditionalCostData? {
+        val atom = (option as? AdditionalCost.Atom)?.atom ?: return null
+        return when (atom) {
+            is CostAtom.Sacrifice -> {
+                val targets = costUtils.findSacrificeTargets(state, playerId, atom)
+                if (targets.size < atom.count) return null
+                AdditionalCostData(
+                    description = atom.description.replaceFirstChar { it.uppercase() },
+                    costType = "SacrificePermanent",
+                    validSacrificeTargets = targets,
+                    sacrificeCount = atom.count,
+                )
+            }
+            is CostAtom.Discard -> {
+                if (atom.random) return null // a random discard needs no selection UI
+                val targets = costUtils.findDiscardTargets(state, playerId, atom.filter).filter { it != cardId }
+                if (targets.size < atom.count) return null
+                AdditionalCostData(
+                    description = atom.description.replaceFirstChar { it.uppercase() },
+                    costType = "DiscardCard",
+                    validDiscardTargets = targets,
+                    discardCount = atom.count,
+                )
+            }
+            is CostAtom.ExileFrom -> {
+                val targets = costUtils.findExileTargets(state, playerId, atom.filter, atom.zone).filter { it != cardId }
+                if (targets.size < atom.count) return null
+                AdditionalCostData(
+                    description = atom.description.replaceFirstChar { it.uppercase() },
+                    costType = "ExileFromGraveyard",
+                    validExileTargets = targets,
+                    exileMinCount = atom.count,
+                    exileMaxCount = atom.count,
+                )
+            }
+            // Other atoms don't yet have a cost-vs-cost picker; add them here alongside a client
+            // costType when a future Choice card needs one.
+            else -> null
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -377,6 +377,14 @@ class CastSpellEnumerator : ActionEnumerator {
                         beholdTargets = allTargets
                         beholdCount = 1
                     }
+                    is AdditionalCost.Choice -> {
+                        // Cost-vs-cost: castable only if at least one option is payable. The per-option
+                        // legal actions are produced by expandChoiceAdditionalCosts in post-processing.
+                        if (com.wingedsheep.engine.handlers.costs.ChoiceCostResolver
+                                .costInfos(state, playerId, cost, context.costUtils, cardId).isEmpty()) {
+                            canPayAdditionalCosts = false
+                        }
+                    }
                     else -> {}
                 }
             }
@@ -1525,7 +1533,51 @@ class CastSpellEnumerator : ActionEnumerator {
         // --- Casualty ---
         enumerateCasualty(context, hand, result)
 
-        return applySpellWaterbendMetadata(context, result)
+        return applySpellWaterbendMetadata(context, expandChoiceAdditionalCosts(context, result))
+    }
+
+    /**
+     * Post-process: expand each normal-cost cast of a card carrying a cost-vs-cost
+     * [AdditionalCost.Choice] into **one legal action per payable option**, each carrying that
+     * option's [AdditionalCostData] picker (SacrificePermanent / DiscardCard / ExileFromGraveyard).
+     * The caster picks the option by choosing which action to play, then the existing per-cost picker
+     * drives the selection — no new client UI (the same multi-action pattern Forage and the `*OrPay`
+     * costs use). Modeled on [applySpellWaterbendMetadata] so it stays out of the branchy per-target
+     * emission above.
+     *
+     * The plain base action is *replaced* (not kept): a mandatory choice cost can't be skipped, so the
+     * un-expanded action — which would let the spell resolve without paying the additional cost — must
+     * not survive. Only the primary "CastSpell" cast is expanded; alternative/free-cast variants pay
+     * printed additional costs through the cast-time selection pause instead (CR 601.2f).
+     */
+    private fun expandChoiceAdditionalCosts(
+        context: EnumerationContext,
+        actions: List<LegalAction>
+    ): List<LegalAction> {
+        val state = context.state
+        val out = mutableListOf<LegalAction>()
+        for (la in actions) {
+            val cs = la.action as? CastSpell
+            val choice = if (cs != null && la.actionType == "CastSpell" && la.affordable) {
+                val name = state.getEntity(cs.cardId)?.get<CardComponent>()?.name
+                name?.let { context.cardRegistry.getCard(it) }?.script?.additionalCosts
+                    ?.filterIsInstance<AdditionalCost.Choice>()?.firstOrNull()
+            } else null
+            if (cs == null || choice == null) {
+                out.add(la)
+                continue
+            }
+            // One action per payable option; if none is payable the card is dropped (uncastable).
+            val optionInfos = com.wingedsheep.engine.handlers.costs.ChoiceCostResolver
+                .costInfos(state, cs.playerId, choice, context.costUtils, cs.cardId)
+            for (info in optionInfos) {
+                out.add(la.copy(
+                    description = "${la.description} (${info.description})",
+                    additionalCostInfo = info
+                ))
+            }
+        }
+        return out
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulsOfTheLostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulsOfTheLostScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SoulsOfTheLost
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Souls of the Lost — {1}{B} Creature — Spirit (LCI #121).
+ *
+ * "As an additional cost to cast this spell, discard a card **or** sacrifice a permanent.
+ *  Fathomless descent — Souls of the Lost's power is equal to the number of permanent cards in your
+ *  graveyard and its toughness is equal to that number plus 1."
+ *
+ * Exercises the new cost-vs-cost [com.wingedsheep.sdk.scripting.AdditionalCost.Choice] additional
+ * cost (both payment paths + the two enumerated cast actions) and the fathomless-descent CDA P/T.
+ */
+class SoulsOfTheLostScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SoulsOfTheLost))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("discard path — pays by discarding a card; CDA P/T counts permanent cards in graveyard") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        // Two permanent cards already in the graveyard, plus a discardable permanent card in hand.
+        driver.putCardInGraveyard(p1, "Swamp")
+        driver.putCardInGraveyard(p1, "Swamp")
+        val souls = driver.putCardInHand(p1, "Souls of the Lost")
+        val toDiscard = driver.putCardInHand(p1, "Swamp")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        driver.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = souls,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(toDiscard)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.bothPass() // resolve the creature spell
+
+        // Discarded card is now in the graveyard → 3 permanent cards total.
+        (toDiscard in driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(p1, Zone.GRAVEYARD))) shouldBe true
+        (souls in driver.state.getBattlefield()) shouldBe true
+        driver.state.projectedState.getPower(souls) shouldBe 3
+        driver.state.projectedState.getToughness(souls) shouldBe 4
+    }
+
+    test("sacrifice path — pays by sacrificing a permanent, which itself feeds the CDA count") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        // Empty graveyard; one sacrificeable permanent on the battlefield.
+        val fodder = driver.putPermanentOnBattlefield(p1, "Swamp")
+        val souls = driver.putCardInHand(p1, "Souls of the Lost")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        driver.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = souls,
+                additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        // The sacrificed permanent is now the only permanent card in the graveyard → 1/2.
+        (fodder in driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(p1, Zone.GRAVEYARD))) shouldBe true
+        (souls in driver.state.getBattlefield()) shouldBe true
+        driver.state.projectedState.getPower(souls) shouldBe 1
+        driver.state.projectedState.getToughness(souls) shouldBe 2
+    }
+
+    test("enumeration — offers exactly one cast action per payable option, no un-costed cast") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(p1, "Swamp") // sacrifice fodder
+        val souls = driver.putCardInHand(p1, "Souls of the Lost")
+        driver.putCardInHand(p1, "Swamp") // discard fodder
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val soulsCasts = driver.legalActions(p1).filter {
+            (it.action as? CastSpell)?.cardId == souls
+        }
+        // Two paths — discard and sacrifice — each with its own picker; and never a bare cast that
+        // would skip the mandatory additional cost.
+        soulsCasts.map { it.additionalCostInfo?.costType } shouldContainExactlyInAnyOrder
+            listOf("DiscardCard", "SacrificePermanent")
+        soulsCasts.all { it.additionalCostInfo != null } shouldBe true
+    }
+
+    test("uncastable — no cast action when no option can be paid") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        // Clear the opening hand so the spell itself is the only card in hand (nothing to discard),
+        // and the fresh board has no permanents to sacrifice. Mana is supplied from the pool so mana
+        // is never the reason the cast is missing.
+        driver.state.getHand(p1).toList().forEach { driver.moveToGraveyard(it) }
+        val souls = driver.putCardInHand(p1, "Souls of the Lost")
+        driver.giveMana(p1, Color.BLACK, 2)
+
+        val soulsCasts = driver.legalActions(p1).filter {
+            (it.action as? CastSpell)?.cardId == souls
+        }
+        soulsCasts shouldBe emptyList()
+        // Sanity: the card really is present; it's just uncastable for want of an additional cost.
+        souls shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Souls of the Lost + cost-vs-cost `Choice` additional cost (LCI)

Implements **Souls of the Lost** ({1}{B} Creature — Spirit, LCI #121) and the reusable engine feature it needs.

### Feature: `AdditionalCost.Choice` — a general cost-vs-cost additional cost

*"As an additional cost to cast this spell, discard a card **or** sacrifice a permanent."*

Before this, the only cost-vs-cost additional cost was **Forage**, a hardcoded `data object`. `AdditionalCost.Choice(options)` generalizes it: each option is itself an `AdditionalCost`, and the caster pays exactly one. Distinct from the existing `*OrPay` family (`SacrificeOrPay`, `ExileFromGraveyardOrPay`, …), which fold a **mana** alternative into the spell's cost — `Choice` is for options that are each independently payable **non-mana** costs.

Threaded through the cast machinery with deliberately minimal new surface:

- **Enumeration** — `CastSpellEnumerator.expandChoiceAdditionalCosts` (a post-process modeled on `applySpellWaterbendMetadata`) + a new `ChoiceCostResolver` emit **one cast action per payable option**, each carrying that option's existing picker (`SacrificePermanent` / `DiscardCard` / `ExileFromGraveyard`) — **no new client UI**, the same multi-action pattern Forage and the `*OrPay` costs already use. The plain un-costed base action is dropped (a mandatory choice can't be skipped); a `Choice` with no payable option makes the card uncastable.
- **Payment** — `CastSpellHandler.reduceChoiceCosts` collapses a `Choice` to the single paid option at every flatten site (validation, application, and the free-cast selection pause), so all three reuse the existing per-atom code paths with **zero** `Choice`-specific branches. The paid option is recovered from which `AdditionalCostPayment` field the client populated; a server-initiated free/AI cast with no payment falls back to the first payable option (mirrors `ForageCostResolver`'s engine-direct fallback).
- `CostHandler.canPayAdditionalCost`: payable iff any option is payable.

**Boundary / known limits (documented in KDoc + SDK reference):** keep options on *distinct* payment fields — two options consuming the same field (e.g. two `Sacrifice` filters) can't be told apart by the payment alone. Free-casting a `Choice` cost auto-selects the first payable option rather than prompting for the sub-cost (matches Forage's engine-direct behavior).

### Card

**Souls of the Lost** = `Choice(discard a card, sacrifice a permanent)` + a **fathomless-descent** characteristic-defining ability: base power = the number of permanent cards in your graveyard, toughness = that + 1, via `dynamicStats(DynamicAmount.Count(You, GRAVEYARD, Permanent), toughnessOffset = 1)` (reusing the same count Squirming Emergence / Song of Stupefaction read).

### Tests

`SoulsOfTheLostScenarioTest` — discard path (P/T counts the discarded card once it hits the graveyard), sacrifice path (the sacrificed permanent itself feeds the CDA count), enumeration (exactly two costed cast actions, no bare cast), and uncastable-when-neither-payable. LCI snapshot re-blessed; SDK reference updated. Regressions green: `ForageCostUnificationTest`, `LouisoixsSacrificeScenarioTest` (SacrificeOrPay), `RovingActuatorAdditionalCostScenarioTest` (free-cast additional-cost pause), and `CardLintTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
