### PR TITLE
Split dynamicStats into reusable dynamicPower / dynamicToughness helpers

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -38,8 +38,15 @@ section; do not let SDK additions land without a corresponding doc update.
   from the type line in both legal-action enumeration and the cast handler; no per-card opt-in needed.
 - `oracleText: String` — rules text; auto-generated from abilities if omitted.
 - `power: Int?`, `toughness: Int?` — base P/T for creatures.
-- `dynamicPower`, `dynamicToughness` — characteristic-defining P/T (e.g. `*/*` Tarmogoyf).
-- `dynamicStats(source, powerOffset?, toughnessOffset?)` — sets both with optional `±` deltas.
+- `dynamicPower`, `dynamicToughness` — characteristic-defining P/T (e.g. `*/*` Tarmogoyf), as
+  `CharacteristicValue` properties. Prefer the builder helpers below over assigning them directly.
+- `dynamicPower(source, offset?)` / `dynamicToughness(source, offset?)` — set one
+  characteristic-defining stat from a `DynamicAmount` with an optional `±` delta. Use these when
+  only one stat is dynamic (Duelist of the Mind's `*`/3) or when the two read *different* sources
+  (Yavimaya Kavu: power = red creatures, toughness = green creatures).
+- `dynamicStats(source, powerOffset?, toughnessOffset?)` — the `*`/`*` cycle: composes
+  `dynamicPower` + `dynamicToughness` over one shared source, with optional `±` deltas
+  (Tarmogoyf's `toughnessOffset = 1`).
 - `startingLoyalty: Int?` — starting loyalty for planeswalkers.
 - `colorIdentity: String?` — override (normally auto-detected). Treated as authoritative in this repo.
 - `colorIndicator: String?` — explicit color indicator (CR 204), e.g. `"B"`. `null` (default) = no

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -216,12 +216,31 @@ class CardBuilder(private val name: String) {
     var dynamicToughness: CharacteristicValue? = null
 
     /**
-     * Set dynamic stats from the same source with optional offsets.
+     * Set a characteristic-defining power from a dynamic source with an optional `±` offset.
+     * Example: `dynamicPower(DynamicAmount.TurnTracking(Player.You, TurnTracker.CARDS_DRAWN))` for
+     * Duelist of the Mind (`*`/3 — only power is dynamic).
+     */
+    fun dynamicPower(source: DynamicAmount, offset: Int = 0) {
+        dynamicPower = CharacteristicValue.dynamic(source, offset)
+    }
+
+    /**
+     * Set a characteristic-defining toughness from a dynamic source with an optional `±` offset.
+     * Example: `dynamicToughness(DynamicAmounts.landsYouControl(), offset = 1)` for a `2`/`*+1`.
+     */
+    fun dynamicToughness(source: DynamicAmount, offset: Int = 0) {
+        dynamicToughness = CharacteristicValue.dynamic(source, offset)
+    }
+
+    /**
+     * Set both dynamic stats from the same source with optional offsets — the common `*`/`*` cycle.
+     * Composes [dynamicPower] and [dynamicToughness]; use those directly when only one stat is
+     * characteristic-defining, or when the two read different sources.
      * Example: `dynamicStats(DynamicAmount.AggregateZone(Player.Each, Zone.GRAVEYARD, aggregation = Aggregation.DISTINCT_TYPES), toughnessOffset = 1)` for Tarmogoyf.
      */
     fun dynamicStats(source: DynamicAmount, powerOffset: Int = 0, toughnessOffset: Int = 0) {
-        dynamicPower = CharacteristicValue.dynamic(source, powerOffset)
-        dynamicToughness = CharacteristicValue.dynamic(source, toughnessOffset)
+        dynamicPower(source, powerOffset)
+        dynamicToughness(source, toughnessOffset)
     }
 
     /**

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CardDslTest.kt
@@ -35,6 +35,7 @@ import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.Aggregation
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
@@ -714,13 +715,67 @@ class CardDslTest : DescribeSpec({
                 manaCost = "{2}{G}{G}"
                 typeLine = "Creature — Lhurgoyf"
 
-                dynamicPower = com.wingedsheep.sdk.model.CharacteristicValue.Dynamic(DynamicAmounts.creatureCardsInYourGraveyard())
-                dynamicToughness = com.wingedsheep.sdk.model.CharacteristicValue.DynamicWithOffset(DynamicAmounts.creatureCardsInYourGraveyard(), 1)
+                dynamicPower(DynamicAmounts.creatureCardsInYourGraveyard())
+                dynamicToughness(DynamicAmounts.creatureCardsInYourGraveyard(), offset = 1)
             }
 
             lhurgoyf.creatureStats shouldNotBe null
             lhurgoyf.creatureStats!!.isDynamic shouldBe true
             lhurgoyf.creatureStats.basePower shouldBe null  // No fixed base power
+
+            lhurgoyf.creatureStats.power.shouldBeInstanceOf<com.wingedsheep.sdk.model.CharacteristicValue.Dynamic>()
+            val toughness = lhurgoyf.creatureStats.toughness
+                .shouldBeInstanceOf<com.wingedsheep.sdk.model.CharacteristicValue.DynamicWithOffset>()
+            toughness.offset shouldBe 1
+        }
+
+        it("should define a power-only CDA, leaving toughness printed") {
+            val duelist = card("Duelist") {
+                manaCost = "{1}{U}"
+                typeLine = "Creature — Human Advisor"
+                toughness = 3
+
+                dynamicPower(DynamicAmount.TurnTracking(Player.You, TurnTracker.CARDS_DRAWN))
+            }
+
+            duelist.creatureStats shouldNotBe null
+            duelist.creatureStats!!.isDynamic shouldBe true
+            duelist.creatureStats.power.shouldBeInstanceOf<com.wingedsheep.sdk.model.CharacteristicValue.Dynamic>()
+            duelist.creatureStats.toughness shouldBe com.wingedsheep.sdk.model.CharacteristicValue.Fixed(3)
+        }
+
+        it("should define power and toughness from two different dynamic sources") {
+            val kavu = card("Yavimaya Kavu") {
+                manaCost = "{2}{R}{G}"
+                typeLine = "Creature — Kavu"
+
+                dynamicPower(DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature.withColor(Color.RED)))
+                dynamicToughness(DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature.withColor(Color.GREEN)))
+            }
+
+            val power = kavu.creatureStats!!.power
+                .shouldBeInstanceOf<com.wingedsheep.sdk.model.CharacteristicValue.Dynamic>()
+            val toughness = kavu.creatureStats.toughness
+                .shouldBeInstanceOf<com.wingedsheep.sdk.model.CharacteristicValue.Dynamic>()
+            power.source shouldNotBe toughness.source
+        }
+
+        it("dynamicStats composes dynamicPower and dynamicToughness over one source") {
+            val shared = DynamicAmounts.creatureCardsInYourGraveyard()
+
+            val viaHelper = card("Composed") {
+                manaCost = "{2}{G}"
+                typeLine = "Creature — Lhurgoyf"
+                dynamicStats(shared, toughnessOffset = 1)
+            }
+            val viaParts = card("Composed") {
+                manaCost = "{2}{G}"
+                typeLine = "Creature — Lhurgoyf"
+                dynamicPower(shared)
+                dynamicToughness(shared, offset = 1)
+            }
+
+            viaHelper.creatureStats shouldBe viaParts.creatureStats
         }
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/EnigmaDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/EnigmaDrake.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.mtg.sets.definitions.akh.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -18,10 +17,10 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Flying
  * Enigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.
  *
- * The characteristic-defining power is a [CharacteristicValue.dynamic] over
+ * The characteristic-defining power is a `dynamicPower(...)` over
  * [DynamicAmount.Count] of instant/sorcery cards in the controller's graveyard
  * ([GameObjectFilter.InstantOrSorcery]). Only power is dynamic; toughness stays a printed 4,
- * so we set `dynamicPower` directly (same shape as Duelist of the Mind).
+ * so we use the single-stat `dynamicPower(...)` helper (same shape as Duelist of the Mind).
  *
  * Canonical printing lives here (Amonkhet, the earliest real expansion); later sets
  * (M19, Foundations, …) contribute only [com.wingedsheep.sdk.model.Printing] rows.
@@ -33,7 +32,7 @@ val EnigmaDrake = card("Enigma Drake") {
     toughness = 4
     oracleText = "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard."
 
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.InstantOrSorcery)
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HaughtyDjinn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HaughtyDjinn.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.mtg.sets.definitions.dmu.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.scripting.CostModification
@@ -30,7 +29,7 @@ val HaughtyDjinn = card("Haughty Djinn") {
     oracleText = "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast."
 
     // Power is dynamic based on instant and sorcery cards in controller's graveyard
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.Count(
             player = Player.You,
             zone = Zone.GRAVEYARD,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/Squawkroaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/Squawkroaster.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.mtg.sets.definitions.ecl.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.DynamicAmounts
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 
 /**
@@ -21,7 +20,7 @@ val Squawkroaster = card("Squawkroaster") {
     typeLine = "Creature — Elemental"
     oracleText = "Double strike\n" +
         "Vivid — Squawkroaster's power is equal to the number of colors among permanents you control."
-    dynamicPower = CharacteristicValue.Dynamic(DynamicAmounts.colorsAmongPermanents())
+    dynamicPower(DynamicAmounts.colorsAmongPermanents())
     toughness = 4
 
     keywords(Keyword.DOUBLE_STRIKE, Keyword.VIVID)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExdeathVoidWarlock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExdeathVoidWarlock.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
@@ -40,7 +39,7 @@ private val NeoExdeathDimensionsEnd = card("Neo Exdeath, Dimension's End") {
     colorIdentity = "BG"
     typeLine = "Legendary Creature — Spirit Avatar"
     oracleText = "Trample\nNeo Exdeath's power is equal to the number of permanent cards in your graveyard."
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent),
     )
     toughness = 3

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SnowVilliers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SnowVilliers.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.mtg.sets.definitions.fin.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -16,7 +15,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Snow Villiers's power is equal to the number of creatures you control.
  *
  * Power is a characteristic-defining ability (printed *), recomputed continuously via
- * [CharacteristicValue.dynamic] over the count of creatures you control (read through projected
+ * `dynamicPower(...)` over the count of creatures you control (read through projected
  * control). Snow himself is a creature you control, so he counts toward his own power. Toughness
  * is the printed fixed value 3, so only `dynamicPower` is set.
  */
@@ -24,7 +23,7 @@ val SnowVilliers = card("Snow Villiers") {
     manaCost = "{2}{W}"
     colorIdentity = "W"
     typeLine = "Legendary Creature — Human Rebel Monk"
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature),
     )
     toughness = 3

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/YavimayaKavu.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.mtg.sets.definitions.inv.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -26,14 +25,14 @@ val YavimayaKavu = card("Yavimaya Kavu") {
     oracleText = "Yavimaya Kavu's power is equal to the number of red creatures on the battlefield.\n" +
         "Yavimaya Kavu's toughness is equal to the number of green creatures on the battlefield."
 
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.AggregateBattlefield(
             player = Player.Each,
             filter = GameObjectFilter.Creature.withColor(Color.RED)
         )
     )
 
-    dynamicToughness = CharacteristicValue.dynamic(
+    dynamicToughness(
         DynamicAmount.AggregateBattlefield(
             player = Player.Each,
             filter = GameObjectFilter.Creature.withColor(Color.GREEN)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SaheelisLattice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SaheelisLattice.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.craft
 import com.wingedsheep.sdk.model.CardDefinition
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
@@ -76,7 +75,7 @@ private val MastercraftRaptor = card("Mastercraft Raptor") {
     typeLine = "Artifact Creature — Dinosaur"
     // Power = total power of cards exiled to craft this permanent (CR 702.167c).
     // The CDA reads CraftedFromExiledComponent on this entity each projection pass.
-    dynamicPower = CharacteristicValue.Dynamic(DynamicAmount.CraftedMaterialsTotalPower)
+    dynamicPower(DynamicAmount.CraftedMaterialsTotalPower)
     toughness = 4
     oracleText = "Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it."
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunbirdStandard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunbirdStandard.kt
@@ -6,7 +6,6 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.craft
 import com.wingedsheep.sdk.model.CardDefinition
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
@@ -81,8 +80,7 @@ private val SunbirdEffigy = card("Sunbird Effigy") {
     typeLine = "Artifact Creature — Bird Construct"
     // P/T CDA: each equal to the number of colors among the cards exiled to craft it
     // (CR 702.167c). Reads CraftedFromExiledComponent on this entity each projection pass.
-    dynamicPower = CharacteristicValue.Dynamic(DynamicAmount.CraftedMaterialsColorCount)
-    dynamicToughness = CharacteristicValue.Dynamic(DynamicAmount.CraftedMaterialsColorCount)
+    dynamicStats(DynamicAmount.CraftedMaterialsColorCount)
     oracleText = "Flying, vigilance, haste\n" +
         "Sunbird Effigy's power and toughness are each equal to the number of colors among the exiled cards used to craft it.\n" +
         "{T}: For each color among the exiled cards used to craft this creature, add one mana of that color."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MinasTirithGarrison.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/MinasTirithGarrison.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.mtg.sets.definitions.ltr.cards
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardSource
@@ -34,7 +33,7 @@ val MinasTirithGarrison = card("Minas Tirith Garrison") {
         "Whenever this creature attacks, you may tap any number of untapped Humans you control. Draw a card for each Human tapped this way."
 
     // Power is equal to the number of cards in your hand.
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.Count(Player.You, Zone.HAND)
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DuelistOfTheMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/DuelistOfTheMind.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.references.Player
@@ -23,8 +22,8 @@ import com.wingedsheep.sdk.scripting.values.TurnTracker
  *
  * The characteristic-defining power uses [DynamicAmount.TurnTracking] with the new
  * [TurnTracker.CARDS_DRAWN] tracker (backed by `CardsDrawnThisTurnComponent`); only power is
- * dynamic, toughness stays a printed 3, so we set `dynamicPower` directly rather than via the
- * both-stats `dynamicStats` helper.
+ * dynamic, toughness stays a printed 3, so we use the single-stat `dynamicPower(...)` helper
+ * rather than the both-stats `dynamicStats(...)`.
  *
  * The crime trigger is the standard [Triggers.YouCommitCrime] capped with `oncePerTurn = true`
  * and runs the optional loot ([MayEffect] wrapping [Patterns.Hand.loot]) — the same composition
@@ -36,7 +35,7 @@ val DuelistOfTheMind = card("Duelist of the Mind") {
     typeLine = "Creature — Human Advisor"
     oracleText = "Flying, vigilance\nDuelist of the Mind's power is equal to the number of cards you've drawn this turn.\nWhenever you commit a crime, you may draw a card. If you do, discard a card. This ability triggers only once each turn."
     toughness = 3
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.TurnTracking(Player.You, TurnTracker.CARDS_DRAWN)
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ZurgosVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ZurgosVanguard.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.mtg.sets.definitions.tdm.cards
 
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.mobilize
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.references.Player
@@ -17,7 +16,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Zurgo's Vanguard's power is equal to the number of creatures you control.
  *
  * `mobilize(1)` supplies the attack-triggered Warrior token. The characteristic-defining power is a
- * power-only [CharacteristicValue.dynamic] over [DynamicAmount.AggregateBattlefield] counting
+ * power-only `dynamicPower(...)` over [DynamicAmount.AggregateBattlefield] counting
  * creatures you control (toughness stays fixed at 3). Because Mobilize's token enters tapped and
  * attacking before damage, the Warrior it makes is itself a creature you control, so the
  * count-based power already reflects the new token when combat damage is assigned.
@@ -32,7 +31,7 @@ val ZurgosVanguard = card("Zurgo's Vanguard") {
         "Zurgo's Vanguard's power is equal to the number of creatures you control."
 
     mobilize(1)
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/DragonflySwarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/DragonflySwarm.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -35,7 +34,7 @@ val DragonflySwarm = card("Dragonfly Swarm") {
         "When this creature dies, if there's a Lesson card in your graveyard, draw a card."
 
     // Power is the number of noncreature, nonland cards in the controller's graveyard (CDA).
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.Count(
             player = Player.You,
             zone = Zone.GRAVEYARD,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SukiKyoshiWarrior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SukiKyoshiWarrior.kt
@@ -3,7 +3,6 @@ package com.wingedsheep.mtg.sets.definitions.tla.cards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
@@ -26,7 +25,7 @@ val SukiKyoshiWarrior = card("Suki, Kyoshi Warrior") {
     manaCost = "{2}{G/W}{G/W}"
     colorIdentity = "GW"
     typeLine = "Legendary Creature — Human Warrior Ally"
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.AggregateBattlefield(
             player = Player.You,
             filter = GameObjectFilter.Creature,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TophTheBlindBandit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TophTheBlindBandit.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.model.CharacteristicValue
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
@@ -26,14 +25,14 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Toph's power is equal to the number of +1/+1 counters on lands you control.
  *
  * Power is a characteristic-defining ability (printed *), recomputed continuously via
- * [CharacteristicValue.dynamic] as the total +1/+1 counters among lands you control (SUM over
+ * `dynamicPower(...)` as the total +1/+1 counters among lands you control (SUM over
  * the +1/+1 counters on each land). Toughness is the printed fixed value 3.
  */
 val TophTheBlindBandit = card("Toph, the Blind Bandit") {
     manaCost = "{2}{G}"
     colorIdentity = "G"
     typeLine = "Legendary Creature — Human Warrior Ally"
-    dynamicPower = CharacteristicValue.dynamic(
+    dynamicPower(
         DynamicAmount.AggregateBattlefield(
             player = Player.You,
             filter = GameObjectFilter.Land,

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -338,4 +338,14 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // trigger." A continuous static that suppresses CR 603.6 enters-the-battlefield triggers caused by a
     // matching permanent entering. Renders to the SuppressEntersTriggers static ability.
     supported("PermanentsEnteringTheBattlefieldDontCauseAbilitiesToTrigger", "rule: matching permanents entering don't cause abilities to trigger (SuppressEntersTriggers)")
+
+    // Characteristic-defining power/toughness (CR 604.3, applied in layer 7a) — "~'s power is equal to
+    // the number of [X]". The card DSL models each stat independently: `dynamicPower(amount, offset)` /
+    // `dynamicToughness(amount, offset)`, with `dynamicStats(...)` composing both over one shared count
+    // (the `*`/`*` cycle). Each stat is its own IR rule, so both are supported on their own — a
+    // power-only CDA (Duelist of the Mind's `*`/3) and two different counts (Yavimaya Kavu) are as
+    // renderable as the matched pair. Whether the *amount* itself is recoverable is the emitter's call;
+    // an unreadable count still scaffolds.
+    supported("CDA_Power", "rule: characteristic-defining power (dynamicPower / dynamicStats)")
+    supported("CDA_Toughness", "rule: characteristic-defining toughness (dynamicToughness / dynamicStats)")
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3374,18 +3374,36 @@ private fun isPlainCreatureFilter(trig: JsonObject): Boolean {
 }
 
 /**
- * A characteristic-defining `CDA_Power` rule (with its matching `CDA_Toughness`) -> a single
- * `dynamicStats(...)` line, when both power and toughness are the same dynamic count (the
- * power-and-toughness-equal-to-the-number-of-X cycle). Differing power/toughness amounts scaffold.
+ * A characteristic-defining `CDA_Power` rule (plus its `CDA_Toughness` sibling, if any) -> the
+ * card-level dynamic P/T line(s). Both stats reading the *same* count (the
+ * power-and-toughness-equal-to-the-number-of-X cycle) collapse to one `dynamicStats(...)`;
+ * a power-only CDA (Duelist of the Mind's `*`/3) or two different counts (Yavimaya Kavu's red
+ * creatures / green creatures) render the single-stat `dynamicPower(...)` / `dynamicToughness(...)`
+ * helpers. An amount we can't recover still scaffolds.
  */
 internal fun EmitCtx.cdaStatsBlock(card: JsonObject, rule: JsonObject): List<Stmt>? {
     val toughnessRule = (card["Rules"].asArr ?: JsonArray(emptyList()))
         .filterIsInstance<JsonObject>().firstOrNull { it.strField("_Rule") == "CDA_Toughness" }
-    if (toughnessRule == null || compact(rule["args"]) != compact(toughnessRule["args"])) {
-        reasons.add("CDA_Power"); return null
+    val power = dynamicAmountExpr(rule["args"]) ?: run { reasons.add("CDA_Power"); return null }
+    if (toughnessRule != null && compact(rule["args"]) == compact(toughnessRule["args"])) {
+        return listOf(Eval(call("dynamicStats", arg(power))))
     }
-    val amount = dynamicAmountExpr(rule["args"]) ?: run { reasons.add("CDA_Power"); return null }
-    return listOf(Eval(call("dynamicStats", arg(amount))))
+    val lines = mutableListOf<Stmt>(Eval(call("dynamicPower", arg(power))))
+    if (toughnessRule != null) {
+        val toughness = dynamicAmountExpr(toughnessRule["args"])
+            ?: run { reasons.add("CDA_Toughness"); return null }
+        lines.add(Eval(call("dynamicToughness", arg(toughness))))
+    }
+    return lines
+}
+
+/**
+ * A `CDA_Toughness` rule with no `CDA_Power` sibling -> a lone `dynamicToughness(...)` line
+ * (the printed power stays a fixed number). The paired case is emitted by [cdaStatsBlock].
+ */
+internal fun EmitCtx.cdaToughnessBlock(rule: JsonObject): List<Stmt>? {
+    val amount = dynamicAmountExpr(rule["args"]) ?: run { reasons.add("CDA_Toughness"); return null }
+    return listOf(Eval(call("dynamicToughness", arg(amount))))
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -234,7 +234,7 @@ object Emitter {
                 rname == "CDA_Power" -> block = ctx.cdaStatsBlock(card, rule)
                 rname == "CDA_Toughness" ->
                     if (jsonContains(card["Rules"], "_Rule", "CDA_Power")) continue  // emitted with CDA_Power
-                    else { gap("CDA_Toughness", addReason = "CDA_Toughness")?.let { return it }; continue }
+                    else block = ctx.cdaToughnessBlock(rule)
                 rname == "Activated" || rname == "ActivatedWithModifiers" -> block = ctx.activatedBlock(rule)
                 rname == "Cycling" -> block = manaKeywordCost(rule)?.let { listOf(Eval(call("keywordAbility", arg(call("KeywordAbility.cycling", arg("\"$it\"")))))) }
                 // Typecycling (CR 702.29) — the land-type "Forestcycling"/"Swampcycling"/… forms carry


### PR DESCRIPTION
## What

`dynamicStats(source, powerOffset, toughnessOffset)` was the only card-DSL path for
characteristic-defining P/T (CR 604.3, applied in layer 7a per CR 613.4a), and it only expressed the
`*`/`*` cycle where both stats read one shared count. Anything else — a power-only CDA (Duelist of
the Mind's `*`/3) or two *different* counts (Yavimaya Kavu: power = red creatures, toughness = green
creatures) — fell out of the DSL and hand-assigned the raw `CharacteristicValue` properties.

Split it into the two single-stat helpers the shape was hiding, with the both-stats form composing them:

```kotlin
fun dynamicPower(source: DynamicAmount, offset: Int = 0)
fun dynamicToughness(source: DynamicAmount, offset: Int = 0)
fun dynamicStats(source: DynamicAmount, powerOffset: Int = 0, toughnessOffset: Int = 0)  // composes both
```

## Changes

- **`CardBuilder`** — the two new helpers; `dynamicStats` now delegates to them. The
  `CharacteristicValue` properties stay as the backing surface but are no longer the ergonomic path.
- **`mtg-sets`** — migrates all 14 hand-rolled `dynamicPower = CharacteristicValue.dynamic(...)`
  call sites (dropping the now-unneeded import) and collapses Sunbird Effigy's duplicated
  power/toughness pair back onto `dynamicStats`.
- **mtgish tooling** — `cdaStatsBlock` no longer scaffolds when the `CDA_Power` / `CDA_Toughness`
  rules differ or when only one is present; it renders the matching single-stat helper(s), and a lone
  `CDA_Toughness` rule gets its own emitter path. `CDA_Power` / `CDA_Toughness` are registered as
  supported bridge capabilities.
- **`docs/card-sdk-language-reference.md`** — documents both helpers and when to reach for which.

## Verification

- `just test` — full suite green (card snapshot + lint nets included; the migration is
  JSON-identical, so no re-bless was needed).
- `:mtgish-tooling:test` / `:mtg-sets:test` force-rerun green after the bridge + emitter change.
- Coverage probe: Enigma Drake (power-only) and Yavimaya Kavu (two counts) flip from
  `BLOCKED` to `COVERABLE-NOW`, and a regenerated Yavimaya Kavu renders whole with
  `dynamicPower(...)` + `dynamicToughness(...)`.
- CR 604.3 and 613.4a verified against the 2026-06-19 Comprehensive Rules text.

New SDK tests in `CardDslTest` cover the power-only CDA, two different sources, offsets, and that
`dynamicStats` produces exactly the same `creatureStats` as calling the two helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)