### PR TITLE
Implement Lupine Prototype (EMN) + 4 INR reprint rows

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/LupinePrototype.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/LupinePrototype.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lupine Prototype
+ * {2}
+ * Artifact Creature — Wolf Construct
+ * 5/5
+ *
+ * This creature can't attack or block unless a player has no cards in hand.
+ *
+ * "A player" is existential over every player, not just controller/opponent. `Exists(Player.Any,
+ * Zone.HAND, negate = true)` is the WRONG shape for this — negating the whole existential yields "no
+ * player among {Any} has a card" (all hands empty), not "some player's hand is empty". The correct
+ * existential-over-players-satisfying-a-per-player-condition primitive is
+ * `Compare(CountPlayersWith(Player.Each, Conditions.EmptyHand), GTE, Fixed(1))`: `CountPlayersWith`
+ * rebinds `Player.You` inside its condition to each candidate player in turn (see
+ * `DynamicAmountEvaluator.CountPlayersWith`), so `Conditions.EmptyHand` (itself `Exists(Player.You,
+ * Zone.HAND, negate = true)`) is evaluated per-player and counted. `CantAttackUnless`/`CantBlockUnless`
+ * route the condition through the standard `ConditionEvaluator`, so this composes unmodified at both
+ * attack- and block-restriction checks.
+ */
+val LupinePrototype = card("Lupine Prototype") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Wolf Construct"
+    oracleText = "This creature can't attack or block unless a player has no cards in hand."
+    power = 5
+    toughness = 5
+
+    val aPlayerHasEmptyHand = Compare(
+        DynamicAmount.CountPlayersWith(Player.Each, Conditions.EmptyHand),
+        ComparisonOperator.GTE,
+        DynamicAmount.Fixed(1)
+    )
+
+    staticAbility {
+        ability = CantAttackUnless(aPlayerHasEmptyHand)
+    }
+    staticAbility {
+        ability = CantBlockUnless(aPlayerHasEmptyHand)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "197"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"Ludevic saw it in a dream and set to work immediately, every detail already known. Can such genius be taught?\"\n—Stitcher Geralf"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg?1783937424"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LupinePrototypeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LupinePrototypeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Lupine Prototype reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val LupinePrototypeReprint = Printing(
+    oracleId = "303f91ae-1acb-4250-a4a5-71207c228dcc",
+    name = "Lupine Prototype",
+    setCode = "INR",
+    collectorNumber = "267",
+    scryfallId = "ae02ff5c-c667-4cb6-8bf4-8532d82c4fbf",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae02ff5c-c667-4cb6-8bf4-8532d82c4fbf.jpg?1783908064",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/OverchargedAmalgamReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/OverchargedAmalgamReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Overcharged Amalgam reprint in INR. Canonical CardDefinition lives in its earliest set (VOW). */
+val OverchargedAmalgamReprint = Printing(
+    oracleId = "d4838305-5392-42b2-81d1-9b9da71b20b1",
+    name = "Overcharged Amalgam",
+    setCode = "INR",
+    collectorNumber = "80",
+    scryfallId = "2fae9b40-a1ee-425d-bbf6-fa4b0861cdc4",
+    artist = "Mike Jordana",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fae9b40-a1ee-425d-bbf6-fa4b0861cdc4.jpg?1783908158",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SplinterfrightReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SplinterfrightReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Splinterfright reprint in INR. Canonical CardDefinition lives in its earliest set (ISD). */
+val SplinterfrightReprint = Printing(
+    oracleId = "e54c6fa9-59ca-47dc-9354-91681228371e",
+    name = "Splinterfright",
+    setCode = "INR",
+    collectorNumber = "217",
+    scryfallId = "d4d5aafc-b1a6-4387-b9bf-59fca23fff94",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d4d5aafc-b1a6-4387-b9bf-59fca23fff94.jpg?1783908094",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TorensFistOfTheAngelsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TorensFistOfTheAngelsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Torens, Fist of the Angels reprint in INR. Canonical CardDefinition lives in its earliest set (VOW). */
+val TorensFistOfTheAngelsReprint = Printing(
+    oracleId = "2cb96408-9195-4e41-ad9a-f8c74fbad083",
+    name = "Torens, Fist of the Angels",
+    setCode = "INR",
+    collectorNumber = "250",
+    scryfallId = "f8566528-ba96-4425-8831-b5d6197da9ae",
+    artist = "Justine Cruz",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8566528-ba96-4425-8831-b5d6197da9ae.jpg?1783908071",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1137,6 +1137,72 @@
     ]
 }
 
+// Lupine Prototype
+{
+    "name": "Lupine Prototype",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Wolf Construct",
+    "oracleText": "This creature can't attack or block unless a player has no cards in hand.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "CountPlayersWith",
+                        "scope": "Each",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Hand",
+                            "negate": true
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "CountPlayersWith",
+                        "scope": "Each",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Hand",
+                            "negate": true
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "RARE",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"Ludevic saw it in a dream and set to work immediately, every detail already known. Can such genius be taught?\"\n—Stitcher Geralf",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd8272ca-8e3d-4980-99f2-352a1db76d74.jpg?1783937424"
+    },
+    "colorIdentityOverride": []
+}
+
 // Midnight Scavengers
 {
     "name": "Midnight Scavengers",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LupinePrototypeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LupinePrototypeScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Lupine Prototype (EMN #197) — {2} Artifact Creature — Wolf Construct, 5/5.
+ *
+ * "This creature can't attack or block unless a player has no cards in hand."
+ *
+ * "A player" is existential over *every* player, not just controller/opponent — modeled with
+ * `Compare(DynamicAmount.CountPlayersWith(Player.Each, Conditions.EmptyHand), GTE, Fixed(1))`
+ * (`Exists(Player.Any, Zone.HAND, negate = true)` is the wrong shape here: negating the whole
+ * existential means "no player has a card," i.e. *every* hand empty, not "some" hand empty).
+ * This test exercises both restrictions (attack and block) and confirms the condition is satisfied
+ * when *either* player (not just the creature's controller) is empty-handed.
+ */
+class LupinePrototypeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lupine Prototype — can't attack or block unless a player has an empty hand") {
+
+            test("cannot attack while both players hold cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lupine Prototype", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("both players have cards in hand — the attack must be rejected") {
+                    game.declareAttackers(mapOf("Lupine Prototype" to 2)).error shouldNotBe null
+                }
+            }
+
+            test("can attack when the controller's own hand is empty") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lupine Prototype", summoningSickness = false)
+                    .withCardInHand(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("controller's hand is empty — the attack is legal") {
+                    game.declareAttackers(mapOf("Lupine Prototype" to 2)).error shouldBe null
+                }
+            }
+
+            test("can attack when only the OPPONENT's hand is empty (existential over any player)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lupine Prototype", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    // Player2's hand is empty.
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("opponent's hand is empty — Player.Any is satisfied and the attack is legal") {
+                    game.declareAttackers(mapOf("Lupine Prototype" to 2)).error shouldBe null
+                }
+            }
+
+            test("cannot block while both players hold cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Lupine Prototype", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInHand(2, "Doom Blade")
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("both players have cards in hand — the block must be rejected") {
+                    game.declareBlockers(mapOf("Lupine Prototype" to listOf("Grizzly Bears"))).error shouldNotBe null
+                }
+            }
+
+            test("can block once a player's hand is empty") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Lupine Prototype", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // Neither player has cards in hand.
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("an empty hand satisfies the condition — the block is legal") {
+                    game.declareBlockers(mapOf("Lupine Prototype" to listOf("Grizzly Bears"))).error shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Implement Lupine Prototype (EMN) + 4 Innistrad Remastered reprint rows

## Summary

Adds one net-new canonical card — **Lupine Prototype** — and four *Innistrad Remastered* (INR)
`Printing(...)` rows.

> **Scope note.** This branch originally implemented Fiend Hunter, Lightning Axe, and Blazing Torch as
> well, but those cards landed independently on `main` (vincent's Innistrad Remastered work,
> `4c1c36859` + `940b64033`) with different SDK shapes while this branch was open. On rebase, our
> versions of those three — plus their reprint rows and scenario tests — were **dropped in favor of
> main's**, leaving only the non-overlapping work below. Reviewers who remember the earlier, larger
> branch should expect those three cards to be absent here.

## Cards (`mtg-sets`)

### Canonical
| Card | Cost | P/T / Type | Behavior | Set |
|------|------|------------|----------|-----|
| **Lupine Prototype** | {2} | 5/5 Artifact Creature — Wolf Construct | Can't attack or block unless a player has no cards in hand. | **EMN** (canonical) |

### INR reprint rows (`Printing(...)`)
| Card | Collector # | Rarity | Canonical lives in |
|------|-------------|--------|--------------------|
| **Lupine Prototype** | 267 | Uncommon | EMN (added in this branch) |
| **Overcharged Amalgam** | 80 | Rare | VOW (already on main) |
| **Splinterfright** | 217 | Uncommon | ISD (already on main) |
| **Torens, Fist of the Angels** | 250 | Rare | VOW (already on main) |

Each reprint is presentation-only data (collector number, artist, image, release date `2025-01-24`)
keyed to its canonical by `oracleId`. All four canonicals already exist on `main` and none had a
competing INR row, so the rows graft on cleanly with no duplicate `(oracleId, setCode, collectorNumber)`
keys.

## Implementation note — Lupine Prototype's attack/block restriction

"This creature can't attack or block unless **a player** has no cards in hand" is *existential over every
player*, not a statement about all hands. The naive `Exists(Player.Any, Zone.HAND, negate = true)` is the
wrong shape — negating the whole existential yields "**no** player has a card" (i.e. *all* hands empty),
not "*some* player's hand is empty." Modeled correctly as:

```
Compare(
    DynamicAmount.CountPlayersWith(Player.Each, Conditions.EmptyHand),
    ComparisonOperator.GTE,
    DynamicAmount.Fixed(1),
)
```

`CountPlayersWith` rebinds `Player.You` inside its condition to each candidate player in turn, so
`Conditions.EmptyHand` (itself `Exists(Player.You, Zone.HAND, negate = true)`) is evaluated per-player and
counted. The same condition is fed to both `CantAttackUnless` and `CantBlockUnless`, which route it
through the standard `ConditionEvaluator` — so it composes unmodified at both the attack- and
block-restriction checks. No new SDK types were needed; this reuses existing primitives.

## Tests

`LupinePrototypeScenarioTest` (4 assertions):
- can attack when the **controller's own** hand is empty;
- can attack when only the **opponent's** hand is empty (proves the existential-over-any-player
  semantics);
- **cannot** block while both players hold cards;
- can block once a player's hand is empty.

`EMN.json` `CardDefinitionSnapshotTest` golden re-blessed — clean pure-addition diff (Lupine Prototype
only, 66 lines).

## Verification

- `CardDefinitionSnapshotTest` and `CardLintTest` pass against the re-blessed EMN golden.
- All 4 Lupine Prototype scenario assertions pass.
- Rebased onto current `main`; the four INR canonicals resolve, with no duplicate reprint keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
