### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SaviorOfTheSleeping.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SaviorOfTheSleeping.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Savior of the Sleeping
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/3
+ *
+ * Vigilance
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, put a
+ * +1/+1 counter on this creature.
+ *
+ * Same shape as Warehouse Tabby: the trigger fires on *any* enchantment you control reaching
+ * the graveyard from the battlefield — destroyed, sacrificed, an Aura falling off, or a Role
+ * token being replaced — so it uses the generic `leavesBattlefield` factory with an
+ * [TriggerBinding.ANY] binding rather than a SELF-bound constant.
+ */
+val SaviorOfTheSleeping = card("Savior of the Sleeping") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Vigilance\n" +
+        "Whenever an enchantment you control is put into a graveyard from the battlefield, " +
+        "put a +1/+1 counter on this creature."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Valera Lutfullina"
+        flavorText = "Even lost in slumber, the citizens of Ardenvale dream of a tireless protector " +
+            "standing guard over their homes."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1783915126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SkybeastTracker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SkybeastTracker.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skybeast Tracker
+ * {3}{G}
+ * Creature — Giant Archer
+ * 2/4
+ *
+ * Reach
+ * Whenever you cast a spell with mana value 5 or greater, create a Food token.
+ *
+ * The trigger fires on cast, so it uses the spell's mana value *on the stack* — X counts as
+ * the chosen value, and a cost reduction doesn't lower it (CR 202.3, 601.2b).
+ */
+val SkybeastTracker = card("Skybeast Tracker") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Giant Archer"
+    oracleText = "Reach\n" +
+        "Whenever you cast a spell with mana value 5 or greater, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.manaValueAtLeast(5))
+        effect = Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Andreas Zafiratos"
+        flavorText = "Cloud eaters, heaven tillers, beanstalk wurms—he favors prey worthy of a giant's appetite."
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg?1783915079"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpitefulHexmage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpitefulHexmage.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spiteful Hexmage
+ * {B}
+ * Creature — Human Warlock
+ * 3/2
+ *
+ * When this creature enters, create a Cursed Role token attached to target creature you control.
+ * (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)
+ *
+ * The target is *not* "another" creature — the Hexmage is a legal target for its own trigger,
+ * so [Targets.CreatureYouControl] (no `excludeSelf`) is correct. Replacing an existing Role on
+ * the chosen creature is handled inside [Effects.CreateRoleToken], not here.
+ */
+val SpitefulHexmage = card("Spiteful Hexmage") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    oracleText = "When this creature enters, create a Cursed Role token attached to target creature you control. " +
+        "(If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)"
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateRoleToken("Cursed Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "108"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Who'll never amount to anything now, Father?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1783915102"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SuccumbToTheCold.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SuccumbToTheCold.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Succumb to the Cold
+ * {2}{U}
+ * Instant
+ *
+ * Tap one or two target creatures an opponent controls. Put a stun counter on each of them.
+ *
+ * "One or two target" is `count = 2, minCount = 1` — the caster picks how many, and the spell
+ * still resolves for the survivor if one of two targets becomes illegal. [ForEachTargetEffect]
+ * runs the tap + stun counter per chosen target, so each is handled independently.
+ */
+val SuccumbToTheCold = card("Succumb to the Cold") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Tap one or two target creatures an opponent controls. Put a stun counter on each of them. " +
+        "(If a permanent with a stun counter would become untapped, remove one from it instead.)"
+
+    spell {
+        target(
+            "target creatures an opponent controls",
+            TargetCreature(count = 2, minCount = 1, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.Tap(EffectTarget.ContextTarget(0)),
+                Effects.AddCounters(Counters.STUN, 1, EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Andrew Mar"
+        flavorText = "\"I've never known cold like it. It burned like fire and bit like an adder's fangs. " +
+            "Call me a coward if you wish, but I won't go back there.\"\n—Syr Lydel, knight of Vantress"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1783915114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VerdantOutrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VerdantOutrider.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Verdant Outrider
+ * {2}{G}
+ * Creature — Human Knight
+ * 4/2
+ *
+ * {1}{G}: This creature can't be blocked by creatures with power 2 or less this turn.
+ *
+ * Modelled as a durational grant of the printed-static [CantBeBlockedBy] restriction rather
+ * than a bespoke effect: the blocking-legality check reads granted statics the same way it
+ * reads printed ones, so power is re-evaluated continuously at declare-blockers (a creature
+ * pumped above 2 after activation *can* block).
+ */
+val VerdantOutrider = card("Verdant Outrider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Knight"
+    oracleText = "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn."
+    power = 4
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = Effects.GrantStaticAbility(
+            ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2)),
+            target = EffectTarget.Self,
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Taras Susak"
+        flavorText = "Some knights who survived the invasion have forsaken what remains of their courts. " +
+            "The newly formed Verdant Order has sworn to defend the last untouched parts of the wilds."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1783915074"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3981,6 +3981,50 @@
     ]
 }
 
+// Savior of the Sleeping
+{
+    "name": "Savior of the Sleeping",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Valera Lutfullina",
+        "flavorText": "Even lost in slumber, the citizens of Ardenvale dream of a tireless protector standing guard over their homes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b4979d9-fafb-4e0e-868f-f4772109d7a7.jpg?1783915126"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scarecrow Guide
 {
     "name": "Scarecrow Guide",
@@ -4195,6 +4239,53 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Skybeast Tracker
+{
+    "name": "Skybeast Tracker",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Giant Archer",
+    "oracleText": "Reach\nWhenever you cast a spell with mana value 5 or greater, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtLeast",
+                                "min": 5
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "Cloud eaters, heaven tillers, beanstalk wurms—he favors prey worthy of a giant's appetite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a08da5c6-ebe7-4166-99d5-2aca5b0b529f.jpg?1783915079"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4467,6 +4558,54 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Spiteful Hexmage
+{
+    "name": "Spiteful Hexmage",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "When this creature enters, create a Cursed Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Cursed Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Who'll never amount to anything now, Father?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40c797b2-db51-4a39-b80e-44d58cd7a07c.jpg?1783915102"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4752,6 +4891,62 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Succumb to the Cold
+{
+    "name": "Succumb to the Cold",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Tap one or two target creatures an opponent controls. Put a stun counter on each of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    {
+                        "type": "AddCounters",
+                        "counterType": "stun",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "target creatures an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "\"I've never known cold like it. It burned like fire and bit like an adder's fangs. Call me a coward if you wish, but I won't go back there.\"\n—Syr Lydel, knight of Vantress",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c14d9fc0-bfbf-4359-93bf-5e53466965d6.jpg?1783915114"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5198,6 +5393,57 @@
                 ]
             }
         }
+    ]
+}
+
+// Verdant Outrider
+{
+    "name": "Verdant Outrider",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantStaticAbility",
+                    "ability": {
+                        "type": "CantBeBlockedBy",
+                        "blockerFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "PowerAtMost",
+                                    "max": 2
+                                }
+                            ]
+                        }
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Taras Susak",
+        "flavorText": "Some knights who survived the invasion have forsaken what remains of their courts. The newly formed Verdant Order has sworn to defend the last untouched parts of the wilds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1783915074"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch4ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch4ScenarioTest.kt
@@ -1,0 +1,336 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for a batch of Wilds of Eldraine cards implemented together:
+ *
+ *  - Verdant Outrider ({2}{G} 4/2) — {1}{G} grants "can't be blocked by creatures with power 2
+ *    or less" for the turn.
+ *  - Succumb to the Cold ({2}{U} instant) — taps *one or two* target creatures an opponent
+ *    controls and stuns each of them.
+ *  - Skybeast Tracker ({3}{G} 2/4, Reach) — Food on every spell you cast with mana value 5+.
+ *  - Savior of the Sleeping ({2}{W} 2/3, Vigilance) — grows whenever an enchantment you control
+ *    hits the graveyard from the battlefield.
+ *  - Spiteful Hexmage ({B} 3/2) — ETB puts a Cursed Role on target creature you control, which
+ *    sets that creature's base P/T to 1/1.
+ */
+class WoeCardsBatch4ScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Verdant Outrider — activated evasion against small blockers") {
+            test("a power-2 creature can't block after the ability resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Verdant Outrider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val outrider = game.findPermanent("Verdant Outrider")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = outrider,
+                        abilityId = outriderAbilityId()
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Verdant Outrider" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Grizzly Bears" to listOf("Verdant Outrider")))
+                withClue("2/2 Grizzly Bears has power 2, so the granted restriction stops the block") {
+                    block.error shouldNotBe null
+                }
+            }
+
+            test("a power-3 creature blocks fine even after the activation") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Verdant Outrider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val outrider = game.findPermanent("Verdant Outrider")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = outrider,
+                        abilityId = outriderAbilityId()
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Verdant Outrider" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("3/3 Hill Giant is above power 2 and blocks normally") {
+                    game.declareBlockers(mapOf("Hill Giant" to listOf("Verdant Outrider")))
+                        .error shouldBe null
+                }
+            }
+
+            test("without activating, a 2/2 blocks it just fine") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Verdant Outrider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Verdant Outrider" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("no activation means no restriction at all") {
+                    game.declareBlockers(mapOf("Grizzly Bears" to listOf("Verdant Outrider")))
+                        .error shouldBe null
+                }
+            }
+        }
+
+        context("Succumb to the Cold — tap and stun one or two") {
+            test("both targets are tapped and each gets a stun counter") {
+                val game = coldScenario()
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castCold(listOf(bears, giant)).error shouldBe null
+                game.resolveStack()
+
+                listOf(bears to "Grizzly Bears", giant to "Hill Giant").forEach { (id, name) ->
+                    withClue("$name is tapped") {
+                        game.state.getEntity(id)?.has<TappedComponent>() shouldBe true
+                    }
+                    withClue("$name has a stun counter") { game.stunCounters(id) shouldBe 1 }
+                }
+            }
+
+            test("choosing a single target is legal — 'one or two'") {
+                val game = coldScenario()
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castCold(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the single chosen target is tapped and stunned") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                    game.stunCounters(bears) shouldBe 1
+                }
+                withClue("the untargeted creature is untouched") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                    game.stunCounters(giant) shouldBe 0
+                }
+            }
+        }
+
+        context("Skybeast Tracker — Food on expensive casts") {
+            test("casting a mana value 5 spell makes a Food, a cheap one does not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skybeast Tracker", summoningSickness = false)
+                    .withCardInHand(1, "Savannah Lions")
+                    .withCardInHand(1, "Serra Angel")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Skybeast Tracker has reach") {
+                    game.state.projectedState.hasKeyword(
+                        game.findPermanent("Skybeast Tracker")!!, Keyword.REACH
+                    ) shouldBe true
+                }
+
+                game.castSpell(1, "Savannah Lions").error shouldBe null
+                game.resolveStack()
+                withClue("mana value 1 is below the threshold — no Food") {
+                    game.findPermanents("Food").size shouldBe 0
+                }
+
+                game.castSpell(1, "Serra Angel").error shouldBe null
+                game.resolveStack()
+                withClue("Serra Angel is mana value 5 — one Food token") {
+                    game.findPermanents("Food").size shouldBe 1
+                }
+            }
+        }
+
+        context("Savior of the Sleeping — grows off dying enchantments") {
+            test("an enchantment you control reaching the graveyard adds a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Savior of the Sleeping", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Test Enchantment")
+                    .withCardInHand(1, "Naturalize")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val savior = game.findPermanent("Savior of the Sleeping")!!
+                withClue("Savior of the Sleeping has vigilance") {
+                    game.state.projectedState.hasKeyword(savior, Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("it starts as a printed 2/3") {
+                    game.state.projectedState.getPower(savior) shouldBe 2
+                    game.state.projectedState.getToughness(savior) shouldBe 3
+                }
+
+                val enchantment = game.findPermanent("Test Enchantment")!!
+                game.castSpell(1, "Naturalize", enchantment).error shouldBe null
+                game.resolveStack()
+
+                withClue("the destroyed enchantment triggered the Savior") {
+                    game.state.projectedState.getPower(savior) shouldBe 3
+                    game.state.projectedState.getToughness(savior) shouldBe 4
+                }
+            }
+
+            test("an opponent's enchantment dying does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Savior of the Sleeping", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Enchantment")
+                    .withCardInHand(1, "Naturalize")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val savior = game.findPermanent("Savior of the Sleeping")!!
+                val enchantment = game.findPermanent("Test Enchantment")!!
+                game.castSpell(1, "Naturalize", enchantment).error shouldBe null
+                game.resolveStack()
+
+                withClue("'an enchantment you control' excludes the opponent's") {
+                    game.state.projectedState.getPower(savior) shouldBe 2
+                    game.state.projectedState.getToughness(savior) shouldBe 3
+                }
+            }
+        }
+
+        context("Spiteful Hexmage — Cursed Role on a creature you control") {
+            test("the chosen creature becomes 1/1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spiteful Hexmage")
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Spiteful Hexmage").error shouldBe null
+                game.resolveStack() // Hexmage enters -> ETB trigger asks for its target
+                game.selectTargets(listOf(giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Cursed Role token exists") {
+                    (game.findPermanent("Cursed Role") != null) shouldBe true
+                }
+                withClue("the Cursed Role sets the enchanted creature's base P/T to 1/1") {
+                    game.state.projectedState.getPower(giant) shouldBe 1
+                    game.state.projectedState.getToughness(giant) shouldBe 1
+                }
+
+                val hexmage = game.findPermanent("Spiteful Hexmage")!!
+                withClue("the Hexmage itself is unenchanted here and stays a 3/2") {
+                    game.state.projectedState.getPower(hexmage) shouldBe 3
+                    game.state.projectedState.getToughness(hexmage) shouldBe 2
+                }
+            }
+
+            test("the Hexmage is a legal target for its own trigger") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spiteful Hexmage")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Spiteful Hexmage").error shouldBe null
+                game.resolveStack()
+
+                val hexmage = game.findPermanent("Spiteful Hexmage")!!
+                game.selectTargets(listOf(hexmage)).error shouldBe null
+                game.resolveStack()
+
+                withClue("cursing itself makes the 3/2 a 1/1") {
+                    game.state.projectedState.getPower(hexmage) shouldBe 1
+                    game.state.projectedState.getToughness(hexmage) shouldBe 1
+                }
+            }
+        }
+    }
+
+    private fun outriderAbilityId() =
+        cardRegistry.getCard("Verdant Outrider")!!.activatedAbilities.first().id
+
+    private fun coldScenario(): TestGame = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Succumb to the Cold")
+        .withCardOnBattlefield(2, "Grizzly Bears")
+        .withCardOnBattlefield(2, "Hill Giant")
+        .withLandsOnBattlefield(1, "Island", 3)
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(2, "Forest")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    private fun TestGame.castCold(targets: List<EntityId>) = execute(
+        CastSpell(
+            playerId = player1Id,
+            cardId = findCardsInHand(1, "Succumb to the Cold").first(),
+            targets = targets.map { ChosenTarget.Permanent(it) }
+        )
+    )
+
+    private fun TestGame.stunCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+}


