### PR TITLE
Implement 5 VOW AUTOGEN cards + a land-type "domain" search predicate

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 118 / 272
+**Implemented:** 123 / 272
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -33,7 +33,7 @@
 - [ ] Bloodvial Purveyor
 - [x] Bloody Betrayal
 - [x] Boarded Window
-- [ ] Bramble Armor
+- [x] Bramble Armor
 - [x] Bramble Wurm
 - [ ] Bride's Gown
 - [ ] Brine Comber
@@ -60,7 +60,7 @@
 - [ ] Crawling Infestation
 - [ ] Creepy Puppeteer
 - [x] Cruel Witness
-- [ ] Crushing Canopy
+- [x] Crushing Canopy
 - [ ] Cultivator Colossus
 - [ ] Curse of Hospitality
 - [x] Dawnhart Disciple
@@ -75,7 +75,7 @@
 - [ ] Diver Skaab
 - [ ] Dollhouse of Horrors
 - [ ] Dominating Vampire
-- [ ] Doomed Dissenter
+- [x] Doomed Dissenter
 - [ ] Dormant Grove
 - [ ] Dorothea, Vengeful Victim
 - [ ] Dread Fugue
@@ -124,7 +124,7 @@
 - [x] Hero's Downfall
 - [ ] Heron of Hope
 - [x] Heron-Blessed Geist
-- [ ] Hiveheart Shaman
+- [x] Hiveheart Shaman
 - [ ] Honeymoon Hearse
 - [x] Honored Heirloom
 - [ ] Hookhand Mariner
@@ -218,7 +218,7 @@
 - [ ] Skulking Killer
 - [ ] Skull Skaab
 - [x] Skywarp Skaab
