### PR TITLE
Rename 'con' package to 'conflux' for Windows compatibility

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/ConfluxSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/ConfluxSet.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con
+package com.wingedsheep.mtg.sets.definitions.conflux
 
 import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
@@ -29,5 +29,5 @@ object ConfluxSet : MtgSet {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
-    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.con.cards"
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.conflux.cards"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ArmillarySphere.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ArmillarySphere.kt
@@ -2,7 +2,7 @@
 // Complete render — no manual wiring needed. Still review the rules text and add a passing
 // scenario test before relying on it.
 
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Patterns

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ExoticOrchard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ExoticOrchard.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ManaCylixReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ManaCylixReprint.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ManiacalRageReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ManiacalRageReprint.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ReliquaryTower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ReliquaryTower.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RuptureSpire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/RuptureSpire.kt
@@ -2,7 +2,7 @@
 // Complete render — no manual wiring needed. Still review the rules text and add a passing
 // scenario test before relying on it.
 
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/UnsummonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/UnsummonReprint.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/WorldlyCounselReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/WorldlyCounselReprint.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.con.cards
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
 
 import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity


### PR DESCRIPTION
The 'con' directory name is reserved in Windows (CON, PRN, AUX, NUL, etc. are DOS device names), preventing users from cloning or using this project on Windows systems. This renaming resolves the issue while preserving the set's identity (CON = Conflux).

Updated all package declarations from com.wingedsheep.mtg.sets.definitions.con.* to com.wingedsheep.mtg.sets.definitions.conflux.*