### PR TITLE
Add Matzalantli, the Great Door (LCI #256)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 268 / 286
+**Implemented:** 269 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -157,7 +157,7 @@
 - [x] Marauding Brinefang
 - [ ] Market Gnome
 - [x] Master's Guide-Mural
-- [ ] Matzalantli, the Great Door
+- [x] Matzalantli, the Great Door
 - [x] Mephitic Draught
 - [x] Merfolk Cave-Diver
 - [x] Might of the Ancestors

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5680,14 +5680,15 @@ default to "you" so card authors don't need to pass it explicitly.
   printed threshold is always four, but `count` is parameterized. Works as a static "as long as …"
   gate (`staticAbility { ability = ModifyStats(...); condition = Conditions.Delirium() }` —
   Spineseeker Centipede) and as an activated-ability `ActivationRestriction.OnlyIfCondition`
-  ("Activate only if there are four or more card types …" — Balustrade Wurm). `Delirium(count)`
-  delegates to `DistinctCardTypesInGraveyard(count, filter = GameObjectFilter.Any)` (below).
-- `DistinctCardTypesInGraveyard(count, filter = GameObjectFilter.Any)` — generalizes `Delirium`:
-  "there are `count` or more distinct card types among the cards in your graveyard that match
-  `filter`." Pass `GameObjectFilter.Permanent` for "N or more **permanent** types among cards in
-  your graveyard" (Matzalantli, the Great Door's transform gate — a permanent card only ever carries
-  permanent card types, so distinct card types among the graveyard's permanent cards is exactly its
-  permanent-type count: artifact, battle, creature, enchantment, land, planeswalker).
+  ("Activate only if there are four or more card types …" — Balustrade Wurm).
+- `DistinctPermanentTypesInGraveyard(count)` — Delirium's permanent-only sibling: "there are `count`
+  or more distinct **permanent** types (CR 110.4: artifact, battle, creature, enchantment, land,
+  planeswalker) among cards in your graveyard" (Matzalantli, the Great Door's transform gate).
+  Composes through `Compare(AggregateZone(Player.You, Zone.GRAVEYARD, Aggregation.DISTINCT_PERMANENT_TYPES),
+  GTE, Fixed(count))`. Non-permanent card types never count: instants and sorceries have no permanent
+  type, and a **kindred** card contributes only its *other* (permanent) type, not "kindred" itself
+  (CR 300.2b) — so this is not the same as counting distinct card types among a graveyard filtered to
+  permanent cards, which would over-count a kindred permanent.
 - `CreatureDiedThisTurn` — intervening-if "if a creature died this turn", **global** (any player's
   control; sums every player's `CreaturesDiedThisTurnComponent`).
 - `ControlledCreatureDiedThisTurn` — intervening-if "if a creature died **under your control** this
@@ -5872,7 +5873,8 @@ Numbers computed at resolution time.
 - `AggregateBattlefield(player, filter, aggregation?, property?, counterType?)` — aggregate over
   matching permanents. `aggregation` defaults to `COUNT`; other modes: `MAX`/`MIN`/`SUM` over a
   `property` (`POWER`/`TOUGHNESS`/`MANA_VALUE`), and the distinct-set counters
-  `DISTINCT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_NAMES`, `DISTINCT_BASIC_LAND_SUBTYPES`
+  `DISTINCT_TYPES`, `DISTINCT_PERMANENT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_NAMES`,
+  `DISTINCT_BASIC_LAND_SUBTYPES`
   (Domain), `DISTINCT_COUNTER_TYPES` (the number of different kinds of counters present
   across the group — same kind on several permanents counts once), and `DISTINCT_VALUES`
   (the number of *distinct values* of the configured `property` — Selvala, Eager Trailblazer's
@@ -5887,7 +5889,11 @@ Numbers computed at resolution time.
   (`filter = GameObjectFilter.NonlandPermanent, aggregation = DISTINCT_TYPES, excludeSelf = true`).
   `DISTINCT_TYPES` counts only true **card types** (CR 205.2a: Artifact/Creature/Enchantment/…), never
   supertypes or subtypes, while still honoring projection-changed types (an animated land that became a
-  Creature counts as a Creature).
+  Creature counts as a Creature). `DISTINCT_PERMANENT_TYPES` is the same but restricted to the six
+  **permanent** types (CR 110.4: artifact, battle, creature, enchantment, land, planeswalker) — instant,
+  sorcery, and kindred never count (a kindred permanent contributes only its *other* type). Used for
+  "N or more permanent types among …" (Matzalantli, the Great Door, via
+  `Conditions.DistinctPermanentTypesInGraveyard`).
   When `counterType` (a `CounterTypeFilter`) is set with `SUM`/`MAX`/`MIN`, the per-permanent value
   aggregated is the count of *that kind* of counter on it — i.e. "the total <kind> counters among
   <filter>" (Tom Bombadil's lore-counter total; reach for it via

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5680,7 +5680,14 @@ default to "you" so card authors don't need to pass it explicitly.
   printed threshold is always four, but `count` is parameterized. Works as a static "as long as …"
   gate (`staticAbility { ability = ModifyStats(...); condition = Conditions.Delirium() }` —
   Spineseeker Centipede) and as an activated-ability `ActivationRestriction.OnlyIfCondition`
-  ("Activate only if there are four or more card types …" — Balustrade Wurm).
+  ("Activate only if there are four or more card types …" — Balustrade Wurm). `Delirium(count)`
+  delegates to `DistinctCardTypesInGraveyard(count, filter = GameObjectFilter.Any)` (below).
+- `DistinctCardTypesInGraveyard(count, filter = GameObjectFilter.Any)` — generalizes `Delirium`:
+  "there are `count` or more distinct card types among the cards in your graveyard that match
+  `filter`." Pass `GameObjectFilter.Permanent` for "N or more **permanent** types among cards in
+  your graveyard" (Matzalantli, the Great Door's transform gate — a permanent card only ever carries
+  permanent card types, so distinct card types among the graveyard's permanent cards is exactly its
+  permanent-type count: artifact, battle, creature, enchantment, land, planeswalker).
 - `CreatureDiedThisTurn` — intervening-if "if a creature died this turn", **global** (any player's
   control; sums every player's `CreaturesDiedThisTurnComponent`).
 - `ControlledCreatureDiedThisTurn` — intervening-if "if a creature died **under your control** this

--- a/manual-scenarios/cards/m/matzalantli-the-great-door.json
+++ b/manual-scenarios/cards/m/matzalantli-the-great-door.json
@@ -1,0 +1,39 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Cavern Stomper", "Seismic Monstrosaur", "Belligerent Yearling"],
+    "battlefield": [
+      {"name": "Matzalantli, the Great Door"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [
+      "Swamp",
+      "Swamp",
+      "Deconstruction Hammer",
+      "Corpses of the Lost"
+    ],
+    "library": ["Bat Colony", "Seismic Monstrosaur", "Cavern Stomper", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -675,26 +675,29 @@ object Conditions {
      * parameterized for "N or more card types" variants.
      * Used by Delirium cards (Spineseeker Centipede, Balustrade Wurm).
      */
-    fun Delirium(count: Int = 4): ConditionInterface = DistinctCardTypesInGraveyard(count)
+    fun Delirium(count: Int = 4): ConditionInterface =
+        graveyardTypeThreshold(count, Aggregation.DISTINCT_TYPES)
 
     /**
-     * If there are [count] or more distinct card types among the cards in your graveyard that match
-     * [filter]. Generalizes [Delirium] (which is this with `filter = GameObjectFilter.Any`): pass
-     * `GameObjectFilter.Permanent` for "N or more permanent types among cards in your graveyard"
-     * (Matzalantli, the Great Door's transform gate). A permanent card only ever carries permanent
-     * card types, so filtering to permanents and counting distinct card types yields exactly the
-     * permanent-type count (artifact, battle, creature, enchantment, land, planeswalker).
+     * If there are [count] or more distinct *permanent* types (CR 110.4: artifact, battle, creature,
+     * enchantment, land, planeswalker) among the cards in your graveyard — Matzalantli, the Great
+     * Door's transform gate. This is [Delirium]'s permanent-only sibling: non-permanent card types
+     * never count. Instants and sorceries have no permanent type, and a kindred card contributes only
+     * its *other* (permanent) type, not "kindred" itself (CR 300.2b). Unlike counting distinct card
+     * types among permanent cards, this does not miscount a kindred permanent. A single card with
+     * several permanent types (an artifact creature) contributes each once; the same type across many
+     * cards still counts once.
      */
-    fun DistinctCardTypesInGraveyard(
-        count: Int,
-        filter: GameObjectFilter = GameObjectFilter.Any
-    ): ConditionInterface =
+    fun DistinctPermanentTypesInGraveyard(count: Int): ConditionInterface =
+        graveyardTypeThreshold(count, Aggregation.DISTINCT_PERMANENT_TYPES)
+
+    /** Shared shape for the graveyard type-count gates ([Delirium], [DistinctPermanentTypesInGraveyard]). */
+    private fun graveyardTypeThreshold(count: Int, aggregation: Aggregation): ConditionInterface =
         Compare(
             DynamicAmount.AggregateZone(
                 player = Player.You,
                 zone = Zone.GRAVEYARD,
-                filter = filter,
-                aggregation = Aggregation.DISTINCT_TYPES
+                aggregation = aggregation
             ),
             ComparisonOperator.GTE,
             DynamicAmount.Fixed(count)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -675,12 +675,25 @@ object Conditions {
      * parameterized for "N or more card types" variants.
      * Used by Delirium cards (Spineseeker Centipede, Balustrade Wurm).
      */
-    fun Delirium(count: Int = 4): ConditionInterface =
+    fun Delirium(count: Int = 4): ConditionInterface = DistinctCardTypesInGraveyard(count)
+
+    /**
+     * If there are [count] or more distinct card types among the cards in your graveyard that match
+     * [filter]. Generalizes [Delirium] (which is this with `filter = GameObjectFilter.Any`): pass
+     * `GameObjectFilter.Permanent` for "N or more permanent types among cards in your graveyard"
+     * (Matzalantli, the Great Door's transform gate). A permanent card only ever carries permanent
+     * card types, so filtering to permanents and counting distinct card types yields exactly the
+     * permanent-type count (artifact, battle, creature, enchantment, land, planeswalker).
+     */
+    fun DistinctCardTypesInGraveyard(
+        count: Int,
+        filter: GameObjectFilter = GameObjectFilter.Any
+    ): ConditionInterface =
         Compare(
             DynamicAmount.AggregateZone(
                 player = Player.You,
                 zone = Zone.GRAVEYARD,
-                filter = GameObjectFilter.Any,
+                filter = filter,
                 aggregation = Aggregation.DISTINCT_TYPES
             ),
             ComparisonOperator.GTE,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
@@ -22,6 +22,14 @@ enum class Aggregation {
     COUNT, MAX, MIN, SUM,
     /** Count distinct card types across all matched entities */
     DISTINCT_TYPES,
+    /**
+     * Count distinct *permanent* card types across all matched entities (CR 110.4: artifact,
+     * battle, creature, enchantment, land, planeswalker). Like [DISTINCT_TYPES] but non-permanent
+     * card types — instant, sorcery, and kindred (CR 300.2b: a kindred card is a permanent only
+     * via its *other* type) — never contribute. Used for "N or more permanent types among …"
+     * (Matzalantli, the Great Door).
+     */
+    DISTINCT_PERMANENT_TYPES,
     /** Count distinct colors across all matched entities */
     DISTINCT_COLORS,
     /** Count distinct English card names across all matched entities */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -930,6 +930,11 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                     if (excludeSelf) append("other ")
                     append(pluralize(filter.description))
                 }
+                Aggregation.DISTINCT_PERMANENT_TYPES -> {
+                    append("the number of permanent types among ")
+                    if (excludeSelf) append("other ")
+                    append(pluralize(filter.description))
+                }
                 Aggregation.DISTINCT_COLORS -> {
                     append("the number of colors among ")
                     if (excludeSelf) append("other ")
@@ -1023,6 +1028,10 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 }
                 Aggregation.DISTINCT_TYPES -> {
                     append("the number of card types among ")
+                    append(pluralize(filter.description))
+                }
+                Aggregation.DISTINCT_PERMANENT_TYPES -> {
+                    append("the number of permanent types among ")
                     append(pluralize(filter.description))
                 }
                 Aggregation.DISTINCT_COLORS -> {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MatzalantliTheGreatDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MatzalantliTheGreatDoor.kt
@@ -31,10 +31,10 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *   in your graveyard.
  *
  * A plain in-place flip (`TransformEffect`, CR 701.27), artifact front / non-creature land back →
- * `CardDefinition.doubleFacedPermanent`. The transform gate reuses the Delirium machinery restricted
- * to permanent cards: `Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)` —
- * a permanent card only ever carries permanent card types, so distinct card types among the
- * graveyard's permanent cards is exactly its permanent-type count. The back's fathomless-descent
+ * `CardDefinition.doubleFacedPermanent`. The transform gate is Delirium's permanent-only sibling:
+ * `Conditions.DistinctPermanentTypesInGraveyard(4)` counts only permanent types (CR 110.4), so a
+ * kindred permanent in the graveyard doesn't spuriously add "kindred" to the tally. The back's
+ * fathomless-descent
  * mana is `AddAnyColorMana` with a dynamic amount counting permanent cards in the graveyard
  * (`DynamicAmount.Count(You, GRAVEYARD, Permanent)`, the Souls of the Lost / Squirming Emergence
  * count) — one chosen color, X of it.
@@ -62,7 +62,7 @@ private val MatzalantliTheGreatDoorFront = card("Matzalantli, the Great Door") {
         effect = TransformEffect(EffectTarget.Self)
         restrictions = listOf(
             ActivationRestriction.OnlyIfCondition(
-                Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)
+                Conditions.DistinctPermanentTypesInGraveyard(4)
             )
         )
         description = "Transform Matzalantli. Activate only if there are four or more permanent " +

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MatzalantliTheGreatDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MatzalantliTheGreatDoor.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Matzalantli, the Great Door // The Core — The Lost Caverns of Ixalan #256
+ * {3} · Legendary Artifact
+ * //  · Legendary Land
+ *
+ * Front — Matzalantli, the Great Door:
+ *   {T}: Draw a card, then discard a card.
+ *   {4}, {T}: Transform Matzalantli. Activate only if there are four or more permanent types among
+ *   cards in your graveyard. (Artifact, battle, creature, enchantment, land, and planeswalker are
+ *   permanent types.)
+ *
+ * Back — The Core:
+ *   Fathomless descent — {T}: Add X mana of any one color, where X is the number of permanent cards
+ *   in your graveyard.
+ *
+ * A plain in-place flip (`TransformEffect`, CR 701.27), artifact front / non-creature land back →
+ * `CardDefinition.doubleFacedPermanent`. The transform gate reuses the Delirium machinery restricted
+ * to permanent cards: `Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)` —
+ * a permanent card only ever carries permanent card types, so distinct card types among the
+ * graveyard's permanent cards is exactly its permanent-type count. The back's fathomless-descent
+ * mana is `AddAnyColorMana` with a dynamic amount counting permanent cards in the graveyard
+ * (`DynamicAmount.Count(You, GRAVEYARD, Permanent)`, the Souls of the Lost / Squirming Emergence
+ * count) — one chosen color, X of it.
+ */
+
+private val MatzalantliTheGreatDoorFront = card("Matzalantli, the Great Door") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "{T}: Draw a card, then discard a card.\n" +
+        "{4}, {T}: Transform Matzalantli. Activate only if there are four or more permanent types " +
+        "among cards in your graveyard. (Artifact, battle, creature, enchantment, land, and " +
+        "planeswalker are permanent types.)"
+
+    // {T}: Draw a card, then discard a card.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(Effects.DrawCards(1), Effects.Discard(1))
+    }
+
+    // {4}, {T}: Transform Matzalantli. Activate only if there are four or more permanent types
+    // among cards in your graveyard.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)
+            )
+        )
+        description = "Transform Matzalantli. Activate only if there are four or more permanent " +
+            "types among cards in your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1782694406"
+    }
+}
+
+private val TheCore = card("The Core") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Legendary Land"
+    oracleText = "(Transforms from Matzalantli.)\n" +
+        "Fathomless descent — {T}: Add X mana of any one color, where X is the number of permanent " +
+        "cards in your graveyard."
+
+    // Fathomless descent — {T}: Add X mana of any one color, X = permanent cards in your graveyard.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1782694406"
+    }
+}
+
+val MatzalantliTheGreatDoor: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = MatzalantliTheGreatDoorFront,
+    backFace = TheCore,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10566,8 +10566,7 @@
                                 "type": "AggregateZone",
                                 "player": "You",
                                 "zone": "Graveyard",
-                                "filter": "permanent",
-                                "aggregation": "DISTINCT_TYPES"
+                                "aggregation": "DISTINCT_PERMANENT_TYPES"
                             },
                             "operator": "GTE",
                             "right": {

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -10482,6 +10482,146 @@
     ]
 }
 