-- [ ] Snarling Wolf
+- [x] Snarling Wolf
 - [ ] Sorin the Mirthless
 - [ ] Soulcipher Board
 - [ ] Spiked Ripsaw

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2388,6 +2388,14 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `.sharingColorWithPermanentYouControl`. Used by Radagast the Brown ("a creature card that doesn't share
   a creature type with a creature you control") with `filter = GameObjectFilter.Creature`. A candidate
   with no creature types of its own shares none, so it matches.
+- `.notSharingLandTypeWithPermanentYouControl(filter)` —
+  `CardPredicate.DoesNotShareLandTypeWithPermanentYouControl`: shares **no** (projected) basic land
+  type with any permanent the evaluating player controls matching `filter`. Land-type sibling of
+  `.notSharingCreatureTypeWithPermanentYouControl`. Used by Hiveheart Shaman ("a basic land card that
+  doesn't share a land type with a land you control") with `filter = GameObjectFilter.Land`. A candidate
+  with no land types of its own shares none, so it matches. Evaluated for real in targeting/search/count
+  contexts; fails closed (false) in static-projection / cast-record matching, permissive (true) in
+  cost-calculation.
 - `.named(name)` — `CardPredicate.NameEquals`: matches a fixed card name.
 - `.notNamed(name)` — `CardPredicate.Not(NameEquals)`: matches cards whose name is **not** `name`. Use for
   "… that don't have the same name as this creature" wording (Marvin, Murderous Mimic — creatures you control

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -580,6 +580,15 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl(filter)
     )
 
+    /**
+     * Must share **no** land type with any permanent the evaluating player controls matching
+     * [filter] (Hiveheart Shaman: "a basic land card that doesn't share a land type with a land
+     * you control").
+     */
+    fun notSharingLandTypeWithPermanentYouControl(filter: GameObjectFilter) = copy(
+        cardPredicates = cardPredicates + CardPredicate.DoesNotShareLandTypeWithPermanentYouControl(filter)
+    )
+
     // =============================================================================
     // Fluent Builder Methods - State Predicates
     // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -781,6 +781,23 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         }
     }
 
+    /**
+     * Matches cards that share **no** land type with any permanent the evaluating player
+     * controls matching [filter]. Used by Hiveheart Shaman ("a basic land card that doesn't
+     * share a land type with a land you control") with `filter = GameObjectFilter.Land`. The
+     * land types of the controlled permanents are read from projected state, so type-changing
+     * effects are honored. A candidate with no land types of its own shares none, so it matches.
+     */
+    @SerialName("DoesNotShareLandTypeWithPermanentYouControl")
+    @Serializable
+    data class DoesNotShareLandTypeWithPermanentYouControl(val filter: GameObjectFilter) : CardPredicate {
+        override val description: String = "that doesn't share a land type with ${filter.description} you control"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
     // =============================================================================
     // Stack Item Type Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DoomedDissenter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DoomedDissenter.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Dissenter
+ * {1}{B}
+ * Creature — Human
+ * 1/1
+ *
+ * When this creature dies, create a 2/2 black Zombie creature token.
+ *
+ * Canonical printing is Amonkhet (earliest real set); Innistrad: Crimson Vow gets a reprint row.
+ */
+val DoomedDissenter = card("Doomed Dissenter") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, create a 2/2 black Zombie creature token."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Tony Foti"
+        flavorText = "There is only one fate left to those banished from the God-Pharaoh's city."
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg?1783936508"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BrambleArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BrambleArmor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bramble Armor
+ * {1}{G}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, attach it to target creature you control.
+ * Equipped creature gets +2/+1.
+ * Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * Canonical printing is Innistrad: Midnight Hunt (earliest real set); Innistrad: Crimson Vow
+ * gets a reprint row. Per Scryfall ruling: casting doesn't require a creature (the attach
+ * trigger simply does nothing if there's no legal target), and if the target becomes illegal
+ * before the trigger resolves, the Equipment stays on the battlefield unattached.
+ */
+val BrambleArmor = card("Bramble Armor") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target creature you control.\n" +
+        "Equipped creature gets +2/+1.\n" +
+        "Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.AttachEquipment(t)
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 1)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Alessandra Pisano"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg?1783925585"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SnarlingWolf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SnarlingWolf.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snarling Wolf
+ * {G}
+ * Creature — Wolf
+ * 1/1
+ *
+ * {1}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn.
+ *
+ * Canonical printing is Innistrad: Midnight Hunt (earliest real set); Innistrad: Crimson Vow
+ * gets a reprint row.
+ */
+val SnarlingWolf = card("Snarling Wolf") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "{1}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Ilse Gort"
+        flavorText = "\"Oh, thank the angels. It's not a werewolf, just a regular wo—\"\n—Bruno, Ulvenwald guide, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg?1783925573"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BrambleArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BrambleArmorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bramble Armor reprint in Innistrad: Crimson Vow. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Innistrad: Midnight Hunt's `cards/` package; this file contributes only presentation data.
+ */
+val BrambleArmorReprint = Printing(
+    oracleId = "25328cab-c7c0-4c55-99bb-a4149f6c511a",
+    name = "Bramble Armor",
+    setCode = "VOW",
+    collectorNumber = "188",
+    scryfallId = "f3017ae1-9744-493b-a1a2-fb2a60f7e7e4",
+    artist = "Alessandra Pisano",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f3017ae1-9744-493b-a1a2-fb2a60f7e7e4.jpg?1783924819",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CrushingCanopyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CrushingCanopyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crushing Canopy reprint in Innistrad: Crimson Vow. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Ixalan's `cards/` package; this file contributes only presentation data.
+ */
+val CrushingCanopyReprint = Printing(
+    oracleId = "618cd1bc-4422-441b-906f-1a209277be93",
+    name = "Crushing Canopy",
+    setCode = "VOW",
+    collectorNumber = "194",
+    scryfallId = "eae67d98-5167-442b-8586-0b2bcb0c56eb",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/eae67d98-5167-442b-8586-0b2bcb0c56eb.jpg?1783924814",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DoomedDissenterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DoomedDissenterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Dissenter reprint in Innistrad: Crimson Vow. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val DoomedDissenterReprint = Printing(
+    oracleId = "11cb509d-21af-48f1-b355-135ebd3e4bd1",
+    name = "Doomed Dissenter",
+    setCode = "VOW",
+    collectorNumber = "106",
+    scryfallId = "f7c0cf16-81ea-45e3-99cc-4424d59bb44b",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7c0cf16-81ea-45e3-99cc-4424d59bb44b.jpg?1783924866",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HiveheartShaman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HiveheartShaman.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hiveheart Shaman
+ * {3}{G}
+ * Creature — Human Shaman
+ * 3/5
+ *
+ * Whenever this creature attacks, you may search your library for a basic land card that
+ * doesn't share a land type with a land you control, put that card onto the battlefield,
+ * then shuffle.
+ * {5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is
+ * the number of basic land types among lands you control. Activate only as a sorcery.
+ *
+ * The attack trigger's search filter is `GameObjectFilter.BasicLand` composed with the new
+ * `notSharingLandTypeWithPermanentYouControl(GameObjectFilter.Land)` predicate (sibling of
+ * Radagast the Brown's creature-type predicate, but comparing land subtypes) — a bare
+ * `GameObjectFilter.BasicLand` would wrongly let the search find a land type already
+ * controlled. The activated ability's counter count uses `DynamicAmounts.domain(Player.You)`
+ * (= number of *distinct* basic land types among lands you control, capped at 5), not a raw
+ * land count — `AggregateBattlefield(You, Land)` would count lands, not distinct types.
+ */
+val HiveheartShaman = card("Hiveheart Shaman") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "Whenever this creature attacks, you may search your library for a basic land " +
+        "card that doesn't share a land type with a land you control, put that card onto the " +
+        "battlefield, then shuffle.\n" +
+        "{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X " +
+        "is the number of basic land types among lands you control. Activate only as a sorcery."
+    power = 3
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand.notSharingLandTypeWithPermanentYouControl(GameObjectFilter.Land),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = Effects.Composite(
+            Effects.CreateToken(power = 1, toughness = 1, colors = setOf(Color.GREEN), creatureTypes = setOf("Insect")),
+            Effects.AddDynamicCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmounts.domain(),
+                target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Eric Deschamps"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg?1783924812"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SnarlingWolfReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SnarlingWolfReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snarling Wolf reprint in Innistrad: Crimson Vow. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Innistrad: Midnight Hunt's `cards/` package; this file contributes only presentation data.
+ */
+val SnarlingWolfReprint = Printing(
+    oracleId = "2c181479-6df0-44ef-a7ce-d1d592735bc6",
+    name = "Snarling Wolf",
+    setCode = "VOW",
+    collectorNumber = "219",
+    scryfallId = "ecd271d7-a3c8-4448-b8e2-bcef5d7e9118",
+    artist = "Ilse Gort",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ecd271d7-a3c8-4448-b8e2-bcef5d7e9118.jpg?1783924801",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CrushingCanopy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CrushingCanopy.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Crushing Canopy
+ * {2}{G}
+ * Instant
+ *
+ * Choose one —
+ * • Destroy target creature with flying.
+ * • Destroy target enchantment.
+ *
+ * Canonical printing is Ixalan (earliest real set); Innistrad: Crimson Vow gets a reprint row.
+ */
+val CrushingCanopy = card("Crushing Canopy") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Destroy target creature with flying.\n• Destroy target enchantment."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target creature with flying") {
+                val t = target("target", TargetCreature(filter = TargetFilter.Creature.withKeyword(Keyword.FLYING)))
+                effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+            }
+            mode("Destroy target enchantment") {
+                val t = target("target", TargetObject(filter = TargetFilter.Enchantment))
+                effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"Do not mistake your lofty vantage point for safety.\"\n—Shaper Tuvasa"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg?1783935728"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -1,3 +1,48 @@
+// Doomed Dissenter
+{
+    "name": "Doomed Dissenter",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human",
+    "oracleText": "When this creature dies, create a 2/2 black Zombie creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Tony Foti",
+        "flavorText": "There is only one fate left to those banished from the God-Pharaoh's city.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg?1783936508"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Enigma Drake
 {
     "name": "Enigma Drake",

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -218,6 +218,85 @@
     ]
 }
 
+// Bramble Armor
+{
+    "name": "Bramble Armor",
+    "manaCost": "{1}{G}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, attach it to target creature you control.\nEquipped creature gets +2/+1.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Alessandra Pisano",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/621b58aa-c809-4baf-b2c8-3a46969598d7.jpg?1783925585"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cathar Commando
 {
     "name": "Cathar Commando",
@@ -1639,6 +1718,56 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Snarling Wolf
+{
+    "name": "Snarling Wolf",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "{1}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Ilse Gort",
+        "flavorText": "\"Oh, thank the angels. It's not a werewolf, just a regular wo—\"\n—Bruno, Ulvenwald guide, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b614b21-69ed-4788-97d7-ad502b634abb.jpg?1783925573"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -3188,6 +3188,123 @@
     ]
 }
 
+// Hiveheart Shaman
+{
+    "name": "Hiveheart Shaman",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Whenever this creature attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.\n{5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsBasicLand",
+                                        {
+                                            "type": "DoesNotShareLandTypeWithPermanentYouControl",
+                                            "filter": "land"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "optional": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Insect"
+                            ]
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "land",
+                                "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+                            },
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "RARE",
+        "artist": "Eric Deschamps",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33efdb5a-7667-4475-9905-95f8fc9be2d3.jpg?1783924812"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Honored Heirloom
 {
     "name": "Honored Heirloom",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -111,6 +111,72 @@
     ]
 }
 
+// Crushing Canopy
+{
+    "name": "Crushing Canopy",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target creature with flying.\n• Destroy target enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:flying"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target creature with flying"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"Do not mistake your lofty vantage point for safety.\"\n—Shaper Tuvasa",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a66b0e45-e585-44f3-8d2b-e887330ba138.jpg?1783935728"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dive Down
 {
     "name": "Dive Down",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -601,6 +601,22 @@ class PredicateEvaluator {
                 }
             }
 
+            is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> {
+                val controllerId = context?.controllerId ?: return false
+                val entityLandTypes = (projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet())
+                    .filter { it in Subtype.ALL_BASIC_LAND_TYPES }
+                // A candidate with no land types of its own shares none, so it matches trivially.
+                if (entityLandTypes.isEmpty()) return true
+                // No shared type when no permanent you control shares any land type with the candidate.
+                state.getBattlefield().none { otherId ->
+                    projected.getController(otherId) == controllerId &&
+                        matches(state, projected, otherId, predicate.filter, context) &&
+                        projected.getSubtypes(otherId).any { otherSubtype ->
+                            entityLandTypes.any { it.equals(otherSubtype, ignoreCase = true) }
+                        }
+                }
+            }
+
             CardPredicate.SharesChosenColorWithSource -> {
                 val sourceId = context?.sourceId ?: return false
                 val chosenColor = state.getEntity(sourceId)
@@ -1355,7 +1371,8 @@ class PredicateEvaluator {
             is CardPredicate.SharesCreatureTypeWith,
             is CardPredicate.SharesColorWith,
             is CardPredicate.SharesColorWithPermanentYouControl,
-            is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl -> false
+            is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
+            is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,
             is CardPredicate.HasSubtypeInEachStoredGroup -> false
             // Source-component name reference is a permanent-static predicate, not meaningful for a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -705,6 +705,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.SharesColorWith,
         is CardPredicate.SharesColorWithPermanentYouControl,
         is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
+        is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl,
         is CardPredicate.HasSubtypeFromVariable,
         is CardPredicate.HasSubtypeInStoredList,
         is CardPredicate.NameEqualsChosen,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1016,6 +1016,7 @@ class CostCalculator(
             is CardPredicate.SharesColorWith -> true
             is CardPredicate.SharesColorWithPermanentYouControl -> true
             is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl -> true
+            is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> true
             CardPredicate.SharesColorWithRecipient -> false
             CardPredicate.SharesChosenColorWithSource -> {
                 if (sourceEntityId == null || state == null) return false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleArmorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleArmorScenarioTest.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.mid.cards.BrambleArmor
@@ -70,5 +72,51 @@ class BrambleArmorScenarioTest : FunSpec({
 
         val armorId = driver.findPermanent(me, "Bramble Armor")!!
         driver.state.getEntity(armorId)?.get<AttachedToComponent>() shouldBe null
+    }
+
+    test("Equip {4} moves the armor to another creature you control, carrying the +2/+1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val firstBear = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+        val secondBear = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+
+        // ETB-attach the armor to the first bear.
+        val armor = driver.putCardInHand(me, "Bramble Armor")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.GREEN, 2)
+        driver.castSpell(me, armor)
+        driver.bothPass() // resolve the spell -> enters -> ETB trigger on stack
+        driver.bothPass() // resolve ETB trigger -> pauses for target selection
+        driver.submitTargetSelection(me, listOf(firstBear))
+        driver.bothPass()
+
+        val armorId = driver.findPermanent(me, "Bramble Armor")!!
+        driver.state.getEntity(armorId)?.get<AttachedToComponent>()?.targetId shouldBe firstBear
+        projector.getProjectedPower(driver.state, firstBear) shouldBe 4
+        projector.getProjectedToughness(driver.state, firstBear) shouldBe 3
+        // The second bear is still an unbuffed 2/2.
+        projector.getProjectedPower(driver.state, secondBear) shouldBe 2
+
+        // Activate Equip {4}, moving the armor onto the second bear.
+        val equipAbilityId = BrambleArmor.activatedAbilities.single { it.isEquipAbility }.id
+        driver.giveColorlessMana(me, 4)
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = armorId,
+                abilityId = equipAbilityId,
+                targets = listOf(ChosenTarget.Permanent(secondBear))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Armor is now on the second bear, which becomes 4/3; the first bear reverts to 2/2.
+        driver.state.getEntity(armorId)?.get<AttachedToComponent>()?.targetId shouldBe secondBear
+        projector.getProjectedPower(driver.state, secondBear) shouldBe 4
+        projector.getProjectedToughness(driver.state, secondBear) shouldBe 3
+        projector.getProjectedPower(driver.state, firstBear) shouldBe 2
+        projector.getProjectedToughness(driver.state, firstBear) shouldBe 2
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleArmorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleArmorScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mid.cards.BrambleArmor
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bramble Armor (MID #171, reprinted VOW #188) — {1}{G} Artifact — Equipment.
+ *
+ * "When this Equipment enters, attach it to target creature you control.
+ *  Equipped creature gets +2/+1.
+ *  Equip {4}"
+ */
+class BrambleArmorScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BrambleArmor)
+        return driver
+    }
+
+    test("ETB attaches to a target creature you control, granting +2/+1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears") // 2/2
+
+        projector.getProjectedPower(driver.state, bear) shouldBe 2
+        projector.getProjectedToughness(driver.state, bear) shouldBe 2
+
+        val armor = driver.putCardInHand(me, "Bramble Armor")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.GREEN, 2)
+        driver.castSpell(me, armor)
+        driver.bothPass() // resolve the equipment spell -> it enters -> ETB trigger on stack
+        driver.bothPass() // resolve ETB trigger -> pauses for target selection
+
+        driver.submitTargetSelection(me, listOf(bear))
+        driver.bothPass()
+
+        val armorId = driver.findPermanent(me, "Bramble Armor")!!
+        driver.state.getEntity(armorId)?.get<AttachedToComponent>()?.targetId shouldBe bear
+        projector.getProjectedPower(driver.state, bear) shouldBe 4
+        projector.getProjectedToughness(driver.state, bear) shouldBe 3
+    }
+
+    test("with no creature you control, the ETB trigger has no legal target and Bramble Armor stays unattached") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        // No creatures on the battlefield at all.
+
+        val armor = driver.putCardInHand(me, "Bramble Armor")
+        driver.giveMana(me, com.wingedsheep.sdk.core.Color.GREEN, 2)
+        driver.castSpell(me, armor)
+        driver.bothPass() // resolve the spell -> it enters; the ETB trigger has no legal target
+        driver.bothPass() // trigger doesn't fire (no legal target) or fizzles harmlessly
+
+        val armorId = driver.findPermanent(me, "Bramble Armor")!!
+        driver.state.getEntity(armorId)?.get<AttachedToComponent>() shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrushingCanopyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrushingCanopyScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Crushing Canopy (XLN #183, reprinted VOW #194).
+ *
+ * {2}{G} Instant. Choose one —
+ *   • Destroy target creature with flying.
+ *   • Destroy target enchantment.
+ */
+class CrushingCanopyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Crushing Canopy — choose one") {
+
+            test("mode 1: destroy target creature with flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crushing Canopy")
+                    .withCardOnBattlefield(2, "Storm Crow") // 1/2 flier
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crow = game.findPermanent("Storm Crow")!!
+                game.castSpellWithMode(1, "Crushing Canopy", modeIndex = 0, targetId = crow).error shouldBe null
+                game.resolveStack()
+
+                withClue("Storm Crow (flying) was destroyed") {
+                    game.findPermanent("Storm Crow") shouldBe null
+                    game.isInGraveyard(2, "Storm Crow") shouldBe true
+                }
+            }
+
+            test("mode 1: a non-flying creature is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crushing Canopy")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // no flying — illegal
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpellWithMode(1, "Crushing Canopy", modeIndex = 0, targetId = bears)
+
+                withClue("Grizzly Bears (no flying) is not a legal target for the flying-destroy mode") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("mode 2: destroy target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crushing Canopy")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(2, "Pacifism", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pacifism = game.findPermanent("Pacifism")!!
+                game.castSpellWithMode(1, "Crushing Canopy", modeIndex = 1, targetId = pacifism).error shouldBe null
+                game.resolveStack()
+
+                withClue("Pacifism was destroyed") {
+                    game.findPermanent("Pacifism") shouldBe null
+                    game.isInGraveyard(2, "Pacifism") shouldBe true
+                }
+            }
+
+            test("mode 2: a creature (non-enchantment) is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Crushing Canopy")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpellWithMode(1, "Crushing Canopy", modeIndex = 1, targetId = bears)
+
+                withClue("Grizzly Bears is not an enchantment, so mode 2 rejects it") {
+                    (result.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomedDissenterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomedDissenterScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.akh.cards.DoomedDissenter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Doomed Dissenter (AKH #87, reprinted VOW #? — canonical is AKH).
+ *
+ * {1}{B} Creature — Human, 1/1.
+ * "When this creature dies, create a 2/2 black Zombie creature token."
+ */
+class DoomedDissenterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DoomedDissenter)
+        return driver
+    }
+
+    test("dying creates a 2/2 black Zombie token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val dissenter = driver.putCreatureOnBattlefield(me, "Doomed Dissenter")
+
+        driver.giveMana(me, Color.RED, 1)
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        val castResult = driver.castSpellWithTargets(
+            me,
+            bolt,
+            listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(dissenter))
+        )
+        castResult.isSuccess shouldBe true
+
+        // Resolve the bolt: Doomed Dissenter (1/1) takes 3 damage and dies.
+        driver.bothPass()
+        driver.findPermanent(me, "Doomed Dissenter") shouldBe null
+
+        // Resolve the dies trigger: create the Zombie token.
+        driver.bothPass()
+
+        val battlefield = driver.getPermanents(me)
+        val zombieToken = battlefield.firstOrNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Zombie Token"
+        }
+        val zombie = requireNotNull(zombieToken) { "Zombie token was not created" }
+
+        val projector = com.wingedsheep.engine.mechanics.layers.StateProjector()
+        projector.getProjectedPower(driver.state, zombie) shouldBe 2
+        projector.getProjectedToughness(driver.state, zombie) shouldBe 2
+        driver.state.getEntity(zombie)?.get<CardComponent>()?.colors shouldBe setOf(Color.BLACK)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomedDissenterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomedDissenterScenarioTest.kt
@@ -58,6 +58,11 @@ class DoomedDissenterScenarioTest : FunSpec({
         val projector = com.wingedsheep.engine.mechanics.layers.StateProjector()
         projector.getProjectedPower(driver.state, zombie) shouldBe 2
         projector.getProjectedToughness(driver.state, zombie) shouldBe 2
-        driver.state.getEntity(zombie)?.get<CardComponent>()?.colors shouldBe setOf(Color.BLACK)
+
+        val zombieCard = driver.state.getEntity(zombie)?.get<CardComponent>()
+        zombieCard?.colors shouldBe setOf(Color.BLACK)
+        // It is specifically a Zombie creature token, not just a colorless 2/2 body.
+        (zombieCard?.typeLine?.isCreature) shouldBe true
+        (zombieCard?.typeLine?.subtypes?.any { it.value == "Zombie" }) shouldBe true
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiveheartShamanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HiveheartShamanScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.vow.cards.HiveheartShaman
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Hiveheart Shaman (VOW #202) — {3}{G} Creature — Human Shaman 3/5.
+ *
+ * "Whenever this creature attacks, you may search your library for a basic land card that
+ * doesn't share a land type with a land you control, put that card onto the battlefield, then
+ * shuffle. {5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where
+ * X is the number of basic land types among lands you control. Activate only as a sorcery."
+ *
+ * Exercises the two fidelity fixes over the mtgish draft:
+ *  1. The attack-trigger search filter must exclude basic lands sharing a type with a land you
+ *     already control — not just "any basic land" (`notSharingLandTypeWithPermanentYouControl`).
+ *  2. The activated ability's counter count is the number of *distinct* basic land types among
+ *     lands you control (`DynamicAmounts.domain`), not the raw number of lands.
+ */
+class HiveheartShamanScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HiveheartShaman)
+        return driver
+    }
+
+    fun libraryNames(driver: GameTestDriver, player: EntityId): List<String> =
+        driver.state.getZone(ZoneKey(player, Zone.LIBRARY)).mapNotNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    fun battlefieldLandNames(driver: GameTestDriver, player: EntityId): List<String> =
+        driver.getLands(player).mapNotNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    /** The optional ("you may") search surfaces a yes/no gate before the card selection. */
+    fun GameTestDriver.acceptOptionalSearch(player: EntityId) {
+        if (pendingDecision is YesNoDecision) {
+            submitYesNo(player, true)
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Attack trigger: only a basic land NOT sharing a type with a controlled land is offered.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("attacking offers only a basic land that doesn't share a type with a land you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val shaman = driver.putCreatureOnBattlefield(me, "Hiveheart Shaman")
+        driver.removeSummoningSickness(shaman)
+        // We already control a Forest, so a Forest in the library must NOT be offered — only
+        // Island/Swamp/Mountain/Plains are legal (no shared land type).
+        driver.putLandOnBattlefield(me, "Forest")
+
+        val forestInLibrary = driver.putCardOnTopOfLibrary(me, "Forest")
+        val islandInLibrary = driver.putCardOnTopOfLibrary(me, "Island")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(shaman), opponent)
+
+        // Resolve the attack trigger.
+        driver.bothPass()
+        driver.acceptOptionalSearch(me)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.maxSelections shouldBe 1
+        decision.options shouldContain islandInLibrary
+        decision.options shouldNotContain forestInLibrary
+
+        driver.submitCardSelection(me, listOf(islandInLibrary))
+
+        battlefieldLandNames(driver, me) shouldContain "Island"
+        libraryNames(driver, me) shouldNotContain "Island"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // A land with no land type of its own (trivial "shares none") — sanity check that the
+    // predicate's own-side check doesn't crash and basics still compose correctly. Covered
+    // implicitly above (basics always have exactly one land type); this test instead confirms
+    // that with NO lands controlled, every basic land in the library is offered.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("with no lands controlled, any basic land in the library is offered") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val shaman = driver.putCreatureOnBattlefield(me, "Hiveheart Shaman")
+        driver.removeSummoningSickness(shaman)
+        // No lands controlled at all.
+
+        val mountainInLibrary = driver.putCardOnTopOfLibrary(me, "Mountain")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(shaman), opponent)
+        driver.bothPass()
+        driver.acceptOptionalSearch(me)
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldContain mountainInLibrary
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Activated ability: counters = number of DISTINCT basic land types, not raw land count.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("activated ability puts counters equal to distinct basic land types, not land count") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val shaman = driver.putCreatureOnBattlefield(me, "Hiveheart Shaman")
+
+        // Four lands controlled, but only TWO distinct basic land types (Forest, Forest, Forest,
+        // Island). A buggy "count lands" implementation would put 4 counters; the correct
+        // "count distinct basic land types" implementation puts 2.
+        driver.putLandOnBattlefield(me, "Forest")
+        driver.putLandOnBattlefield(me, "Forest")
+        driver.putLandOnBattlefield(me, "Forest")
+        driver.putLandOnBattlefield(me, "Island")
+
+        driver.giveMana(me, Color.GREEN, 6)
+        val abilityId = HiveheartShaman.activatedAbilities.first().id
+        driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = shaman,
+                abilityId = abilityId,
+                targets = emptyList()
+            )
+        )
+        driver.bothPass()
+
+        val battlefield = driver.getPermanents(me)
+        val insectToken = battlefield.firstOrNull {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Insect Token"
+        }
+        val insect = requireNotNull(insectToken) { "Insect token was not created" }
+
+        val counters = driver.state.getEntity(insect)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
+            ?.getCount(com.wingedsheep.sdk.core.CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+        counters shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SnarlingWolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SnarlingWolfScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Snarling Wolf (MID #199, reprinted VOW #219).
+ *
+ * {G} Creature — Wolf, 1/1
+ * "{1}{G}: This creature gets +2/+2 until end of turn. Activate only once each turn."
+ */
+class SnarlingWolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Snarling Wolf") {
+
+            test("activating {1}{G} gives it +2/+2 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Snarling Wolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Snarling Wolf")!!
+                val abilityId = cardRegistry.getCard("Snarling Wolf")!!
+                    .script.activatedAbilities[0].id
+
+                game.state.projectedState.getPower(wolf) shouldBe 1
+                game.state.projectedState.getToughness(wolf) shouldBe 1
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wolf,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Snarling Wolf should be 3/3 after +2/+2") {
+                    game.state.projectedState.getPower(wolf) shouldBe 3
+                    game.state.projectedState.getToughness(wolf) shouldBe 3
+                }
+            }
+
+            test("the pump ability can only be activated once each turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Snarling Wolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Snarling Wolf")!!
+                val abilityId = cardRegistry.getCard("Snarling Wolf")!!
+                    .script.activatedAbilities[0].id
+
+                withClue("the pump ability should be available before any activation") {
+                    game.getLegalActions(1).find {
+                        it.actionType == "ActivateAbility" &&
+                            (it.action as? ActivateAbility)?.sourceId == wolf
+                    } shouldNotBe null
+                }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wolf,
+                        abilityId = abilityId
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the pump ability should NOT be available a second time this turn") {
+                    game.getLegalActions(1).find {
+                        it.actionType == "ActivateAbility" &&
+                            (it.action as? ActivateAbility)?.sourceId == wolf
+                    } shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Implement 5 VOW AUTOGEN cards + a land-type "domain" search predicate

## Summary

Implements five *Innistrad: Crimson Vow* cards flagged AUTOGEN by the mtgish coverage tooling, plus the
one small SDK/engine feature the hardest of them needed. Four are reprints whose earliest real printing
is in another set — those get a full `cardDef` in their canonical set and a `Printing(...)` row in VOW —
and one (**Hiveheart Shaman**) is canonical to VOW.

The only card requiring more than authoring was **Hiveheart Shaman**, whose attack trigger searches for
"a basic land card that **doesn't share a land type** with a land you control." That needed a new
`CardPredicate` — the land-type sibling of the existing "doesn't share a creature type" predicate — so
the search can't re-fetch a basic land type the player already controls. Its activated ability's counter
count is "the number of basic land types among lands you control," which is exactly *domain*, so it reuses
`DynamicAmounts.domain()` rather than a raw land count.

## Cards (`mtg-sets`)

| Card | Cost | P/T / Type | Behavior | Canonical set |
|------|------|------------|----------|---------------|
| **Hiveheart Shaman** | {3}{G} | 3/5 Human Shaman | Attack trigger: may search library for a basic land that shares no land type with a land you control, put it onto the battlefield, shuffle. {5}{G} sorcery-speed: make a 1/1 green Insect with X +1/+1 counters, X = distinct basic land types you control. | **VOW** (canonical) |
| **Bramble Armor** | {1}{G} | Artifact — Equipment | ETB auto-attach to a creature you control; equipped creature gets +2/+1; Equip {4}. | MID |
| **Snarling Wolf** | {G} | 1/1 Wolf | {1}{G}: +2/+2 until end of turn, once each turn. | MID |
| **Crushing Canopy** | {2}{G} | Instant | Choose one — destroy target creature with flying; or destroy target enchantment. | XLN |
| **Doomed Dissenter** | {1}{B} | 1/1 Human | When it dies, create a 2/2 black Zombie. | AKH |

Per the repo's reprint rule, only the earliest real printing gets a canonical `card(...)`. So Bramble
Armor / Snarling Wolf live under `definitions/mid/cards/`, Crushing Canopy under `xln/`, Doomed Dissenter
under `akh/`, and VOW carries `BrambleArmorReprint` / `SnarlingWolfReprint` / `CrushingCanopyReprint` /
`DoomedDissenterReprint` `Printing(...)` rows (presentation data only).

## SDK (`mtg-sdk`)

- **`CardPredicate.DoesNotShareLandTypeWithPermanentYouControl(filter)`** — matches a card that shares
  **no** (projected) basic land type with any permanent the evaluating player controls matching `filter`.
  Land-type sibling of the existing `DoesNotShareCreatureTypeWithPermanentYouControl`. A candidate with
  no land types of its own shares none, so it matches trivially.
- **`GameObjectFilter.notSharingLandTypeWithPermanentYouControl(filter)`** — fluent builder that appends
  the predicate. Hiveheart Shaman composes `GameObjectFilter.BasicLand.notSharingLandTypeWithPermanentYouControl(GameObjectFilter.Land)`.
- Hiveheart Shaman's counter count reuses the existing `DynamicAmounts.domain()` (distinct basic land
  types among lands you control), not `AggregateBattlefield(You, Land)`, which would count lands rather
  than distinct types.

## Engine (`rules-engine`)

- `PredicateEvaluator` evaluates the new predicate against **projected** state (so type-changing effects
  are honored): reads the candidate's basic land subtypes, matches trivially when it has none, otherwise
  returns true only when no controlled permanent matching `filter` shares any of those land types.
- Classified the new predicate across the three predicate-category switchboards consistently with its
  creature-type sibling: evaluated for real in targeting/search/count contexts, fails **closed** (false)
  in static-projection matching (`AffectsFilterResolver`), and permissive (true) in cost calculation
  (`CostCalculator`).

## Tests

- Scenario coverage in `rules-engine` (`com.wingedsheep.engine.scenarios.*`), 12 assertions across the
  five cards:
  - **HiveheartShaman**: attacking offers only a basic land that doesn't share a type with a controlled
    land; with no lands controlled, any basic in the library is offered; the activated ability adds
    counters equal to distinct basic land types, not land count.
  - **BrambleArmor**: ETB auto-attach; no-legal-target path leaves it unattached; **Equip {4}** re-attach
    carries the +2/+1 to the new bearer (new bearer 4/3, old reverts to 2/2).
  - **SnarlingWolf**: {1}{G} grants +2/+2; only activatable once per turn.
  - **CrushingCanopy**: both modes, with legal-target guards (non-flying creature / non-enchantment are
    not legal targets).
  - **DoomedDissenter**: dying makes a token that is specifically a black 2/2 **Zombie**.
- `AKH.json` / `MID.json` / `VOW.json` / `XLN.json` `CardDefinitionSnapshotTest` goldens re-blessed —
  clean pure-addition diffs (the new cards only).

## Docs

- `docs/card-sdk-language-reference.md`: new `.notSharingLandTypeWithPermanentYouControl(filter)` entry
  documenting the predicate, its projected-state evaluation, and its fail-closed / permissive behavior in
  the non-evaluation contexts.

## Verification

- `CardDefinitionSnapshotTest` and `CardLintTest` pass against the re-blessed goldens.
- All 12 card scenario assertions pass.
- Rebased cleanly onto current `main` (VOW backlog checklist reconciled to **123 / 272**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
