### PR TITLE
Fix Whiskervale Forerunner Valiant feedback

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WhiskervaleForerunner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WhiskervaleForerunner.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.conditions.IsYourTurn
 import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -55,13 +56,16 @@ val WhiskervaleForerunner = card("Whiskervale Forerunner") {
                 filter = GameObjectFilter.Creature.manaValueAtMost(3),
                 storeSelected = "kept",
                 storeRemainder = "rest",
+                prompt = "You may reveal a creature card with mana value 3 or less",
                 selectedLabel = "Reveal",
-                remainderLabel = "Put on bottom"
+                remainderLabel = "Put on bottom",
+                showAllCards = true
             ),
             // Rest on bottom in random order
             MoveCollectionEffect(
                 from = "rest",
-                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
             ),
             // If your turn: choose to put on battlefield or hand
             // If not your turn: put in hand

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -21847,8 +21847,10 @@
                             "filter": "creature mv<=3",
                             "storeSelected": "kept",
                             "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card with mana value 3 or less",
                             "selectedLabel": "Reveal",
-                            "remainderLabel": "Put on bottom"
+                            "remainderLabel": "Put on bottom",
+                            "showAllCards": true
                         },
                         {
                             "type": "MoveCollection",
@@ -21857,7 +21859,8 @@
                                 "type": "ToZone",
                                 "zone": "Library",
                                 "placement": "Bottom"
-                            }
+                            },
+                            "order": "Random"
                         },
                         {
                             "type": "Gated",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhiskervaleForerunnerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhiskervaleForerunnerScenarioTest.kt
@@ -63,5 +63,49 @@ class WhiskervaleForerunnerScenarioTest : ScenarioTestBase() {
             game.isOnBattlefield("Grizzly Bears") shouldBe true
             game.state.stack.single() shouldBe polliwallop
         }
+
+        test("Valiant shows all five cards when none can be selected") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Polliwallop")
+                .withCardOnBattlefield(1, "Whiskervale Forerunner")
+                .withCardOnBattlefield(2, "Craw Wurm")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val forerunner = game.findPermanent("Whiskervale Forerunner")!!
+            val opponentCreature = game.findPermanent("Craw Wurm")!!
+            val polliwallop = game.findCardsInHand(1, "Polliwallop").single()
+
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = polliwallop,
+                    targets = listOf(
+                        ChosenTarget.Permanent(forerunner),
+                        ChosenTarget.Permanent(opponentCreature)
+                    )
+                )
+            ).error shouldBe null
+
+            game.resolveStack()
+
+            val decision = game.getPendingDecision() as SelectCardsDecision
+            decision.options shouldBe emptyList()
+            decision.nonSelectableOptions.size shouldBe 5
+            decision.maxSelections shouldBe 0
+
+            game.selectCards(emptyList()).error shouldBe null
+
+            game.state.stack.single() shouldBe polliwallop
+            game.findCardsInLibrary(1, "Forest").size shouldBe 5
+        }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhiskervaleForerunnerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhiskervaleForerunnerScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class WhiskervaleForerunnerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("Polliwallop targeting Whiskervale Forerunner triggers Valiant") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Polliwallop")
+                .withCardOnBattlefield(1, "Whiskervale Forerunner")
+                .withCardOnBattlefield(2, "Craw Wurm")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val forerunner = game.findPermanent("Whiskervale Forerunner")!!
+            val opponentCreature = game.findPermanent("Craw Wurm")!!
+            val polliwallop = game.findCardsInHand(1, "Polliwallop").single()
+
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = polliwallop,
+                    targets = listOf(
+                        ChosenTarget.Permanent(forerunner),
+                        ChosenTarget.Permanent(opponentCreature)
+                    )
+                )
+            ).error shouldBe null
+
+            game.state.stack.size shouldBe 2
+            game.state.getEntity(game.state.stack.first())
+                ?.get<CardComponent>()?.name shouldBe "Polliwallop"
+            game.state.getEntity(game.state.stack.last())
+                ?.get<TriggeredAbilityOnStackComponent>()?.sourceName shouldBe "Whiskervale Forerunner"
+
+            game.resolveStack()
+            val revealDecision = game.getPendingDecision() as SelectCardsDecision
+            val bears = revealDecision.options.single { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+            }
+            game.selectCards(listOf(bears)).error shouldBe null
+
+            val destinationDecision = game.getPendingDecision() as SelectCardsDecision
+            game.selectCards(listOf(destinationDecision.options.single())).error shouldBe null
+
+            game.isOnBattlefield("Grizzly Bears") shouldBe true
+            game.state.stack.single() shouldBe polliwallop
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an engine scenario for Polliwallop targeting Whiskervale Forerunner as its first of two targets
- show Whiskervale's five looked-at cards even when none are eligible, using the existing private selection modal with disabled cards and a `Select None` acknowledgement
- put the remaining cards on the library bottom in random order as printed

## Testing
- `just test-class WhiskervaleForerunnerScenarioTest`
- `scripts/gradle-locked :mtg-sets:test --tests \"*CardDefinitionSnapshotTest\" -DupdateSnapshots=true`
- `just check-card-printing \"Whiskervale Forerunner\"`
- `just test`