### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -915,7 +915,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Duskmourn's Glimmer cards create a "1/1 white Glimmer enchantment creature token" via `enchantmentToken = true`).
   `count` accepts an `Int` or a `DynamicAmount` (the latter for "create X tokens" wording — e.g. Verdeloth the
   Ancient passes `count = DynamicAmount.XValue` to make X Saprolings when kicked); both count overloads accept
-  `tapped` (The Final Days creates a `DynamicAmount.Conditional` number of **tapped** Horror tokens). Publishes the created token
+  `tapped` and `staticAbilities` (The Final Days creates a `DynamicAmount.Conditional` number of **tapped** Horror
+  tokens; Song of Totentanz creates `DynamicAmount.XValue` Rats carrying `CantBlock()`). Publishes the created token
   entity IDs to the `CREATED_TOKENS` pipeline collection, so a sibling effect in a `CompositeEffect` can address
   each token via `EffectTarget.PipelineTarget(CREATED_TOKENS, index)` — e.g. Mardu Monument grants menace and haste
   until end of turn to each of its three freshly-created Warriors with one `GrantKeyword` per token. For a *named*

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2064,11 +2064,13 @@ object Effects {
         controller: EffectTarget? = null,
         imageUri: String? = null,
         legendary: Boolean = false,
-        tapped: Boolean = false
+        tapped: Boolean = false,
+        staticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList()
     ): Effect = CreateTokenEffect(
         count = count, power = power, toughness = toughness, colors = colors,
         creatureTypes = creatureTypes, keywords = keywords,
-        controller = controller, imageUri = imageUri, legendary = legendary, tapped = tapped
+        controller = controller, imageUri = imageUri, legendary = legendary, tapped = tapped,
+        staticAbilities = staticAbilities
     )
 
     /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshioksReaper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshioksReaper.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Ashiok's Reaper
