### PR TITLE
Add Darksteel Colossus and Ancestor Dragon (Foundations)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6749,18 +6749,29 @@ replacementEffect {
   covered too: e.g. Dauntless Dismantler's "Artifacts your opponents control enter tapped" taps an
   opponent's Map/Treasure/Clue token, and Authority of the Consuls taps opponents' creature tokens (a token
   entering attacking keeps its tapped state and is not overridden).
-- `RedirectZoneChange(newDestination, appliesTo, linkToSource = false)` — redirect a zone change to a
-  different destination (Rest in Peace / Leyline of the Void: graveyard → exile). `appliesTo` is an
-  `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s `controllerPredicate` scopes it
-  (e.g. `OwnedByOpponent` for Leyline). When `linkToSource = true` and `newDestination = Zone.EXILE`,
-  each redirected card is added to the source permanent's `LinkedExileComponent`, so the source can
-  later reference — and grant playing of — the cards it exiled. Valgavoth, Terror Eater pairs it with
-  `GrantMayCastFromLinkedExile`: "If a card you didn't control would be put into an opponent's graveyard
-  from anywhere, exile it instead" is `RedirectZoneChange(newDestination = Zone.EXILE, linkToSource =
-  true, appliesTo = ZoneChangeEvent(to = Zone.GRAVEYARD, filter = GameObjectFilter(cardPredicates =
-  listOf(CardPredicate.IsNontoken), controllerPredicate = ControllerPredicate.And(listOf(OwnedByOpponent,
-  Not(ControlledByYou))))))`. The redirect (and link) is honored across every graveyard path: SBA deaths,
-  mill/discard/destroy (`ZoneTransitionService`), spell resolution, counters, and fizzles (`StackResolver`).
+- `RedirectZoneChange(newDestination, appliesTo, linkToSource = false, selfOnly = false, shuffleIntoLibrary = false, reveal = false)`
+  — redirect a zone change to a different destination (Rest in Peace / Leyline of the Void: graveyard →
+  exile). `appliesTo` is an `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s
+  `controllerPredicate` scopes it (e.g. `OwnedByOpponent` for Leyline). When `linkToSource = true` and
+  `newDestination = Zone.EXILE`, each redirected card is added to the source permanent's
+  `LinkedExileComponent`, so the source can later reference — and grant playing of — the cards it exiled.
+  Valgavoth, Terror Eater pairs it with `GrantMayCastFromLinkedExile`: "If a card you didn't control
+  would be put into an opponent's graveyard from anywhere, exile it instead" is
+  `RedirectZoneChange(newDestination = Zone.EXILE, linkToSource = true, appliesTo = ZoneChangeEvent(to =
+  Zone.GRAVEYARD, filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsNontoken),
+  controllerPredicate = ControllerPredicate.And(listOf(OwnedByOpponent, Not(ControlledByYou))))))`. The
+  redirect (and link) is honored across every graveyard path: SBA deaths, mill/discard/destroy
+  (`ZoneTransitionService`), spell resolution, counters, and fizzles (`StackResolver`).
+  **Card-intrinsic "from anywhere" self-replacements:** set `selfOnly = true` when the redirect is the
+  moving card's *own* ability referring to itself ("If ~ would be put into a graveyard from anywhere,
+  …"). It then functions in **every** zone (CR 614.12), carried on the card entity via
+  `SelfZoneRedirectComponent` rather than scanned off the battlefield, so the card is redirected whether
+  it dies, is milled, is discarded, or is countered on the stack — and it stops applying only while the
+  source is on the battlefield with all abilities removed. `shuffleIntoLibrary = true` (with
+  `newDestination = Zone.LIBRARY`) shuffles the card in rather than placing it on top; `reveal = true`
+  is the flavor "reveal it and …" (informational — a public-zone card is already known). Darksteel
+  Colossus / Progenitus: `RedirectZoneChange(newDestination = Zone.LIBRARY, appliesTo =
+  ZoneChangeEvent(to = Zone.GRAVEYARD), selfOnly = true, shuffleIntoLibrary = true, reveal = true)`.
 - `RedirectZoneChangeWithEffect(newDestination, additionalEffect, selfOnly = false, linkToSource = false,
   appliesTo)` — like `RedirectZoneChange` but also runs `additionalEffect` when the replacement fires.
   The additional effect is applied through a small executor whitelist (not the full pipeline) —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -237,16 +237,39 @@ data class ModifyCounterPlacement(
  * can later reference the cards it exiled — e.g. Valgavoth, Terror Eater ("If a card you didn't
  * control would be put into an opponent's graveyard from anywhere, exile it instead." + "you may
  * play cards exiled with Valgavoth"). Ignored for non-exile destinations.
+ *
+ * ## Card-intrinsic "from anywhere" self-replacements
+ *
+ * When [selfOnly] is true the redirect is the moving card's own ability referring to itself
+ * ("If ~ would be put into a graveyard from anywhere, …") and therefore functions in **every**
+ * zone (CR 614.12), not just while the source is on the battlefield. The engine carries it on the
+ * card entity itself rather than scanning the battlefield, so a card milled, discarded, or
+ * countered on the stack is redirected too. It stops applying only while the source is on the
+ * battlefield and has lost all abilities.
+ *
+ * [shuffleIntoLibrary] pairs with `newDestination = Zone.LIBRARY` for the Darksteel Colossus /
+ * Progenitus family ("reveal ~ and shuffle it into its owner's library instead") — the card is
+ * shuffled in rather than placed on top. [reveal] shows the card as it is shuffled away.
  */
 @SerialName("RedirectZoneChange")
 @Serializable
 data class RedirectZoneChange(
     val newDestination: Zone,
     override val appliesTo: EventPattern,
-    val linkToSource: Boolean = false
+    val linkToSource: Boolean = false,
+    val selfOnly: Boolean = false,
+    val shuffleIntoLibrary: Boolean = false,
+    val reveal: Boolean = false
 ) : ReplacementEffect {
-    override val description: String =
-        "If ${appliesTo.description}, put it into ${newDestination.displayName} instead"
+    override val description: String = buildString {
+        append("If ${appliesTo.description}, ")
+        if (reveal) append("reveal it and ")
+        if (shuffleIntoLibrary && newDestination == Zone.LIBRARY) {
+            append("shuffle it into its owner's library instead")
+        } else {
+            append("put it into ${newDestination.displayName} instead")
+        }
+    }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dst/cards/DarksteelColossus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dst/cards/DarksteelColossus.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dst.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Darksteel Colossus — Darksteel #109 (canonical printing; reprinted in Foundations #671).
+ * {11} · Artifact Creature — Golem · 11/11
+ *
+ * Trample, indestructible.
+ * If Darksteel Colossus would be put into a graveyard from anywhere, reveal it and shuffle it
+ * into its owner's library instead.
+ *
+ * The shuffle-back is a card-intrinsic zone-change replacement (`selfOnly = true`), so it functions
+ * in every zone (CR 614.12): the Colossus shuffles back not only when it dies, but also when it is
+ * milled from the library, discarded, or countered on the stack. It is carried on the card entity
+ * via [com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent] rather than being
+ * a battlefield-only static, and [shuffleIntoLibrary] shuffles it in rather than placing it on top.
+ * `reveal` is informational — a public-zone card is already known — so it drives the flavor text of
+ * the redirect, not a separate game action.
+ */
+val DarksteelColossus = card("Darksteel Colossus") {
+    manaCost = "{11}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    oracleText = "Trample, indestructible\n" +
+        "If Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel " +
+        "Colossus and shuffle it into its owner's library instead."
+    power = 11
+    toughness = 11
+    keywords(Keyword.TRAMPLE, Keyword.INDESTRUCTIBLE)
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.LIBRARY,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+            shuffleIntoLibrary = true,
+            reveal = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "109"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg?1783944427"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AncestorDragonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AncestorDragonReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancestor Dragon reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * GS1's `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val AncestorDragonReprint = Printing(
+    oracleId = "60b03a44-a7bd-48fa-8c8f-1704aed02cd7",
+    name = "Ancestor Dragon",
+    setCode = "FDN",
+    collectorNumber = "489",
+    scryfallId = "df43d9d4-3fef-4a56-8b38-d52824117201",
+    artist = "Shinchuen Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df43d9d4-3fef-4a56-8b38-d52824117201.jpg?1783908968",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DarksteelColossusReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DarksteelColossusReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darksteel Colossus reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * DST's `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DarksteelColossusReprint = Printing(
+    oracleId = "1b09d0cf-403c-4a15-aeee-602a1bdaf0c1",
+    name = "Darksteel Colossus",
+    setCode = "FDN",
+    collectorNumber = "671",
+    scryfallId = "70197723-c61b-4600-b61d-41380c8f3067",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/70197723-c61b-4600-b61d-41380c8f3067.jpg?1783908906",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/GlobalSeriesSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/GlobalSeriesSet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.gs1
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Global Series: Jiang Yanggu & Mu Yanling (2018)
+ *
+ * Scaffolded to host the earliest real printing of cards later reprinted in newer sets
+ * (e.g. Ancestor Dragon, reprinted in Foundations). Intentionally incomplete relative to the
+ * official product — only cards with a canonical [CardDefinition] here are present.
+ *
+ * Set Code: GS1
+ * Release Date: 2018-06-22
+ */
+object GlobalSeriesSet : MtgSet {
+
+    override val code = "GS1"
+    override val displayName = "Global Series: Jiang Yanggu & Mu Yanling"
+    override val releaseDate = "2018-06-22"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.gs1.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/AncestorDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/AncestorDragon.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Ancestor Dragon — Global Series: Jiang Yanggu & Mu Yanling #12 (canonical printing; reprinted
+ * in Foundations #489).
+ * {4}{W}{W} · Creature — Dragon · 5/6
+ *
+ * Flying.
+ * Whenever one or more creatures you control attack, you gain 1 life for each attacking creature.
+ *
+ * The second ability is a single batch trigger (CR 508.3) that fires once per combat no matter how
+ * many creatures attack, and gains life equal to the number of attacking creatures you control at
+ * resolution — the same shape as Grand Warlord Radha, gaining life instead of mana.
+ */
+val AncestorDragon = card("Ancestor Dragon") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 6
+    oracleText = "Flying\n" +
+        "Whenever one or more creatures you control attack, you gain 1 life for each attacking creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = Effects.GainLife(
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.attacking()).count()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Shinchuen Chen"
+        flavorText = "It is said that Yinglong gave birth to the qilin and the phoenix, and after " +
+            "them, all the hairy and winged beings in the world. Thus it is known as the Ancestor Dragon."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9ba9d1f0-a864-490c-b258-6bf9de251c4b.jpg?1783934632"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DarksteelColossusReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DarksteelColossusReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darksteel Colossus reprint in Magic 2010.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in DST's `cards/` package (the
+ * card's earliest real printing). This file contributes only the M10-specific presentation row.
+ */
+val DarksteelColossusReprint = Printing(
+    oracleId = "1b09d0cf-403c-4a15-aeee-602a1bdaf0c1",
+    name = "Darksteel Colossus",
+    setCode = "M10",
+    collectorNumber = "208",
+    scryfallId = "5a3aa1ce-8757-4541-8ac7-1e7e203b60fc",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a3aa1ce-8757-4541-8ac7-1e7e203b60fc.jpg?1783942356",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/AncestorDragonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/AncestorDragonReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancestor Dragon reprint in Treasure Chest (PZ2).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in GS1's `cards/` package (the
+ * card's earliest real printing). This file contributes only the PZ2-specific presentation row.
+ */
+val AncestorDragonReprint = Printing(
+    oracleId = "60b03a44-a7bd-48fa-8c8f-1704aed02cd7",
+    name = "Ancestor Dragon",
+    setCode = "PZ2",
+    collectorNumber = "70829",
+    scryfallId = "423e005b-965a-4a3f-8a55-6d4371982a6e",
+    artist = "Shinchuen Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/423e005b-965a-4a3f-8a55-6d4371982a6e.jpg?1783933899",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DST.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DST.json
@@ -59,6 +59,44 @@
     "colorIdentityOverride": []
 }
 
+// Darksteel Colossus
+{
+    "name": "Darksteel Colossus",
+    "manaCost": "{11}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Trample, indestructible\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.",
+    "creatureStats": {
+        "power": 11,
+        "toughness": 11
+    },
+    "keywords": [
+        "TRAMPLE",
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChange",
+                "newDestination": "Library",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Graveyard"
+                },
+                "selfOnly": true,
+                "shuffleIntoLibrary": true,
+                "reveal": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "RARE",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbc27b24-f085-48b0-8757-cd11fbf25b91.jpg?1783944427"
+    },
+    "colorIdentityOverride": []
+}
+
 // Darksteel Forge
 {
     "name": "Darksteel Forge",

--- a/mtg-sets/src/test/resources/snapshots/cards/GS1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GS1.json
@@ -1,0 +1,41 @@
+// Ancestor Dragon
+{
+    "name": "Ancestor Dragon",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever one or more creatures you control attack, you gain 1 life for each attacking creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature attacking"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "RARE",
+        "artist": "Shinchuen Chen",
+        "flavorText": "It is said that Yinglong gave birth to the qilin and the phoenix, and after them, all the hairy and winged beings in the world. Thus it is known as the Ancestor Dragon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9ba9d1f0-a864-490c-b258-6bf9de251c4b.jpg?1783934632"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.model.PrintingRef
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
 
 /**
  * Builds the per-entity [ComponentContainer] for a card from its [CardDefinition].
@@ -111,6 +112,16 @@ object CardEntityFactory {
 
         if (protectionColors.isNotEmpty() || protectionSubtypes.isNotEmpty() || protectionSupertypes.isNotEmpty()) {
             container = container.with(ProtectionComponent(protectionColors, protectionSubtypes, protectionSupertypes))
+        }
+
+        // Card-intrinsic "would be put into [zone] from anywhere → redirect instead" self-replacements
+        // (Darksteel Colossus, Progenitus). Carried on the card entity so they function in every zone,
+        // not just on the battlefield — see [SelfZoneRedirectComponent].
+        val selfRedirects = cardDef.script.replacementEffects
+            .filterIsInstance<RedirectZoneChange>()
+            .filter { it.selfOnly }
+        if (selfRedirects.isNotEmpty()) {
+            container = container.with(SelfZoneRedirectComponent(selfRedirects))
         }
 
         val hexproofFromColors = cardDef.keywordAbilities

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -350,6 +350,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TextReplacementComponent::class)
         subclass(ProtectionComponent::class)
         subclass(HexproofFromColorComponent::class)
+        subclass(SelfZoneRedirectComponent::class)
         subclass(ToxicComponent::class)
         subclass(CopyOfComponent::class)
         subclass(RevertCopyAtEndOfTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -73,12 +73,19 @@ import com.wingedsheep.sdk.scripting.predicates.evaluateWith
  *        card should be linked to this source permanent's `LinkedExileComponent` after the move
  *        — set by a [RedirectZoneChange] with `linkToSource = true` (Valgavoth, Terror Eater).
  *        Each mover applies the link via [ZoneMovementUtils.linkExiledToSource].
+ * @param shuffleIntoLibrary When true (and [destinationZone] is [Zone.LIBRARY]), the card is
+ *        shuffled into its owner's library rather than placed on top — Darksteel Colossus /
+ *        Progenitus. Movers translate this into [LibraryPlacement.Shuffled].
+ * @param reveal When true, the card is revealed as it is redirected (informational — the shuffle
+ *        destination is otherwise hidden). Darksteel Colossus / Progenitus.
  */
 data class ZoneChangeRedirectResult(
     val destinationZone: Zone,
     val additionalEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null,
     val effectControllerId: EntityId? = null,
-    val linkSourceId: EntityId? = null
+    val linkSourceId: EntityId? = null,
+    val shuffleIntoLibrary: Boolean = false,
+    val reveal: Boolean = false
 )
 
 /**
@@ -473,6 +480,28 @@ object ZoneMovementUtils {
     ): ZoneChangeRedirectResult {
         val container = state.getEntity(entityId) ?: return ZoneChangeRedirectResult(toZone)
 
+        // Card-intrinsic "would be put into [zone] from anywhere → redirect instead" self-replacement
+        // (Darksteel Colossus, Progenitus). It functions in every zone (CR 614.12), so it is read off
+        // the moving card itself rather than by scanning the battlefield. It stops applying only while
+        // the source is on the battlefield and has lost all abilities.
+        val selfRedirect = container
+            .get<com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent>()
+        if (selfRedirect != null &&
+            !(fromZone == Zone.BATTLEFIELD && state.projectedState.hasLostAllAbilities(entityId))
+        ) {
+            for (effect in selfRedirect.redirects) {
+                val event = effect.appliesTo
+                if (event !is com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent) continue
+                if (event.to != null && event.to != toZone) continue
+                if (event.from != null && event.from != fromZone) continue
+                return ZoneChangeRedirectResult(
+                    effect.newDestination,
+                    shuffleIntoLibrary = effect.shuffleIntoLibrary,
+                    reveal = effect.reveal
+                )
+            }
+        }
+
         // Check if the entity itself has ExileOnLeaveBattlefieldComponent
         // (e.g., creature returned by Kheru Lich Lord, Whip of Erebos)
         if (fromZone == Zone.BATTLEFIELD && toZone != Zone.EXILE &&
@@ -517,6 +546,11 @@ object ZoneMovementUtils {
             for (effect in replacementComponent.replacementEffects) {
                 when (effect) {
                     is RedirectZoneChange -> {
+                        // selfOnly redirects are the moving card's own ability and are handled
+                        // above via SelfZoneRedirectComponent (in every zone); never let them
+                        // redirect other cards passing through the battlefield source.
+                        if (effect.selfOnly) continue
+
                         val event = effect.appliesTo
                         if (event !is com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -217,6 +217,17 @@ object ZoneTransitionService {
         }
         val actualDestZone = redirectResult.destinationZone
 
+        // A card-intrinsic redirect into the library shuffles the card in rather than placing it on
+        // top (Darksteel Colossus, Progenitus). This holds even when the caller skipped the redirect
+        // check and passed the result in via the destination zone — such callers set libraryPlacement
+        // themselves, so honour whichever is Shuffled.
+        val effectiveLibraryPlacement =
+            if (redirectResult.shuffleIntoLibrary && actualDestZone == Zone.LIBRARY) {
+                LibraryPlacement.Shuffled
+            } else {
+                options.libraryPlacement
+            }
+
         // Determine controller and destination zone key. Control-changing effects (Threaten,
         // Empress Galina) live in Layer 2 of the projection and never touch the base
         // ControllerComponent, so a battlefield exit must read the projected controller first —
@@ -429,13 +440,13 @@ object ZoneTransitionService {
                 events.addAll(sagaEvents)
             }
             Zone.LIBRARY -> {
-                if (options.libraryPlacement is LibraryPlacement.Shuffled) {
+                if (effectiveLibraryPlacement is LibraryPlacement.Shuffled) {
                     // Drop reveals on every other library card before mixing the new one in
                     newState = com.wingedsheep.engine.handlers.effects.library.LibraryRevealUtils
                         .clearLibraryReveals(newState, ownerId)
                 }
-                newState = placeInLibrary(newState, entityId, destZoneKey, options.libraryPlacement)
-                if (options.libraryPlacement is LibraryPlacement.Shuffled) {
+                newState = placeInLibrary(newState, entityId, destZoneKey, effectiveLibraryPlacement)
+                if (effectiveLibraryPlacement is LibraryPlacement.Shuffled) {
                     events.add(com.wingedsheep.engine.core.LibraryShuffledEvent(ownerId))
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
@@ -91,10 +91,21 @@ object SbaZoneMovementHelper {
             }
         }
 
-        // Delegate zone movement to ZoneTransitionService for full cleanup
+        // Delegate zone movement to ZoneTransitionService for full cleanup. A card-intrinsic
+        // redirect into the library (Darksteel Colossus, Progenitus) shuffles the card in — the
+        // redirect check ran above, so carry its Shuffled placement through the skipped move.
+        val deathLibraryPlacement =
+            if (redirectResult.shuffleIntoLibrary && destinationZone == Zone.LIBRARY) {
+                com.wingedsheep.engine.handlers.effects.LibraryPlacement.Shuffled
+            } else {
+                com.wingedsheep.engine.handlers.effects.LibraryPlacement.Top
+            }
         val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
             newState, entityId, destinationZone,
-            com.wingedsheep.engine.handlers.effects.ZoneEntryOptions(skipZoneChangeRedirect = true)
+            com.wingedsheep.engine.handlers.effects.ZoneEntryOptions(
+                skipZoneChangeRedirect = true,
+                libraryPlacement = deathLibraryPlacement
+            )
         )
         newState = transitionResult.state
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2200,6 +2200,10 @@ class StackResolver(
             c.without<SpellOnStackComponent>().without<TargetsComponent>()
         }
         newState = newState.addToZone(destZoneKey, spellId)
+        // A card-intrinsic redirect into the library shuffles the card in (Progenitus).
+        if (destZone == Zone.LIBRARY && fizzleRedirect.shuffleIntoLibrary) {
+            newState = shuffleOwnerLibrary(newState, ownerId)
+        }
         if (destZone == Zone.EXILE && fizzleRedirect.linkSourceId != null) {
             newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                 .linkExiledToSource(newState, spellId, fizzleRedirect.linkSourceId)
@@ -2550,6 +2554,10 @@ class StackResolver(
         val destZone = counterRedirect.destinationZone
         val destZoneKey = ZoneKey(ownerId, destZone)
         newState = newState.addToZone(destZoneKey, spellId)
+        // A card-intrinsic redirect into the library shuffles the card in (Progenitus).
+        if (destZone == Zone.LIBRARY && counterRedirect.shuffleIntoLibrary) {
+            newState = shuffleOwnerLibrary(newState, ownerId)
+        }
         if (destZone == Zone.EXILE && counterRedirect.linkSourceId != null) {
             newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                 .linkExiledToSource(newState, spellId, counterRedirect.linkSourceId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/SelfZoneRedirectComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/SelfZoneRedirectComponent.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.engine.state.components.identity
+
+import com.wingedsheep.engine.state.Component
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import kotlinx.serialization.Serializable
+
+/**
+ * A card's own "would be put into [zone] from anywhere → redirect instead" replacement
+ * effect(s), carried on the card entity so they function in **every** zone (CR 614.12), not
+ * only while the source is on the battlefield.
+ *
+ * Built at entity creation from the printed [RedirectZoneChange] effects marked
+ * `selfOnly = true` (Darksteel Colossus, Blightsteel Colossus, Progenitus, …). Because it lives
+ * on the moving card rather than on a battlefield permanent, the redirect fires when the card is
+ * milled from the library, discarded from hand, or countered on the stack — not just when it dies.
+ *
+ * [com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.checkZoneChangeRedirect] reads this
+ * before scanning the battlefield for other permanents' redirects.
+ */
+@Serializable
+data class SelfZoneRedirectComponent(
+    val redirects: List<RedirectZoneChange>
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncestorDragonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncestorDragonScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ancestor Dragon (GS1, reprinted in FDN) — {4}{W}{W} Creature — Dragon 5/6, Flying.
+ *
+ * "Whenever one or more creatures you control attack, you gain 1 life for each attacking creature."
+ *
+ * A single batch trigger (CR 508.3) that fires once per combat and gains life equal to the number
+ * of attacking creatures you control at resolution.
+ */
+class AncestorDragonScenarioTest : ScenarioTestBase() {
+
+    private val name = "Ancestor Dragon"
+
+    init {
+        test("attacking with two creatures gains 2 life (one per attacker), from a single trigger") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, name, summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf(name to 2, "Grizzly Bears" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("1 life for each of the two attacking creatures") {
+                game.getLifeTotal(1) shouldBe lifeBefore + 2
+            }
+        }
+
+        test("attacking with only Ancestor Dragon gains 1 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, name, summoningSickness = false)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf(name to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("a lone attacker gains exactly 1 life") {
+                game.getLifeTotal(1) shouldBe lifeBefore + 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarksteelColossusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarksteelColossusScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Darksteel Colossus (DST, reprinted in FDN) — {11} Artifact Creature — Golem 11/11, Trample,
+ * Indestructible.
+ *
+ * "If Darksteel Colossus would be put into a graveyard from anywhere, reveal it and shuffle it
+ * into its owner's library instead."
+ *
+ * The redirect is a card-intrinsic self-replacement (CR 614.12) carried on the card entity via
+ * [com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent], so it functions in
+ * every zone — not just on the battlefield. These tests drive a graveyard-bound move from the
+ * battlefield, the library (mill), and the hand (discard) and assert the Colossus ends up shuffled
+ * back into its owner's library rather than in the graveyard.
+ */
+class DarksteelColossusScenarioTest : ScenarioTestBase() {
+
+    private val name = "Darksteel Colossus"
+
+    init {
+        test("dies from the battlefield: shuffled into its owner's library, never reaching the graveyard") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, name, summoningSickness = false)
+                // Library padding so a shuffle is observable and placement isn't trivially "the only card".
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val colossus = game.findPermanent(name)!!
+            val libraryBefore = game.librarySize(1)
+
+            game.state = ZoneTransitionService.moveToZone(game.state, colossus, Zone.GRAVEYARD).state
+
+            withClue("it must not land in the graveyard") {
+                game.isInGraveyard(1, name) shouldBe false
+            }
+            withClue("it must be shuffled back into the library") {
+                game.findCardsInLibrary(1, name).size shouldBe 1
+                game.librarySize(1) shouldBe libraryBefore + 1
+            }
+        }
+
+        test("milled from the library: redirected right back into the library") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(1, name)
+                .withCardInLibrary(1, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val colossus = game.findCardsInLibrary(1, name).single()
+            game.state = ZoneTransitionService.moveToZone(game.state, colossus, Zone.GRAVEYARD).state
+
+            withClue("a card put into the graveyard from the library is redirected too") {
+                game.isInGraveyard(1, name) shouldBe false
+                game.findCardsInLibrary(1, name).size shouldBe 1
+            }
+        }
+
+        test("discarded from hand: redirected into the library instead of the graveyard") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, name)
+                .withCardInLibrary(1, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val colossus = game.findCardsInHand(1, name).single()
+            game.state = ZoneTransitionService.moveToZone(game.state, colossus, Zone.GRAVEYARD).state
+
+            withClue("a card put into the graveyard from the hand is redirected too") {
+                game.isInGraveyard(1, name) shouldBe false
+                game.isInHand(1, name) shouldBe false
+                game.findCardsInLibrary(1, name).size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -501,6 +501,18 @@ abstract class ScenarioTestBase : FunSpec() {
                 container = container.with(ToxicComponent(toxicAmount))
             }
 
+            // Attach SelfZoneRedirectComponent for card-intrinsic "from anywhere" zone-redirect
+            // self-replacements (Darksteel Colossus, Progenitus) — mirrors CardEntityFactory so
+            // the redirect fires in every zone in scenario tests too.
+            val selfRedirects = cardDef.script.replacementEffects
+                .filterIsInstance<com.wingedsheep.sdk.scripting.RedirectZoneChange>()
+                .filter { it.selfOnly }
+            if (selfRedirects.isNotEmpty()) {
+                container = container.with(
+                    com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent(selfRedirects)
+                )
+            }
+
             state = state.withEntity(cardId, container)
             return cardId
         }


### PR DESCRIPTION
## Summary

Two Foundations cards, each placed canonically in its earliest real printing with a Foundations `Printing` row.

- **Darksteel Colossus** — {11} Artifact Creature — Golem 11/11, Trample, Indestructible. "If Darksteel Colossus would be put into a graveyard from anywhere, reveal it and shuffle it into its owner's library instead." Canonical in **Darksteel (DST)**; reprint rows added to **M10** and **FDN**.
- **Ancestor Dragon** — {4}{W}{W} Creature — Dragon 5/6, Flying. "Whenever one or more creatures you control attack, you gain 1 life for each attacking creature." Pure authoring (the Grand Warlord Radha batch-attack shape, gaining life instead of mana). Canonical in **Global Series: Jiang Yanggu & Mu Yanling (GS1)** — newly scaffolded — with reprint rows in **PZ2** and **FDN**.

## New engine capability — card-intrinsic "from anywhere" zone-redirect self-replacement

Shared by Darksteel Colossus and the wider family (Blightsteel Colossus, Progenitus, …):

- `RedirectZoneChange` gains `selfOnly` / `shuffleIntoLibrary` / `reveal`.
- A `selfOnly` redirect is the moving card's own ability referring to itself, so it functions in **every** zone (CR 614.12). It is carried on the card entity via the new `SelfZoneRedirectComponent` (built in `CardEntityFactory`) rather than scanned off the battlefield, so the card is redirected whether it **dies, is milled, is discarded, or is countered on the stack** — and stops applying only while on the battlefield with all abilities removed.
- `checkZoneChangeRedirect` reads the moving card's own component before scanning the battlefield. `shuffleIntoLibrary` shuffles the card in (not on top) across `ZoneTransitionService` (mill / discard / destroy / SBA death) and `StackResolver` (counter / fizzle).

## Testing

- `DarksteelColossusScenarioTest` — redirect + shuffle-back verified from the **battlefield**, **library** (mill), and **hand** (discard).
- `AncestorDragonScenarioTest` — life gained equals the number of attackers, from a single batch trigger.
- Card snapshots re-blessed (DST + new GS1); `SelfZoneRedirectComponent` registered for polymorphic serialization; SDK reference (`docs/card-sdk-language-reference.md`) updated.
- `just build` green (7706 tests). `just check-card-printing` passes for both cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)