### PR DESCRIPTION
Five WOE commons/uncommons/rare that compose existing SDK primitives — **no new effect, trigger, condition, or static-ability types**.

| Card | Modelling note |
|---|---|
| **Verdant Outrider** {2}{G} 4/2 | `{1}{G}` grants a durational `CantBeBlockedBy(Creature.powerAtMost(2))`. Granted statics read the same way printed ones do, so a blocker pumped above power 2 after activation *can* block. |
| **Succumb to the Cold** {2}{U} | "One or two target" = `count = 2, minCount = 1`; `ForEachTargetEffect` runs tap + stun counter per chosen target, so each is handled independently. |
| **Skybeast Tracker** {3}{G} 2/4 | Reach + `Triggers.youCastSpell(spellFilter = Any.manaValueAtLeast(5))` → `Effects.CreateFood()`. Fires on cast, so X counts as chosen and cost reduction doesn't lower MV. |
| **Savior of the Sleeping** {2}{W} 2/3 | Vigilance + the Warehouse Tabby-shaped `leavesBattlefield(Enchantment.youControl(), to = GRAVEYARD, binding = ANY)` — catches destroyed/sacrificed enchantments, Auras falling off, and replaced Role tokens. |
| **Spiteful Hexmage** {B} 3/2 | ETB Cursed Role on target creature you control. Oracle says "target creature you control", not "another", so no `excludeSelf` — the Hexmage can curse itself. |

**Not** implemented from this set: anything with Bargain or Celebration. Neither mechanic exists in the SDK yet, and adding them is `add-feature` work rather than card authoring.

## Testing

`WoeCardsBatch4ScenarioTest` — 10 tests, all passing, including the negative cases:

- Verdant Outrider: power-2 blocker rejected after activation; power-3 blocker allowed; **without** activating, the 2/2 blocks fine.
- Succumb to the Cold: two targets both tapped + stunned; single target legal, with the untargeted creature verified untouched.
- Skybeast Tracker: a MV-1 cast makes no Food, a MV-5 cast makes exactly one.
- Savior of the Sleeping: your enchantment dying grows it 2/3 → 3/4; an **opponent's** enchantment dying does not.
- Spiteful Hexmage: the chosen creature drops to 1/1 while the Hexmage stays 3/2; and the Hexmage cursing itself works.

`just build` green. WOE card snapshot re-blessed — diff is additions only, no other card moved. `just check-card-printing` confirms WOE is the canonical set for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)