### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/GlassCasket.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/GlassCasket.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Glass Casket
+ * {1}{W}
+ * Artifact
+ *
+ * When this artifact enters, exile target creature an opponent controls with mana value 3 or less
+ * until this artifact leaves the battlefield.
+ *
+ * Canonical printing is Throne of Eldraine; Wilds of Eldraine reprints it (see
+ * `definitions/woe/cards/GlassCasketReprint.kt`).
+ *
+ * The exile is linked (CR 610.3): the leaves-the-battlefield trigger returns whatever this
+ * artifact exiled, so a second Glass Casket never returns the first one's prisoner. If the
+ * artifact leaves before its enter-trigger resolves, the return trigger fires with nothing linked
+ * and the creature stays exiled forever — the printed behavior.
+ */
+val GlassCasket = card("Glass Casket") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, exile target creature an opponent controls with " +
+        "mana value 3 or less until this artifact leaves the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter.Creature.manaValueAtMost(3).opponentControls())
+        )
+        effect = Effects.ExileUntilLeaves(t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "Fate will decide whether it's a bed or a tomb."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg?1783932673"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BitterChill.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BitterChill.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bitter Chill
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * When this Aura is put into a graveyard from the battlefield, you may pay {1}. If you do,
+ * scry 1, then draw a card.
+ *
+ * The lock half is Charmed Sleep's shape (tap on entry + [AbilityFlag.DOESNT_UNTAP] granted to the
+ * enchanted creature). The refund half fires on *any* trip from battlefield to graveyard — the Aura
+ * being destroyed, sacrificed, or falling off as a state-based action when its creature leaves —
+ * which is exactly [Triggers.PutIntoGraveyardFromBattlefield].
+ */
+val BitterChill = card("Bitter Chill") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap enchanted creature.\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "When this Aura is put into a graveyard from the battlefield, you may pay {1}. " +
+        "If you do, scry 1, then draw a card."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.PutIntoGraveyardFromBattlefield
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Patterns.Library.scry(1).then(Effects.DrawCards(1))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Julie Dillon"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg?1783915122"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CharmedClothier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CharmedClothier.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charmed Clothier
+ * {4}{W}
+ * Creature — Faerie Advisor
+ * 3/3
+ *
+ * Flying
+ * When this creature enters, create a Royal Role token attached to another target creature you
+ * control. (If you control another Role on it, put that one into the graveyard. Enchanted creature
+ * gets +1/+1 and has ward {1}.)
+ *
+ * "Another" excludes Charmed Clothier itself, hence [Targets.OtherCreatureYouControl]. The
+ * one-Role-per-creature rule (CR 704.5s) lives in the Role token machinery behind
+ * [Effects.CreateRoleToken], not here.
+ */
+val CharmedClothier = card("Charmed Clothier") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Faerie Advisor"
+    oracleText = "Flying\n" +
+        "When this creature enters, create a Royal Role token attached to another target creature " +
+        "you control. (If you control another Role on it, put that one into the graveyard. " +
+        "Enchanted creature gets +1/+1 and has ward {1}.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.OtherCreatureYouControl)
+        effect = Effects.CreateRoleToken("Royal Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg?1783915135"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DreamSpoilers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DreamSpoilers.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dream Spoilers
+ * {3}{B}
+ * Creature — Faerie Warlock
+ * 2/2
+ *
+ * Flying
+ * Whenever you cast a spell during an opponent's turn, up to one target creature an opponent
+ * controls gets -1/-1 until end of turn.
+ *
+ * "During an opponent's turn" is checked when the ability would trigger, so it rides on
+ * `triggerCondition` ([Conditions.IsNotYourTurn]) rather than gating the resolved effect —
+ * only players take turns, so "not your turn" is exactly "an opponent's turn".
+ * "Up to one target" is an optional target, so the ability still resolves (doing nothing)
+ * when no creature is chosen or the chosen one has left.
+ */
+val DreamSpoilers = card("Dream Spoilers") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Warlock"
+    oracleText = "Flying\n" +
+        "Whenever you cast a spell during an opponent's turn, up to one target creature an " +
+        "opponent controls gets -1/-1 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        triggerCondition = Conditions.IsNotYourTurn
+        val t = target(
+            "target",
+            TargetCreature(optional = true, filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.ModifyStats(power = -1, toughness = -1, target = t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "85"
+        artist = "Jodie Muir"
+        flavorText = "The Wicked Slumber saved Eldraine from Phyrexia's grasp, but instead of " +
+            "fading when the invasion ended, it continued to spread."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg?1783915109"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallPack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallPack.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Edgewall Pack
+ * {3}{R}
+ * Creature — Dog
+ * 3/3
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * When this creature enters, create a 1/1 black Rat creature token with "This token can't block."
+ *
+ * The Rat is WOE's shared type-named token, so it comes from [woeRatToken] rather than being
+ * re-declared here.
+ */
+val EdgewallPack = card("Edgewall Pack") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "When this creature enters, create a 1/1 black Rat creature token with \"This token can't block.\""
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = woeRatToken()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Leesha Hannigan"
+        flavorText = "The mayor sent hounds to root out Lord Skitter, but their loyalty was easily " +
+            "bought with a handful of bones."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg?1783915097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GlassCasketReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GlassCasketReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glass Casket reprint in WOE.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * `definitions/eld/cards/GlassCasket.kt` (Throne of Eldraine is the earliest real printing);
+ * this file contributes only the WOE-specific presentation row.
+ */
+val GlassCasketReprint = Printing(
+    oracleId = "d9167046-7908-4d16-8cc1-3eb02d1ba547",
+    name = "Glass Casket",
+    setCode = "WOE",
+    collectorNumber = "16",
+    scryfallId = "02c5c395-ee8b-47fd-ac52-256354c19cdf",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02c5c395-ee8b-47fd-ac52-256354c19cdf.jpg?1783915132",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -209,6 +209,75 @@
     "colorIdentityOverride": []
 }
 
+// Glass Casket
+{
+    "name": "Glass Casket",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, exile target creature an opponent controls with mana value 3 or less until this artifact leaves the battlefield.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "Fate will decide whether it's a bed or a tomb.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/562f1c51-d245-4771-bf61-415297e4f9d5.jpg?1783932673"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Heraldic Banner
 {
     "name": "Heraldic Banner",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -470,6 +470,84 @@
     ]
 }
 
+// Bitter Chill
+{
+    "name": "Bitter Chill",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\nWhen this Aura is put into a graveyard from the battlefield, you may pay {1}. If you do, scry 1, then draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Scry",
+                                "count": 1
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "UNCOMMON",
+        "artist": "Julie Dillon",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/888e3c71-e21d-4e77-b1b6-09769f9cd3d6.jpg?1783915122"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Boundary Lands Ranger
 {
     "name": "Boundary Lands Ranger",
@@ -728,6 +806,56 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Charmed Clothier
+{
+    "name": "Charmed Clothier",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Faerie Advisor",
+    "oracleText": "Flying\nWhen this creature enters, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Royal Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "Winona Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/994f4473-dfc9-45cd-8528-945db3aa6a9a.jpg?1783915135"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Charming Scoundrel
@@ -1163,6 +1291,64 @@
     ]
 }
 
+// Dream Spoilers
+{
+    "name": "Dream Spoilers",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Faerie Warlock",
+    "oracleText": "Flying\nWhenever you cast a spell during an opponent's turn, up to one target creature an opponent controls gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "triggerCondition": "IsNotYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "UNCOMMON",
+        "artist": "Jodie Muir",
+        "flavorText": "The Wicked Slumber saved Eldraine from Phyrexia's grasp, but instead of fading when the invasion ended, it continued to spread.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4efd1963-fe71-42c1-8ad7-53fd80145ca6.jpg?1783915109"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dutiful Griffin
 {
     "name": "Dutiful Griffin",
@@ -1218,6 +1404,56 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Edgewall Pack
+{
+    "name": "Edgewall Pack",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, create a 1/1 black Rat creature token with \"This token can't block.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Leesha Hannigan",
+        "flavorText": "The mayor sent hounds to root out Lord Skitter, but their loyalty was easily bought with a handful of bones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/acda9d02-00fc-49e2-a9f3-176e9c0a8c5f.jpg?1783915097"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch3ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch3ScenarioTest.kt
@@ -1,0 +1,270 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for a batch of Wilds of Eldraine cards implemented together:
+ *
+ *  - Edgewall Pack ({3}{R} 3/3, Menace) — ETB makes WOE's 1/1 black Rat that can't block.
+ *  - Charmed Clothier ({4}{W} 3/3, Flying) — ETB attaches a Royal Role to *another* creature
+ *    you control.
+ *  - Dream Spoilers ({3}{B} 2/2, Flying) — casting a spell during an opponent's turn shrinks
+ *    a creature an opponent controls; the trigger stays silent on your own turn.
+ *  - Bitter Chill ({1}{U} Aura) — taps and locks down the enchanted creature, and refunds a
+ *    scry-and-draw for {1} when it hits the graveyard.
+ *  - Glass Casket ({1}{W} artifact, canonical in ELD) — linked-exile removal for cheap
+ *    creatures, returned when the Casket leaves.
+ */
+class WoeCardsBatch3ScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Edgewall Pack — menace plus a can't-block Rat") {
+            test("entering the battlefield creates a 1/1 black Rat that can't block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Edgewall Pack")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Edgewall Pack")
+                game.resolveStack()
+
+                val pack = game.findPermanent("Edgewall Pack")!!
+                withClue("Edgewall Pack has menace") {
+                    game.state.projectedState.hasKeyword(pack, Keyword.MENACE) shouldBe true
+                }
+
+                val rat = game.findPermanent("Rat Token")
+                withClue("the ETB trigger created a Rat token") { (rat != null) shouldBe true }
+
+                withClue("the Rat is a 1/1") {
+                    game.state.projectedState.getPower(rat!!) shouldBe 1
+                    game.state.projectedState.getToughness(rat) shouldBe 1
+                }
+            }
+        }
+
+        context("Charmed Clothier — Royal Role on another creature you control") {
+            test("the Role lands on the other creature, not on the Clothier itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Charmed Clothier")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val card = game.findCardsInHand(1, "Charmed Clothier").first()
+                game.execute(CastSpell(game.player1Id, card, emptyList())).error shouldBe null
+                game.resolveStack() // Clothier enters -> ETB trigger asks for its target
+
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Royal Role token exists") {
+                    (game.findPermanent("Royal Role") != null) shouldBe true
+                }
+                withClue("2/2 Bears + Royal Role's +1/+1 = 3/3") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+
+                val clothier = game.findPermanent("Charmed Clothier")!!
+                withClue("the Clothier is unenchanted — 'another target creature' excludes itself") {
+                    game.state.projectedState.getPower(clothier) shouldBe 3
+                    game.state.projectedState.getToughness(clothier) shouldBe 3
+                }
+                withClue("the Clothier has flying") {
+                    game.state.projectedState.hasKeyword(clothier, Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+
+        context("Dream Spoilers — only on an opponent's turn") {
+            test("casting an instant on the opponent's turn shrinks their creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dream Spoilers", summoningSickness = false)
+                    .withCardInHand(1, "Shock")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Shock goes at the opponent's face so the only shrink comes from Dream Spoilers.
+                game.castSpellTargetingPlayer(1, "Shock", 2)
+                if (game.hasPendingDecision()) game.selectTargets(listOf(giant)).error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.selectTargets(listOf(giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent lost 2 life to Shock") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("3/3 Hill Giant gets -1/-1 from the Dream Spoilers trigger") {
+                    game.state.projectedState.getPower(giant) shouldBe 2
+                    game.state.projectedState.getToughness(giant) shouldBe 2
+                }
+            }
+
+            test("casting a spell on your own turn does not trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dream Spoilers", summoningSickness = false)
+                    .withCardInHand(1, "Giant Growth")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Giant Growth", bears)
+                game.resolveStack()
+
+                withClue("no pending target decision — the trigger never fired on our own turn") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("the opponent's Hill Giant is untouched") {
+                    game.state.projectedState.getPower(giant) shouldBe 3
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                }
+            }
+        }
+
+        context("Bitter Chill — tap, lock, and a {1} refund") {
+            test("entering taps the enchanted creature and keeps it from untapping") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bitter Chill")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Bitter Chill", bears)
+                game.resolveStack()
+
+                withClue("the ETB trigger tapped the enchanted creature") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("the enchanted creature carries DOESNT_UNTAP") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.DOESNT_UNTAP) shouldBe true
+                }
+            }
+
+            test("destroying the enchanted creature offers the {1} scry-and-draw refund") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Bitter Chill", "Grizzly Bears")
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Doom Blade", bears)
+                game.resolveStack()
+
+                withClue("the Aura followed its creature into the graveyard") {
+                    game.isInGraveyard(1, "Bitter Chill") shouldBe true
+                }
+
+                // "You may pay {1}. If you do, scry 1, then draw a card."
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+                game.skipSelection()    // scry 1: nothing to the bottom
+                game.keepLibraryOrder() // …and leave the top card where it is
+                game.resolveStack()
+
+                withClue("Doom Blade left the hand and the refund drew a card back — net zero") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("the scried-then-drawn card is the top of the library") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+            }
+        }
+
+        context("Glass Casket — linked exile for cheap creatures") {
+            test("exiles a cheap creature and returns it when the Casket dies") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Glass Casket")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Shatter")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val card = game.findCardsInHand(1, "Glass Casket").first()
+                game.execute(CastSpell(game.player1Id, card, emptyList())).error shouldBe null
+                game.resolveStack() // Casket enters -> ETB trigger asks for its target
+
+                if (game.hasPendingDecision()) game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears (mana value 2) is exiled") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                }
+
+                val casket = game.findPermanent("Glass Casket")!!
+                game.castSpell(1, "Shatter", casket)
+                game.resolveStack()
+
+                withClue("the Casket leaving returns its linked exile to the battlefield") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more WOE cards, all composed from existing SDK primitives — no new effects, triggers, or conditions.

| Card | Shape |
|---|---|
| **Edgewall Pack** `{3}{R}` | Menace + ETB, reusing the shared `woeRatToken()` (1/1 black Rat that can't block) |
| **Charmed Clothier** `{4}{W}` | Flying + ETB Royal Role on `Targets.OtherCreatureYouControl` — "another" excludes the Clothier itself |
| **Dream Spoilers** `{3}{B}` | `Triggers.YouCastSpell` gated at fire time by `Conditions.IsNotYourTurn`, with an optional ("up to one") target |
| **Bitter Chill** `{1}{U}` | Charmed Sleep's tap + `DOESNT_UNTAP` shape, plus a put-into-graveyard trigger with a `MayPayManaEffect({1})` scry-and-draw refund |
| **Glass Casket** `{1}{W}` | Linked exile for mana value ≤ 3; canonical lands in **ELD** (its earliest real printing, 2019), WOE gets a `Printing` row |

Cards deliberately skipped: anything with **Bargain** or **Celebration**, neither of which the engine supports yet — those are `add-feature` work, not card authoring.

## Verification

- `just build` green.
- `WoeCardsBatch3ScenarioTest` — 7 tests, all passing. Includes the negative case that Dream Spoilers stays silent on your own turn, that the Royal Role does *not* land on the Clothier, and that Glass Casket's linked exile returns when the Casket is destroyed.
- `just check-card-printing` clean for all five (Glass Casket correctly reports ELD canonical + WOE reprint row).
- Snapshot goldens re-blessed; the diff is additive only — no unrelated card moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)