+// Matzalantli, the Great Door
+{
+    "name": "Matzalantli, the Great Door",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{T}: Draw a card, then discard a card.\n{4}, {T}: Transform Matzalantli. Activate only if there are four or more permanent types among cards in your graveyard. (Artifact, battle, creature, enchantment, land, and planeswalker are permanent types.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "Transform",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateZone",
+                                "player": "You",
+                                "zone": "Graveyard",
+                                "filter": "permanent",
+                                "aggregation": "DISTINCT_TYPES"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Transform Matzalantli. Activate only if there are four or more permanent types among cards in your graveyard."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "The Core",
+        "manaCost": "",
+        "typeLine": "Legendary Land",
+        "oracleText": "(Transforms from Matzalantli.)\nFathomless descent — {T}: Add X mana of any one color, where X is the number of permanent cards in your graveyard.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddManaOfChoice",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "permanent"
+                        }
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "256",
+            "rarity": "RARE",
+            "artist": "Piotr Dura",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1782694406"
+        },
+        "colorIdentityOverride": []
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4c31b29-06ba-436d-a3d9-18f4796c39be.jpg?1782694406"
+    },
+    "colorIdentityOverride": []
+}
+
 // Mephitic Draught
 {
     "name": "Mephitic Draught",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -56,6 +56,16 @@ private val CARD_TYPE_NAMES: Set<String> =
     com.wingedsheep.sdk.core.CardType.entries.mapTo(mutableSetOf()) { it.name }
 
 /**
+ * The names of every permanent card type (CR 110.4: artifact, battle, creature, enchantment, land,
+ * planeswalker). Used to count "permanent types" via [Aggregation.DISTINCT_PERMANENT_TYPES]. Derived
+ * from [com.wingedsheep.sdk.core.CardType.isPermanent], so kindred/instant/sorcery are excluded — a
+ * kindred permanent (e.g. a kindred enchantment) contributes only its permanent type(s), never
+ * "kindred" itself.
+ */
+private val PERMANENT_TYPE_NAMES: Set<String> =
+    com.wingedsheep.sdk.core.CardType.entries.filter { it.isPermanent }.mapTo(mutableSetOf()) { it.name }
+
+/**
  * Every official creature type (CR 205.3m), proper-cased to match the subtype strings carried in
  * [ProjectedState.getSubtypes]. Used by [DynamicAmount.LargestSharedCreatureTypeCount] to keep
  * non-creature subtypes (Equipment, Vehicle, basic land types, …) from polluting the tribe tally.
@@ -826,6 +836,15 @@ class DynamicAmountEvaluator(
                         ?: emptySet()
                 }
             }.size
+            // Like DISTINCT_TYPES but restricted to permanent card types (CR 110.4), so a projection-
+            // changed type still counts (an animated land that became a Creature).
+            Aggregation.DISTINCT_PERMANENT_TYPES -> matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
+                projection.getTypes(entityId).filterTo(mutableSetOf()) { it in PERMANENT_TYPE_NAMES }.ifEmpty {
+                    state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes
+                        ?.filter { it.isPermanent }?.map { it.name }?.toSet()
+                        ?: emptySet()
+                }
+            }.size
             Aggregation.DISTINCT_COLORS -> matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
                 projection.getColors(entityId).ifEmpty {
                     state.getEntity(entityId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
@@ -896,6 +915,15 @@ class DynamicAmountEvaluator(
             Aggregation.DISTINCT_TYPES -> {
                 matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
                     state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes?.map { it.name }?.toSet()
+                        ?: emptySet()
+                }.size
+            }
+            // Permanent card types only (CR 110.4) — kindred/instant/sorcery never count. This is
+            // Matzalantli, the Great Door's "N or more permanent types among cards in your graveyard".
+            Aggregation.DISTINCT_PERMANENT_TYPES -> {
+                matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
+                    state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes
+                        ?.filter { it.isPermanent }?.map { it.name }?.toSet()
                         ?: emptySet()
                 }.size
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MatzalantliTheGreatDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MatzalantliTheGreatDoorScenarioTest.kt
@@ -22,10 +22,12 @@ import io.kotest.matchers.shouldBe
  * Matzalantli, the Great Door // The Core (LCI #256).
  *
  * The novel building block is the transform gate:
- * `Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)` — "four or more permanent
- * types among cards in your graveyard". Proven by activating the transform with a graveyard holding 3
- * permanent types (+ non-permanent cards that must NOT count) → rejected, then 4 permanent types →
- * allowed. Also covers The Core's fathomless-descent mana (X = permanent cards in the graveyard).
+ * `Conditions.DistinctPermanentTypesInGraveyard(4)` — "four or more permanent types among cards in
+ * your graveyard" (CR 110.4). Proven by activating the transform with a graveyard holding 3 permanent
+ * types (+ non-permanent cards that must NOT count) → rejected, then 4 permanent types → allowed; and
+ * that a kindred permanent contributes only its permanent type, not "kindred" (CR 300.2b), so a
+ * kindred enchantment among 3 permanent types does not spuriously reach four. Also covers The Core's
+ * fathomless-descent mana (X = permanent cards in the graveyard).
  */
 class MatzalantliTheGreatDoorScenarioTest : FunSpec({
 
@@ -42,6 +44,11 @@ class MatzalantliTheGreatDoorScenarioTest : FunSpec({
     val gySorcery = card("GY Sorcery") {
         manaCost = "{B}"; colorIdentity = "B"; typeLine = "Sorcery"; spell { effect = Effects.GainLife(1) }
     }
+    // A kindred enchantment: card types {KINDRED, ENCHANTMENT}. Only ENCHANTMENT is a permanent type
+    // (CR 110.4/300.2b) — the gate must not count "kindred" as a fourth permanent type.
+    val gyKindredEnchantment = card("GY Kindred Enchantment") {
+        manaCost = "{1}{W}"; colorIdentity = "W"; typeLine = "Kindred Enchantment — Bear"
+    }
 
     fun resolveStack(driver: GameTestDriver) {
         var guard = 0
@@ -51,7 +58,10 @@ class MatzalantliTheGreatDoorScenarioTest : FunSpec({
     fun newDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(
-            TestCards.all + listOf(MatzalantliTheGreatDoor, gyCreature, gyArtifact, gyEnchantment, gyInstant, gySorcery)
+            TestCards.all + listOf(
+                MatzalantliTheGreatDoor, gyCreature, gyArtifact, gyEnchantment, gyInstant, gySorcery,
+                gyKindredEnchantment
+            )
         )
         driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
@@ -82,6 +92,22 @@ class MatzalantliTheGreatDoorScenarioTest : FunSpec({
 
         // 3 permanent types (creature/artifact/enchantment); the instant + sorcery are not permanent
         // types, so the "four or more permanent types" gate is unmet — activation is rejected.
+        driver.submit(ActivateAbility(playerId = active, sourceId = matz, abilityId = transformId))
+            .isSuccess shouldBe false
+    }
+
+    test("a kindred permanent doesn't count 'kindred' as a permanent type (3 types stays blocked)") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val matz = driver.putPermanentOnBattlefield(active, "Matzalantli, the Great Door")
+        // creature + artifact + a kindred enchantment: 3 permanent types (creature/artifact/enchantment),
+        // but 4 *card* types once KINDRED is included. Counting distinct card types among permanent cards
+        // would wrongly reach four; counting permanent types (CR 110.4) correctly stays at three.
+        driver.putCardInGraveyard(active, "GY Creature")
+        driver.putCardInGraveyard(active, "GY Artifact")
+        driver.putCardInGraveyard(active, "GY Kindred Enchantment")
+        driver.giveColorlessMana(active, 4)
+
         driver.submit(ActivateAbility(playerId = active, sourceId = matz, abilityId = transformId))
             .isSuccess shouldBe false
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MatzalantliTheGreatDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MatzalantliTheGreatDoorScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MatzalantliTheGreatDoor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Matzalantli, the Great Door // The Core (LCI #256).
+ *
+ * The novel building block is the transform gate:
+ * `Conditions.DistinctCardTypesInGraveyard(4, GameObjectFilter.Permanent)` — "four or more permanent
+ * types among cards in your graveyard". Proven by activating the transform with a graveyard holding 3
+ * permanent types (+ non-permanent cards that must NOT count) → rejected, then 4 permanent types →
+ * allowed. Also covers The Core's fathomless-descent mana (X = permanent cards in the graveyard).
+ */
+class MatzalantliTheGreatDoorScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    val gyCreature = card("GY Creature") {
+        manaCost = "{1}{G}"; colorIdentity = "G"; typeLine = "Creature — Bear"; power = 2; toughness = 2
+    }
+    val gyArtifact = card("GY Artifact") { manaCost = "{1}"; colorIdentity = ""; typeLine = "Artifact" }
+    val gyEnchantment = card("GY Enchantment") { manaCost = "{1}{W}"; colorIdentity = "W"; typeLine = "Enchantment" }
+    val gyInstant = card("GY Instant") {
+        manaCost = "{U}"; colorIdentity = "U"; typeLine = "Instant"; spell { effect = Effects.GainLife(1) }
+    }
+    val gySorcery = card("GY Sorcery") {
+        manaCost = "{B}"; colorIdentity = "B"; typeLine = "Sorcery"; spell { effect = Effects.GainLife(1) }
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(MatzalantliTheGreatDoor, gyCreature, gyArtifact, gyEnchantment, gyInstant, gySorcery)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Matzalantli on the battlefield; graveyard seeded with 3 permanent types (creature, artifact,
+    // enchantment) plus two non-permanent cards (instant, sorcery). [includeLand] adds a Swamp for a
+    // 4th permanent type (land). Returns Matzalantli's entity id.
+    fun setup(driver: GameTestDriver, active: EntityId, includeLand: Boolean): EntityId {
+        val matz = driver.putPermanentOnBattlefield(active, "Matzalantli, the Great Door")
+        driver.putCardInGraveyard(active, "GY Creature")
+        driver.putCardInGraveyard(active, "GY Artifact")
+        driver.putCardInGraveyard(active, "GY Enchantment")
+        driver.putCardInGraveyard(active, "GY Instant")
+        driver.putCardInGraveyard(active, "GY Sorcery")
+        if (includeLand) driver.putCardInGraveyard(active, "Swamp")
+        return matz
+    }
+
+    val transformId = MatzalantliTheGreatDoor.activatedAbilities[1].id
+
+    test("transform is blocked with only 3 permanent types (instant + sorcery don't count)") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val matz = setup(driver, active, includeLand = false)
+        driver.giveColorlessMana(active, 4)
+
+        // 3 permanent types (creature/artifact/enchantment); the instant + sorcery are not permanent
+        // types, so the "four or more permanent types" gate is unmet — activation is rejected.
+        driver.submit(ActivateAbility(playerId = active, sourceId = matz, abilityId = transformId))
+            .isSuccess shouldBe false
+    }
+
+    test("transform is allowed with 4 permanent types (adds a land) and flips to The Core, a land") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val matz = setup(driver, active, includeLand = true)
+        driver.giveColorlessMana(active, 4)
+
+        driver.submit(ActivateAbility(playerId = active, sourceId = matz, abilityId = transformId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        resolveStack(driver)
+
+        driver.state.getEntity(matz)!!.get<CardComponent>()!!.name shouldBe "The Core"
+        projector.project(driver.state).hasType(matz, "LAND") shouldBe true
+    }
+
+    test("The Core's fathomless descent taps for X mana of one color, X = permanent cards in graveyard") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val matz = setup(driver, active, includeLand = true) // 4 permanent cards + 2 non-permanent
+        driver.giveColorlessMana(active, 4)
+
+        driver.submit(ActivateAbility(playerId = active, sourceId = matz, abilityId = transformId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        resolveStack(driver)
+        driver.untapPermanent(matz)
+
+        // {T}: Add X mana of any one color — choose green; X = the 4 permanent cards (the instant and
+        // sorcery in the graveyard are not permanent cards and don't count).
+        val manaAbilityId = MatzalantliTheGreatDoor.backFace!!.activatedAbilities[0].id
+        driver.submit(
+            ActivateAbility(playerId = active, sourceId = matz, abilityId = manaAbilityId, manaColorChoice = Color.GREEN)
+        ).isSuccess shouldBe true
+        if (driver.isPaused) {
+            val decision = driver.pendingDecision!!
+            if (decision is ChooseColorDecision) driver.submitDecision(active, ColorChosenResponse(decision.id, Color.GREEN))
+        }
+
+        driver.state.getEntity(active)!!.get<ManaPoolComponent>()!!.green shouldBe 4
+    }
+})


### PR DESCRIPTION
## Matzalantli, the Great Door // The Core (LCI #256)

Implements the LCI double-faced permanent and the small SDK capability its transform gate needs.

### Front — Matzalantli, the Great Door ({3} Legendary Artifact)
- `{T}: Draw a card, then discard a card.`
- `{4}, {T}: Transform Matzalantli. Activate only if there are four or more permanent types among cards in your graveyard.`

### Back — The Core (Legendary Land)
- `Fathomless descent — {T}: Add X mana of any one color, where X is the number of permanent cards in your graveyard.`

Built from existing primitives — `CardDefinition.doubleFacedPermanent`, `TransformEffect`, `AddAnyColorMana(DynamicAmount.Count)`, `Composite(Draw, Discard)`.

### SDK addition: `Aggregation.DISTINCT_PERMANENT_TYPES`

The transform gate counts **permanent types** (CR 110.4: artifact, battle, creature, enchantment, land, planeswalker), which is *not* the same as distinct card types among permanent cards: a **kindred** permanent (e.g. a kindred enchantment) carries card types `{KINDRED, ENCHANTMENT}`, and KINDRED is a card type but not a permanent type — a kindred card is a permanent only via its *other* type (CR 300.2b). Counting distinct card types would over-count such a card by one.

- New `Aggregation.DISTINCT_PERMANENT_TYPES` — like `DISTINCT_TYPES` but restricted via `CardType.isPermanent`, so instant/sorcery/kindred never contribute. Wired into both `DynamicAmountEvaluator` paths (battlefield + zone) and both SDK description branches.
- New `Conditions.DistinctPermanentTypesInGraveyard(count)` — Delirium's permanent-only sibling; Matzalantli's gate routes through it. `Delirium`'s serialized output is unchanged (only `LCI.json` changed across the whole snapshot corpus).
- `docs/card-sdk-language-reference.md` updated for the new aggregation + condition.

### Tests
`MatzalantliTheGreatDoorScenarioTest` (rules-engine), all green:
- transform blocked at 3 permanent types (instant + sorcery excluded);
- **kindred regression** — creature + artifact + kindred enchantment = 3 permanent types but 4 distinct *card* types → still blocked (fails under the old logic);
- transform allowed at 4 permanent types → flips to The Core, a land;
- The Core's fathomless descent taps for X mana of one color, X = permanent cards in the graveyard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