+ * {3}{B}
+ * Creature — Nightmare
+ * 3/3
+ *
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, draw a card.
+ *
+ * Same trigger shape as Warehouse Tabby: any enchantment you control hitting the graveyard from
+ * the battlefield — destroyed, sacrificed, or a Role token falling off when it's replaced — so it
+ * uses the generic `leavesBattlefield` factory with an `ANY` binding rather than a SELF-bound
+ * constant. Role tokens count: per the WOE ruling, an enchantment token is put into its owner's
+ * graveyard before it ceases to exist, so the Reaper sees it.
+ */
+val AshioksReaper = card("Ashiok's Reaper") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever an enchantment you control is put into a graveyard from the battlefield, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "79"
+        artist = "Denis Zhbankov"
+        flavorText = "Neva's dreams were haunted by memories of the invasion—oil-black tendrils " +
+            "grasping at her through the mist. Or . . . was this something new?"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg?1783915111"
+
+        ruling(
+            "2023-09-01",
+            "Enchantment tokens (such as Roles) that are sacrificed, destroyed, or would otherwise go to " +
+                "the graveyard are put into their owner's graveyard before ceasing to exist. If you controlled " +
+                "the token, Ashiok's Reaper's ability will trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ImodanesRecruiter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ImodanesRecruiter.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Imodane's Recruiter // Train Troops
+ * {2}{R}
+ * Creature — Human Knight
+ * 2/2
+ *
+ * When this creature enters, creatures you control get +1/+0 and gain haste until end of turn.
+ *
+ * Adventure: Train Troops — {4}{W}, Sorcery — Adventure
+ * Create two 2/2 white Knight creature tokens with vigilance.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ *
+ * The ETB pump is a `ForEachInGroup` over creatures you control, enumerated once at resolution —
+ * the Recruiter itself is included, and creatures that arrive later in the turn are not (WOE
+ * ruling). Both halves of the grant are `EndOfTurn`-duration and target the iteration entity.
+ */
+val ImodanesRecruiter = card("Imodane's Recruiter") {
+    manaCost = "{2}{R}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, creatures you control get +1/+0 and gain haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(1, 0, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+            )
+        )
+    }
+
+    adventure("Train Troops") {
+        manaCost = "{4}{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create two 2/2 white Knight creature tokens with vigilance. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Knight"),
+                keywords = setOf(Keyword.VIGILANCE),
+                count = 2,
+                imageUri = "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1783914992"
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1783915064"
+
+        ruling(
+            "2023-09-01",
+            "Imodane's Recruiter's triggered ability affects only creatures you control at the time it " +
+                "resolves. Creatures you begin to control later in the turn won't get +1/+0 or gain haste."
+        )
+        ruling(
+            "2023-09-01",
+            "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its " +
+                "owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it " +
+                "as a permanent spell."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ProtectiveParents.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ProtectiveParents.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Protective Parents
+ * {2}{W}
+ * Creature — Human Peasant
+ * 3/2
+ *
+ * When this creature dies, create a Young Hero Role token attached to up to one target creature you
+ * control. (If you control another Role on it, put that one into the graveyard. Enchanted creature
+ * has "Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.")
+ *
+ * "Up to one target" is optional targeting, so the trigger still resolves with no target chosen —
+ * it just creates nothing (WOE ruling). The Parents themselves are in the graveyard by the time the
+ * trigger resolves, so they're never a legal target; the same optional-role shape as Cut In.
+ */
+val ProtectiveParents = card("Protective Parents") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Peasant"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature dies, create a Young Hero Role token attached to up to one " +
+        "target creature you control. (If you control another Role on it, put that one into the " +
+        "graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 " +
+        "or less, put a +1/+1 counter on it.\")"
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.CreateRoleToken("Young Hero Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg?1783915130"
+
+        ruling(
+            "2023-09-01",
+            "If you don't choose a target for Protective Parents's ability, the Young Hero Role token " +
+                "won't be created."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each of " +
+                "those Roles except the one with the most recent timestamp is put into its owner's graveyard. " +
+                "This is a state-based action."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedtoothGenealogist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedtoothGenealogist.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Redtooth Genealogist
+ * {2}{G}
+ * Creature — Elf Advisor
+ * 2/3
+ *
+ * When this creature enters, create a Royal Role token attached to another target creature you
+ * control. (If you control another Role on it, put that one into the graveyard. Enchanted creature
+ * gets +1/+1 and has ward {1}.)
+ *
+ * "Another target creature you control" — the Genealogist can't crown itself, hence
+ * [Targets.OtherCreatureYouControl] rather than the plain creature-you-control filter. With no
+ * other creature on board the trigger simply has no legal target and is removed from the stack.
+ * The one-Role-per-creature rule lives behind [Effects.CreateRoleToken].
+ */
+val RedtoothGenealogist = card("Redtooth Genealogist") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Advisor"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, create a Royal Role token attached to another target " +
+        "creature you control. (If you control another Role on it, put that one into the graveyard. " +
+        "Enchanted creature gets +1/+1 and has ward {1}.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("another target creature you control", Targets.OtherCreatureYouControl)
+        effect = Effects.CreateRoleToken("Royal Role", t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Gaboleps"
+        flavorText = "Some family trees are thornier than others."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg?1783915079"
+
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each of " +
+                "those Roles except the one with the most recent timestamp is put into its owner's graveyard. " +
+                "This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "Some spells and abilities that create Role tokens require targets. If each target chosen is an " +
+                "illegal target as that spell or ability tries to resolve, it won't resolve. The Role token " +
+                "won't be created."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SongOfTotentanz.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SongOfTotentanz.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Song of Totentanz
+ * {X}{R}
+ * Sorcery
+ *
+ * Create X 1/1 black Rat creature tokens with "This token can't block."
+ * Creatures you control gain haste until end of turn.
+ *
+ * The two halves are ordered, not simultaneous: the Rats are created first, so the haste grant —
+ * a `ForEachInGroup` over creatures you control, snapshotted at resolution — catches them too.
+ * Creatures that arrive later in the turn don't get haste (WOE ruling), which falls out of the
+ * group being enumerated once, at resolution.
+ */
+val SongOfTotentanz = card("Song of Totentanz") {
+    manaCost = "{X}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create X 1/1 black Rat creature tokens with \"This token can't block.\" " +
+        "Creatures you control gain haste until end of turn."
+
+    spell {
+        effect = Effects.Composite(
+            woeRatToken(count = DynamicAmount.XValue),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.youControl()),
+                Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Randy Gallegos"
+        flavorText = "Townsfolk tapped their feet and hummed along, unwittingly amplifying the tune " +
+            "that would summon their doom."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg?1783915088"
+
+        ruling(
+            "2023-09-01",
+            "Only creatures you control at the time Song of Totentanz resolves, including the Rat tokens " +
+                "it creates, will gain haste. Creatures you begin to control later in the turn won't be affected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.scripting.CantBlock
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Wilds of Eldraine's Rat token: a 1/1 black Rat creature token with "This token can't block."
@@ -12,8 +13,12 @@ import com.wingedsheep.sdk.scripting.effects.Effect
  * [Effects.CreateToken] rather than a [com.wingedsheep.mtg.sets.tokens.PredefinedTokens] entry.
  * Several WOE cards create it (Harried Spearguard, Warehouse Tabby, Rat Out, …), so the shape —
  * including the token's art — lives here rather than being copied per card.
+ *
+ * [count] is a [DynamicAmount] so the same helper covers the fixed-count cards and Song of
+ * Totentanz's "create X … Rat creature tokens".
  */
-internal fun woeRatToken(): Effect = Effects.CreateToken(
+internal fun woeRatToken(count: DynamicAmount = DynamicAmount.Fixed(1)): Effect = Effects.CreateToken(
+    count = count,
     power = 1,
     toughness = 1,
     colors = setOf(Color.BLACK),

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,55 @@
     ]
 }
 
+// Ashiok's Reaper
+{
+    "name": "Ashiok's Reaper",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Nightmare",
+    "oracleText": "Whenever an enchantment you control is put into a graveyard from the battlefield, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "UNCOMMON",
+        "artist": "Denis Zhbankov",
+        "flavorText": "Neva's dreams were haunted by memories of the invasion—oil-black tendrils grasping at her through the mist. Or . . . was this something new?",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83957fe0-6500-420c-9b7a-2448a1c1d3b3.jpg?1783915111",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Enchantment tokens (such as Roles) that are sacrificed, destroyed, or would otherwise go to the graveyard are put into their owner's graveyard before ceasing to exist. If you controlled the token, Ashiok's Reaper's ability will trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Barrow Naughty
 {
     "name": "Barrow Naughty",
@@ -2833,6 +2882,110 @@
     ]
 }
 
+// Imodane's Recruiter
+{
+    "name": "Imodane's Recruiter",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "When this creature enters, creatures you control get +1/+0 and gain haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dbaa855-3f8e-42e6-8ec8-5ffbc5c8acf0.jpg?1783915064",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Imodane's Recruiter's triggered ability affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't get +1/+0 or gain haste."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it as a permanent spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Train Troops",
+            "manaCost": "{4}{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create two 2/2 white Knight creature tokens with vigilance. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1783914992"
+                }
+            }
+        }
+    ]
+}
+
 // Kindled Heroism
 {
     "name": "Kindled Heroism",
@@ -3587,6 +3740,64 @@
     ]
 }
 
+// Protective Parents
+{
+    "name": "Protective Parents",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "When this creature dies, create a Young Hero Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Young Hero Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "up to one target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68cc9653-80ef-4606-a0ec-6d4228fdb118.jpg?1783915130",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a target for Protective Parents's ability, the Young Hero Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Quick Study
 {
     "name": "Quick Study",
@@ -3710,6 +3921,64 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Redtooth Genealogist
+{
+    "name": "Redtooth Genealogist",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Advisor",
+    "oracleText": "When this creature enters, create a Royal Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Royal Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Gaboleps",
+        "flavorText": "Some family trees are thornier than others.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99c81440-66eb-4443-a83f-e2f15cb68a3e.jpg?1783915079",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some spells and abilities that create Role tokens require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. The Role token won't be created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4368,6 +4637,67 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Song of Totentanz
+{
+    "name": "Song of Totentanz",
+    "manaCost": "{X}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create X 1/1 black Rat creature tokens with \"This token can't block.\" Creatures you control gain haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": "XValue",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "flavorText": "Townsfolk tapped their feet and hummed along, unwittingly amplifying the tune that would summon their doom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/940e8bb7-0251-4fac-945c-d83618c10447.jpg?1783915088",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Only creatures you control at the time Song of Totentanz resolves, including the Rat tokens it creates, will gain haste. Creatures you begin to control later in the turn won't be affected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch5ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch5ScenarioTest.kt
@@ -1,0 +1,316 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the fifth batch of Wilds of Eldraine cards:
+ *
+ *  - Ashiok's Reaper ({3}{B} 3/3) — draws whenever an enchantment you control hits the graveyard
+ *    from the battlefield.
+ *  - Song of Totentanz ({X}{R}) — X Rat tokens, then haste for the creatures you control
+ *    (including the freshly-made Rats).
+ *  - Redtooth Genealogist ({2}{G} 2/3) — enters with a Royal Role for *another* creature you control.
+ *  - Protective Parents ({2}{W} 3/2) — dies into a Young Hero Role on up to one creature you control.
+ *  - Imodane's Recruiter // Train Troops ({2}{R} 2/2 // {4}{W}) — team pump + haste on enter; the
+ *    Adventure makes two vigilant Knights.
+ */
+class WoeCardsBatch5ScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ashiok's Reaper — your enchantments dying draw cards") {
+            test("an enchantment you control hitting the graveyard draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ashiok's Reaper", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Castle")
+                    .withCardInHand(1, "Disenchant")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Disenchant", game.findPermanent("Castle")!!).error shouldBe null
+                game.resolveStack()
+
+                withClue("Disenchant left hand (-1) and the Reaper's trigger drew a card (+1)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("an opponent's enchantment dying does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ashiok's Reaper", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Castle")
+                    .withCardInHand(1, "Disenchant")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Disenchant", game.findPermanent("Castle")!!).error shouldBe null
+                game.resolveStack()
+
+                withClue("the enchantment was not yours, so no draw — only Disenchant left hand") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+        }
+
+        context("Song of Totentanz — X Rats, then haste for the team") {
+            test("X=2 makes two Rats and every creature you control gains haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Song of Totentanz")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castXSpell(1, "Song of Totentanz", 2).error shouldBe null
+                game.resolveStack()
+
+                val rats = game.findAllPermanents("Rat Token")
+                withClue("X = 2, so two Rat tokens") { rats.size shouldBe 2 }
+
+                withClue("the Rats were created before the haste grant, so they get haste too") {
+                    rats.forEach { game.state.projectedState.hasKeyword(it, Keyword.HASTE) shouldBe true }
+                }
+                withClue("creatures you already controlled gain haste") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+                withClue("an opponent's creature is untouched") {
+                    game.state.projectedState.hasKeyword(wurm, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("X=0 makes no Rats but still grants haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Song of Totentanz")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castXSpell(1, "Song of Totentanz", 0).error shouldBe null
+                game.resolveStack()
+
+                game.findAllPermanents("Rat Token").size shouldBe 0
+                game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+            }
+        }
+
+        context("Redtooth Genealogist — a Royal Role for another creature you control") {
+            test("the Role lands on the other creature and grants +1/+1 and ward") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Redtooth Genealogist")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Redtooth Genealogist").error shouldBe null
+                game.resolveStack() // Genealogist enters -> ETB trigger asks for its target
+
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Royal Role token was created") {
+                    (game.findPermanent("Royal Role") != null) shouldBe true
+                }
+                withClue("the Bears are 2/2 base plus the Role's +1/+1") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+                withClue("and the Genealogist itself stayed a plain 2/3 — it can't crown itself") {
+                    val genealogist = game.findPermanent("Redtooth Genealogist")!!
+                    game.state.projectedState.getPower(genealogist) shouldBe 2
+                    game.state.projectedState.getToughness(genealogist) shouldBe 3
+                }
+            }
+
+            test("with no other creature there is no legal target and no Role appears") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Redtooth Genealogist")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Redtooth Genealogist").error shouldBe null
+                game.resolveStack()
+
+                withClue("'another target creature you control' has no legal choice") {
+                    (game.findPermanent("Royal Role") == null) shouldBe true
+                }
+            }
+        }
+
+        context("Protective Parents — a Young Hero Role on death") {
+            test("dying creates the Role on the chosen creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Protective Parents", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val parents = game.findPermanent("Protective Parents")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // 3 damage kills the 3/2 Parents.
+                game.castSpell(1, "Lightning Bolt", parents).error shouldBe null
+                game.resolveStack()
+
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Parents died and their trigger made a Young Hero Role") {
+                    game.isInGraveyard(1, "Protective Parents") shouldBe true
+                    (game.findPermanent("Young Hero Role") != null) shouldBe true
+                }
+            }
+
+            test("'up to one' may be declined — no Role is created") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Protective Parents", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val parents = game.findPermanent("Protective Parents")!!
+
+                game.castSpell(1, "Lightning Bolt", parents).error shouldBe null
+                game.resolveStack()
+
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                withClue("declining the optional target creates nothing") {
+                    (game.findPermanent("Young Hero Role") == null) shouldBe true
+                }
+            }
+        }
+
+        context("Imodane's Recruiter // Train Troops") {
+            test("the enters trigger gives creatures you control +1/+0 and haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Imodane's Recruiter")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castSpell(1, "Imodane's Recruiter").error shouldBe null
+                game.resolveStack()
+
+                val recruiter = game.findPermanent("Imodane's Recruiter")!!
+
+                withClue("the Bears got +1/+0 and haste") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+                withClue("the Recruiter is on the battlefield when its own trigger resolves") {
+                    game.state.projectedState.getPower(recruiter) shouldBe 3
+                    game.state.projectedState.hasKeyword(recruiter, Keyword.HASTE) shouldBe true
+                }
+                withClue("the opponent's creature is untouched") {
+                    game.state.projectedState.getPower(wurm) shouldBe 6
+                    game.state.projectedState.hasKeyword(wurm, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("Train Troops makes two 2/2 vigilant Knights and exiles the card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Imodane's Recruiter")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Imodane's Recruiter"
+                }
+
+                // faceIndex = 0 casts the Adventure half, Train Troops.
+                game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                ).error shouldBe null
+                game.resolveStack()
+
+                val knights = game.findAllPermanents("Knight Token")
+                withClue("two Knight tokens") { knights.size shouldBe 2 }
+                knights.forEach {
+                    game.state.projectedState.getPower(it) shouldBe 2
+                    game.state.projectedState.getToughness(it) shouldBe 2
+                    game.state.projectedState.hasKeyword(it, Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("the Adventure exiled itself so the creature can be cast later") {
+                    game.isInExile(1, "Imodane's Recruiter") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more Wilds of Eldraine cards. All compose existing SDK primitives — no new effect, trigger, condition, or keyword types.

| Card | Shape |
|---|---|
| **Ashiok's Reaper** `{3}{B}` 3/3 | `leavesBattlefield(Enchantment.youControl(), GRAVEYARD, ANY)` → draw — the Warehouse Tabby shape. Role tokens count, since an enchantment token is put into the graveyard before it ceases to exist. |
| **Song of Totentanz** `{X}{R}` | `woeRatToken(count = XValue)` then a `ForEachInGroup` haste grant over creatures you control. The ordering is load-bearing: the fresh Rats get haste, creatures arriving later in the turn don't. |
| **Redtooth Genealogist** `{2}{G}` 2/3 | ETB Royal Role on `Targets.OtherCreatureYouControl` — it can't crown itself, and with no other creature the trigger has no legal target. |
| **Protective Parents** `{2}{W}` 3/2 | Dies trigger with an optional ("up to one") creature-you-control target for a Young Hero Role. |
| **Imodane's Recruiter // Train Troops** `{2}{R}` 2/2 // `{4}{W}` | ETB `ForEachInGroup(+1/+0, haste)` over creatures you control; the Adventure makes two 2/2 vigilant Knights. |

## SDK change

One defaulted parameter: the `DynamicAmount`-count `Effects.CreateToken` overload now takes `staticAbilities`, matching what the `Int`-count overload already exposed. Song of Totentanz needs X Rats that each carry `CantBlock()`. `docs/card-sdk-language-reference.md` updated in the same change.

`woeRatToken` now takes a `DynamicAmount` count (default `Fixed(1)`), so the existing fixed-count Rat cards and Song of Totentanz share one shape.

## Testing

`WoeCardsBatch5ScenarioTest` — 10 tests, all passing. Beyond the happy paths: an opponent's enchantment dying does *not* trigger the Reaper, X=0 makes no Rats but still grants haste, the Genealogist finds no legal target alone, the "up to one" target is declined, and the Adventure face is cast and exiles itself.

`:mtg-sets:test` and `:mtg-sdk:test` green (card lint, facade boundary, snapshot round-trip). WOE golden re-blessed — additions only, no other card moved. `just check-card-printing` clean for all five (WOE is the earliest real printing of each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)