### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ReturnTriumphant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ReturnTriumphant.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Return Triumphant
+ * {1}{W}
+ * Sorcery
+ *
+ * Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ * Create a Young Hero Role token attached to it.
+ *
+ * "Attached to it" is the creature this spell just reanimated, not a second target — the Role
+ * rides along on the same [target] handle. Entity identity survives the graveyard → battlefield
+ * move, so the reanimation and the attach can be sequenced in one [Effects.Composite]: by the
+ * time [Effects.CreateRoleToken] runs, the card is already a permanent and a legal host.
+ *
+ * The single target is mandatory (not "up to one"), so with no legal creature card in your
+ * graveyard the spell can't be cast, and a target that leaves the graveyard in response fizzles
+ * the whole spell — no Role either.
+ */
+val ReturnTriumphant = card("Return Triumphant") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card with mana value 3 or less from your graveyard to " +
+        "the battlefield. Create a Young Hero Role token attached to it. (Enchanted creature has " +
+        "\"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on " +
+        "it.\" If you put another Role on the creature later, put this one into the graveyard.)"
+
+    spell {
+        val t = target(
+            "target creature card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.ownedByYou().manaValueAtMost(3),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Composite(
+            Effects.PutOntoBattlefield(t),
+            Effects.CreateRoleToken("Young Hero Role", t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Will Gist"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg?1783915128"
+
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each of " +
+                "those Roles except the one with the most recent timestamp is put into its owner's graveyard. " +
+                "This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "Some spells and abilities that create Role tokens require targets. If each target chosen is an " +
+                "illegal target as that spell or ability tries to resolve, it won't resolve. The Role token " +
+                "won't be created."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TatteredRatter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TatteredRatter.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Tattered Ratter
+ * {1}{R}
+ * Creature — Human Peasant
+ * 2/2
+ *
+ * Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.
+ *
+ * The Berserk Murlodont shape: an ANY-bound `becomesBlocked` watching every Rat *you control*
+ * (not just this creature), with the pump applied to [EffectTarget.TriggeringEntity] — the Rat
+ * that got blocked, which may well not be the Ratter. Untargeted, so a hexproof Rat is still
+ * pumped. The trigger fires once per Rat that becomes blocked, and once only per combat for that
+ * Rat regardless of how many creatures block it (CR 509.1h) — the +2/+0 doesn't scale with the
+ * number of blockers.
+ */
+val TatteredRatter = card("Tattered Ratter") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Peasant"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.withSubtype("Rat").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.ModifyStats(2, 0, EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Tyler Walpole"
+        flavorText = "\"What's that, Snappers? Yes, you're right! It *was* very rude of the " +
+            "innkeeper to throw us out!\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg?1783915087"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/UnassumingSage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/UnassumingSage.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Unassuming Sage
+ * {1}{W}
+ * Creature — Human Peasant Wizard
+ * 2/2
+ *
+ * When this creature enters, you may pay {2}. If you do, create a Sorcerer Role token attached
+ * to it. (Enchanted creature gets +1/+1 and has "Whenever this creature attacks, scry 1.")
+ *
+ * "Attached to it" points back at the Sage, not at a target — the trigger is untargeted, so
+ * hexproof/shroud never enter into it and there's nothing to fizzle. [MayPayManaEffect] models
+ * "you may pay {2}. If you do" as one step: declining, or being unable to produce the mana,
+ * simply skips the Role. If the Sage has left the battlefield by the time the trigger resolves,
+ * there's no legal host and the Role isn't created.
+ */
+val UnassumingSage = card("Unassuming Sage") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Peasant Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you may pay {2}. If you do, create a Sorcerer Role " +
+        "token attached to it. (Enchanted creature gets +1/+1 and has \"Whenever this creature " +
+        "attacks, scry 1.\")"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = Effects.CreateRoleToken("Sorcerer Role", EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Michele Giorgi"
+        flavorText = "\"The archmage Valya? Why yes, I do believe I've heard of her.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg?1783915126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VerdantOutrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VerdantOutrider.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Verdant Outrider
+ * {2}{G}
+ * Creature — Human Knight
+ * 4/2
+ *
+ * {1}{G}: This creature can't be blocked by creatures with power 2 or less this turn.
+ *
+ * A durational blocking restriction granted to the Outrider itself, so it's the
+ * [Effects.GrantStaticAbility] wrapper around a printed-style [CantBeBlockedBy] rather than a new
+ * effect type. Power is read from projected state when blockers are declared, so a blocker pumped
+ * above 2 after the fact can still block — and, per the 2023-09-01 ruling, activating this *after*
+ * blockers are declared doesn't retroactively unblock the Outrider. Both fall out of the
+ * restriction being consulted only at declare-blockers time.
+ */
+val VerdantOutrider = card("Verdant Outrider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Knight"
+    power = 4
+    toughness = 2
+    oracleText = "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = Effects.GrantStaticAbility(
+            ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2)),
+            target = EffectTarget.Self
+        )
+        description = "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Taras Susak"
+        flavorText = "Some knights who survived the invasion have forsaken what remains of their " +
+            "courts. The newly formed Verdant Order has sworn to defend the last untouched parts " +
+            "of the wilds."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1783915074"
+
+        ruling(
+            "2023-09-01",
+            "Activating Verdant Outrider's ability after it has become blocked by a creature with " +
+                "power 2 or less won't cause it to become unblocked."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WitchsMark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WitchsMark.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Witch's Mark
+ * {1}{R}
+ * Sorcery
+ *
+ * You may discard a card. If you do, draw two cards.
+ * Create a Wicked Role token attached to up to one target creature you control.
+ *
+ * Two independent halves, and only the second one targets. "Up to one target" is optional
+ * targeting, so the spell is castable with no target at all — you then just loot (2023-09-01
+ * ruling). If you *do* pick a target and it's illegal on resolution, the spell doesn't resolve
+ * and **none** of its effects happen: no discard, no draw, no Role. That all-or-nothing fizzle
+ * is the engine's ordinary targeting behavior (CR 608.2b), so the two halves can sit in a plain
+ * [Effects.Composite] rather than being separated.
+ *
+ * The loot half is the [MayEffect] + [IfYouDoEffect] shape: declining the "may" skips the draw,
+ * and so does an empty hand — the discard accomplishes nothing, so the `ifYouDo` never fires.
+ * The one-Role-per-creature rule (a state-based action) lives behind [Effects.CreateRoleToken].
+ */
+val WitchsMark = card("Witch's Mark") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "You may discard a card. If you do, draw two cards.\n" +
+        "Create a Wicked Role token attached to up to one target creature you control. (If you " +
+        "control another Role on it, put that one into the graveyard. Enchanted creature gets " +
+        "+1/+1. When this token is put into a graveyard, each opponent loses 1 life.)"
+
+    spell {
+        val t = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.Composite(
+            MayEffect(
+                effect = IfYouDoEffect(
+                    action = Patterns.Hand.discardCards(1),
+                    ifYouDo = Effects.DrawCards(2)
+                ),
+                descriptionOverride = "You may discard a card. If you do, draw two cards."
+            ),
+            Effects.CreateRoleToken("Wicked Role", t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg?1783915086"
+
+        ruling(
+            "2023-09-01",
+            "You can cast Witch's Mark without a target just to discard a card and draw two cards. " +
+                "However, if you do choose a target, and that target is illegal at the time Witch's Mark " +
+                "tries to resolve, the spell won't resolve and none of its effects will happen. You won't " +
+                "discard, draw, or create a Wicked Role token."
+        )
+        ruling(
+            "2023-09-01",
+            "If you don't choose a target for Witch's Mark, the Wicked Role token won't be created."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each of " +
+                "those Roles except the one with the most recent timestamp is put into its owner's graveyard. " +
+                "This is a state-based action."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -4074,6 +4074,65 @@
     ]
 }
 
+// Return Triumphant
+{
+    "name": "Return Triumphant",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Create a Young Hero Role token attached to it. (Enchanted creature has \"Whenever this creature attacks, if its toughness is 3 or less, put a +1/+1 counter on it.\" If you put another Role on the creature later, put this one into the graveyard.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Young Hero Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=3 own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card with mana value 3 or less from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Will Gist",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5209c13-9591-48eb-8d6c-112b3bdd429a.jpg?1783915128",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some spells and abilities that create Role tokens require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. The Role token won't be created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Rimefur Reindeer
 {
     "name": "Rimefur Reindeer",
@@ -5387,6 +5446,52 @@
     ]
 }
 
+// Tattered Ratter
+{
+    "name": "Tattered Ratter",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "Whenever a Rat you control becomes blocked, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature Rat ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "TriggeringEntity"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Walpole",
+        "flavorText": "\"What's that, Snappers? Yes, you're right! It *was* very rude of the innkeeper to throw us out!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30f505b4-d61c-4da8-ab45-37125260d556.jpg?1783915087"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Three Bowls of Porridge
 {
     "name": "Three Bowls of Porridge",
@@ -5592,6 +5697,53 @@
     ]
 }
 
+// Unassuming Sage
+{
+    "name": "Unassuming Sage",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Peasant Wizard",
+    "oracleText": "When this creature enters, you may pay {2}. If you do, create a Sorcerer Role token attached to it. (Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateRoleToken",
+                        "roleName": "Sorcerer Role",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Michele Giorgi",
+        "flavorText": "\"The archmage Valya? Why yes, I do believe I've heard of her.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a66fbaeb-1624-43b3-83e2-a37ce7588a5a.jpg?1783915126"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Unruly Catapult
 {
     "name": "Unruly Catapult",
@@ -5775,6 +5927,64 @@
                 ]
             }
         }
+    ]
+}
+
+// Verdant Outrider
+{
+    "name": "Verdant Outrider",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantStaticAbility",
+                    "ability": {
+                        "type": "CantBeBlockedBy",
+                        "blockerFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "PowerAtMost",
+                                    "max": 2
+                                }
+                            ]
+                        }
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{G}: This creature can't be blocked by creatures with power 2 or less this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Taras Susak",
+        "flavorText": "Some knights who survived the invasion have forsaken what remains of their courts. The newly formed Verdant Order has sworn to defend the last untouched parts of the wilds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c34830e4-823a-40fa-ba41-bb2afbf1e499.jpg?1783915074",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Activating Verdant Outrider's ability after it has become blocked by a creature with power 2 or less won't cause it to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -6127,5 +6337,113 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Witch's Mark
+{
+    "name": "Witch's Mark",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "You may discard a card. If you do, draw two cards.\nCreate a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may discard a card. If you do, draw two cards."
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "up to one target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/0685afcb-06f6-4d18-b8c2-510764558dc1.jpg?1783915086",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You can cast Witch's Mark without a target just to discard a card and draw two cards. However, if you do choose a target, and that target is illegal at the time Witch's Mark tries to resolve, the spell won't resolve and none of its effects will happen. You won't discard, draw, or create a Wicked Role token."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a target for Witch's Mark, the Wicked Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch6ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch6ScenarioTest.kt
@@ -1,0 +1,316 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for a batch of Wilds of Eldraine cards implemented together. All five are pure
+ * composition over existing SDK primitives, so these tests pin the *composition* — the bits that
+ * could plausibly be wired wrong:
+ *
+ *  - Witch's Mark ({1}{R} sorcery) — an optional loot half and an optional-target Wicked Role
+ *    half in one spell; the two must be independent (declining the loot still makes the Role).
+ *  - Return Triumphant ({1}{W} sorcery) — reanimate, then attach a Young Hero Role to *the same*
+ *    card. This is the risky one: it relies on entity identity surviving the graveyard →
+ *    battlefield move so the second effect finds a battlefield host.
+ *  - Verdant Outrider ({2}{G} 4/2) — an activated, until-end-of-turn `CantBeBlockedBy` on itself.
+ *  - Unassuming Sage ({1}{W} 2/2) — untargeted "you may pay {2}" ETB that crowns itself.
+ *  - Tattered Ratter ({1}{R} 2/2) — ANY-bound "a Rat you control becomes blocked" pumping the
+ *    blocked Rat, which is generally *not* the Ratter.
+ */
+class WoeCardsBatch6ScenarioTest : ScenarioTestBase() {
+
+    private val outriderAbilityId by lazy {
+        cardRegistry.requireCard("Verdant Outrider").activatedAbilities[0].id
+    }
+
+    init {
+        context("Witch's Mark — loot half and Role half are independent") {
+            test("accepting the discard draws two and still creates the Wicked Role") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Witch's Mark")
+                    .withCardInHand(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val spareMountain = game.findCardsInHand(1, "Mountain").first()
+
+                // Hand after casting: the spare Mountain only (Witch's Mark goes to the stack).
+                game.castSpell(1, "Witch's Mark", bear)
+                game.resolveStack()
+
+                // "You may discard a card." — say yes; with a single card in hand the engine
+                // auto-selects it, so only prompt-driven cases need an explicit selection.
+                game.getPendingDecision() shouldNotBe null
+                game.answerYesNo(true)
+                if (game.isInHand(1, "Mountain")) game.selectCards(listOf(spareMountain))
+                game.resolveStack()
+
+                withClue("discarded 1, drew 2 -> net +1 card in hand") {
+                    game.handSize(1) shouldBe 2
+                }
+                withClue("Mountain went to the graveyard") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                }
+                val role = game.findPermanent("Wicked Role")
+                withClue("the Wicked Role token was created") { role shouldNotBe null }
+                withClue("the Role is attached to the targeted Bear") {
+                    game.state.getEntity(role!!)?.get<AttachedToComponent>()?.targetId shouldBe bear
+                }
+                withClue("2/2 Bear + Wicked Role's +1/+1 = 3/3") {
+                    game.state.projectedState.getPower(bear) shouldBe 3
+                    game.state.projectedState.getToughness(bear) shouldBe 3
+                }
+            }
+
+            test("declining the discard skips the draw but still creates the Wicked Role") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Witch's Mark")
+                    .withCardInHand(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Witch's Mark", bear)
+                game.resolveStack()
+
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("no discard and no draw — the spare Mountain is untouched") {
+                    game.handSize(1) shouldBe 1
+                    game.isInHand(1, "Mountain") shouldBe true
+                }
+                withClue("the Role half is independent of the loot half") {
+                    game.findPermanent("Wicked Role") shouldNotBe null
+                    game.state.projectedState.getPower(bear) shouldBe 3
+                }
+            }
+        }
+
+        context("Return Triumphant — reanimate, then crown the same creature") {
+            test("the returned creature enters and gets a Young Hero Role attached to it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Return Triumphant")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Return Triumphant", 1, "Grizzly Bears")
+                game.resolveStack()
+
+                val bear = game.findPermanent("Grizzly Bears")
+                withClue("mana value 2 <= 3, so the Bears come back") { bear shouldNotBe null }
+                withClue("it left the graveyard") { game.isInGraveyard(1, "Grizzly Bears") shouldBe false }
+
+                val role = game.findPermanent("Young Hero Role")
+                withClue("the Role token was created") { role shouldNotBe null }
+                withClue("attached to the creature this spell just reanimated") {
+                    game.state.getEntity(role!!)?.get<AttachedToComponent>()?.targetId shouldBe bear
+                }
+                withClue("the Young Hero Role is stats-neutral — the Bears are still 2/2") {
+                    game.state.projectedState.getPower(bear!!) shouldBe 2
+                    game.state.projectedState.getToughness(bear) shouldBe 2
+                }
+            }
+        }
+
+        context("Verdant Outrider — activated blocking restriction") {
+            test("after activating, a power-2 creature can't block it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Verdant Outrider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val outrider = game.findPermanent("Verdant Outrider")!!
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = outrider, abilityId = outriderAbilityId)
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Verdant Outrider" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("the 2/2 Bears has power 2, so the restriction forbids the block") {
+                    game.declareBlockers(
+                        mapOf("Grizzly Bears" to listOf("Verdant Outrider"))
+                    ).error shouldNotBe null
+                }
+            }
+
+            test("without activating, the same creature blocks fine") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Verdant Outrider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Verdant Outrider" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                game.declareBlockers(
+                    mapOf("Grizzly Bears" to listOf("Verdant Outrider"))
+                ).error shouldBe null
+            }
+        }
+
+        context("Unassuming Sage — optional {2} for a self-attached Sorcerer Role") {
+            test("paying {2} crowns the Sage itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Unassuming Sage")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Unassuming Sage")
+                game.resolveStack()
+
+                // The ETB trigger offers the {2}: say yes, then auto-tap for it.
+                game.answerYesNo(true)
+                if (game.getPendingDecision() != null) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val sage = game.findPermanent("Unassuming Sage")!!
+                val role = game.findPermanent("Sorcerer Role")
+                withClue("the Sorcerer Role token was created") { role shouldNotBe null }
+                withClue("\"attached to it\" means the Sage itself, not a target") {
+                    game.state.getEntity(role!!)?.get<AttachedToComponent>()?.targetId shouldBe sage
+                }
+                withClue("2/2 base + the Sorcerer Role's +1/+1 = 3/3") {
+                    game.state.projectedState.getPower(sage) shouldBe 3
+                    game.state.projectedState.getToughness(sage) shouldBe 3
+                }
+            }
+
+            test("declining the {2} leaves the Sage a plain 2/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Unassuming Sage")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Unassuming Sage")
+                game.resolveStack()
+
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                val sage = game.findPermanent("Unassuming Sage")!!
+                withClue("declining skips the Role entirely") {
+                    game.findPermanent("Sorcerer Role") shouldBe null
+                    game.state.projectedState.getPower(sage) shouldBe 2
+                    game.state.projectedState.getToughness(sage) shouldBe 2
+                }
+            }
+        }
+
+        context("Tattered Ratter — pumps whichever Rat you control got blocked") {
+            test("a blocked Rat gets +2/+0, not the Ratter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tattered Ratter", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Mind Drill Assailant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Mind Drill Assailant is a 2/5 Rat Warlock; the Ratter itself is a Human Peasant.
+                val rat = game.findPermanent("Mind Drill Assailant")!!
+                val ratter = game.findPermanent("Tattered Ratter")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Mind Drill Assailant" to 2, "Tattered Ratter" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(
+                    mapOf("Grizzly Bears" to listOf("Mind Drill Assailant"))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the blocked Rat gets +2/+0 (2/5 -> 4/5)") {
+                    game.state.projectedState.getPower(rat) shouldBe 4
+                    game.state.projectedState.getToughness(rat) shouldBe 5
+                }
+                withClue("the unblocked, non-Rat Ratter is untouched") {
+                    game.state.projectedState.getPower(ratter) shouldBe 2
+                }
+            }
+
+            test("a blocked non-Rat doesn't trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tattered Ratter", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val attackingBear = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Craw Wurm" to listOf("Grizzly Bears"))).error shouldBe null
+                game.resolveStack()
+
+                withClue("Bears aren't Rats — no pump") {
+                    game.state.projectedState.getPower(attackingBear) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five WOE commons/uncommons, all pure composition over existing SDK primitives — no engine, SDK, or client changes, so `docs/card-sdk-language-reference.md` is unchanged.

I skipped the Bargain and Celebration cards in the missing list on purpose: neither mechanic exists in the SDK yet, and approximating Celebration with `EnteredThisTurn` (which only sees permanents *still* on the battlefield) would be wrong. Those are `add-feature` work.

## Cards

| Card | Shape |
|---|---|
| **Witch's Mark** {1}{R} | `MayEffect` + `IfYouDo` loot half and an optional-target Wicked Role half in one `Composite` |
| **Return Triumphant** {1}{W} | Reanimate MV≤3, then attach a Young Hero Role to *that same* card |
| **Verdant Outrider** {2}{G} | `{1}{G}`: until-EOT `CantBeBlockedBy(power ≤ 2)` on itself |
| **Unassuming Sage** {1}{W} | Untargeted `MayPayManaEffect({2})` ETB, Sorcerer Role on itself |
| **Tattered Ratter** {1}{R} | ANY-bound `becomesBlocked` over Rats you control, pumping `TriggeringEntity` |

## Notes on the tricky ones

- **Witch's Mark** — the two halves are independent, so declining the discard still creates the Role. Per the 2023-09-01 ruling the spell is castable with no target at all, and a chosen-but-illegal target fizzles *everything* (no discard, no draw, no Role); both fall out of ordinary optional targeting rather than needing special handling.
- **Return Triumphant** — "attached to it" reuses the single target handle instead of adding a second target. This is the one that relies on entity identity surviving the graveyard → battlefield move; the scenario test pins that the Role lands on the reanimated permanent.
- **Verdant Outrider** — the restriction is only consulted at declare-blockers, which is exactly why activating *after* blockers are declared doesn't retroactively unblock it (2023-09-01 ruling).
- **Tattered Ratter** — the Berserk Murlodont shape. The pumped creature is the blocked Rat, generally *not* the Ratter (a Human Peasant).

## Testing

`WoeCardsBatch6ScenarioTest` — 9 tests, all passing. Covers both branches of every optional choice (pay/decline, discard/decline) and the negative cases (a blocked non-Rat gets no pump; an un-activated Outrider is blocked normally).

`just test` green. WOE card snapshot re-blessed — the diff adds only these five cards, no drift elsewhere. `just check-card-printing` confirms WOE is the earliest real printing for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)