### PR TITLE
Add back navigation to multi-target spell targeting

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -335,6 +335,16 @@ list (3-4 seats ⇒ hotseat) — see `ScenarioSeat` in `ScenarioDtos.kt`.
 4. User clicks target → add to selection
 5. When enough targets → submit action
 
+Spells with multiple target requirements (e.g. "2 damage to any target and 1 damage to any
+other target") walk the requirements one step at a time inside a single targeting phase.
+Confirming a step snapshots the outgoing `TargetingState` onto
+`TargetingState.previousRequirementStates`; a **Back** button (`goBackTargeting`) pops that
+stack so the player can revise an already-confirmed target before the action is submitted —
+the restored step keeps its confirmed picks selected, and re-confirming recomputes later
+steps' valid-target pools against the revised selection. The resolution-time
+`ChooseTargetsDecision` flow (`BattlefieldTargetingUI`) implements the same back navigation
+over its local requirement index. Cancel still aborts the whole action.
+
 ## Type Mapping
 
 ### Backend → Frontend

--- a/e2e-scenarios/helpers/gamePage.ts
+++ b/e2e-scenarios/helpers/gamePage.ts
@@ -144,6 +144,12 @@ export class GamePage {
     await this.screenshot('Targeting decision ready')
   }
 
+  /** Step back to the previous target requirement of a multi-target spell (clicks "← Back"). */
+  async goBackTargetStep() {
+    await this.page.getByRole('button', { name: '← Back' }).first().click()
+    await this.screenshot('Back to previous target step')
+  }
+
   /** Confirm target selection (clicks "Confirm Target", "Confirm (N)", or a zone-specific confirmation). */
   async confirmTargets() {
     await this.page

--- a/e2e-scenarios/playwright.config.ts
+++ b/e2e-scenarios/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
 const skipWebServer = !!process.env.SKIP_WEB_SERVER
+// Override when the client under test runs on a non-default port (e.g. a worktree's dev
+// server next to an already-running main checkout). Pair with SKIP_WEB_SERVER=true.
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5173'
 
 export default defineConfig({
   testDir: './tests',
@@ -10,7 +13,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/e2e-scenarios/tests/lorwyn-eclipsed/boulder-dash-back.spec.ts
+++ b/e2e-scenarios/tests/lorwyn-eclipsed/boulder-dash-back.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+
+/**
+ * E2E browser tests for multi-target back navigation (Boulder Dash).
+ *
+ * Card: Boulder Dash ({1}{R}) — Sorcery
+ * "Boulder Dash deals 2 damage to any target and 1 damage to any other target."
+ *
+ * Covers: revising an already-confirmed target via the "← Back" button before
+ * the spell is submitted — the restored step keeps its pick selected, and the
+ * revised pick correctly re-filters the second requirement ("any other target").
+ */
+test.describe('Boulder Dash — multi-target back navigation', () => {
+  test('go back to revise the first target before casting', async ({ createGame }) => {
+    const { player1, player2 } = await createGame({
+      player1Name: 'Caster',
+      player2Name: 'Opponent',
+      player1: {
+        hand: ['Boulder Dash'],
+        battlefield: [{ name: 'Mountain' }, { name: 'Mountain' }],
+      },
+      player2: {
+        battlefield: [{ name: 'Glory Seeker' }, { name: 'Grizzly Bears' }],
+        library: ['Mountain'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+    })
+
+    const p1 = player1.gamePage
+    const p2 = player2.gamePage
+
+    // Cast Boulder Dash — first target requirement (2 damage)
+    await p1.clickCard('Boulder Dash')
+    await p1.selectAction('Cast Boulder Dash')
+    await expect(p1.page.getByText('Step 1/2')).toBeVisible()
+
+    // Pick Glory Seeker for the 2 damage and confirm
+    await p1.selectTarget('Glory Seeker')
+    await p1.confirmTargets()
+    await expect(p1.page.getByText('Step 2/2')).toBeVisible()
+
+    // Second thoughts — step back. The first step returns with its pick intact.
+    await p1.goBackTargetStep()
+    await expect(p1.page.getByText('Step 1/2')).toBeVisible()
+    await expect(p1.page.getByRole('button', { name: 'Confirm (1)' })).toBeVisible()
+
+    // Revise: the 2 damage should hit Grizzly Bears instead (single-target step,
+    // so clicking a new target replaces the previous pick)
+    await p1.selectTarget('Grizzly Bears')
+    await p1.confirmTargets()
+    await expect(p1.page.getByText('Step 2/2')).toBeVisible()
+
+    // 1 damage to Glory Seeker, and submit
+    await p1.selectTarget('Glory Seeker')
+    await p1.confirmTargets()
+
+    // Opponent lets it resolve
+    await p2.resolveStack('Boulder Dash')
+
+    // Grizzly Bears (2/2) took 2 damage and died; Glory Seeker (2/2) took 1 and lives
+    await p1.expectNotOnBattlefield('Grizzly Bears')
+    await p1.expectOnBattlefield('Glory Seeker')
+
+    await p1.screenshot('End state')
+  })
+})

--- a/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
+++ b/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
 import type { DecisionSelectionState } from '@/store/slices'
 import type { EntityId, ChooseTargetsDecision } from '@/types'
@@ -29,6 +29,9 @@ export function BattlefieldTargetingUI({
   // Multi-requirement state: track which requirement we're on and accumulated targets
   const [currentReqIndex, setCurrentReqIndex] = useState(0)
   const [collectedTargets, setCollectedTargets] = useState<Record<number, readonly EntityId[]>>({})
+  // Picks to pre-select when the requirement changes because the player stepped Back;
+  // consumed (and cleared) by the selection-state effect below.
+  const restoredSelectionRef = useRef<readonly EntityId[] | null>(null)
 
   const totalRequirements = decision.targetRequirements.length
   const targetReq = decision.targetRequirements[currentReqIndex]
@@ -50,11 +53,12 @@ export function BattlefieldTargetingUI({
     const selectionState: DecisionSelectionState = {
       decisionId: decision.id,
       validOptions: [...filteredLegalTargets],
-      selectedOptions: [],
+      selectedOptions: restoredSelectionRef.current ? [...restoredSelectionRef.current] : [],
       minSelections: minTargets,
       maxSelections: maxTargets,
       prompt: targetReq?.description ?? decision.prompt,
     }
+    restoredSelectionRef.current = null
     startDecisionSelection(selectionState)
 
     return () => {
@@ -100,6 +104,20 @@ export function BattlefieldTargetingUI({
     submitCancelDecision()
   }
 
+  const handleBack = () => {
+    // Step back to the previous requirement, restoring its confirmed picks so the
+    // player can revise them. The current requirement's in-progress picks are
+    // discarded; its pool is recomputed on re-confirm against the revised selection.
+    if (currentReqIndex === 0) return
+    const prevIndex = currentReqIndex - 1
+    restoredSelectionRef.current = collectedTargets[prevIndex] ?? []
+    const remaining = { ...collectedTargets }
+    delete remaining[prevIndex]
+    setCollectedTargets(remaining)
+    cancelDecisionSelection()
+    setCurrentReqIndex(prevIndex)
+  }
+
   const requirementLabel = totalRequirements > 1
     ? `Choose Target (${currentReqIndex + 1}/${totalRequirements})`
     : 'Choose Target'
@@ -136,6 +154,11 @@ export function BattlefieldTargetingUI({
       </div>
 
       <div className={styles.buttonContainerSmall}>
+        {currentReqIndex > 0 && (
+          <button onClick={handleBack} className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}>
+            ← Back
+          </button>
+        )}
         {canDecline && selectedCount === 0 && (
           <button onClick={handleDecline} className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}>
             Decline

--- a/web-client/src/components/game/overlay/TargetingOverlay.tsx
+++ b/web-client/src/components/game/overlay/TargetingOverlay.tsx
@@ -24,6 +24,7 @@ function ZoneCardTargetingOverlay({
   onDeselect,
   onConfirm,
   onCancel,
+  onBack,
 }: {
   zoneCards: ClientCard[]
   targetingState: { selectedTargets: readonly EntityId[]; minTargets: number; maxTargets: number; targetDescription?: string; currentRequirementIndex?: number; totalRequirements?: number; sourceCardName?: string }
@@ -32,6 +33,8 @@ function ZoneCardTargetingOverlay({
   onDeselect: (cardId: EntityId) => void
   onConfirm: () => void
   onCancel: () => void
+  /** Present when an earlier target requirement can be revised (multi-target spells). */
+  onBack?: () => void
 }) {
   const hoverCard = useGameStore((s) => s.hoverCard)
   const gameState = useGameStore((s) => s.gameState)
@@ -394,6 +397,24 @@ function ZoneCardTargetingOverlay({
 
       {/* Buttons */}
       <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+        {onBack && (
+          <button
+            onClick={onBack}
+            style={{
+              padding: responsive.isMobile ? '10px 24px' : '12px 36px',
+              fontSize: responsive.fontSize.large,
+              backgroundColor: '#444',
+              color: 'white',
+              border: 'none',
+              borderRadius: 8,
+              cursor: 'pointer',
+              fontWeight: 600,
+              transition: 'all 0.15s',
+            }}
+          >
+            ← Back
+          </button>
+        )}
         <button
           onClick={() => setMinimized(true)}
           style={{
@@ -456,6 +477,7 @@ export function TargetingOverlay() {
   const targetingState = useGameStore((state) => state.targetingState)
   const cancelTargeting = useGameStore((state) => state.cancelTargeting)
   const confirmTargeting = useGameStore((state) => state.confirmTargeting)
+  const goBackTargeting = useGameStore((state) => state.goBackTargeting)
   const responsive = useResponsiveContext()
   const draggable = useDraggable()
 
@@ -477,6 +499,7 @@ export function TargetingOverlay() {
   const maxTargets = targetingState.maxTargets
   const hasEnoughTargets = selectedCount >= minTargets
   const hasMaxTargets = selectedCount >= maxTargets
+  const canGoBack = (targetingState.previousRequirementStates?.length ?? 0) > 0
   const isSacrifice = targetingState.isSacrificeSelection
   const isBounce = targetingState.isBounceSelection
   const isTapPermanent = targetingState.isTapPermanentSelection
@@ -518,6 +541,7 @@ export function TargetingOverlay() {
         onDeselect={removeTarget}
         onConfirm={confirmTargeting}
         onCancel={cancelTargeting}
+        {...(canGoBack ? { onBack: goBackTargeting } : {})}
       />
     )
   }
@@ -635,6 +659,15 @@ export function TargetingOverlay() {
         </div>
       )}
       <div style={{ display: 'flex', gap: 8, marginTop: 8, pointerEvents: 'auto' }}>
+        {canGoBack && (
+          <button onClick={goBackTargeting} style={{
+            ...styles.cancelButton,
+            padding: responsive.isMobile ? '8px 12px' : '10px 16px',
+            fontSize: responsive.fontSize.normal,
+          }}>
+            ← Back
+          </button>
+        )}
         {hasEnoughTargets && (
           <button onClick={confirmTargeting} style={{
             ...styles.actionButton,

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -112,6 +112,15 @@ export interface TargetingState {
   /** Transient warning shown when the user tries an illegal toggle (e.g. clicking past max
    * on a multi-target step). Cleared on the next successful add/remove. */
   warning?: string | null
+  /**
+   * Snapshot stack of already-confirmed requirements' states (multi-target spells).
+   * confirmTargeting pushes the outgoing state when advancing to the next requirement;
+   * goBackTargeting pops it so the player can revise an earlier target before the
+   * action is submitted. Each snapshot carries its own shorter stack, so a pop
+   * restores the full targeting state as it was presented (including X-narrowed
+   * valid-target pools and the picks that were confirmed).
+   */
+  previousRequirementStates?: readonly TargetingState[]
 }
 
 /**
@@ -1047,6 +1056,7 @@ export type GameStore = {
   removeTarget: (targetId: EntityId) => void
   cancelTargeting: () => void
   confirmTargeting: () => void
+  goBackTargeting: () => void
   startCombat: (state: CombatState) => void
   toggleAttacker: (creatureId: EntityId) => void
   assignBlocker: (blockerId: EntityId, attackerId: EntityId) => void

--- a/web-client/src/store/slices/ui/targetingSlice.test.ts
+++ b/web-client/src/store/slices/ui/targetingSlice.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest'
+import { create } from 'zustand'
+import { createTargetingSlice, type TargetingSlice } from './targetingSlice'
+import type { GameStore, TargetingState } from '../types'
+import type { LegalActionInfo, GameAction, EntityId } from '@/types'
+
+const id = (s: string): EntityId => s as unknown as EntityId
+
+/**
+ * Minimal store harness: the real targeting slice plus stubs for the pipeline
+ * fields confirmTargeting reads. Everything else in GameStore is untouched.
+ */
+function makeStore() {
+  const advancePipeline = vi.fn()
+  const cancelPipeline = vi.fn()
+  const action: GameAction = { type: 'CastSpell', playerId: 'p1', cardId: 'spell1' } as GameAction
+  const store = create<GameStore>()((set, get, api) => ({
+    ...createTargetingSlice(set, get, api),
+    pipelineState: {
+      actionInfo: { actionType: 'CastSpell', description: 'Cast Test', action } as LegalActionInfo,
+      accumulatedAction: action,
+      remainingPhases: [{ type: 'targeting' }],
+    },
+    gameState: {},
+    advancePipeline,
+    cancelPipeline,
+  }) as unknown as GameStore)
+  return { store, advancePipeline, cancelPipeline }
+}
+
+/** Two-requirement targeting state as pipelinePhases.enterPhase('targeting') builds it. */
+function twoRequirementState(action: GameAction): TargetingState {
+  return {
+    action,
+    validTargets: [id('a'), id('b'), id('c')],
+    selectedTargets: [],
+    minTargets: 1,
+    maxTargets: 1,
+    currentRequirementIndex: 0,
+    allSelectedTargets: [],
+    targetRequirements: [
+      { index: 0, description: 'any target (takes 2 damage)', minTargets: 1, maxTargets: 1, validTargets: [id('a'), id('b'), id('c')] },
+      { index: 1, description: 'any other target (takes 1 damage)', minTargets: 1, maxTargets: 1, validTargets: [id('a'), id('b'), id('c')] },
+    ],
+    targetDescription: 'any target (takes 2 damage)',
+    totalRequirements: 2,
+  }
+}
+
+function targeting(store: ReturnType<typeof makeStore>['store']): TargetingState {
+  const state = (store.getState() as unknown as TargetingSlice).targetingState
+  if (!state) throw new Error('expected active targetingState')
+  return state
+}
+
+describe('targetingSlice — multi-target back navigation', () => {
+  it('confirming a requirement snapshots it for goBackTargeting', () => {
+    const { store } = makeStore()
+    const s = store.getState() as unknown as TargetingSlice
+    s.startTargeting(twoRequirementState(store.getState().pipelineState!.accumulatedAction))
+
+    s.addTarget(id('a'))
+    s.confirmTargeting()
+
+    const state = targeting(store)
+    expect(state.currentRequirementIndex).toBe(1)
+    // Dependent-target dedup: the pick for requirement 0 leaves the pool
+    expect(state.validTargets).toEqual([id('b'), id('c')])
+    expect(state.previousRequirementStates).toHaveLength(1)
+    expect(state.previousRequirementStates![0]!.selectedTargets).toEqual([id('a')])
+  })
+
+  it('goBackTargeting restores the previous requirement with its picks selected', () => {
+    const { store } = makeStore()
+    const s = store.getState() as unknown as TargetingSlice
+    s.startTargeting(twoRequirementState(store.getState().pipelineState!.accumulatedAction))
+
+    s.addTarget(id('a'))
+    s.confirmTargeting()
+    store.getState().goBackTargeting()
+
+    const state = targeting(store)
+    expect(state.currentRequirementIndex).toBe(0)
+    expect(state.selectedTargets).toEqual([id('a')])
+    expect(state.validTargets).toEqual([id('a'), id('b'), id('c')])
+    expect(state.allSelectedTargets).toEqual([])
+    expect(state.previousRequirementStates ?? []).toHaveLength(0)
+  })
+
+  it('re-confirming after a revised pick re-filters the next requirement', () => {
+    const { store } = makeStore()
+    const s = store.getState() as unknown as TargetingSlice
+    s.startTargeting(twoRequirementState(store.getState().pipelineState!.accumulatedAction))
+
+    s.addTarget(id('a'))
+    s.confirmTargeting()
+    store.getState().goBackTargeting()
+    // maxTargets is 1, so picking 'b' replaces 'a'
+    store.getState().addTarget(id('b'))
+    store.getState().confirmTargeting()
+
+    const state = targeting(store)
+    expect(state.currentRequirementIndex).toBe(1)
+    expect(state.validTargets).toEqual([id('a'), id('c')])
+    expect(state.previousRequirementStates![0]!.selectedTargets).toEqual([id('b')])
+  })
+
+  it('goBackTargeting is a no-op on the first requirement', () => {
+    const { store } = makeStore()
+    const s = store.getState() as unknown as TargetingSlice
+    s.startTargeting(twoRequirementState(store.getState().pipelineState!.accumulatedAction))
+
+    s.addTarget(id('a'))
+    store.getState().goBackTargeting()
+
+    const state = targeting(store)
+    expect(state.currentRequirementIndex).toBe(0)
+    expect(state.selectedTargets).toEqual([id('a')])
+  })
+
+  it('confirming the last requirement submits all picks in requirement order', () => {
+    const { store, advancePipeline } = makeStore()
+    const s = store.getState() as unknown as TargetingSlice
+    s.startTargeting(twoRequirementState(store.getState().pipelineState!.accumulatedAction))
+
+    s.addTarget(id('a'))
+    s.confirmTargeting()
+    store.getState().addTarget(id('c'))
+    store.getState().confirmTargeting()
+
+    expect(store.getState().targetingState).toBeNull()
+    expect(advancePipeline).toHaveBeenCalledWith({ type: 'targeting', selectedTargets: [id('a'), id('c')] })
+  })
+})

--- a/web-client/src/store/slices/ui/targetingSlice.ts
+++ b/web-client/src/store/slices/ui/targetingSlice.ts
@@ -21,6 +21,7 @@ export interface TargetingSliceActions {
   removeTarget: (targetId: EntityId) => void
   cancelTargeting: () => void
   confirmTargeting: () => void
+  goBackTargeting: () => void
 }
 
 export type TargetingSlice = TargetingSliceState & TargetingSliceActions
@@ -86,6 +87,18 @@ export const createTargetingSlice: SliceCreator<TargetingSlice> = (set, get) => 
     set({ targetingState: null })
   },
 
+  goBackTargeting: () => {
+    // Step back to the previous requirement of a multi-target spell, restoring it
+    // exactly as it was presented (pool, bounds, zone) with its confirmed picks
+    // still selected. The current requirement's in-progress picks are discarded;
+    // re-confirming recomputes later pools against the revised selection.
+    set((state) => {
+      const prev = state.targetingState?.previousRequirementStates?.at(-1)
+      if (!prev) return state
+      return { targetingState: { ...prev, warning: null } }
+    })
+  },
+
   confirmTargeting: () => {
     const { targetingState, pipelineState, gameState, startTargeting } = get()
     if (!targetingState || !gameState || !pipelineState) return
@@ -139,6 +152,11 @@ export const createTargetingSlice: SliceCreator<TargetingSlice> = (set, get) => 
             ...(targetingState.requiresDamageDistribution
               ? { requiresDamageDistribution: true }
               : {}),
+            // Snapshot the outgoing requirement so goBackTargeting can restore it.
+            previousRequirementStates: [
+              ...(targetingState.previousRequirementStates ?? []),
+              targetingState,
+            ],
           })
           return
         }


### PR DESCRIPTION
## Problem

Casting a spell with multiple targets (e.g. **Boulder Dash** — "2 damage to any target and 1 damage to any other target") walks the target requirements step by step, but confirming a step was one-way: once the first target was confirmed, the only options were to finish the spell or cancel the entire cast.

## Change

Both targeting step-machines now support stepping back to revise an already-confirmed target before the action is submitted. This is a **client-only** change — the server already sends every requirement's legal targets up front and only validates the complete target set on submit, so no engine/SDK/server surface is touched (hence no SDK-reference or mtgish updates).

- **Cast-time pipeline** (`targetingSlice.ts`): `confirmTargeting` snapshots the outgoing `TargetingState` onto a `previousRequirementStates` stack; the new `goBackTargeting` action pops it. The restored step is exactly as it was presented (valid-target pool including X-narrowing, min/max, zone, description) with its confirmed picks still selected, so Back → Confirm is a lossless round trip. Re-confirming a revised pick recomputes later requirements' pools, preserving the "any *other* target" dedup.
- **Resolution-time `ChooseTargetsDecision`** (`BattlefieldTargetingUI.tsx`): the symmetric back step over its local requirement index — used by triggered/activated abilities, per-mode modal targets, and retargeting.
- **UI**: a "← Back" button in the targeting banner, the graveyard/exile card picker, and the battlefield decision banner — shown only past the first step. Cancel keeps its existing meaning (abort the whole action). Cost-payment selections (single-step) are unaffected.

`playwright.config.ts` additionally gains an `E2E_BASE_URL` override so a worktree's dev client on a non-default port can be tested against an already-running server (`SKIP_WEB_SERVER=true`).

## Screenshots

Step 2/2 now offers Back:

![Step 2 with Back button](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multi-target-back-screenshots/step2-back-button.png)

After clicking Back: Step 1/2 returns with the confirmed pick still selected (green) and ready to revise:

![Step 1 restored with pick selected](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multi-target-back-screenshots/step1-restored.png)

(The `multi-target-back-screenshots` branch is throwaway hosting for these images.)

## Testing

- `targetingSlice.test.ts` (new, vitest): snapshot on confirm, restore with picks selected, revised pick re-filters the next requirement, no-op on first step, final submit order. Full web-client suite: **180/180 green**; `npm run typecheck` and `npm run build` pass.
- `e2e-scenarios/tests/lorwyn-eclipsed/boulder-dash-back.spec.ts` (new, Playwright, passes against the full stack): cast Boulder Dash, confirm Glory Seeker, Back, revise to Grizzly Bears, finish targeting, resolve — Grizzly Bears dies to the 2 damage, Glory Seeker survives the 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)