### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SaviorOfTheSleeping.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SaviorOfTheSleeping.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Savior of the Sleeping
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/3
+ *
+ * Vigilance
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, put a
+ * +1/+1 counter on this creature.
+ *
+ * Same trigger shape as Wicked Visitor: any enchantment you control hitting the graveyard from
+ * the battlefield — destroyed, sacrificed, self-sacrificing (Hopeless Nightmare), or a Role token
+ * falling off when replaced — so it uses the generic `leavesBattlefield` factory with an `ANY`
+ * binding rather than the SELF-bound named constants.
+ */
+val SaviorOfTheSleeping = card("Savior of the Sleeping") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "Whenever an enchantment you control is put into a graveyard from the battlefield, " +
+        "put a +1/+1 counter on this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Valera Lutfullina"
+        flavorText = "Even lost in slumber, the citizens of Ardenvale dream of a tireless " +
+            "protector standing guard over their homes."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1783915126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpitefulHexmage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpitefulHexmage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spiteful Hexmage
+ * {B}
+ * Creature — Human Warlock
+ * 3/2
+ *
+ * When this creature enters, create a Cursed Role token attached to target creature you control.
+ * (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)
+ *
+ * A 3/2 for one whose drawback is self-inflicted: the Cursed Role sets a creature you control to
+ * base 1/1, so the Hexmage usually curses itself. The oracle text says "target creature you
+ * control" (not "another"), so [Targets.CreatureYouControl] is correct — the Hexmage is a legal
+ * target for its own trigger. The one-Role-per-creature rule (CR 704.5s) lives in the Role token
+ * machinery behind [Effects.CreateRoleToken].
+ */
+val SpitefulHexmage = card("Spiteful Hexmage") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, create a Cursed Role token attached to target " +
+        "creature you control. (If you control another Role on it, put that one into the " +
+        "graveyard. Enchanted creature is 1/1.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateRoleToken("Cursed Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "108"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Who'll never amount to anything now, Father?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1783915102"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SuccumbToTheCold.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SuccumbToTheCold.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Succumb to the Cold
+ * {2}{U}
+ * Instant
+ *
+ * Tap one or two target creatures an opponent controls. Put a stun counter on each of them.
+ * (If a permanent with a stun counter would become untapped, remove one from it instead.)
+ *
+ * "One or two target" is `TargetCreature(count = 2, minCount = 1)`; the tap-and-stun rider runs
+ * per chosen target via [ForEachTargetEffect], so a target that has become illegal by resolution
+ * is simply skipped rather than fizzling the whole spell.
+ */
+val SuccumbToTheCold = card("Succumb to the Cold") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Tap one or two target creatures an opponent controls. Put a stun counter on " +
+        "each of them. (If a permanent with a stun counter would become untapped, remove one " +
+        "from it instead.)"
+
+    spell {
+        target = TargetCreature(
+            count = 2,
+            minCount = 1,
+            filter = TargetFilter.Creature.opponentControls()
+        )
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.Tap(EffectTarget.ContextTarget(0)),
+                AddCountersEffect(
+                    counterType = Counters.STUN,
+                    count = 1,
+                    target = EffectTarget.ContextTarget(0)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Andrew Mar"
+        flavorText = "\"I've never known cold like it. It burned like fire and bit like an adder's " +
+            "fangs. Call me a coward if you wish, but I won't go back there.\"\n" +
+            "—Syr Lydel, knight of Vantress"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1783915114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TanglespanLookout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TanglespanLookout.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Tanglespan Lookout
+ * {2}{G}
+ * Creature — Satyr
+ * 2/3
+ *
+ * Whenever an Aura you control enters, draw a card.
+ *
+ * The trigger fires once per Aura, so it uses the generic `entersBattlefield` factory with an
+ * `ANY` binding rather than one of the SELF-bound constants. WOE's Role tokens are
+ * "Enchantment — Aura Role" tokens, so they match this filter too — that's the card's main
+ * payoff in limited.
+ */
+val TanglespanLookout = card("Tanglespan Lookout") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Satyr"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever an Aura you control enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.withSubtype(Subtype.AURA).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "188"
+        artist = "Dmitry Burmak"
+        flavorText = "\"The trolls have your scent, traveler. Hurry on, and let me take care of them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg?1783915077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/UpTheBeanstalk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/UpTheBeanstalk.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Up the Beanstalk
+ * {1}{G}
+ * Enchantment
+ *
+ * When this enchantment enters and whenever you cast a spell with mana value 5 or greater,
+ * draw a card.
+ *
+ * Printed as a single sentence, but it is two separate triggered abilities (CR 603.1) — an
+ * enters trigger and a cast trigger — so it follows the repo's "enters or attacks" idiom of one
+ * `triggeredAbility` block per condition. The cast trigger fires on *cast*, not on resolution,
+ * so it still draws if the spell is countered.
+ */
+val UpTheBeanstalk = card("Up the Beanstalk") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters and whenever you cast a spell with mana value 5 " +
+        "or greater, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Any.manaValueAtLeast(5))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Lucas Graciano"
+        flavorText = "\"It's not so bad. All you have to do is keep from looking down.\"\n" +
+            "—Troyan, to Kellan and Ruby"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg?1783915075"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3981,6 +3981,50 @@
     ]
 }
 
