### PR TITLE
Fix Invisibility block restriction

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Invisibility.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Invisibility.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 
 /**
@@ -26,7 +27,10 @@ val Invisibility = card("Invisibility") {
     oracleText = "Enchant creature\nEnchanted creature can't be blocked except by Walls."
     auraTarget = Targets.Creature
     staticAbility {
-        ability = CantBeBlockedExceptBy(blockerFilter = GameObjectFilter.Creature.withSubtype(Subtype.WALL))
+        ability = CantBeBlockedExceptBy(
+            blockerFilter = GameObjectFilter.Creature.withSubtype(Subtype.WALL),
+            filter = GroupFilter.attachedCreature()
+        )
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -1990,6 +1990,10 @@
                             "subtype": "Wall"
                         }
                     ]
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
                 }
             }
         ],

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -97,6 +97,15 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<Stmt>? {
             val ability = when (r.strField("_PermanentRule")!!) {
                 "MustAttack" -> call("MustAttack", arg(call("GroupFilter.attachedCreature")))
                 "CantBlock" -> call("CantBlock", arg(call("GroupFilter.attachedCreature")))
+                "CantBeBlockedExceptByDefenders" -> {
+                    val blockerFilter = cantBeBlockedExceptByFilter(r)
+                        ?: run { reasons.add("PermanentRuleEffect"); return null }
+                    call(
+                        "CantBeBlockedExceptBy",
+                        arg("blockerFilter", blockerFilter),
+                        arg("filter", call("GroupFilter.attachedCreature"))
+                    )
+                }
                 else -> { reasons.add("PermanentRuleEffect"); return null }
             }
             stmts.add(staticAbilityStmt(ability))

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvisibilityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvisibilityScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Invisibility — "Enchanted creature can't be blocked except by Walls."
+ */
+class InvisibilityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("enchanted creature can only be blocked by Walls") {
+
+            test("a non-Wall creature cannot block it") {
+                val game = combatScenario("Grizzly Bears")
+
+                val result = game.declareBlockers(
+                    mapOf("Grizzly Bears" to listOf("Hill Giant"))
+                )
+
+                withClue("a non-Wall must not be allowed to block a creature enchanted by Invisibility") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("a Wall creature can block it") {
+                val game = combatScenario("Wall of Mulch")
+
+                val result = game.declareBlockers(
+                    mapOf("Wall of Mulch" to listOf("Hill Giant"))
+                )
+
+                withClue("a Wall must be allowed to block a creature enchanted by Invisibility") {
+                    result.error shouldBe null
+                }
+            }
+        }
+    }
+
+    private fun combatScenario(blockerName: String) = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+        .withCardAttachedTo(1, "Invisibility", "Hill Giant")
+        .withCardOnBattlefield(2, blockerName, summoningSickness = false)
+        .withActivePlayer(1)
+        .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+        .build()
+        .also { game ->
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+        }
+}


### PR DESCRIPTION
## Summary

- apply Invisibility’s blocking restriction to the enchanted creature instead of the Aura
- teach the card generator to retain attached-creature scope for this restriction
- cover both non-Wall rejection and Wall acceptance

## Testing

- `./gradlew :mtgish-tooling:compileKotlin :rules-engine:test --tests com.wingedsheep.engine.scenarios.InvisibilityScenarioTest`
- `git diff --check`

Fixes #1363