### PR TITLE
Add two Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IntoTheFaeCourt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IntoTheFaeCourt.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Fae Court
+ * {3}{U}{U}
+ * Sorcery
+ *
+ * Draw three cards. Create a 1/1 blue Faerie creature token with flying and
+ * "This token can block only creatures with flying."
+ */
+val IntoTheFaeCourt = card("Into the Fae Court") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw three cards. Create a 1/1 blue Faerie creature token with flying and " +
+        "\"This token can block only creatures with flying.\""
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(3),
+            woeFaerieToken()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Anna Steinbauer"
+        flavorText = "Kellan stepped from his village into a strange world where trees bore jeweled " +
+            "fruit. A regal, inhuman voice rang in his ears: \"Tell me, brave hero, are you true of heart?\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg?1783915119"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MisleadingMotes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MisleadingMotes.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Misleading Motes
+ * {3}{U}
+ * Instant
+ *
+ * Target creature's owner puts it on their choice of the top or bottom of their library.
+ */
+val MisleadingMotes = card("Misleading Motes") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature's owner puts it on their choice of the top or bottom of their library."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PutOnTopOrBottomOfLibrary(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Raoul Vitale"
+        flavorText = "Yarvis was almost certain he'd seen the same tree an hour ago, but then again, " +
+            "didn't all trees look alike? He shelved his doubts and followed the friendly, twinkling " +
+            "motes deeper into the forest."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg?1783915117"
+
+        ruling(
+            "2023-09-01",
+            "The creature's owner chooses whether to put it on the top or bottom of their library. " +
+                "If multiple cards are put into the library this way (such as when the spell targets " +
+                "a melded permanent), that creature's owner puts all the cards on top or all the " +
+                "cards on the bottom. They put them in whatever order they wish, and do not need to " +
+                "reveal the order."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
@@ -1,8 +1,11 @@
 package com.wingedsheep.mtg.sets.definitions.woe.cards
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
 import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
@@ -25,4 +28,23 @@ internal fun woeRatToken(count: DynamicAmount = DynamicAmount.Fixed(1)): Effect 
     creatureTypes = setOf("Rat"),
     imageUri = "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
     staticAbilities = listOf(CantBlock())
+)
+
+/**
+ * Wilds of Eldraine's Faerie token: a 1/1 blue Faerie creature token with flying that can block
+ * only creatures with flying.
+ */
+internal fun woeFaerieToken(count: DynamicAmount = DynamicAmount.Fixed(1)): Effect = Effects.CreateToken(
+    count = count,
+    power = 1,
+    toughness = 1,
+    colors = setOf(Color.BLUE),
+    creatureTypes = setOf("Faerie"),
+    keywords = setOf(Keyword.FLYING),
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg?1783914992",
+    staticAbilities = listOf(
+        CanOnlyBlockCreaturesWith(
+            blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+        )
+    )
 )

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2986,6 +2986,66 @@
     ]
 }
 
+// Into the Fae Court
+{
+    "name": "Into the Fae Court",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw three cards. Create a 1/1 blue Faerie creature token with flying and \"This token can block only creatures with flying.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Faerie"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg?1783914992",
+                    "staticAbilities": [
+                        {
+                            "type": "CanOnlyBlockCreaturesWith",
+                            "blockerFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Anna Steinbauer",
+        "flavorText": "Kellan stepped from his village into a strange world where trees bore jeweled fruit. A regal, inhuman voice rang in his ears: \"Tell me, brave hero, are you true of heart?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/969b13bb-6411-41f9-b6b4-af4ffca62e17.jpg?1783915119"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Kindled Heroism
 {
     "name": "Kindled Heroism",
@@ -3377,6 +3437,47 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Misleading Motes
+{
+    "name": "Misleading Motes",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature's owner puts it on their choice of the top or bottom of their library.",
+    "script": {
+        "spellEffect": {
+            "type": "PutOnLibraryPositionOfChoice",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Raoul Vitale",
+        "flavorText": "Yarvis was almost certain he'd seen the same tree an hour ago, but then again, didn't all trees look alike? He shelved his doubts and followed the friendly, twinkling motes deeper into the forest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c6c7a43-c3d1-450e-834a-54e1b9def1cd.jpg?1783915117",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The creature's owner chooses whether to put it on the top or bottom of their library. If multiple cards are put into the library this way (such as when the spell targets a melded permanent), that creature's owner puts all the cards on top or all the cards on the bottom. They put them in whatever order they wish, and do not need to reveal the order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeMotesAndFaeCourtScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeMotesAndFaeCourtScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Misleading Motes and Into the Fae Court.
+ *
+ * Misleading Motes must give the top-or-bottom decision to the target's owner. Into the Fae Court
+ * must perform both halves in printed order and create the WOE Faerie token rather than a generic
+ * creature. The token helper's full static-ability tree is additionally pinned by the card snapshot.
+ */
+class WoeMotesAndFaeCourtScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Misleading Motes") {
+            test("the targeted creature's owner chooses to put it on the bottom") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Misleading Motes")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Misleading Motes", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the targeted creature's owner gets the top-or-bottom decision") {
+                    game.getPendingDecision()!!.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(game.getPendingDecision()!!.id, 1))
+                game.resolveStack()
+
+                withClue("the creature is on the bottom, below the existing Forest") {
+                    game.state.getLibrary(game.player2Id).last() shouldBe bears
+                }
+            }
+        }
+
+        context("Into the Fae Court") {
+            test("draws three cards and creates the complete WOE Faerie token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Into the Fae Court")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Into the Fae Court").error shouldBe null
+                game.resolveStack()
+
+                withClue("all three cards were drawn") {
+                    game.handSize(1) shouldBe 3
+                    game.state.getLibrary(game.player1Id).size shouldBe 0
+                }
+
+                val faerie = game.findPermanent("Faerie Token")!!
+                withClue("the token is a 1/1 flyer") {
+                    game.state.projectedState.getPower(faerie) shouldBe 1
+                    game.state.projectedState.getToughness(faerie) shouldBe 1
+                    game.state.projectedState.hasKeyword(faerie, Keyword.FLYING) shouldBe true
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Misleading Motes with the owner-controlled top/bottom library choice
- add Into the Fae Court with its exact WOE Faerie token shape and art
- add scenario coverage and update the WOE card snapshot

## Verification
- `just build`
- focused `WoeMotesAndFaeCourtScenarioTest`
- `CardDefinitionSnapshotTest` reblessed and passing
- `just check-card-printing` for both cards
- Scryfall card and token image URLs return HTTP 200

## Tooling note
`just coverage-verify WOE` compiled all 49 generated drafts, then reported nine pre-existing generator/golden gameplay-tree mismatches in other WOE cards. Neither card in this PR is a mismatch; Into the Fae Court is intentionally not auto-emitted because its token requires hand-wiring.