+// Savior of the Sleeping
+{
+    "name": "Savior of the Sleeping",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Valera Lutfullina",
+        "flavorText": "Even lost in slumber, the citizens of Ardenvale dream of a tireless protector standing guard over their homes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1783915126"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scarecrow Guide
 {
     "name": "Scarecrow Guide",
@@ -4470,6 +4514,54 @@
     ]
 }
 
+// Spiteful Hexmage
+{
+    "name": "Spiteful Hexmage",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "When this creature enters, create a Cursed Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Cursed Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Who'll never amount to anything now, Father?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1783915102"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Stingblade Assassin
 {
     "name": "Stingblade Assassin",
@@ -4755,6 +4847,61 @@
     ]
 }
 
+// Succumb to the Cold
+{
+    "name": "Succumb to the Cold",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Tap one or two target creatures an opponent controls. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "AddCounters",
+                        "counterType": "stun",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "\"I've never known cold like it. It burned like fire and bit like an adder's fangs. Call me a coward if you wish, but I won't go back there.\"\n—Syr Lydel, knight of Vantress",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1783915114"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sugar Rush
 {
     "name": "Sugar Rush",
@@ -4865,6 +5012,48 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Tanglespan Lookout
+{
+    "name": "Tanglespan Lookout",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Satyr",
+    "oracleText": "Whenever an Aura you control enters, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment Aura ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "UNCOMMON",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"The trolls have your scent, traveler. Hurry on, and let me take care of them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3bc5c32d-be0a-4a5f-a8c7-9767a895bc76.jpg?1783915077"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -5138,6 +5327,64 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Up the Beanstalk
+{
+    "name": "Up the Beanstalk",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters and whenever you cast a spell with mana value 5 or greater, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtLeast",
+                                "min": 5
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"It's not so bad. All you have to do is keep from looking down.\"\n—Troyan, to Kellan and Ruby",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d5e991f-23b2-4db0-a452-7755125b1fd2.jpg?1783915075"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch4ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch4ScenarioTest.kt
@@ -1,0 +1,225 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the fourth batch of Wilds of Eldraine cards:
+ *
+ *  - Tanglespan Lookout ({2}{G} 2/3) — draws a card whenever an Aura you control enters
+ *    (Role tokens are Auras, so they count).
+ *  - Up the Beanstalk ({1}{G}) — draws on enter and on each mana value 5+ spell you cast.
+ *  - Succumb to the Cold ({2}{U}) — taps one or two target creatures an opponent controls and
+ *    puts a stun counter on each.
+ *  - Savior of the Sleeping ({2}{W} 2/3, vigilance) — grows when an enchantment you control
+ *    hits the graveyard from the battlefield.
+ *  - Spiteful Hexmage ({B} 3/2) — enters with a Cursed Role for a creature you control.
+ */
+class WoeCardsBatch4ScenarioTest : ScenarioTestBase() {
+
+    private fun stunCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.get<TappedComponent>() != null
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Tanglespan Lookout — an Aura you control entering draws a card") {
+            test("a Role token created by another spell triggers the draw") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tanglespan Lookout", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Monstrous Rage")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Monstrous Rage", bear).error shouldBe null
+                game.resolveStack()
+
+                withClue("Monstrous Rage's Monster Role is an Aura, so the Lookout draws a card") {
+                    (game.findPermanent("Monster Role") != null) shouldBe true
+                    // -1 for the Monstrous Rage that left hand, +1 for the Lookout's draw.
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+
+        context("Up the Beanstalk — draws on enter and on expensive spells") {
+            test("entering draws one card, then a mana value 6 spell draws another") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Up the Beanstalk")
+                    .withCardInHand(1, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Up the Beanstalk").error shouldBe null
+                game.resolveStack()
+
+                withClue("Beanstalk left hand (-1) and its enters trigger drew a card (+1)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+
+                game.castSpell(1, "Craw Wurm").error shouldBe null
+                game.resolveStack()
+
+                withClue("Craw Wurm is mana value 6, so casting it drew another card") {
+                    // Craw Wurm left hand (-1), the cast trigger drew (+1).
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+
+        context("Succumb to the Cold — taps one or two creatures and stuns them") {
+            test("two targets are each tapped with a stun counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Succumb to the Cold")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+                val spell = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Succumb to the Cold"
+                }
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(wurm))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("both targets tapped") {
+                    isTapped(game, bears) shouldBe true
+                    isTapped(game, wurm) shouldBe true
+                }
+                withClue("one stun counter each") {
+                    stunCounters(game, bears) shouldBe 1
+                    stunCounters(game, wurm) shouldBe 1
+                }
+            }
+
+            test("a single target is legal — minCount is 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Succumb to the Cold")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Succumb to the Cold", bears).error shouldBe null
+                game.resolveStack()
+
+                isTapped(game, bears) shouldBe true
+                stunCounters(game, bears) shouldBe 1
+            }
+        }
+
+        context("Savior of the Sleeping — grows when your enchantments die") {
+            test("a Role token falling off the battlefield adds a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Savior of the Sleeping", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Castle")
+                    .withCardInHand(1, "Disenchant")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val savior = game.findPermanent("Savior of the Sleeping")!!
+                plusOneCounters(game, savior) shouldBe 0
+
+                // Castle is a plain static enchantment (no death trigger of its own), so
+                // Disenchanting it isolates the Savior's trigger.
+                game.castSpell(1, "Disenchant", game.findPermanent("Castle")!!).error shouldBe null
+                game.resolveStack()
+
+                withClue("an enchantment you control hit the graveyard from the battlefield") {
+                    plusOneCounters(game, savior) shouldBe 1
+                }
+                withClue("2/3 base plus one +1/+1 counter") {
+                    game.state.projectedState.getPower(savior) shouldBe 3
+                    game.state.projectedState.getToughness(savior) shouldBe 4
+                }
+            }
+        }
+
+        context("Spiteful Hexmage — enters with a Cursed Role") {
+            test("the Cursed Role sets the enchanted creature to base 1/1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spiteful Hexmage")
+                    .withCardOnBattlefield(1, "Craw Wurm", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castSpell(1, "Spiteful Hexmage").error shouldBe null
+                game.resolveStack() // Hexmage enters -> ETB trigger asks for its target
+
+                game.selectTargets(listOf(wurm)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Cursed Role token was created") {
+                    (game.findPermanent("Cursed Role") != null) shouldBe true
+                }
+                withClue("Cursed Role sets base P/T to 1/1, overriding the Wurm's 6/4") {
+                    game.state.projectedState.getPower(wurm) shouldBe 1
+                    game.state.projectedState.getToughness(wurm) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five WOE cards. All of them compose existing SDK primitives — **no engine or SDK changes**.

| Card | Cost | Shape |
|---|---|---|
| Tanglespan Lookout | `{2}{G}` | `Triggers.entersBattlefield` filtered to Auras you control, `ANY` binding → draw. WOE's Role tokens are Auras, so they feed it. |
| Up the Beanstalk | `{1}{G}` | Printed as one sentence, but two triggered abilities (CR 603.1): an enters trigger + `Triggers.youCastSpell(manaValueAtLeast(5))`. The cast trigger fires on cast, so it still draws if the spell is countered. |
| Succumb to the Cold | `{2}{U}` | `TargetCreature(count = 2, minCount = 1)` with a per-target tap + stun rider via `ForEachTargetEffect`, so an illegal target is skipped rather than fizzling the spell. |
| Savior of the Sleeping | `{2}{W}` | Wicked Visitor's `leavesBattlefield(Enchantment.youControl(), to = GRAVEYARD, ANY)` trigger shape, paying off with a +1/+1 counter on itself. |
| Spiteful Hexmage | `{B}` | ETB Cursed Role on **target** creature you control — oracle says "target", not "another target", so the Hexmage is a legal target for its own trigger. |

## Testing

`WoeCardsBatch4ScenarioTest` covers all five (6 tests, all passing):

- Lookout draws off a Monster Role token created by Monstrous Rage.
- Beanstalk draws on enter, then again off a mana-value-6 cast.
- Succumb to the Cold with two targets (both tapped + stunned) and with one target (proving `minCount = 1`).
- Savior grows when a plain enchantment (Castle) is Disenchanted.
- Hexmage's Cursed Role overrides Craw Wurm's 6/4 to base 1/1.

`:mtg-sets:test` green (card lint, facade boundary, snapshot). WOE snapshot re-blessed — the diff is
additive only, no other card moved. `just check-card-printing` confirms WOE is the canonical
(earliest real) printing for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)