### PR TITLE
Fix wither + deathtouch not destroying creatures

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -301,6 +301,19 @@ object DamageUtils {
                 events.add(CountersAddedEvent(targetId, CounterType.MINUS_ONE_MINUS_ONE.name, effectiveAmount,
                     newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature",
                     placedBy = sourceId?.let { newState.projectedState.getController(it) }))
+                // Wither only changes the FORM of the damage (CR 702.80a); the creature was still
+                // dealt damage by this source, so a deathtouch source still marks it for
+                // destruction as an SBA (CR 702.2b / 704.5h) even though nothing is marked as
+                // normal damage. Record the deathtouch flag without marking damage.
+                if (sourceId != null && projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)) {
+                    newState = newState.updateEntity(targetId) { container ->
+                        val existing = container.get<DamageComponent>()
+                        container.with(DamageComponent(
+                            amount = existing?.amount ?: 0,
+                            deathtouchDamageReceived = true
+                        ))
+                    }
+                }
             } else {
                 val existingDamage = newState.getEntity(targetId)?.get<DamageComponent>()
                 val currentDamage = existingDamage?.amount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -1126,6 +1126,19 @@ internal class CombatDamageManager(
                 events.add(CountersAddedEvent(targetId, com.wingedsheep.sdk.core.CounterType.MINUS_ONE_MINUS_ONE.name, amount,
                     newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature", firstThisTurn,
                     placedBy = projected.getController(sourceId)))
+                // Wither only changes the FORM of the damage (CR 702.80a); the creature was still
+                // dealt damage by this source, so a deathtouch source still marks it for
+                // destruction as an SBA (CR 702.2b / 704.5h) even though nothing is marked as
+                // normal damage. Record the deathtouch flag without marking damage.
+                if (projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)) {
+                    newState = newState.updateEntity(targetId) { container ->
+                        val existing = container.get<DamageComponent>()
+                        container.with(DamageComponent(
+                            amount = existing?.amount ?: 0,
+                            deathtouchDamageReceived = true
+                        ))
+                    }
+                }
             } else {
                 val existingDamage = newState.getEntity(targetId)?.get<DamageComponent>()
                 val currentDamage = existingDamage?.amount ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/LethalDamageCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/LethalDamageCheck.kt
@@ -45,7 +45,13 @@ class LethalDamageCheck : StateBasedActionCheck {
             val effectiveToughness = projected.getToughness(entityId) ?: 0
 
             val hasLethalDamage = damageComponent.amount >= effectiveToughness
-            val hasDeathtouch = damageComponent.deathtouchDamageReceived && damageComponent.amount > 0
+            // CR 704.5h — destroyed if dealt damage by a deathtouch source, regardless of the
+            // form that damage took. `deathtouchDamageReceived` is only ever set when a deathtouch
+            // source actually dealt nonzero damage (marked, or as wither -1/-1 counters), so no
+            // separate `amount > 0` guard is needed — and requiring marked `amount > 0` would
+            // wrongly spare a creature whose deathtouch damage arrived as wither counters (which
+            // are not marked damage, CR 702.80a).
+            val hasDeathtouch = damageComponent.deathtouchDamageReceived
 
             if (hasLethalDamage || hasDeathtouch) {
                 // Check for regeneration shields

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitherLifelinkDeathtouchTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitherLifelinkDeathtouchTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wither (CR 702.80) only changes the *form* in which damage is dealt — as -1/-1 counters
+ * instead of being marked against toughness. It does not change the fact that damage is being
+ * dealt, so damage-associated keywords still apply:
+ *  - Lifelink (CR 702.15b): the source's controller still gains that much life.
+ *  - Deathtouch (CR 702.2b): any nonzero amount is lethal, destroying the creature as an SBA
+ *    (CR 704.5h) even though only a few -1/-1 counters were placed and toughness stays > 0.
+ *
+ * Repro of the reported bug: a creature given wither (Barbed Bloodletter) plus deathtouch and
+ * lifelink (Scarblade's Malice) dealt its wither damage but neither gained life nor killed the
+ * blocker via deathtouch.
+ */
+class WitherLifelinkDeathtouchTest : FunSpec({
+
+    // 1 power so a single -1/-1 counter is not lethal by itself; high toughness so it survives
+    // the block and we can attribute the blocker's death purely to deathtouch.
+    val WitherStinger = CardDefinition.creature(
+        name = "Wither Stinger",
+        manaCost = ManaCost.parse("{B}"),
+        subtypes = setOf(Subtype("Insect")),
+        power = 1,
+        toughness = 5,
+        oracleText = "Wither, deathtouch, lifelink",
+        keywords = setOf(Keyword.WITHER, Keyword.DEATHTOUCH, Keyword.LIFELINK)
+    )
+
+    val WitherOnly = CardDefinition.creature(
+        name = "Wither Only",
+        manaCost = ManaCost.parse("{B}"),
+        subtypes = setOf(Subtype("Insect")),
+        power = 1,
+        toughness = 5,
+        oracleText = "Wither",
+        keywords = setOf(Keyword.WITHER)
+    )
+
+    val BigBlocker = CardDefinition.creature(
+        name = "Big Blocker",
+        manaCost = ManaCost.parse("{3}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 4,
+        toughness = 4,
+        oracleText = ""
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(WitherStinger, WitherOnly, BigBlocker))
+        return driver
+    }
+
+    /** Drive a full block: [attacker] attacks, [blocker] blocks it, damage is dealt. */
+    fun blockCombat(driver: GameTestDriver, attacker: EntityId, blocker: EntityId, defender: EntityId, attackerOwner: EntityId) {
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attackerOwner, listOf(attacker), defender)
+        driver.bothPass()
+        driver.declareBlockers(defender, mapOf(blocker to listOf(attacker)))
+        driver.bothPass()
+        // First strike step (none), then combat damage step
+        driver.bothPass()
+        driver.bothPass()
+    }
+
+    test("wither + deathtouch destroys the blocker even though only one -1/-1 counter is placed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attackerOwner = driver.activePlayer!!
+        val defender = driver.getOpponent(attackerOwner)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stinger = driver.putCreatureOnBattlefield(attackerOwner, "Wither Stinger")
+        driver.removeSummoningSickness(stinger)
+        val blocker = driver.putCreatureOnBattlefield(defender, "Big Blocker")
+        driver.removeSummoningSickness(blocker)
+
+        blockCombat(driver, stinger, blocker, defender, attackerOwner)
+
+        // Deathtouch made the 1 point of wither damage lethal -> blocker destroyed.
+        driver.assertInGraveyard(defender, "Big Blocker")
+        // The wither attacker survived (toughness 5 vs 4 marked damage).
+        driver.assertPermanentExists(attackerOwner, "Wither Stinger")
+    }
+
+    test("wither + lifelink gains life equal to the wither damage dealt") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attackerOwner = driver.activePlayer!!
+        val defender = driver.getOpponent(attackerOwner)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stinger = driver.putCreatureOnBattlefield(attackerOwner, "Wither Stinger")
+        driver.removeSummoningSickness(stinger)
+        val blocker = driver.putCreatureOnBattlefield(defender, "Big Blocker")
+        driver.removeSummoningSickness(blocker)
+
+        blockCombat(driver, stinger, blocker, defender, attackerOwner)
+
+        // Lifelink: controller gains 1 life for the 1 wither damage dealt.
+        driver.assertLifeTotal(attackerOwner, 21)
+    }
+
+    test("plain wither (no deathtouch) does not destroy a creature whose toughness stays above zero") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attackerOwner = driver.activePlayer!!
+        val defender = driver.getOpponent(attackerOwner)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stinger = driver.putCreatureOnBattlefield(attackerOwner, "Wither Only")
+        driver.removeSummoningSickness(stinger)
+        val blocker = driver.putCreatureOnBattlefield(defender, "Big Blocker")
+        driver.removeSummoningSickness(blocker)
+
+        blockCombat(driver, stinger, blocker, defender, attackerOwner)
+
+        // One -1/-1 counter, 4/4 -> 3/3, survives; no deathtouch, no life gained.
+        driver.assertPermanentExists(defender, "Big Blocker")
+        val counters = driver.state.getEntity(blocker)?.get<CountersComponent>()
+        counters?.getCount(CounterType.MINUS_ONE_MINUS_ONE) shouldBe 1
+        driver.assertLifeTotal(attackerOwner, 20)
+    }
+})


### PR DESCRIPTION
Fixes #1367.

## Problem

A creature given **wither** (Barbed Bloodletter) plus **deathtouch** and **lifelink** (Scarblade's Malice) dealt its wither damage as `-1/-1` counters but the deathtouch never destroyed the blocked/blocking creature.

Wither only changes the *form* in which damage is dealt — as `-1/-1` counters instead of marked damage (CR 702.80a) — but the creature is still **dealt damage by the source**. Both damage paths took a wither branch that placed the `-1/-1` counters but never wrote a `DamageComponent`, so a deathtouch source's damage was never recorded, and the deathtouch state-based action (CR 702.2b / 704.5h) never fired.

- `CombatDamageManager.dealFinalDamage` — combat damage
- `DamageUtils.dealDamageToTarget` — noncombat damage

## Fix

- In each wither branch, when the source also has deathtouch, record `deathtouchDamageReceived = true` on the target **without** marking normal damage. Existing marked `amount` is preserved, so plain wither still can't wrongly trip the lethal-damage SBA (CR 704.5g) from the counters' toughness reduction.
- `LethalDamageCheck` drops its redundant `&& amount > 0` guard on the deathtouch clause. `deathtouchDamageReceived` is only ever set when a deathtouch source actually dealt nonzero damage (and "remove damage" always drops the whole component), so the guard changed nothing for marked damage — but requiring marked `amount > 0` wrongly spared a creature whose deathtouch damage arrived as wither counters (which aren't marked damage).

## Lifelink note

Combat **lifelink already worked** with wither — `applyLifelinkFromDamageEvents` reads `DamageDealtEvent`, which the wither branch still emits with the full amount. The reported lifelink failure did not reproduce in the engine; a regression test now pins this behavior so it stays working.

## Tests

New `WitherLifelinkDeathtouchTest` (rules-engine):
- wither + deathtouch destroys a blocker whose toughness stays above 0 (only one `-1/-1` counter placed) ✅ (failed before this change)
- wither + lifelink gains life equal to the wither damage dealt ✅
- plain wither (no deathtouch) does **not** destroy a creature whose toughness stays above 0 ✅ (guards against over-destroying)

Full `rules-engine` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)