### PR TITLE
Add Banner of Kinship, Blasphemous Edict, and Infernal Vessel to Foundations

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -280,7 +280,14 @@ excluded.
 
 **Spell-level alternatives**
 
-- `selfAlternativeCost` — generic "cast instead for" alt-cost.
+- `selfAlternativeCost` — generic "cast instead for" alt-cost. Optional `condition` gates whether
+  the alternative is available at all — the "…rather than pay this spell's mana cost **if**
+  <condition>" clause (Blasphemous Edict: `condition = Conditions.CompareAmounts(
+  DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature), GTE,
+  DynamicAmount.Fixed(13))`). Evaluated with no target/trigger context at two mirrored sites —
+  `CastSpellEnumerator` (so the action isn't offered) and `CastSpellHandler.validate` (so an
+  authorization can't outlive the enumeration that offered it). Omit for an unconditional
+  alternative (Zahid, Djinn of the Lamp).
 - `evoke` — pay evoke cost; creature is sacrificed at ETB.
 - `morph` — cast face-down for `{3}`-ish.
 - `warp` — cast from anywhere; exiled at end of turn.
@@ -5188,6 +5195,14 @@ answer it and would silently return `false`.
   `Effects.MoveAllLastKnownCounters` for "whenever this or another creature you control dies, if it
   had counters on it, move its counters" (Host of the Hereafter). Companion to the existing
   `TriggeringEntityHadMinusOneMinusOneCounter` (which checks only -1/-1 counters, e.g. Retched Wretch).
+- `TriggeringEntityHadSubtype(subtype)` — intervening-if for dies/leaves triggers: true when the
+  triggering entity had `subtype` among its **projected** subtypes the moment it left the battlefield
+  (CR 603.10), so continuous-effect-granted types count and not just printed ones. Resolution-only.
+  Wrap in `Conditions.Not(...)` for the "if it wasn't a X" wording — Infernal Vessel's
+  `triggerCondition = Conditions.Not(Conditions.TriggeringEntityHadSubtype(Subtype.DEMON.value))`,
+  where the Demon type the card grants itself on return (`Effects.AddCreatureType(..., Duration.Permanent)`)
+  is what stops the second death from returning it again. Reads `TriggerContext.lastKnownSubtypes`,
+  populated from the `ZoneChangeEvent`'s `EntitySnapshot.subtypes`.
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.
@@ -6833,6 +6848,11 @@ substitution.
   "that many" via `AddDynamicCounters(Counters.INCUBATION, DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT), Self)`;
   an activated ability spends three via `Costs.RemoveCounterFromSelf(Counters.INCUBATION, 3)` to hatch a Drake token) —
   a pure passive resource counter with no inherent rule. Not MTG's Incubate/incubator-token mechanic.
+  `fellowship` (`Counters.FELLOWSHIP`): FDN — Banner of Kinship (enters with one per creature you control of
+  the as-enters chosen type via `EntersWithDynamicCounters(CounterTypeFilter.Named(Counters.FELLOWSHIP),
+  DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.withChosenSubtype()))`; a
+  `GrantDynamicStatsEffect` sized by `DynamicAmounts.countersOnSelf(...)` reads the count back) — a pure
+  passive resource counter with no inherent rule.
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -68,7 +68,8 @@ enum class CounterType {
     LANDMARK,
     DREAD,
     SPORE,
-    INCUBATION;
+    INCUBATION,
+    FELLOWSHIP;
 
     companion object {
         /**
@@ -283,6 +284,14 @@ object Counters {
      * Not MTG's Incubate/incubator-token mechanic.
      */
     const val INCUBATION = "incubation"
+
+    /**
+     * Fellowship counter (FDN — Banner of Kinship). Passive storage counter with no inherent rule;
+     * the Banner enters with one per creature of its chosen type and its static ability reads the
+     * count to size the anthem. NOT a keyword counter, so it is intentionally absent from
+     * `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val FELLOWSHIP = "fellowship"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1499,6 +1499,15 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCounters
 
     /**
+     * If the triggering entity had [subtype] among its **projected** subtypes when it left the
+     * battlefield (CR 603.10 last-known information). Wrap in [Not] for the "if it wasn't a X"
+     * wording — e.g. Infernal Vessel's `Not(TriggeringEntityHadSubtype(Subtype.DEMON.value))`,
+     * where the Demon type the card grants itself on return is what stops it looping.
+     */
+    fun TriggeringEntityHadSubtype(subtype: String): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadSubtype(subtype)
+
+    /**
      * If the triggering entity was NOT put onto the battlefield by this source's ability.
      * Used to break ETB-trigger loops on cards like Kodama of the East Tree:
      * "if it wasn't put onto the battlefield with this ability". Pair with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SelfAlternativeCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SelfAlternativeCost.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.scripting
 
 import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.scripting.conditions.Condition
 import kotlinx.serialization.Serializable
 
 /**
@@ -19,9 +20,16 @@ import kotlinx.serialization.Serializable
  *           Typed like every other cost; serializes as its string form.
  * @property additionalCosts Non-mana costs that must be paid alongside the alternative
  *           mana cost (e.g., tapping an artifact)
+ * @property condition Game-state gate on the alternative being *available at all* — the
+ *           "…if <condition>" clause on cards like Blasphemous Edict ("You may pay {B} rather
+ *           than pay this spell's mana cost if there are thirteen or more creatures on the
+ *           battlefield"). Evaluated with no target/trigger context, at the two mirrored sites
+ *           that decide legality: action enumeration and cast authorization. `null` (the default)
+ *           means unconditionally available, which is Zahid's shape.
  */
 @Serializable
 data class SelfAlternativeCost(
     val manaCost: ManaCost,
-    val additionalCosts: List<AdditionalCost> = emptyList()
+    val additionalCosts: List<AdditionalCost> = emptyList(),
+    val condition: Condition? = null
 )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -169,6 +169,23 @@ data object TriggeringEntityHadCounters : Condition {
 }
 
 /**
+ * Condition: "if it was a <subtype>" (intervening-if for dies/leaves triggers).
+ * Reads the last-known **projected** subtypes captured on the triggering entity at the moment it
+ * left the battlefield (Rule 603.10 last-known information), so subtypes granted by continuous
+ * effects — not just printed ones — count.
+ *
+ * Wrap in [com.wingedsheep.sdk.dsl.Conditions.Not] for the "if it wasn't a <subtype>" wording used
+ * by self-recursion loop guards such as Infernal Vessel ("When this creature dies, if it wasn't a
+ * Demon, return it … It's a Demon in addition to its other types"), where the returned permanent's
+ * granted subtype is what stops the second death from triggering again.
+ */
+@SerialName("TriggeringEntityHadSubtype")
+@Serializable
+data class TriggeringEntityHadSubtype(val subtype: String) : Condition {
+    override val description: String = "if it was a $subtype"
+}
+
+/**
  * Condition: "with a single target" — true iff the triggering spell or ability
  * has exactly one target chosen. Reads the triggering entity's TargetsComponent.
  * Used by cards like Spinerock Tyrant whose trigger fires only when you cast an

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BannerOfKinship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BannerOfKinship.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Banner of Kinship
+ * {5}
+ * Artifact
+ *
+ * As this artifact enters, choose a creature type. This artifact enters with a fellowship counter
+ * on it for each creature you control of the chosen type.
+ * Creatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.
+ *
+ * Both as-enters effects are replacement effects that apply while the Banner is entering, so their
+ * order is fixed by the engine: [EntersWithChoice] resumes first and writes the chosen type onto
+ * the entering entity's `CastChoicesComponent`, and only then does the enters-with-counters pass
+ * evaluate `count`. That's what lets the dynamic count filter on `withChosenSubtype()`.
+ *
+ * The counter total is a *snapshot* taken on entry (CR 614.1c) — later creatures of the chosen type
+ * do not add counters. The anthem, by contrast, is a live static ability sized by
+ * [Counters.FELLOWSHIP] currently on the Banner, so removing counters shrinks it.
+ */
+val BannerOfKinship = card("Banner of Kinship") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "As this artifact enters, choose a creature type. This artifact enters with a " +
+        "fellowship counter on it for each creature you control of the chosen type.\n" +
+        "Creatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact."
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = CounterTypeFilter.Named(Counters.FELLOWSHIP),
+            count = DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature.withChosenSubtype()
+            )
+        )
+    )
+
+    staticAbility {
+        val fellowship = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.FELLOWSHIP))
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.ChosenSubtypeCreatures().youControl(),
+            powerBonus = fellowship,
+            toughnessBonus = fellowship
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Olena Richards"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg?1783909089"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BlasphemousEdict.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BlasphemousEdict.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SelfAlternativeCost
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Blasphemous Edict
+ * {3}{B}{B}
+ * Sorcery
+ *
+ * You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures
+ * on the battlefield.
+ * Each player sacrifices thirteen creatures of their choice.
+ *
+ * The alternative cost is gated on a *global* creature count — every creature on the battlefield,
+ * not just yours — hence `Player.Each` on the [DynamicAmount.AggregateBattlefield]. The gate is
+ * checked when actions are enumerated and again when the cast is authorized, so it can't be paid
+ * once the thirteenth creature has left in response.
+ *
+ * "Each player sacrifices thirteen creatures **of their choice**" fans out from
+ * `EffectTarget.PlayerRef(Player.Each)` in APNAP order; players choosing later see the earlier
+ * choices, per the card's ruling. A player controlling fewer than thirteen creatures sacrifices
+ * all of them with no prompt (also per ruling) — the sacrifice executor already treats the count
+ * as an upper bound rather than a requirement.
+ */
+val BlasphemousEdict = card("Blasphemous Edict") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "You may pay {B} rather than pay this spell's mana cost if there are thirteen or " +
+        "more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice."
+
+    selfAlternativeCost = SelfAlternativeCost(
+        manaCost = ManaCost.parse("{B}"),
+        condition = Conditions.CompareAmounts(
+            DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(13)
+        )
+    )
+
+    spell {
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            count = 13,
+            target = EffectTarget.PlayerRef(Player.Each)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "Andrew Mar"
+        flavorText = "\"A demonic pact is all fun and games until the bill comes due.\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg?1783909112"
+        ruling("2024-11-08", "If a player controls fewer than thirteen creatures when Blasphemous Edict resolves, they will sacrifice all of their creatures.")
+        ruling("2024-11-08", "Starting with the player whose turn it is, each player in turn order chooses which creatures they will sacrifice, then all the creatures chosen by all players are sacrificed at the same time. Players get to know the choices made by players who chose before them.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/InfernalVessel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/InfernalVessel.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Infernal Vessel
+ * {2}{B}
+ * Creature — Human Cleric
+ * 2/1
+ *
+ * When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's
+ * control with two +1/+1 counters on it. It's a Demon in addition to its other types.
+ *
+ * The intervening-if is the loop guard, and it has to read *last-known* information: by the time the
+ * trigger is considered, the Vessel is already a card in the graveyard with its printed
+ * `Human Cleric` type line, so asking the live entity would answer "not a Demon" forever.
+ * [Conditions.TriggeringEntityHadSubtype] reads the projected subtypes captured when the permanent
+ * left the battlefield (CR 603.10), which is exactly where the granted Demon type shows up.
+ *
+ * The three effects run in order on the same entity id — the graveyard → battlefield return keeps
+ * it, so `EffectTarget.Self` in the counter and type effects lands on the returned permanent.
+ * `fromZone = GRAVEYARD` makes the return a no-op if something else already moved the card out.
+ * [Duration.Permanent] on the added type lasts until the permanent next leaves the battlefield,
+ * so it is still in force at the moment the snapshot for the *second* death is taken.
+ */
+val InfernalVessel = card("Infernal Vessel") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, if it wasn't a Demon, return it to the battlefield under " +
+        "its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerCondition = Conditions.Not(Conditions.TriggeringEntityHadSubtype(Subtype.DEMON.value))
+        effect = Effects.Composite(
+            Effects.Move(
+                target = EffectTarget.Self,
+                destination = Zone.BATTLEFIELD,
+                fromZone = Zone.GRAVEYARD
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+            Effects.AddCreatureType(Subtype.DEMON.value, EffectTarget.Self, Duration.Permanent)
+        )
+        description = "When this creature dies, if it wasn't a Demon, return it to the battlefield " +
+            "under its owner's control with two +1/+1 counters on it. It's a Demon in addition to " +
+            "its other types."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Franz Vohwinkel"
+        flavorText = "\"Rise, my liege! Rise, and blanket the world in eternal night!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg?1783909112"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -557,6 +557,77 @@
     ]
 }
 
+// Banner of Kinship
+{
+    "name": "Banner of Kinship",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter on it for each creature you control of the chosen type.\nCreatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "chosenSubtypeKey": "chosenCreatureType"
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "fellowship"
+                        }
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "fellowship"
+                        }
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            },
+            {
+                "type": "EntersWithDynamicCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "fellowship"
+                },
+                "count": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "HasChosenSubtype"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Olena Richards",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a14c16c0-4053-46b0-8fa6-be8b4a7a1c8a.jpg?1783909089"
+    },
+    "colorIdentityOverride": []
+}
+
 // Battlesong Berserker
 {
     "name": "Battlesong Berserker",
@@ -800,6 +871,61 @@
         "rarity": "UNCOMMON",
         "artist": "Brent Hollowell",
         "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b3587a9-0667-4d53-807b-c437bcb1d7b3.jpg?1782689217"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blasphemous Edict
+{
+    "name": "Blasphemous Edict",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield.\nEach player sacrifices thirteen creatures of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "ForceSacrifice",
+            "filter": "creature",
+            "count": 13,
+            "target": {
+                "type": "PlayerRef",
+                "player": "Each"
+            }
+        },
+        "selfAlternativeCost": {
+            "manaCost": "{B}",
+            "condition": {
+                "type": "Compare",
+                "left": {
+                    "type": "AggregateBattlefield",
+                    "player": "Each",
+                    "filter": "creature"
+                },
+                "operator": "GTE",
+                "right": {
+                    "type": "Fixed",
+                    "amount": 13
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "Andrew Mar",
+        "flavorText": "\"A demonic pact is all fun and games until the bill comes due.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11040ecd-3153-4029-b42b-1441bc51ec34.jpg?1783909112",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If a player controls fewer than thirteen creatures when Blasphemous Edict resolves, they will sacrifice all of their creatures."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Starting with the player whose turn it is, each player in turn order chooses which creatures they will sacrifice, then all the creatures chosen by all players are sacrificed at the same time. Players get to know the choices made by players who chose before them."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -4028,6 +4154,69 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Infernal Vessel
+{
+    "name": "Infernal Vessel",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Demon"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "TriggeringEntityHadSubtype",
+                        "subtype": "Demon"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "\"Rise, my liege! Rise, and blanket the world in eternal night!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/877b6330-2d0b-4f2f-a848-f10b06fb4ef5.jpg?1783909112"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -44,6 +44,14 @@ data class TriggerContext(
     /** Last known toughness when the triggering entity left the battlefield (for dies/leaves triggers) */
     val lastKnownToughness: Int? = null,
     /**
+     * Last-known **projected** subtypes when the triggering entity left the battlefield (CR 603.10),
+     * so continuous-effect-granted types count and not just printed ones. Read by
+     * [com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadSubtype] as an intervening-if on
+     * dies/leaves triggers (Infernal Vessel's "if it wasn't a Demon" self-recursion guard). Null
+     * when the trigger's source never left the battlefield.
+     */
+    val lastKnownSubtypes: Set<String>? = null,
+    /**
      * Last-known counter map (counter-type-string → count) when the triggering source left
      * the battlefield. Used by triggers that move every counter onto another permanent
      * (e.g., Essence Channeler's "put its counters on target creature you control").
@@ -166,6 +174,7 @@ data class TriggerContext(
                     xValue = event.xValue,
                     lastKnownPower = event.lastKnown?.power,
                     lastKnownToughness = event.lastKnown?.toughness,
+                    lastKnownSubtypes = event.lastKnown?.subtypes?.takeIf { it.isNotEmpty() },
                     lastKnownCounters = event.lastKnown?.counters?.takeIf { it.isNotEmpty() },
                     lastKnownDamageDealtByPlayers =
                         event.lastKnown?.damageDealtByPlayers?.takeIf { it.isNotEmpty() },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1594,6 +1594,7 @@ class TriggerMatcher(
                 triggerCounterCount = trigger.triggerContext.counterCount,
                 triggerTotalCounterCount = trigger.triggerContext.totalCounterCount,
                 triggerMinusOneMinusOneCounterCount = trigger.triggerContext.minusOneMinusOneCounterCount,
+                triggerLastKnownSubtypes = trigger.triggerContext.lastKnownSubtypes,
                 triggerLastKnownPower = trigger.triggerContext.lastKnownPower,
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,
                 triggerScryCount = trigger.triggerContext.scryCount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -496,6 +496,12 @@ class ConditionEvaluator(
                 ifResolution { (it.triggerMinusOneMinusOneCounterCount ?: 0) > 0 }
             is TriggeringEntityHadCounters ->
                 ifResolution { (it.triggerTotalCounterCount ?: 0) > 0 }
+            is com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadSubtype ->
+                // Subtype names are captured in projected form (e.g. "Demon"); compare
+                // case-insensitively so card authors can pass either Subtype.X.value or a literal.
+                ifResolution { ctx ->
+                    ctx.triggerLastKnownSubtypes.orEmpty().any { it.equals(condition.subtype, ignoreCase = true) }
+                }
             is TriggeringEntityWasNotPutByThisSource ->
                 ifResolution { evaluateTriggeringEntityWasNotPutByThisSource(state, it) }
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -190,6 +190,12 @@ data class EffectContext(
     val triggerTotalCounterCount: Int? = null,
     /** Last known -1/-1 counter count from a death trigger context (e.g., Retched Wretch) */
     val triggerMinusOneMinusOneCounterCount: Int? = null,
+    /**
+     * Last-known projected subtypes from a dies/leaves trigger context (CR 603.10). Read by
+     * `TriggeringEntityHadSubtype` as an intervening-if — e.g. Infernal Vessel's "if it wasn't a
+     * Demon". Null when the trigger wasn't driven by a permanent leaving the battlefield.
+     */
+    val triggerLastKnownSubtypes: Set<String>? = null,
     /** The entity that caused the trigger to fire (e.g., creature that dealt damage for Aurification) */
     val triggeringEntityId: EntityId? = null,
     /** The player associated with the trigger event (e.g., the player who cast a spell for SpellCastEvent) */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -369,6 +369,18 @@ class CastSpellHandler(
         // Validate self-alternative cost's additional costs when using alternative cost
         if (action.useAlternativeCost && cardDef != null && action.altAllows(AlternativeCostType.SELF_ALTERNATIVE)) {
             val selfAltCost = cardDef.script.selfAlternativeCost
+            // "…rather than pay this spell's mana cost **if** <condition>" (Blasphemous Edict).
+            // Mirrors the availability gate in CastSpellEnumerator so an authorization can't
+            // outlive the enumeration that offered it.
+            val selfAltCondition = selfAltCost?.condition
+            if (selfAltCondition != null && !conditionEvaluator.evaluate(
+                    state,
+                    selfAltCondition,
+                    EffectContext(sourceId = action.cardId, controllerId = action.playerId)
+                )
+            ) {
+                return "Alternative cost is not available: ${selfAltCondition.description}"
+            }
             if (selfAltCost != null && selfAltCost.additionalCosts.isNotEmpty()) {
                 val selfAltCostError = validateAdditionalCosts(state, selfAltCost.additionalCosts, action)
                 if (selfAltCostError != null) return selfAltCostError

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -247,6 +247,11 @@ object ZoneTransitionService {
                 entityId = entityId,
                 power = lastKnownPower,
                 toughness = lastKnownToughness,
+                // Mirror the projected type line's subtypes into the snapshot's own `subtypes`
+                // field so it carries the same meaning here as on the `fromProjection` path.
+                // Read by `TriggeringEntityHadSubtype` ("if it wasn't a Demon" — Infernal Vessel),
+                // which must see continuous-effect-granted types, not just printed ones.
+                subtypes = lastKnownTypeLine?.subtypes?.mapTo(mutableSetOf()) { it.value } ?: emptySet(),
                 controllerId = controllerId,
                 counters = lastKnownCounters,
                 keywords = lastKnownKeywords,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -492,6 +492,19 @@ class CastSpellEnumerator : ActionEnumerator {
 
             // Check self-alternative cost (e.g., Zahid's {3}{U} + tap an artifact)
             val selfAltCost = cardDef.script.selfAlternativeCost
+                // "…rather than pay this spell's mana cost **if** <condition>" (Blasphemous Edict).
+                // Gate availability here and mirror it in CastSpellHandler's authorization, so the
+                // permission can't outlive the enumeration that offered it.
+                ?.takeIf { alt ->
+                    alt.condition == null || context.conditionEvaluator.evaluate(
+                        state,
+                        alt.condition!!,
+                        com.wingedsheep.engine.handlers.EffectContext(
+                            sourceId = cardId,
+                            controllerId = playerId
+                        )
+                    )
+                }
             val canAffordSelfAlternative = if (selfAltCost != null) {
                 val selfAltMana = selfAltCost.manaCost
                 val selfAltEffective = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, selfAltMana, playerId)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BannerOfKinshipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BannerOfKinshipScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.BannerOfKinship
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Banner of Kinship {5} — Artifact.
+ *
+ * "As this artifact enters, choose a creature type. This artifact enters with a fellowship counter
+ *  on it for each creature you control of the chosen type.
+ *  Creatures you control of the chosen type get +1/+1 for each fellowship counter on this artifact."
+ *
+ * The load-bearing ordering claim: the as-enters *choice* must land before the as-enters *count* is
+ * evaluated, otherwise the dynamic count filters on an unset chosen type and the Banner arrives
+ * blank. These tests pin the count against boards where the two candidate types have different
+ * populations, so a mis-ordered implementation cannot pass by coincidence.
+ */
+class BannerOfKinshipScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BannerOfKinship))
+        return driver
+    }
+
+    fun fellowshipCounters(driver: GameTestDriver, banner: EntityId): Int =
+        driver.state.getEntity(banner)?.get<CountersComponent>()
+            ?.counters?.get(CounterType.FELLOWSHIP) ?: 0
+
+    /**
+     * Cast the Banner and answer the as-enters creature-type choice with [creatureType].
+     * Returns the Banner's battlefield entity id.
+     */
+    fun castBannerChoosing(driver: GameTestDriver, player: EntityId, creatureType: String): EntityId {
+        driver.giveColorlessMana(player, 5)
+        val card = driver.putCardInHand(player, "Banner of Kinship")
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val index = decision.options.indexOf(creatureType)
+        (index >= 0) shouldBe true // the chosen type is offered
+        driver.submitDecision(player, OptionChosenResponse(decision.id, index))
+
+        return driver.findPermanent(player, "Banner of Kinship")!!
+    }
+
+    test("enters with one fellowship counter per creature of the chosen type, and anthems only those") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // Three Zombies and one Human Soldier — so "Zombie" and "Human" give different counts.
+        val zombieA = driver.putCreatureOnBattlefield(you, "Fear Creature")     // Zombie 2/2
+        val zombieB = driver.putCreatureOnBattlefield(you, "Black Creature")    // Zombie 2/2
+        val zombieC = driver.putCreatureOnBattlefield(you, "Black Creature")    // Zombie 2/2
+        val soldier = driver.putCreatureOnBattlefield(you, "Banding Scout")     // Human Soldier 2/2
+
+        val banner = castBannerChoosing(driver, you, "Zombie")
+
+        fellowshipCounters(driver, banner) shouldBe 3
+
+        val projected = projector.project(driver.state)
+        listOf(zombieA, zombieB, zombieC).forEach { zombie ->
+            projected.getPower(zombie) shouldBe 5      // 2 + 3
+            projected.getToughness(zombie) shouldBe 5  // 2 + 3
+        }
+        projected.getPower(soldier) shouldBe 2         // not a Zombie — unaffected
+        projected.getToughness(soldier) shouldBe 2
+    }
+
+    test("counts only creatures YOU control, and the count is a snapshot taken on entry") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Fear Creature")       // your Zombie
+        driver.putCreatureOnBattlefield(opponent, "Black Creature") // opponent's Zombie — not counted
+        driver.putCreatureOnBattlefield(opponent, "Black Creature")
+
+        val banner = castBannerChoosing(driver, you, "Zombie")
+        fellowshipCounters(driver, banner) shouldBe 1
+
+        // A Zombie arriving later does NOT add a counter (CR 614.1c — the replacement effect only
+        // applies while the Banner itself is entering), but it DOES get the live anthem.
+        val lateZombie = driver.putCreatureOnBattlefield(you, "Black Creature")
+        fellowshipCounters(driver, banner) shouldBe 1
+
+        val projected = projector.project(driver.state)
+        projected.getPower(lateZombie) shouldBe 3      // 2 + 1
+        projected.getToughness(lateZombie) shouldBe 3
+    }
+
+    test("no creatures of the chosen type: enters with no counters and grants nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val zombie = driver.putCreatureOnBattlefield(you, "Fear Creature")
+        val banner = castBannerChoosing(driver, you, "Goblin")
+
+        fellowshipCounters(driver, banner) shouldBe 0
+
+        val projected = projector.project(driver.state)
+        projected.getPower(zombie) shouldBe 2
+        projected.getToughness(zombie) shouldBe 2
+    }
+
+    test("the anthem is sized live: removing the Banner's counters shrinks it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val zombie = driver.putCreatureOnBattlefield(you, "Fear Creature")
+        driver.putCreatureOnBattlefield(you, "Black Creature")
+        val banner = castBannerChoosing(driver, you, "Zombie")
+        fellowshipCounters(driver, banner) shouldBe 2
+
+        projector.project(driver.state).getPower(zombie) shouldBe 4 // 2 + 2
+
+        driver.replaceState(
+            driver.state.updateEntity(banner) { it.with(CountersComponent(mapOf(CounterType.FELLOWSHIP to 1))) }
+        )
+        projector.project(driver.state).getPower(zombie) shouldBe 3 // 2 + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlasphemousEdictScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlasphemousEdictScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.BlasphemousEdict
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blasphemous Edict {3}{B}{B} — Sorcery.
+ *
+ * "You may pay {B} rather than pay this spell's mana cost if there are thirteen or more creatures
+ *  on the battlefield.
+ *  Each player sacrifices thirteen creatures of their choice."
+ *
+ * Two things are worth pinning: the alternative cost is gated on a *global* creature count (both
+ * players' creatures, not just the caster's), and the gate is enforced on the authorization path
+ * too — not only by hiding the action from the enumerator.
+ */
+class BlasphemousEdictScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BlasphemousEdict))
+        return driver
+    }
+
+    /** Put [count] vanilla 2/2s onto [player]'s battlefield. */
+    fun fillBoard(driver: GameTestDriver, player: EntityId, count: Int): List<EntityId> =
+        (1..count).map { driver.putCreatureOnBattlefield(player, "Black Creature") }
+
+    /** True when the enumerator is currently offering the self-alternative cast of [cardId]. */
+    fun altCastOffered(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean =
+        driver.legalActions(player).any { legal: LegalAction ->
+            val action = legal.action
+            action is CastSpell &&
+                action.cardId == cardId &&
+                action.useAlternativeCost &&
+                action.alternativeCostType == AlternativeCostType.SELF_ALTERNATIVE
+        }
+
+    /** Answer every sacrifice-selection decision until the stack is empty. */
+    fun resolveSacrifices(driver: GameTestDriver) {
+        var safety = 0
+        while (safety < 60) {
+            val pending = driver.state.pendingDecision
+            when {
+                pending is SelectCardsDecision ->
+                    driver.submitCardSelection(pending.playerId, pending.options.take(pending.minSelections))
+                driver.stackSize > 0 -> driver.bothPass()
+                else -> return
+            }
+            safety++
+        }
+    }
+
+    test("fewer than thirteen creatures on the battlefield: the {B} alternative is not offered") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        fillBoard(driver, you, 6)
+        fillBoard(driver, opponent, 6) // 12 total — one short
+
+        driver.giveMana(you, Color.BLACK, 1)
+        val edict = driver.putCardInHand(you, "Blasphemous Edict")
+
+        altCastOffered(driver, you, edict) shouldBe false
+
+        // …and the gate is enforced on authorization, not just in the enumerator.
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = edict,
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE
+            )
+        ).error shouldBe "Alternative cost is not available: ${BlasphemousEdict.script.selfAlternativeCost!!.condition!!.description}"
+    }
+
+    test("thirteen creatures across BOTH battlefields unlocks the {B} alternative") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Deliberately lopsided: neither player alone reaches thirteen.
+        fillBoard(driver, you, 4)
+        fillBoard(driver, opponent, 9)
+
+        driver.giveMana(you, Color.BLACK, 1)
+        val edict = driver.putCardInHand(you, "Blasphemous Edict")
+
+        altCastOffered(driver, you, edict) shouldBe true
+
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = edict,
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE
+            )
+        ).error shouldBe null
+        resolveSacrifices(driver)
+
+        // Everyone controlled fewer than thirteen, so every creature goes (per the card's ruling).
+        driver.getCreatures(you).size shouldBe 0
+        driver.getCreatures(opponent).size shouldBe 0
+    }
+
+    test("each player sacrifices at most thirteen — a fourteenth creature survives") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        fillBoard(driver, you, 14)
+        fillBoard(driver, opponent, 2)
+
+        driver.giveMana(you, Color.BLACK, 5)
+        val edict = driver.putCardInHand(you, "Blasphemous Edict")
+        driver.castSpell(you, edict).error shouldBe null
+        resolveSacrifices(driver)
+
+        driver.getCreatures(you).size shouldBe 1  // 14 - 13
+        driver.getCreatures(opponent).size shouldBe 0 // fewer than 13 — all of them
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InfernalVesselScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InfernalVesselScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.InfernalVessel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Infernal Vessel {2}{B} — Creature — Human Cleric 2/1.
+ *
+ * "When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's
+ *  control with two +1/+1 counters on it. It's a Demon in addition to its other types."
+ *
+ * The interesting behaviour is the self-recursion guard. The first death returns the Vessel as a
+ * 4/3 Demon; the *second* death must not return it again, and the only thing distinguishing the two
+ * is the Demon subtype the card granted itself — which by then exists solely as last-known
+ * information on a card sitting in the graveyard. That is what
+ * `Conditions.TriggeringEntityHadSubtype` reads.
+ *
+ * Deaths are staged with real damage (Lightning Bolt, 3 damage) rather than the blunt
+ * `moveToGraveyard` test helper, which by design skips dies triggers entirely. Three damage is
+ * lethal to both the printed 2/1 and the returned 4/3.
+ */
+class InfernalVesselScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(InfernalVessel))
+        return driver
+    }
+
+    /** Bolt [creature] for 3 and let the resulting death trigger (if any) resolve. */
+    fun bolt(driver: GameTestDriver, caster: EntityId, creature: EntityId) {
+        driver.giveMana(caster, Color.RED, 1)
+        val boltCard = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpell(caster, boltCard, targets = listOf(creature)).error shouldBe null
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    fun vesselOnBattlefield(driver: GameTestDriver, player: EntityId): EntityId? =
+        driver.findPermanent(player, "Infernal Vessel")
+
+    test("first death: returns as a 4/3 that is a Demon in addition to Human Cleric") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val vessel = driver.putCreatureOnBattlefield(you, "Infernal Vessel")
+        bolt(driver, you, vessel)
+
+        val returned = vesselOnBattlefield(driver, you)
+        (returned != null) shouldBe true
+
+        val projected = projector.project(driver.state)
+        projected.getPower(returned!!) shouldBe 4      // 2 + two +1/+1 counters
+        projected.getToughness(returned) shouldBe 3    // 1 + two +1/+1 counters
+
+        val subtypes = projected.getSubtypes(returned)
+        subtypes.contains(Subtype.DEMON.value) shouldBe true
+        // "in addition to its other types" — the printed types survive.
+        subtypes.contains("Human") shouldBe true
+        subtypes.contains("Cleric") shouldBe true
+
+        driver.getGraveyardCardNames(you).contains("Infernal Vessel") shouldBe false
+    }
+
+    test("second death: the granted Demon type stops it from returning again") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val vessel = driver.putCreatureOnBattlefield(you, "Infernal Vessel")
+        bolt(driver, you, vessel)
+        val returned = vesselOnBattlefield(driver, you)!!
+
+        // It is a Demon now, so this death must NOT trigger the return.
+        bolt(driver, you, returned)
+
+        vesselOnBattlefield(driver, you) shouldBe null
+        driver.getGraveyardCardNames(you).contains("Infernal Vessel") shouldBe true
+    }
+
+    test("returns under its OWNER's control even when an opponent controlled it at death") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val owner = driver.activePlayer!!
+        val thief = driver.getOpponent(owner)
+
+        val vessel = driver.putCreatureOnBattlefield(owner, "Infernal Vessel")
+        driver.replaceState(
+            driver.state.updateEntity(vessel) { it.with(ControllerComponent(thief)) }
+        )
+        driver.getController(vessel) shouldBe thief
+
+        bolt(driver, owner, vessel)
+
+        (vesselOnBattlefield(driver, owner) != null) shouldBe true
+        vesselOnBattlefield(driver, thief) shouldBe null
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -123,4 +123,5 @@ export const counterManaClass: Record<string, string> = {
   LANDMARK: 'counter-charge',
   DREAD: 'counter-doom',
   INCUBATION: 'counter-slime',
+  FELLOWSHIP: 'counter-devotion',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -682,6 +682,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.LANDMARK,
   CounterType.DREAD,
   CounterType.INCUBATION,
+  CounterType.FELLOWSHIP,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1895,6 +1895,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   LANDMARK: { bg: 'rgba(60, 50, 15, 0.95)', border: 'rgba(220, 190, 80, 0.7)', color: '#e8cf68', glow: 'rgba(220, 190, 80, 0.55)' },
   DREAD: { bg: 'rgba(25, 15, 35, 0.95)', border: 'rgba(120, 90, 160, 0.7)', color: '#b59ad0', glow: 'rgba(120, 90, 160, 0.55)' },
   INCUBATION: { bg: 'rgba(20, 45, 65, 0.95)', border: 'rgba(110, 190, 220, 0.65)', color: '#a0d4e8', glow: 'rgba(110, 190, 220, 0.5)' },
+  FELLOWSHIP: { bg: 'rgba(58, 44, 20, 0.95)', border: 'rgba(214, 178, 96, 0.65)', color: '#e8d3a0', glow: 'rgba(214, 178, 96, 0.5)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -400,6 +400,7 @@ export enum CounterType {
   LANDMARK = 'LANDMARK',
   DREAD = 'DREAD',
   INCUBATION = 'INCUBATION',
+  FELLOWSHIP = 'FELLOWSHIP',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -458,6 +459,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.LANDMARK]: 'Landmark',
   [CounterType.DREAD]: 'Dread',
   [CounterType.INCUBATION]: 'Incubation',
+  [CounterType.FELLOWSHIP]: 'Fellowship',
 }
 
 /**


### PR DESCRIPTION
Three FDN cards. Each needed one small, reusable SDK/engine addition rather than a card-specific effect.

## Cards

**Banner of Kinship** `{5}` Artifact — *As this enters, choose a creature type. Enters with a fellowship counter for each creature you control of that type. Creatures you control of that type get +1/+1 for each fellowship counter on it.*

Pure composition — `EntersWithChoice(CREATURE_TYPE)` + `EntersWithDynamicCounters(…, AggregateBattlefield(You, Creature.withChosenSubtype()))` + `GrantDynamicStatsEffect` sized by `DynamicAmounts.countersOnSelf`. The only new surface is the `fellowship` passive counter type (SDK enum + `Counters` constant, plus the four client registration points: `enums.ts`, `counterManaClass`, `PASSIVE_COUNTER_TYPES`, `passiveCounterPalette`).

The load-bearing ordering claim — the as-enters *choice* resolves before the as-enters *count* is evaluated — is pinned by tests using boards where the two candidate types have different populations, so a mis-ordered implementation can't pass by coincidence.

**Blasphemous Edict** `{3}{B}{B}` Sorcery — *You may pay `{B}` rather than pay this spell's mana cost if there are thirteen or more creatures on the battlefield. Each player sacrifices thirteen creatures of their choice.*

`SelfAlternativeCost` gains an optional `condition`. It's gated at the two mirrored sites that decide legality — `CastSpellEnumerator` (so the action isn't offered) and `CastSpellHandler.validate` (so an authorization can't outlive the enumeration that offered it), matching the existing `MayCastSelfFromZones` gating idiom. Zahid's unconditional shape is unchanged (`condition` defaults to null).

Note the count is *global* (`Player.Each`), not just the caster's board — a test uses a 4/9 split so neither player alone reaches thirteen.

**Infernal Vessel** `{2}{B}` 2/1 — *When this creature dies, if it wasn't a Demon, return it to the battlefield under its owner's control with two +1/+1 counters on it. It's a Demon in addition to its other types.*

Adds `Conditions.TriggeringEntityHadSubtype(subtype)`, an intervening-if that reads the leaving permanent's **projected** subtypes as last-known information (CR 603.10). This has to be LKI: by the time the trigger is considered, the Vessel is a card in the graveyard with its printed `Human Cleric` line, so asking the live entity would answer "not a Demon" forever and it would loop. The Demon type the card grants itself on return (`AddCreatureType(…, Duration.Permanent)`) is exactly what the snapshot captures.

One supporting fix: the battlefield-exit `EntitySnapshot` populated `typeLine` but left its own `subtypes` field empty, while the `fromProjection` path fills it. It now mirrors the projected type line's subtypes, so the field means the same thing on both paths. The only other consumer (`SacrificedPermanentHadSubtype`) uses the cost-time capture path and is unaffected.

## Testing

- `BannerOfKinshipScenarioTest` (4) — counter count per chosen type; you-control-only + snapshot-on-entry vs live anthem; zero-of-that-type; anthem shrinks when counters are removed.
- `BlasphemousEdictScenarioTest` (3) — alternative not offered below thirteen **and** rejected on the authorization path; unlocked by a cross-battlefield total; the thirteen cap (a 14th creature survives) and the fewer-than-thirteen ruling.
- `InfernalVesselScenarioTest` (3) — first death returns a 4/3 Demon that keeps Human Cleric; second death does not return; returns under the owner's control after a control change.

`just test` green, `web-client` typecheck clean. `just check-card-printing` confirms FDN is the canonical set for all three (no earlier printings). Card snapshot golden re-blessed — the diff is purely additive, only the three new cards.

## Not included

Considered and dropped as too complex for this batch: **Fishing Pole**, which hits three separate engine gaps at once (no `TapGrantingPermanent` cost atom, `TriggerBinding.ATTACHED` + `UntapEvent` is unwired in `AttachmentTriggerDetector` and would misfire globally as-is, and a new `bait` counter). Worth doing as its own `add-feature` change.

The mtgish generator was not taught these new building blocks (Step 4.11); its IR does model both shapes (`AlternateCastingCostIf`, `DeadPermanentPassesFilter`), so bridge + emitter entries are a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)