### PR TITLE
Implement SPM AUTOGEN tier + generalize `MayCastSelfFromZones` additional costs

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 87 / 189
+**Implemented:** 88 / 189
 - [x] Agent Venom
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
@@ -104,7 +104,7 @@
 - [x] Robotics Mastery
 - [ ] Rocket-Powered Goblin Glider
 - [x] Romantic Rendezvous
-- [ ] SP//dr, Piloted by Peni
+- [x] SP//dr, Piloted by Peni
 - [ ] Sandman's Quicksand
 - [ ] Sandman, Shifting Scoundrel
 - [x] Savage Mansion

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,8 +2,9 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 88 / 189
+**Implemented:** 89 / 190
 - [x] Agent Venom
+- [x] Alien Symbiosis
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
 - [ ] Anti-Venom, Horrifying Healer

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4425,17 +4425,27 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   `effectiveSneakCost` are read by `SneakCastEnumerator` (a graveyard loop) and four sites in
   `CastSpellHandler` (zone gate, both cost paths, the enters-tapped/bounce resolution). No
   exile-on-resolution (unlike flashback) — the creature simply moves graveyard → stack → battlefield.
-- `MayCastSelfFromZones(zones, condition = null)` — intrinsic *self* permission: this card may be
-  cast from any of `zones` (graveyard/exile) following normal timing and for its normal mana cost.
-  Squee, the Immortal = `MayCastSelfFromZones(listOf(GRAVEYARD, EXILE))`. When `condition` is
-  non-null the permission is **gated**: it is available only while the condition holds, evaluated in
-  the casting player's context at cast-legality time *and* re-checked when the cast is authorized
-  (so it can't outlive the permission). Undead Sprinter (DSK) = `MayCastSelfFromZones(listOf(GRAVEYARD),
-  condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))` for "You may cast this card
-  from your graveyard if a non-Zombie creature died this turn." Pair with an
-  `EntersWithCounters(selfOnly = true, condition = Conditions.WasCastFromGraveyard)` rider to model
-  "if you do, this creature enters with a +1/+1 counter on it" — the counter is tied to the
+- `MayCastSelfFromZones(zones, condition = null, additionalCost = null)` — intrinsic *self*
+  permission: this card may be cast from any of `zones` (graveyard/exile) following normal timing
+  and for its normal mana cost. Squee, the Immortal = `MayCastSelfFromZones(listOf(GRAVEYARD,
+  EXILE))`. When `condition` is non-null the permission is **gated**: it is available only while the
+  condition holds, evaluated in the casting player's context at cast-legality time *and* re-checked
+  when the cast is authorized (so it can't outlive the permission). Undead Sprinter (DSK) =
+  `MayCastSelfFromZones(listOf(GRAVEYARD), condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))`
+  for "You may cast this card from your graveyard if a non-Zombie creature died this turn." Pair
+  with an `EntersWithCounters(selfOnly = true, condition = Conditions.WasCastFromGraveyard)` rider to
+  model "if you do, this creature enters with a +1/+1 counter on it" — the counter is tied to the
   graveyard cast (`CastFromGraveyardComponent` stamped on resolution), not to the gate condition.
+  When `additionalCost` is non-null, casting through this permission also requires paying that cost
+  (mirrors `GrantMayCastFromLinkedExile.additionalCost`). Alien Symbiosis (SPM) =
+  `MayCastSelfFromZones(listOf(GRAVEYARD), additionalCost = Costs.additional.DiscardCards(1))` for
+  "You may cast this card from your graveyard by discarding a card in addition to paying its other
+  costs." Wired through `CastZoneResolver.findMayCastSelfFromZoneAbility` (returns the applicable
+  ability so callers can read its `additionalCost`), validated/collected in `CastSpellHandler`
+  alongside the other additional-cost sources, and surfaced to legal-action enumeration in
+  `CastFromZoneEnumerator.enumerateIntrinsicZoneCast` via the same `AdditionalCostData` /
+  `buildLinkedExileAdditionalCostInfo` plumbing used for linked-exile grants (including a
+  `DiscardCard` rendering with `validDiscardTargets`).
 - `GrantWarpToCardsInHand(filter, cost)` — cards in the controller's hand matching `filter` gain
   warp (CR 702.185) with mana cost `cost`. Behaves identically to a printed warp keyword: surfaces a
   "Cast (Warp)" legal action, marks `wasWarped` on resolution, and the post-resolution permanent is

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -440,27 +440,41 @@ data object OpponentsPlayWithHandsRevealed : StaticAbility {
  * this card from your graveyard if a non-Zombie creature died this turn" —
  * `MayCastSelfFromZones(listOf(Zone.GRAVEYARD), condition = Conditions.NonSubtypeCreatureDiedThisTurn(Subtype.ZOMBIE))`.
  *
+ * When [additionalCost] is non-null, casting through this permission requires paying that cost in
+ * addition to the card's normal mana cost — mirrors [GrantMayCastFromLinkedExile.additionalCost].
+ * Used by Alien Symbiosis (SPM): "You may cast this card from your graveyard by discarding a card
+ * in addition to paying its other costs" —
+ * `MayCastSelfFromZones(listOf(Zone.GRAVEYARD), additionalCost = Costs.additional.DiscardCards(1))`.
+ *
  * Normal timing rules still apply — a creature with no flash is castable this way only at sorcery
- * speed, on the player's turn with an empty stack. The card is cast for its normal mana cost.
+ * speed, on the player's turn with an empty stack. The card is cast for its normal mana cost (plus
+ * [additionalCost], if any).
  *
  * @property zones The zones from which this card may be cast.
  * @property condition Optional gate; null = always available (the Squee shape).
+ * @property additionalCost Optional additional cost required alongside the card's mana cost when
+ *   cast through this permission; null = no additional cost (the Squee/Gravecrawler shape).
  */
 @SerialName("MayCastSelfFromZones")
 @Serializable
 data class MayCastSelfFromZones(
     val zones: List<Zone>,
-    val condition: Condition? = null
+    val condition: Condition? = null,
+    val additionalCost: AdditionalCost? = null
 ) : StaticAbility {
     override val description: String = buildString {
         append("You may cast this card from ${zones.joinToString(" or ") { it.displayName }}")
+        if (additionalCost != null) append(" by ${additionalCost.description.lowercase()} in addition to paying its other costs")
         if (condition != null) append(" ${condition.description}")
         append(".")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newCondition = condition?.applyTextReplacement(replacer)
-        return if (newCondition !== condition) copy(condition = newCondition) else this
+        val newAdditionalCost = additionalCost?.applyTextReplacement(replacer)
+        return if (newCondition !== condition || newAdditionalCost !== additionalCost) {
+            copy(condition = newCondition, additionalCost = newAdditionalCost)
+        } else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/SpiderManSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/SpiderManSet.kt
@@ -22,6 +22,10 @@ object SpiderManSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AlienSymbiosis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AlienSymbiosis.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Alien Symbiosis
+ * {1}{B}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+1, has menace, and is a Symbiote in addition to its other types.
+ * You may cast this card from your graveyard by discarding a card in addition to paying its
+ * other costs.
+ */
+val AlienSymbiosis = card("Alien Symbiosis") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1, has menace, and is a Symbiote in addition to its other types.\n" +
+        "You may cast this card from your graveyard by discarding a card in addition to paying its other costs."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.MENACE)
+    }
+
+    staticAbility {
+        ability = GrantSubtype("Symbiote", Filters.EnchantedCreature)
+    }
+
+    // "You may cast this card from your graveyard by discarding a card in addition to paying
+    // its other costs." Self-referential cast-from-graveyard permission with a bundled
+    // additional cost. Normal (sorcery-speed) timing and the {1}{B} mana cost still apply.
+    staticAbility {
+        ability = MayCastSelfFromZones(
+            zones = listOf(Zone.GRAVEYARD),
+            additionalCost = Costs.additional.DiscardCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "JB Casacop"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b898ccb7-758e-4f11-95e0-b412721d8bf9.jpg?1783905348"
+        ruling("2025-09-19", "You must follow all normal timing rules when casting Alien Symbiosis using its last ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SPDrPilotedByPeni.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SPDrPilotedByPeni.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * SP//dr, Piloted by Peni
+ * {3}{W}{U}
+ * Legendary Artifact Creature — Spider Hero, 4/4
+ *
+ * Vigilance
+ * When SP//dr enters, put a +1/+1 counter on target creature.
+ * Whenever a modified creature you control deals combat damage to a player, draw a card.
+ * (Equipment, Auras you control, and counters are modifications.)
+ */
+val SPDrPilotedByPeni = card("SP//dr, Piloted by Peni") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Artifact Creature — Spider Hero"
+    oracleText = "Vigilance\nWhen SP//dr enters, put a +1/+1 counter on target creature.\nWhenever a modified creature you control deals combat damage to a player, draw a card. (Equipment, Auras you control, and counters are modifications.)"
+    power = 4
+    toughness = 4
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            DamageType.Combat,
+            RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().copy(
+                statePredicates = GameObjectFilter.Creature.youControl().statePredicates +
+                    StatePredicate.IsModified
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = DrawCardsEffect(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Toni Infante"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c47c1d83-e76d-4939-9ed6-05a9e709dea1.jpg?1783905311"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderManBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderManBasicLands.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Marvel's Spider-Man Basic Lands
+ *
+ * Two full-art variants of each basic land type, collector numbers 189-198.
+ */
+
+val SpmPlains189 = basicLand("Plains") {
+    collectorNumber = "189"
+    artist = "Sarah Finnigan"
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/1164f7ec-7b2f-4cc9-90bb-7eaaa331b4cd.jpg?1783905295"
+}
+
+val SpmPlains194 = basicLand("Plains") {
+    collectorNumber = "194"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94e88862-d53d-49b6-8aa5-95f07507c6e1.jpg?1783905294"
+}
+
+val SpmIsland190 = basicLand("Island") {
+    collectorNumber = "190"
+    artist = "Sarah Finnigan"
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d59cb0b5-fd4f-4dde-a69f-7ca6aa12b89f.jpg?1783905295"
+}
+
+val SpmIsland195 = basicLand("Island") {
+    collectorNumber = "195"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/14fcdc57-12e2-429b-8916-4df752e462d4.jpg?1783905292"
+}
+
+val SpmSwamp191 = basicLand("Swamp") {
+    collectorNumber = "191"
+    artist = "Sarah Finnigan"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cb03b18-d74c-4c89-9539-3549d2e8ff5f.jpg?1783905295"
+}
+
+val SpmSwamp196 = basicLand("Swamp") {
+    collectorNumber = "196"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7150a6e-240f-4628-acdc-153d404370ff.jpg?1783905294"
+}
+
+val SpmMountain192 = basicLand("Mountain") {
+    collectorNumber = "192"
+    artist = "Sarah Finnigan"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b044630d-50e7-431b-8e91-bd53e967f594.jpg?1783905295"
+}
+
+val SpmMountain197 = basicLand("Mountain") {
+    collectorNumber = "197"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc5004db-8db3-4506-bb01-f41be7968824.jpg?1783905292"
+}
+
+val SpmForest193 = basicLand("Forest") {
+    collectorNumber = "193"
+    artist = "Sarah Finnigan"
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b6c2532-be5a-4f1f-893c-36bcda2a699d.jpg?1783905294"
+}
+
+val SpmForest198 = basicLand("Forest") {
+    collectorNumber = "198"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4fec728-8e3f-427d-81ab-e06114910223.jpg?1783905292"
+}
+
+/**
+ * All Marvel's Spider-Man basic land variants.
+ */
+val SpiderManBasicLands = listOf(
+    SpmPlains189, SpmPlains194,
+    SpmIsland190, SpmIsland195,
+    SpmSwamp191, SpmSwamp196,
+    SpmMountain192, SpmMountain197,
+    SpmForest193, SpmForest198,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -58,6 +58,66 @@
     ]
 }
 
+// Alien Symbiosis
+{
+    "name": "Alien Symbiosis",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+1, has menace, and is a Symbiote in addition to its other types.\nYou may cast this card from your graveyard by discarding a card in addition to paying its other costs.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE"
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Symbiote",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "MayCastSelfFromZones",
+                "zones": [
+                    "Graveyard"
+                ],
+                "additionalCost": {
+                    "type": "AdditionalAtom",
+                    "atom": "AtomDiscard"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "JB Casacop",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b898ccb7-758e-4f11-95e0-b412721d8bf9.jpg?1783905348",
+        "rulings": [
+            {
+                "date": "2025-09-19",
+                "text": "You must follow all normal timing rules when casting Alien Symbiosis using its last ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Amazing Acrobatics
 {
     "name": "Amazing Acrobatics",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -2983,6 +2983,83 @@
     ]
 }
 
+// SP//dr, Piloted by Peni
+{
+    "name": "SP//dr, Piloted by Peni",
+    "manaCost": "{3}{W}{U}",
+    "typeLine": "Legendary Artifact Creature — Spider Hero",
+    "oracleText": "Vigilance\nWhen SP//dr enters, put a +1/+1 counter on target creature.\nWhenever a modified creature you control deals combat damage to a player, draw a card. (Equipment, Auras you control, and counters are modifications.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsModified"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Toni Infante",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c47c1d83-e76d-4939-9ed6-05a9e709dea1.jpg?1783905311"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Savage Mansion
 {
     "name": "Savage Mansion",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -344,6 +344,15 @@ class CastSpellHandler(
             if (linkedCostError != null) return linkedCostError
         }
 
+        // Validate a self-referential MayCastSelfFromZones grant's additional cost (e.g. Alien
+        // Symbiosis: "cast this from your graveyard by discarding a card").
+        val mayCastFromZoneAbility = zoneResolver.findMayCastSelfFromZoneAbility(state, action.playerId, action.cardId)
+        val mayCastFromZoneAdditionalCost = mayCastFromZoneAbility?.additionalCost
+        if (mayCastFromZoneAdditionalCost != null) {
+            val zoneCostError = validateAdditionalCosts(state, listOf(mayCastFromZoneAdditionalCost), action)
+            if (zoneCostError != null) return zoneCostError
+        }
+
         // Validate runtime additional costs from PlayWithAdditionalCostComponent (e.g., The Infamous Cruelclaw)
         val runtimeAdditionalCostComponent = state.getEntity(action.cardId)
             ?.get<PlayWithAdditionalCostComponent>()
@@ -2149,6 +2158,11 @@ class CastSpellHandler(
             // "remove three counters from among creatures you control")
             val linkedGranter = zoneResolver.findLinkedExileGranter(currentState, action.playerId, action.cardId)
             linkedGranter?.additionalCost?.let { add(it) }
+
+            // Self-referential MayCastSelfFromZones grant's additional cost (e.g. Alien
+            // Symbiosis' "by discarding a card")
+            zoneResolver.findMayCastSelfFromZoneAbility(currentState, action.playerId, action.cardId)
+                ?.additionalCost?.let { add(it) }
         }
 
         val flattenedAllCosts = reduceChoiceCosts(allAdditionalCosts, currentState, action.playerId, action.additionalCostPayment)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -131,16 +131,29 @@ class CastZoneResolver(
         state: GameState,
         playerId: EntityId,
         cardId: EntityId
-    ): Boolean {
-        val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return false
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return false
+    ): Boolean = findMayCastSelfFromZoneAbility(state, playerId, cardId) != null
+
+    /**
+     * Locate the [MayCastSelfFromZones] ability (if any) that currently permits casting [cardId]
+     * from its present zone for [playerId] — honoring the zone match and optional [Condition] gate.
+     * Callers that need the ability's [MayCastSelfFromZones.additionalCost] (e.g. Alien Symbiosis'
+     * "by discarding a card") use this overload; [hasMayCastSelfFromZonePermission] is the boolean
+     * convenience wrapper.
+     */
+    fun findMayCastSelfFromZoneAbility(
+        state: GameState,
+        playerId: EntityId,
+        cardId: EntityId
+    ): MayCastSelfFromZones? {
+        val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return null
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return null
 
         // A permission applies if the card is currently in one of its named zones for this player
         // AND its optional condition (e.g. Undead Sprinter's "a non-Zombie creature died this turn")
         // holds — mirroring the enumerator gate so the authorization can't outlive the permission.
         return cardDef.script.staticAbilities
             .filterIsInstance<MayCastSelfFromZones>()
-            .any { ability ->
+            .firstOrNull { ability ->
                 val inNamedZone = ability.zones.any { zone ->
                     cardId in state.getZone(ZoneKey(playerId, zone))
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -901,6 +901,16 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     )
                     info to canPay
                 }
+                is CostAtom.Discard -> {
+                    val handCards = state.getZone(ZoneKey(playerId, Zone.HAND))
+                    val info = AdditionalCostData(
+                        description = additionalCost.description,
+                        costType = "DiscardCard",
+                        validDiscardTargets = handCards.toList(),
+                        discardCount = atom.count
+                    )
+                    info to (handCards.size >= atom.count)
+                }
                 else -> AdditionalCostData(
                     description = additionalCost.description,
                     costType = "Other"
@@ -939,9 +949,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 // The card grants its own cast-from-zone permission only if some MayCastSelfFromZones
                 // names this zone AND its optional condition (e.g. Undead Sprinter's "a non-Zombie
                 // creature died this turn") currently holds in the casting player's context.
-                val hasCastFromZone = cardDef.script.staticAbilities
+                val zoneCastAbility = cardDef.script.staticAbilities
                     .filterIsInstance<MayCastSelfFromZones>()
-                    .any { ability ->
+                    .firstOrNull { ability ->
                         zone in ability.zones && (ability.condition == null ||
                             context.conditionEvaluator.evaluate(
                                 state,
@@ -951,10 +961,16 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 )
                             ))
                     }
-                if (!hasCastFromZone) continue
+                if (zoneCastAbility == null) continue
 
                 // Only non-land spells (Squee is a creature)
                 if (cardComponent.typeLine.isLand) continue
+
+                // Additional cost bundled with the permission (e.g. Alien Symbiosis: "by
+                // discarding a card in addition to paying its other costs").
+                val (zoneAdditionalCostInfo, canPayZoneAdditionalCost) = buildLinkedExileAdditionalCostInfo(
+                    state, playerId, zoneCastAbility.additionalCost, context.costUtils
+                )
 
                 val sourceZoneName = zone.name
                 if (context.cantCastSpell(cardId)) {
@@ -965,7 +981,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                             action = CastSpell(playerId, cardId),
                             affordable = false,
                             manaCostString = cardComponent.manaCost.toString(),
-                            sourceZone = sourceZoneName
+                            sourceZone = sourceZoneName,
+                            additionalCostInfo = zoneAdditionalCostInfo
                         )
                     )
                 } else {
@@ -977,7 +994,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     val costString = effectiveCost.toString()
                     val canAfford = context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
 
-                    if (hasCorrectTiming && meetsRestrictions && canAfford) {
+                    if (hasCorrectTiming && meetsRestrictions && canAfford && canPayZoneAdditionalCost) {
                         val targetReqs = buildList {
                             addAll(cardDef.script.targetRequirements)
                             cardDef.script.auraTarget?.let { add(it) }
@@ -1003,7 +1020,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                         xConstrainsTargetManaValue = firstInfo.xConstrainsManaValue,
                                         xConstrainsTargetCount = firstInfo.xConstrainsCount,
                                         manaCostString = costString,
-                                        sourceZone = sourceZoneName
+                                        sourceZone = sourceZoneName,
+                                        additionalCostInfo = zoneAdditionalCostInfo
                                     )
                                 )
                             }
@@ -1014,7 +1032,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                     description = "Cast ${cardComponent.name}",
                                     action = CastSpell(playerId, cardId),
                                     manaCostString = costString,
-                                    sourceZone = sourceZoneName
+                                    sourceZone = sourceZoneName,
+                                    additionalCostInfo = zoneAdditionalCostInfo
                                 )
                             )
                         }
@@ -1026,7 +1045,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 action = CastSpell(playerId, cardId),
                                 affordable = false,
                                 manaCostString = costString,
-                                sourceZone = sourceZoneName
+                                sourceZone = sourceZoneName,
+                                additionalCostInfo = zoneAdditionalCostInfo
                             )
                         )
                     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlienSymbiosisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlienSymbiosisScenarioTest.kt
@@ -1,0 +1,158 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alien Symbiosis (SPM #50) — {1}{B} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  Enchanted creature gets +1/+1, has menace, and is a Symbiote in addition to its other types.
+ *  You may cast this card from your graveyard by discarding a card in addition to paying its
+ *  other costs."
+ *
+ * Exercises:
+ *  - the Aura's continuous +1/+1 / menace / Symbiote-subtype grant while attached; and
+ *  - the self cast-from-graveyard permission bundled with a discard-a-card additional cost
+ *    (`MayCastSelfFromZones(GRAVEYARD, additionalCost = Costs.additional.DiscardCards(1))`).
+ */
+class AlienSymbiosisScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun canCastFromGraveyard(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+        // affordable == false covers both "can't pay the mana cost" and "can't pay the bundled
+        // additional cost" (e.g. no card left in hand to discard) — the enumerator still emits a
+        // LegalAction in that case, just marked unaffordable.
+        return actions.any {
+            it.sourceZone == "GRAVEYARD" && it.affordable && (it.action as? CastSpell)?.cardId == cardId
+        }
+    }
+
+    test("enchanted creature gets +1/+1, menace, and becomes a Symbiote in addition to its other types") {
+        val d = newDriver()
+        val you = d.player1
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val aura = d.putCardInHand(you, "Alien Symbiosis")
+        d.giveMana(you, Color.BLACK, 2)
+        d.castSpell(you, aura, targets = listOf(bear))
+        d.bothPass()
+
+        val projected = d.state.projectedState
+        projector.getProjectedPower(d.state, bear) shouldBe 3 // base 2 + 1
+        projector.getProjectedToughness(d.state, bear) shouldBe 3 // base 2 + 1
+        projected.hasKeyword(bear, Keyword.MENACE) shouldBe true
+        projected.hasSubtype(bear, "Symbiote") shouldBe true
+        // Kept its original creature type (added to, not replaced).
+        projected.hasSubtype(bear, "Bear") shouldBe true
+    }
+
+    test("castable from the graveyard by discarding a card, in addition to paying its mana cost") {
+        val d = newDriver()
+        val you = d.player1
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val aura = d.putCardInGraveyard(you, "Alien Symbiosis")
+        val fodder = d.putCardInHand(you, "Grizzly Bears")
+        d.giveMana(you, Color.BLACK, 2)
+
+        canCastFromGraveyard(d, you, aura) shouldBe true
+
+        val result = d.submit(
+            CastSpell(
+                playerId = you,
+                cardId = aura,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.FromPool,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(fodder))
+            )
+        )
+        result.isSuccess shouldBe true
+        d.bothPass()
+
+        // Resolved onto the battlefield attached to the bear.
+        val resolvedAura = d.findPermanent(you, "Alien Symbiosis")
+        (resolvedAura != null) shouldBe true
+        val projected = d.state.projectedState
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+        projected.hasKeyword(bear, Keyword.MENACE) shouldBe true
+        // The discarded fodder card actually left the hand and landed in the graveyard.
+        d.state.getZone(ZoneKey(you, Zone.GRAVEYARD)).contains(fodder) shouldBe true
+    }
+
+    test("casting from the graveyard fails without a card in hand to discard") {
+        val d = newDriver()
+        val you = d.player1
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val aura = d.putCardInGraveyard(you, "Alien Symbiosis")
+        d.giveMana(you, Color.BLACK, 2)
+
+        // Empty the starting hand (dealt by initMirrorMatch) — no cards left to discard.
+        val handZone = ZoneKey(you, Zone.HAND)
+        val handCards = d.state.getZone(handZone).toList()
+        d.replaceState(handCards.fold(d.state) { s, cardId -> s.removeFromZone(handZone, cardId) })
+        d.state.getZone(handZone).size shouldBe 0
+
+        canCastFromGraveyard(d, you, aura) shouldBe false
+
+        val result = d.submit(
+            CastSpell(
+                playerId = you,
+                cardId = aura,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.FromPool,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = emptyList())
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("cast normally from hand: still costs {1}{B}, no discard required") {
+        val d = newDriver()
+        val you = d.player1
+
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val aura = d.putCardInHand(you, "Alien Symbiosis")
+        d.giveMana(you, Color.BLACK, 2)
+
+        val handSizeBefore = d.state.getZone(ZoneKey(you, Zone.HAND)).size
+        d.castSpell(you, aura, targets = listOf(bear))
+        d.bothPass()
+
+        val handSizeAfter = d.state.getZone(ZoneKey(you, Zone.HAND)).size
+        // Only the Aura itself left the hand (cast normally) — no additional discard.
+        handSizeAfter shouldBe handSizeBefore - 1
+
+        val projected = d.state.projectedState
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+        projected.hasSubtype(bear, "Symbiote") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SPDrPilotedByPeniScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SPDrPilotedByPeniScenarioTest.kt
@@ -121,6 +121,11 @@ class SPDrPilotedByPeniScenarioTest : FunSpec({
         val handSizeBeforeCombat = driver.getHandSize(p1)
 
         driver.declareAttackers(p1, listOf(spdr, plainBear), p2)
+
+        // Vigilance: SP//dr attacked without tapping; the vanilla bear (no vigilance) is tapped.
+        driver.isTapped(spdr) shouldBe false
+        driver.isTapped(plainBear) shouldBe true
+
         // Actually advance through declare blockers + the combat damage step (resolveStack()
         // alone is a no-op here — right after declaring attackers there's nothing on the stack
         // yet; the trigger only appears once damage is dealt).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SPDrPilotedByPeniScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SPDrPilotedByPeniScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * SP//dr, Piloted by Peni (SPM) — {3}{W}{U} Legendary Artifact Creature 4/4.
+ *
+ *  "Vigilance
+ *   When SP//dr enters, put a +1/+1 counter on target creature.
+ *   Whenever a modified creature you control deals combat damage to a player, draw a card."
+ *
+ * Two independent pieces to prove:
+ *  1. The ETB trigger targets *any* creature (including an opponent's) and puts a counter on it.
+ *  2. The combat-damage trigger only fires for a *modified* creature you control — an unmodified
+ *     creature dealing combat damage to a player does not draw a card, but a modified one does
+ *     (whether the modification is SP//dr's own counter, or a counter placed on another creature).
+ */
+class SPDrPilotedByPeniScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Cast SP//dr from hand, paying its {3}{W}{U} cost from a freshly-filled mana pool. */
+    fun GameTestDriver.castSPDr(playerId: EntityId): EntityId {
+        val spdrCard = putCardInHand(playerId, "SP//dr, Piloted by Peni")
+        giveColorlessMana(playerId, 3)
+        giveMana(playerId, Color.WHITE, 1)
+        giveMana(playerId, Color.BLUE, 1)
+        castSpell(playerId, spdrCard).isSuccess shouldBe true
+        bothPass() // resolve the creature spell itself; the ETB trigger goes on the stack next
+        return findPermanent(playerId, "SP//dr, Piloted by Peni")!!
+    }
+
+    /** Fully resolve the stack, resolving every triggered ability that lands on it. */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    /** Pass priority until a target-selection decision appears (or the stack empties). */
+    fun GameTestDriver.advanceToTargetDecision() {
+        var guard = 0
+        while (guard++ < 20) {
+            if (pendingDecision is ChooseTargetsDecision) return
+            if (state.stack.isNotEmpty() || state.priorityPlayerId != null) bothPass() else break
+        }
+    }
+
+    fun GameTestDriver.advanceToOwnDeclareAttackers(owner: EntityId) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        var safety = 0
+        while (activePlayer != owner && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.DECLARE_ATTACKERS)
+            safety++
+        }
+    }
+
+    test("ETB trigger puts a +1/+1 counter on target creature, including an opponent's") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opposingBear = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        driver.castSPDr(p1)
+
+        // The creature spell resolves, then the ETB trigger goes on the stack and resolving
+        // it prompts target selection.
+        driver.advanceToTargetDecision()
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        val legalTargets = decision.legalTargets.values.flatten().toSet()
+        legalTargets.contains(opposingBear) shouldBe true
+
+        driver.submitTargetSelection(p1, listOf(opposingBear))
+        driver.resolveStack()
+
+        driver.state.getEntity(opposingBear)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+    }
+
+    test("only a modified creature dealing combat damage to a player draws a card") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spdr = driver.castSPDr(p1)
+        driver.advanceToTargetDecision()
+        // Put the ETB counter on SP//dr itself, making it modified.
+        driver.submitTargetSelection(p1, listOf(spdr))
+        driver.resolveStack()
+        driver.removeSummoningSickness(spdr)
+
+        // An unmodified vanilla creature that will also attack.
+        val plainBear = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.removeSummoningSickness(plainBear)
+
+        driver.advanceToOwnDeclareAttackers(p1)
+        val handSizeBeforeCombat = driver.getHandSize(p1)
+
+        driver.declareAttackers(p1, listOf(spdr, plainBear), p2)
+        // Actually advance through declare blockers + the combat damage step (resolveStack()
+        // alone is a no-op here — right after declaring attackers there's nothing on the stack
+        // yet; the trigger only appears once damage is dealt).
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // SP//dr (modified, +1/+1 counter) draws a card; the plain bear does not.
+        driver.getHandSize(p1) shouldBe handSizeBeforeCombat + 1
+    }
+
+    test("a creature that becomes modified via an unrelated counter also triggers the draw") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Create the bear *before* casting SP//dr so it's already on the battlefield (and thus a
+        // legal target) by the time the ETB trigger's target decision is generated.
+        val bear = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+
+        driver.castSPDr(p1)
+        driver.advanceToTargetDecision()
+
+        // Send the ETB counter onto the bear instead, making it modified.
+        driver.submitTargetSelection(p1, listOf(bear))
+        driver.resolveStack()
+        driver.removeSummoningSickness(bear)
+
+        driver.advanceToOwnDeclareAttackers(p1)
+        val handSizeBeforeCombat = driver.getHandSize(p1)
+
+        driver.declareAttackers(p1, listOf(bear), p2)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.getHandSize(p1) shouldBe handSizeBeforeCombat + 1
+    }
+})


### PR DESCRIPTION
# Implement SPM AUTOGEN tier + generalize `MayCastSelfFromZones` additional costs

## Summary

Implements the *Marvel's Spider-Man* (SPM) AUTOGEN-tier cards flagged by the mtgish coverage tooling —
the full-art basic land variants and two spells — plus the one small SDK/engine extension the hardest
card needed. The only non-authoring work is **Alien Symbiosis**, whose "cast from your graveyard by
discarding a card in addition to paying its other costs" clause generalized `MayCastSelfFromZones` to
carry an optional additional cost, wired end-to-end through the cast-from-zone machinery rather than as a
one-off.

## Cards (`mtg-sets`)

| Card | Cost | P/T / Type | Behavior |
|------|------|------------|----------|
| **SP//dr, Piloted by Peni** | {3}{W}{U} | 4/4 Legendary Artifact Creature — Spider Hero | Vigilance. ETB: put a +1/+1 counter on target creature. Whenever a **modified** creature you control deals combat damage to a player, draw a card. |
| **Alien Symbiosis** | {1}{B} | Enchantment — Aura | Enchant creature; enchanted creature gets +1/+1, has menace, and is a Symbiote in addition to its other types. May be cast from your graveyard by discarding a card in addition to its other costs. |
| **Basic lands** | — | Basic Land | Full-art Plains/Island/Swamp/Mountain/Forest, two art variants each (collector numbers 189–198), registered via `basicLand()` + `CardDiscovery`. |

- **SP//dr** models the modified-creature trigger with the existing `StatePredicate.IsModified` filter on
  a combat-damage trigger (`TriggerBinding.ANY`, any-player recipient), and the ETB counter as a
  targeted `AddCountersEffect`.
- **Alien Symbiosis** is composed from `ModifyStats` + `GrantKeyword(MENACE)` + `GrantSubtype("Symbiote")`
  static abilities over `Filters.EnchantedCreature`, plus the new `MayCastSelfFromZones(..., additionalCost = Costs.additional.DiscardCards(1))`.
  Canonical placement was verified with `check-card-printing.py`: an earlier `om1` (Through the
  Omenpaths) printing exists but is a digital-only set already in the script's `IGNORED_SET_CODES`, so
  SPM correctly stays canonical.

## SDK (`mtg-sdk`)

- **`MayCastSelfFromZones` gained an optional `additionalCost: AdditionalCost?`** field (mirroring
  `GrantMayCastFromLinkedExile.additionalCost`'s existing shape). When non-null, casting through the
  permission requires paying that cost alongside the card's normal mana cost; the ability's
  `description` and `applyTextReplacement` were updated to thread it through. Default `null` preserves
  the Squee / Gravecrawler / Undead Sprinter shapes unchanged.

## Engine (`rules-engine`)

- **`CastZoneResolver.findMayCastSelfFromZoneAbility`** — new accessor returning the *matched*
  `MayCastSelfFromZones` ability (honoring zone match + optional condition gate) so callers can read its
  `additionalCost`. The existing `hasMayCastSelfFromZonePermission` boolean is now a thin wrapper over it
  (`… != null`), and the internal scan switched `.any { }` → `.firstOrNull { }`.
- **`CastSpellHandler`** — validates the grant's additional cost (via `validateAdditionalCosts`) and
  collects it alongside the other additional-cost sources when authorizing the cast.
- **`CastFromZoneEnumerator.enumerateIntrinsicZoneCast`** — surfaces the additional cost to legal-action
  enumeration through the same `AdditionalCostData` / linked-exile plumbing (including a `DiscardCard`
  rendering with valid discard targets for the UI).

## Tests

- `SPDrPilotedByPeniScenarioTest` (4 assertions): ETB counter targets any creature including an
  opponent's; only a **modified** creature dealing combat damage to a player draws; a creature made
  modified via an *unrelated* counter also triggers the draw; and (added in a follow-up audit pass)
  SP//dr stays untapped after attacking (**Vigilance**) while a vanilla attacker taps normally.
- `AlienSymbiosisScenarioTest` (3 assertions): the enchanted creature gets +1/+1, menace, and the
  Symbiote type in addition to its others; cast-from-graveyard succeeds by discarding a card in addition
  to paying {1}{B}; fails with no card in hand to discard; and casting normally from hand still costs
  {1}{B} with no discard required.
- `SPM.json` `CardDefinitionSnapshotTest` golden re-blessed — clean pure-addition diffs for the new
  cards.

## Docs

- `docs/card-sdk-language-reference.md`: `MayCastSelfFromZones` entry updated to document the new
  `additionalCost` parameter, the Alien Symbiosis example, and the `CastZoneResolver` /
  `CastSpellHandler` / `CastFromZoneEnumerator` wiring.

## Verification

- `CardDefinitionSnapshotTest` and `CardLintTest` pass against the re-blessed golden.
- All 7 scenario assertions across the two cards pass.
- Rebased cleanly onto current `main` (no conflicts); SPM backlog checklist reads **89 / 190**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
