### PR TITLE
Add Foundations (FDN) basic lands

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
@@ -26,6 +26,10 @@ object FoundationsSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FoundationsBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FoundationsBasicLands.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Foundations Basic Lands
+ *
+ * Foundations contains 4 art variants of each basic land type (cards 272-291).
+ * Plains 272-273/282-283, Island 274-275/284-285, Swamp 276-277/286-287,
+ * Mountain 278-279/288-289, Forest 280-281/290-291.
+ */
+
+// =============================================================================
+// Plains (Cards 272, 273, 282, 283)
+// =============================================================================
+
+val FdnPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Rebecca Guay"
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4ef17ed4-a9b5-4b8e-b4cb-2ecb7e5898c3.jpg?1783909043"
+}
+
+val FdnPlains273 = basicLand("Plains") {
+    collectorNumber = "273"
+    artist = "Tingting Yeh"
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37edc4b5-75f5-4b43-a57e-a8192565a2a0.jpg?1783909042"
+}
+
+val FdnPlains282 = basicLand("Plains") {
+    collectorNumber = "282"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e6f19b3-4c76-4078-8ed2-b2832a33d066.jpg?1783909039"
+}
+
+val FdnPlains283 = basicLand("Plains") {
+    collectorNumber = "283"
+    artist = "Julian Kok Joon Wen"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a0f9892-89cd-46ff-bc87-114e175cb575.jpg?1783909039"
+}
+
+// =============================================================================
+// Island (Cards 274, 275, 284, 285)
+// =============================================================================
+
+val FdnIsland274 = basicLand("Island") {
+    collectorNumber = "274"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17e2b637-72b1-4457-aaba-66d51107be4c.jpg?1783909041"
+}
+
+val FdnIsland275 = basicLand("Island") {
+    collectorNumber = "275"
+    artist = "Rebecca Guay"
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23635e40-d040-40b7-8b98-90ed362aa028.jpg?1783909042"
+}
+
+val FdnIsland284 = basicLand("Island") {
+    collectorNumber = "284"
+    artist = "Daniel Ljunggren"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/886eae6e-ced2-4d94-96fa-9bb5385b06f4.jpg?1783909038"
+}
+
+val FdnIsland285 = basicLand("Island") {
+    collectorNumber = "285"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f534ddc-f610-45cd-84dc-bb6df6c5a84f.jpg?1783909039"
+}
+
+// =============================================================================
+// Swamp (Cards 276, 277, 286, 287)
+// =============================================================================
+
+val FdnSwamp276 = basicLand("Swamp") {
+    collectorNumber = "276"
+    artist = "Mike Bierek"
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/319bc1f0-ee42-44e5-b08b-735613ded2ba.jpg?1783909041"
+}
+
+val FdnSwamp277 = basicLand("Swamp") {
+    collectorNumber = "277"
+    artist = "Rebecca Guay"
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13505c15-14e0-4200-82bd-fb9bce949e68.jpg?1783909041"
+}
+
+val FdnSwamp286 = basicLand("Swamp") {
+    collectorNumber = "286"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f23a73a-522b-40cf-a14b-ffdf47a24c01.jpg?1783909038"
+}
+
+val FdnSwamp287 = basicLand("Swamp") {
+    collectorNumber = "287"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fda1dbfa-a57b-4aa8-9993-c8f97aec28bb.jpg?1783909038"
+}
+
+// =============================================================================
+// Mountain (Cards 278, 279, 288, 289)
+// =============================================================================
+
+val FdnMountain278 = basicLand("Mountain") {
+    collectorNumber = "278"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/279df7e2-2a3b-464a-a7df-e91da28e3a8c.jpg?1783909041"
+}
+
+val FdnMountain279 = basicLand("Mountain") {
+    collectorNumber = "279"
+    artist = "Rebecca Guay"
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1edc5050-69bd-416d-b04c-7f82de2a1901.jpg?1783909039"
+}
+
+val FdnMountain288 = basicLand("Mountain") {
+    collectorNumber = "288"
+    artist = "Dan Murayama Scott"
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a3afd00-da06-4a9f-8cd1-7133728e0fdd.jpg?1783909037"
+}
+
+val FdnMountain289 = basicLand("Mountain") {
+    collectorNumber = "289"
+    artist = "Salvatorre Zee Yazzie"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/042b04b4-f7f4-4c1a-86ad-b50d788aa99e.jpg?1783909036"
+}
+
+// =============================================================================
+// Forest (Cards 280, 281, 290, 291)
+// =============================================================================
+
+val FdnForest280 = basicLand("Forest") {
+    collectorNumber = "280"
+    artist = "Rebecca Guay"
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d232fcc2-12f6-401a-b1aa-ddff11cb9378.jpg?1783909039"
+}
+
+val FdnForest281 = basicLand("Forest") {
+    collectorNumber = "281"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/ab8affbb-d2a2-436b-bbc2-9e8b6cf0d2c4.jpg?1783909043"
+}
+
+val FdnForest290 = basicLand("Forest") {
+    collectorNumber = "290"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbbeb57d-5fa0-4ff7-b5e8-caafc139669b.jpg?1783909036"
+}
+
+val FdnForest291 = basicLand("Forest") {
+    collectorNumber = "291"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/117ab60a-b888-4585-b0c6-769d387069f7.jpg?1783909035"
+}
+
+/**
+ * All Foundations basic land variants.
+ */
+val FoundationsBasicLands = listOf(
+    FdnPlains272, FdnPlains273, FdnPlains282, FdnPlains283,
+    FdnIsland274, FdnIsland275, FdnIsland284, FdnIsland285,
+    FdnSwamp276, FdnSwamp277, FdnSwamp286, FdnSwamp287,
+    FdnMountain278, FdnMountain279, FdnMountain288, FdnMountain289,
+    FdnForest280, FdnForest281, FdnForest290, FdnForest291,
+)


### PR DESCRIPTION
## Summary
Adds the full set of Foundations (FDN) basic lands — 4 art variants of each of the 5 basic land types (collector numbers 272–291, 20 cards total).

- New `FoundationsBasicLands.kt` defining each variant via the `basicLand` DSL (name, collector number, artist, Scryfall image URI).
- `FoundationsSet` now overrides `basicLands` via `CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)`, so booster / sealed / random-deck consumers receive set-stamped FDN lands (matching the convention in `InvasionSet`, `DuskmournSet`, etc.).

## Variants
| Type | Collector # |
|------|-------------|
| Plains | 272, 273, 282, 283 |
| Island | 274, 275, 284, 285 |
| Swamp | 276, 277, 286, 287 |
| Mountain | 278, 279, 288, 289 |
| Forest | 280, 281, 290, 291 |

Data sourced from Scryfall (`set:fdn type:"basic land"`).

## Testing
- `:mtg-sets:test` passes, including `CardDiscoveryEquivalenceTest` (verifies `findBasicLandsIn` agrees with `MtgSet.basicLands`). Basic lands are discovered separately from `set.cards`, so `CardDefinitionSnapshotTest` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)