### PR TITLE
Add 4 Foundations cards: Venom Connoisseur, Ayli, Dread Summons, Consuming Aberration

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/DreadSummons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/DreadSummons.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dread Summons
+ * {X}{B}{B}
+ * Sorcery
+ *
+ * Each player mills X cards. For each creature card put into a graveyard this way, you
+ * create a tapped 2/2 black Zombie creature token.
+ *
+ * Pipeline (Saruman of Many Colors pattern): [Patterns.Library.mill] aimed at
+ * [Player.Each] fans out across all players (turn order) and surfaces every milled card
+ * in the "milled" collection; [SelectFromCollectionEffect] with [SelectionMode.All]
+ * auto-filters the creature cards into "milledCreatures"; [ForEachInCollectionEffect]
+ * then creates one tapped Zombie per creature card milled this way. X is read at
+ * resolution time via [DynamicAmount.XValue].
+ */
+val DreadSummons = card("Dread Summons") {
+    manaCost = "{X}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.mill(DynamicAmount.XValue, EffectTarget.PlayerRef(Player.Each)),
+            SelectFromCollectionEffect(
+                from = "milled",
+                selection = SelectionMode.All,
+                filter = GameObjectFilter.Creature,
+                storeSelected = "milledCreatures"
+            ),
+            ForEachInCollectionEffect(
+                "milledCreatures",
+                CreateTokenEffect(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf("Zombie"),
+                    tapped = true,
+                    imageUri = "https://cards.scryfall.io/normal/front/8/f/8ffaa67e-32fa-4843-8858-feed2ebb40df.jpg?1783938021"
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Izzy"
+        flavorText = "\"Did you have a nice nap?\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2c20cb1-3e3d-4fea-b617-bd6d796c8d10.jpg?1783938113"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AyliEternalPilgrimReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AyliEternalPilgrimReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ayli, Eternal Pilgrim reprint in FDN. Canonical CardDefinition lives in OGW
+ * (its earliest real printing).
+ */
+val AyliEternalPilgrimReprint = Printing(
+    oracleId = "e6a35729-edee-4a8c-9aa1-041114d66c69",
+    name = "Ayli, Eternal Pilgrim",
+    setCode = "FDN",
+    collectorNumber = "652",
+    scryfallId = "06969031-2c13-4b5a-bb4e-86eed025e614",
+    artist = "Cynthia Sheppard",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06969031-2c13-4b5a-bb4e-86eed025e614.jpg?1783908914",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ConsumingAberrationReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ConsumingAberrationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Consuming Aberration reprint in FDN. Canonical CardDefinition lives in GTC
+ * (its earliest real printing).
+ */
+val ConsumingAberrationReprint = Printing(
+    oracleId = "9b55fb72-237d-4935-b645-8ebc6eb4140e",
+    name = "Consuming Aberration",
+    setCode = "FDN",
+    collectorNumber = "238",
+    scryfallId = "bc2b28fd-66b0-457c-80ea-7caed2cc7926",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc2b28fd-66b0-457c-80ea-7caed2cc7926.jpg?1783909053",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DreadSummonsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DreadSummonsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dread Summons reprint in FDN. Canonical CardDefinition lives in C15
+ * (its earliest real printing).
+ */
+val DreadSummonsReprint = Printing(
+    oracleId = "642fa01d-025e-44dd-8360-5325e5a28282",
+    name = "Dread Summons",
+    setCode = "FDN",
+    collectorNumber = "604",
+    scryfallId = "dfb5dd33-6e5b-4d78-92fa-678c9f01c606",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/dfb5dd33-6e5b-4d78-92fa-678c9f01c606.jpg?1783908931",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VenomConnoisseurReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VenomConnoisseurReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Venom Connoisseur reprint in FDN. Canonical CardDefinition lives in SNC
+ * (its earliest real printing).
+ */
+val VenomConnoisseurReprint = Printing(
+    oracleId = "03ebc100-68ac-4d53-adc2-d537212f7d31",
+    name = "Venom Connoisseur",
+    setCode = "FDN",
+    collectorNumber = "648",
+    scryfallId = "90f8d876-3697-4359-9f2b-6053682b556c",
+    artist = "Marta Nael",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90f8d876-3697-4359-9f2b-6053682b556c.jpg?1783908915",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/ConsumingAberration.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/ConsumingAberration.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Consuming Aberration
+ * {3}{U}{B}
+ * Creature — Horror
+ * ✶/✶
+ *
+ * Consuming Aberration's power and toughness are each equal to the number of cards in your
+ * opponents' graveyards.
+ * Whenever you cast a spell, each opponent reveals cards from the top of their library until
+ * they reveal a land card, then puts those cards into their graveyard.
+ *
+ * The characteristic-defining P/T is [dynamicStats] with a [DynamicAmount.Count] over all
+ * opponents' graveyards (Soulless One pattern). The spell-cast trigger wraps the
+ * GatherUntilMatch + RevealCollection + MoveCollection pipeline (Sméagol, Helpful Guide
+ * pattern) in [Effects.ForEachPlayer] so each opponent walks and bins their own library —
+ * the revealed cards, land included, go to that opponent's graveyard.
+ */
+val ConsumingAberration = card("Consuming Aberration") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Horror"
+    oracleText = "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\n" +
+        "Whenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard."
+
+    dynamicStats(
+        DynamicAmount.Count(Player.EachOpponent, Zone.GRAVEYARD, GameObjectFilter.Any)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        effect = Effects.ForEachPlayer(
+            Player.EachOpponent,
+            listOf(
+                GatherUntilMatchEffect(
+                    player = Player.You,
+                    filter = GameObjectFilter.Land,
+                    storeMatch = "revealedLand",
+                    storeRevealed = "allRevealed"
+                ),
+                RevealCollectionEffect(from = "allRevealed"),
+                MoveCollectionEffect(
+                    from = "allRevealed",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, player = Player.You)
+                )
+            )
+        )
+        description = "Whenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg?1783940111"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/DreadSummonsNccReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/DreadSummonsNccReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dread Summons reprint in NCC. Canonical CardDefinition lives in C15
+ * (its earliest real printing).
+ */
+val DreadSummonsNccReprint = Printing(
+    oracleId = "642fa01d-025e-44dd-8360-5325e5a28282",
+    name = "Dread Summons",
+    setCode = "NCC",
+    collectorNumber = "249",
+    scryfallId = "5fcac17f-8fdc-4cb2-a4c5-ea44155ce852",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fcac17f-8fdc-4cb2-a4c5-ea44155ce852.jpg?1783923268",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/AyliEternalPilgrim.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/AyliEternalPilgrim.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ayli, Eternal Pilgrim
+ * {W}{B}
+ * Legendary Creature — Kor Cleric
+ * 2/3
+ *
+ * Deathtouch
+ * {1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.
+ * {1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate only if
+ * you have at least 10 life more than your starting life total.
+ *
+ * The life-gain ability reuses [DynamicAmounts.sacrificedToughness] (same shape as Kheru
+ * Dreadmaw). The exile ability is gated with [ActivationRestriction.OnlyIfCondition] on a
+ * [Compare] of your life total against starting-life-total + 10 (same shape as Leyline of
+ * Hope's static ability).
+ */
+val AyliEternalPilgrim = card("Ayli, Eternal Pilgrim") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Kor Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n" +
+        "{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate only if you have at least 10 life more than your starting life total."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = Effects.GainLife(DynamicAmounts.sacrificedToughness())
+        description = "You gain life equal to the sacrificed creature's toughness."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{W}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    left = DynamicAmount.LifeTotal(Player.You),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Add(
+                        DynamicAmount.StartingLifeTotal(Player.You),
+                        DynamicAmount.Fixed(10)
+                    )
+                )
+            )
+        )
+        val t = target("target", Targets.NonlandPermanent)
+        effect = Effects.Exile(t)
+        description = "Exile target nonland permanent."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Cynthia Sheppard"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg?1783937898"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/VenomConnoisseur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/VenomConnoisseur.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.IncrementAbilityResolutionCountEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Venom Connoisseur
+ * {1}{G}
+ * Creature — Human Druid
+ * 2/2
+ *
+ * Alliance — Whenever another creature you control enters, this creature gains deathtouch
+ * until end of turn. If this is the second time this ability has resolved this turn, all
+ * creatures you control gain deathtouch until end of turn.
+ *
+ * The "second time this ability has resolved" clause uses the same pattern as Harvestrite
+ * Host: increment the source's AbilityResolutionCountThisTurnComponent, then gate the
+ * team-wide grant on [Conditions.SourceAbilityResolvedNTimes]. The team-wide grant is a
+ * [Effects.ForEachInGroup] over AllCreaturesYouControl because GrantKeywordExecutor only
+ * handles single targets.
+ */
+val VenomConnoisseur = card("Venom Connoisseur") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 2
+    toughness = 2
+    oracleText = "Alliance — Whenever another creature you control enters, this creature gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+            .then(IncrementAbilityResolutionCountEffect)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(2),
+                    effect = Effects.ForEachInGroup(
+                        GroupFilter.AllCreaturesYouControl,
+                        Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+                    )
+                )
+            )
+        description = "Alliance — Whenever another creature you control enters, this creature gains deathtouch until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Marta Nael"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg?1783923099"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/C15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C15.json
@@ -1,3 +1,79 @@
+// Dread Summons
+{
+    "name": "Dread Summons",
+    "manaCost": "{X}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player mills X cards. For each creature card put into a graveyard this way, you create a tapped 2/2 black Zombie creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": "XValue",
+                                "player": "Each",
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "Each"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "milled",
+                    "selection": "SelectAll",
+                    "filter": "creature",
+                    "storeSelected": "milledCreatures"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "milledCreatures"
+                    },
+                    "body": {
+                        "type": "CreateToken",
+                        "power": 2,
+                        "toughness": 2,
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Zombie"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8ffaa67e-32fa-4843-8858-feed2ebb40df.jpg?1783938021",
+                        "tapped": true
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "flavorText": "\"Did you have a nice nap?\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2c20cb1-3e3d-4fea-b617-bd6d796c8d10.jpg?1783938113"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Oreskos Explorer
 {
     "name": "Oreskos Explorer",

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -264,6 +264,82 @@
     ]
 }
 
+// Consuming Aberration
+{
+    "name": "Consuming Aberration",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.\nWhenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "EachOpponent",
+                "zone": "Graveyard"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "EachOpponent",
+                "zone": "Graveyard"
+            }
+        }
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherUntilMatch",
+                                "filter": "land",
+                                "storeMatch": "revealedLand",
+                                "storeRevealed": "allRevealed"
+                            },
+                            {
+                                "type": "RevealCollection",
+                                "from": "allRevealed"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "allRevealed",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Karl Kopinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6354de66-f7f8-4e33-98d0-52624d3d7828.jpg?1783940111"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Court Street Denizen
 {
     "name": "Court Street Denizen",

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -1,3 +1,129 @@
+// Ayli, Eternal Pilgrim
+{
+    "name": "Ayli, Eternal Pilgrim",
+    "manaCost": "{W}{B}",
+    "typeLine": "Legendary Creature — Kor Cleric",
+    "oracleText": "Deathtouch\n{1}, Sacrifice another creature: You gain life equal to the sacrificed creature's toughness.\n{1}{W}{B}, Sacrifice another creature: Exile target nonland permanent. Activate only if you have at least 10 life more than your starting life total.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Sacrificed",
+                        "numericProperty": "Toughness"
+                    }
+                },
+                "descriptionOverride": "You gain life equal to the sacrificed creature's toughness."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "LifeTotal",
+                                "player": "You"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Add",
+                                "left": {
+                                    "type": "StartingLifeTotal",
+                                    "player": "You"
+                                },
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 10
+                                }
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Exile target nonland permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Cynthia Sheppard",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7b5893d-6df6-4cae-ae70-d02d443d1740.jpg?1783937898"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Expedite
 {
     "name": "Expedite",

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -233,6 +233,76 @@
     ]
 }
 
+// Venom Connoisseur
+{
+    "name": "Venom Connoisseur",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "Alliance — Whenever another creature you control enters, this creature gains deathtouch until end of turn. If this is the second time this ability has resolved this turn, all creatures you control gain deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DEATHTOUCH",
+                            "target": "Self"
+                        },
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 2
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "DEATHTOUCH",
+                                    "target": "Self"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, this creature gains deathtouch until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Marta Nael",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04897d8c-ee05-45eb-80f7-76487dbcc449.jpg?1783923099"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Witness Protection
 {
     "name": "Witness Protection",


### PR DESCRIPTION
Adds four missing Foundations (FDN) cards, each modeled with the `/add-card` flow. All use existing engine building blocks — no new effects, executors, or keywords.

| Card | Canonical set | Notes |
|---|---|---|
| Venom Connoisseur | SNC | Alliance trigger; "second time this ability resolved" reuses the Harvestrite Host resolution-count pattern |
| Ayli, Eternal Pilgrim | OGW | Sac-outlet life gain via `DynamicAmounts.sacrificedToughness`; exile ability gated on life ≥ starting + 10 |
| Dread Summons | C15 | Each-player mill pipeline + one tapped Zombie per milled creature (SelectFromCollection → ForEachInCollection) |
| Consuming Aberration | GTC | CDA via `dynamicStats` opponent-graveyard count; mill-until-land trigger per opponent (Sméagol pattern) |

Each card gets an FDN `Printing` row (Dread Summons also gets its NCC row, flagged by `check-card-printing`). Image URIs verified against Scryfall with HEAD requests; `just check-card-printing` passes for all four; card-definition snapshots re-blessed (additions only for the four cards).

`just build` passes.