### PR TITLE
Multiplayer UI: table overview, other-player combat split, eliminated spectating, attack-direction clarity

### DIFF
--- a/backlog/multiplayer-ui-followups.md
+++ b/backlog/multiplayer-ui-followups.md
@@ -1,0 +1,122 @@
+# Multiplayer UI — Follow-ups
+
+Follow-up work after the multiplayer UI pass of **2026-07-23** (commit `19dd44b2f`), which shipped:
+table overview mode (rail toggle / key `0`), the combat defender-focus split (combat between two
+*other* players shows both boards side-by-side with real arrows), eliminated-player spectating
+("Keep Watching" on the defeat overlay), attack-direction clarity (restriction banner + dimmed
+🚫 rail chips + sole-defender auto-assign), and the zone-browser portal fix (browsing any player's
+graveyard/exile/library works in multiplayer). Architecture notes live in
+[`docs/web-client-architecture.md`](../docs/web-client-architecture.md) § *Multiplayer (3-4 player)
+board*; original design history in [`multiplayer.md`](multiplayer.md) Phase 3.
+
+Ordered roughly by value.
+
+## 1. Verify + e2e the eliminated-spectating path (unverified!)
+
+The one shipped flow that was **not live-verified**: hotseat connections never receive
+`PlayerEliminatedMessage` (the single connection keeps driving the other seats), so the
+"Keep Watching" path needs a real multi-connection FFA game.
+
+- Build a 3-4 seat **multi-connection** Playwright fixture (the existing `scenarioFixture.ts` is
+  two-context; scenario `mode` currently caps non-hotseat pods — may need a server-side
+  `TWO_PLAYER`-style N-token mode, or drive it through the FFA lobby).
+- Assert: eliminated overlay shows *Keep Watching* → overlay dismissed, bottom half collapsed,
+  overview on, banner + Leave Game button visible, no action UI.
+- Confirm server behavior: does an eliminated player's connection keep receiving
+  `StateUpdate`/`StateDelta` for the rest of the game (and the final `GameOver` overlay lands on
+  top of the spectating layout)? If updates stop, spectating silently freezes — that would need a
+  server change.
+- Client entry points: `GameOverState.eliminated` (`store/slices/types.ts`),
+  `enterEliminatedSpectate` (`boardViewSlice.ts`), `isEliminatedSpectator` in `GameBoard.tsx`.
+
+## 2. Per-board "face" anchor for arrows and player targeting
+
+In shared-strip views (overview / combat split), arrows targeting a *player* aim at the top-center
+of their board cell — which is usually their lands row. Add a small per-cell **name plate** (name +
+life, seat-colored) rendered inside `OpponentBoardArea` when the board is visible in a multi-view,
+carrying the player anchors (`data-life-id` etc.) so:
+
+- attack/targeting arrows end somewhere that reads as "the player",
+- the plate doubles as a defender-assignment / player-target click target (today those clicks go
+  to the rail chip or the center-HUD orb, which only represents the *viewed* opponent).
+
+Anchor uniqueness rule (one `data-life-id` per player, see `OpponentRail.tsx` comment): the plate
+must take over from the rail chip while the board is visible, mirroring the existing viewed-orb
+handoff. `CombatArrows.getVisibleBoardRect` then becomes unnecessary — resolve to the plate.
+
+## 3. Overview polish
+
+- **Concede overlap**: top-right Concede button sits over the rightmost cell's deck pile in
+  overview (`ZonePiles.OPPONENT_TOP_RESERVED` only reserves height, and only helps the viewed
+  layout). Reserve right-edge space in multi-view or move the pile column inward.
+- **Viewed-board indicator**: in overview there's no visual for which board is "viewed" (the one
+  the center-HUD orb and `1`-`9` focus tracks). A subtle seat-colored inset ring on that cell.
+- **Phones/tablets**: three ~33% cells are unusable on portrait phones. Either disable the toggle
+  on `isMobile`, or make overview a 1×N vertically scrollable list there.
+- **MTGO-style per-opponent collapse** (bigger lift): instead of all-or-one, let each opponent
+  cell be individually collapsed (+/-) so the remaining boards grow — MTGO's model. The
+  `stripWidthPct` plumbing already supports arbitrary shares; needs UI + state
+  (`collapsedSeats: Set<EntityId>` in `boardViewSlice`).
+
+## 4. Combat split-view refinements
+
+- **Split during declaration**: the split activates on *confirmed* combat
+  (`gameState.combat.attackers`). The real-time `opponentAttackerTargets` echo could trigger it
+  earlier so you watch the attack being assembled. Guard against flicker (attackers toggle on/off
+  while declaring).
+- **"Me + another defender" combats**: when the attacker hits you *and* a third player, today only
+  the attacker slides in (pre-existing behavior); the other defender's board stays hidden. The
+  split (`useCombatDefenderFocus` early-returns when you're a defender) could include the other
+  defender's board alongside the attacker's.
+- **Attacker-left ordering**: cells keep turn order; reading combat left→right as
+  attacker→defender may parse faster. Trade-off: boards jump if defenders change mid-declaration.
+- **Width crunch at 3+ combatants**: attacker + two defenders = three ~30% cells (fine on
+  desktop); decide a cap for narrow viewports (e.g. bundle the smaller defender back to their
+  chip).
+
+## 5. Attack-direction / restriction follow-ups
+
+- **Authoritative `attackMode` for phrasing**: the banner's "Attack left/right —" prefix reads
+  from `lobbyState.settings.attackMode`, which is absent on reconnect-into-game, replays, and
+  scenario games (legality itself is always server-authoritative via `validAttackTargets`).
+  Carry `attackMode` in `GameStartedMessage` (next to the seat roster) and stamp it in the store
+  like `teamByPlayerId`.
+- **Goad**: goaded creatures have *forced* attack requirements the rail doesn't surface. A chip
+  marker ("must be attacked"/"can't attack you" cases) once goad-heavy sets matter.
+- **E2E**: an `attackMode: LEFT` FFA scenario asserting banner text, dimmed chips, and that the
+  defender popup never appears (sole-defender auto-assign, incl. mandatory attackers and
+  Attack All).
+- **Stale scope note**: `multiplayer.md` still says attack-left/right is "permanently out of
+  scope" — it shipped (`AttackMode.kt`, CR 803.1); update the doc.
+
+## 6. Spectator-mode parity
+
+The Overview toggle and combat split are gated to players (`!spectatorMode`). Spectators watching
+a pod (and the replay viewer) would benefit at least as much — they have no combat to declare and
+purely consume the table state. Longer term, eliminated-spectating (#1) and the spectator feature
+should converge on one layout: an eliminated player is effectively a spectator whose bottom seat
+died (`spectatorBottomSeatId` machinery already exists in `boardViewSlice`).
+
+## 7. Eliminated-spectator layout polish
+
+- The center HUD's right orb still shows the dead player's last life total; replace with a
+  tombstone treatment or repurpose the slot (e.g. whose turn / turn number).
+- Optionally let an eliminated spectator put a *chosen living player* in the (now empty) bottom
+  half instead of collapsing it — closer to how spectating renders a bottom seat.
+
+## 8. Overlay-inside-strip audit (transform trap)
+
+The strip track's `translateX` turns `position: fixed` descendants into cell-relative boxes —
+that's what broke multiplayer zone browsing (fixed by portalling the `ZonePiles` browsers to
+`document.body`). Audit the remaining subtree rendered under `OpponentBoardArea` for other
+fixed/full-screen elements (card context menus, yield menus, any future in-board overlay) and
+portal or hoist them. A lint-ish guard is hard; a checklist note in
+`web-client-architecture.md` may be enough.
+
+## 9. Overview performance sanity check
+
+Overview keeps *all* boards mounted with live `ResizeObserver` slot-sizing per cell, and
+`CombatArrows` polls DOM rects every 100 ms with more anchors on screen. No jank observed with
+small boards; re-check with 3 crowded boards (token swarms) — the wrap-line search in
+`useSlotSizedResponsive` runs per cell on every resize. If needed: memoize per-cell sizing by
+(cardCount, cellWidth) or pause sizing for cells at 0 width.

--- a/backlog/multiplayer-ui-followups.md
+++ b/backlog/multiplayer-ui-followups.md
@@ -29,33 +29,26 @@ The one shipped flow that was **not live-verified**: hotseat connections never r
 - Client entry points: `GameOverState.eliminated` (`store/slices/types.ts`),
   `enterEliminatedSpectate` (`boardViewSlice.ts`), `isEliminatedSpectator` in `GameBoard.tsx`.
 
-## 2. Per-board "face" anchor for arrows and player targeting
+## 2. ~~Per-board "face" anchor for arrows and player targeting~~ — DONE (2026-07-24)
 
-In shared-strip views (overview / combat split), arrows targeting a *player* aim at the top-center
-of their board cell — which is usually their lands row. Add a small per-cell **name plate** (name +
-life, seat-colored) rendered inside `OpponentBoardArea` when the board is visible in a multi-view,
-carrying the player anchors (`data-life-id` etc.) so:
+Shipped as `BoardNamePlate` in `OpponentBoardArea.tsx`: a seat-colored name + life pill at the
+top of every visible shared-strip cell. It carries the player anchors (`data-life-id` etc.) for
+every visible board except the viewed one (whose anchors stay on the center-HUD orb; rail chips
+now drop anchors whenever the board is visible — `OpponentRail visibleBoardIds`), and doubles as
+the defender-assignment / player-target click target. `CombatArrows` bundles to the chip only
+when no plate is on screen and otherwise ends player arrows on the plate.
 
-- attack/targeting arrows end somewhere that reads as "the player",
-- the plate doubles as a defender-assignment / player-target click target (today those clicks go
-  to the rail chip or the center-HUD orb, which only represents the *viewed* opponent).
+## 3. Overview polish — mostly DONE (2026-07-24)
 
-Anchor uniqueness rule (one `data-life-id` per player, see `OpponentRail.tsx` comment): the plate
-must take over from the rail chip while the board is visible, mirroring the existing viewed-orb
-handoff. `CombatArrows.getVisibleBoardRect` then becomes unnecessary — resolve to the plate.
-
-## 3. Overview polish
-
-- **Concede overlap**: top-right Concede button sits over the rightmost cell's deck pile in
-  overview (`ZonePiles.OPPONENT_TOP_RESERVED` only reserves height, and only helps the viewed
-  layout). Reserve right-edge space in multi-view or move the pile column inward.
-- **Viewed-board indicator**: in overview there's no visual for which board is "viewed" (the one
-  the center-HUD orb and `1`-`9` focus tracks). A subtle seat-colored inset ring on that cell.
-- **Phones/tablets**: three ~33% cells are unusable on portrait phones. Either disable the toggle
-  on `isMobile`, or make overview a 1×N vertically scrollable list there.
-- **MTGO-style per-opponent collapse** (bigger lift): instead of all-or-one, let each opponent
-  cell be individually collapsed (+/-) so the remaining boards grow — MTGO's model. The
-  `stripWidthPct` plumbing already supports arbitrary shares; needs UI + state
+- ~~**Concede overlap**~~ — the strip gets `paddingTop: 48` in shared-strip views, clearing the
+  Fullscreen/Concede row for every cell.
+- ~~**Viewed-board indicator**~~ — seat-colored inset ring on the viewed cell
+  (`viewedRingColor` on `OpponentBoardArea`).
+- ~~**Phones**~~ — shared-strip views are disabled on `isMobile` (focused camera only; the rail
+  hides the Overview toggle). A 1×N vertically scrollable phone overview remains an idea.
+- **MTGO-style per-opponent collapse** (bigger lift, still open): instead of all-or-one, let
+  each opponent cell be individually collapsed (+/-) so the remaining boards grow — MTGO's
+  model. The `stripWidthPct` plumbing already supports arbitrary shares; needs UI + state
   (`collapsedSeats: Set<EntityId>` in `boardViewSlice`).
 
 ## 4. Combat split-view refinements

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -245,6 +245,25 @@ are gated on `players.length > 2`).
   boundaries — an opponent's turn starting, the attacker's board when you're attacked, the
   priority seat in hotseat — and is refused inside `followViewTo` while any input is
   pending (the camera never moves under an in-progress selection).
+- **Table overview** (`boardView.overviewMode`, rail toggle or key `0`): every living
+  opponent's board shares the strip side-by-side instead of the one-board camera — cells
+  split the width evenly (padded clear of the fixed rail via `railReservedWidth`), hand
+  fans hide (chips carry the counts), and the per-slot card sizer shrinks cards to fit.
+  Hidden boards stay mounted after the visible cells at full width, overflowing
+  off-screen right, so their card anchors keep remapping to rail chips. Selecting a
+  single board (chip click / `1`-`9`) exits back to the focused camera.
+- **Combat defender-focus split** (`useCombatDefenderFocus`): when the server's confirmed
+  combat is between two *other* players, the attacker's and defenders' boards share the
+  strip so the fight renders as real arrows between real boards instead of a bundled
+  arrow onto a rail chip. Entering the split respects the camera guards (follow on,
+  unpinned, no pending input — `hasPendingInputSelection`); once active it holds for the
+  whole combat so boards don't shift mid-fight.
+- **Eliminated spectator** (`boardView.eliminatedSpectating`): a personal
+  `PlayerEliminatedMessage` marks the defeat overlay `GameOverState.eliminated`, which
+  adds a "Keep Watching" button. It dismisses the overlay, forces the table overview, and
+  collapses the dead bottom half (grid rows 4-5 → 0, hand/pass/undo/concede hidden) with
+  a "spectating" banner + Leave Game button; the freed height flows to the opponent
+  strip.
 - **Seat identity**: `styles/seatColors.ts` (Okabe-Ito, by seat index = turn-order index in
   `gameState.players`) colors rail chips, combat arrows and chevrons, stack item borders
   (caster), and log entry names.
@@ -255,13 +274,24 @@ are gated on `players.length > 2`).
 - **Combat**: with >1 possible defender, the first attacker selection pops a defender pick;
   assignment is sticky (`CombatState.stickyDefenderId`) and per-creature reassignable via
   rail-chip clicks, the viewed opponent's life orb, or the chip's planeswalker flyout. Confirm is disabled until every
-  selected attacker has an explicit defender. Arrows against the viewed defender render
-  per-creature in the defender's seat color; attacks on slid-away boards bundle into one
-  arrow to the defender's rail chip with a creature-count badge (`CombatArrows`), and any
-  card anchor on a slid-away board remaps to its controller's chip (also in
+  selected attacker has an explicit defender. When exactly one player is a legal attack
+  target (attack left/right — CR 803.1, last opponent standing) the sticky defender is
+  pre-assigned so the popup never asks; a restriction banner names who can legally be
+  attacked (phrased with the lobby's `attackMode` when known) and rail chips of
+  unattackable living seats dim with a 🚫 marker. Arrows against the viewed defender render
+  per-creature in the defender's seat color; attacks on boards visible in a shared-strip
+  view aim near the top of the defender's board cell; attacks on off-screen boards bundle
+  into one arrow to the defender's rail chip with a creature-count badge (`CombatArrows`),
+  and any card anchor on an off-screen board remaps to its controller's chip (also in
   `TargetingArrows`). While you declare blocks, attackers aimed at other defenders render
   dimmed (CR 509.1b — `CombatState.actingSeat` scopes `attackingCreatures` to attacks on
   you).
+- **Zone browsers portal to `<body>`**: the graveyard/exile/library/plotted/paradigm
+  browsers are `position: fixed` overlays, but an opponent's `ZonePile` sits inside the
+  strip whose `translateX` transform would make `fixed` resolve against the (clipped,
+  possibly off-screen) cell — so `ZonePiles.tsx` renders them through `createPortal`.
+  Titles carry the owner's name ("Carol's Graveyard") since "Opponent's" is ambiguous at
+  a multiplayer table.
 - **Spectator/replay** reuse the same layout anchored to a chosen bottom seat
   (`spectatorBottomSeatId`, cycled from the spectator header); replays render through the
   same `GameBoard spectatorMode` path.

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -236,19 +236,24 @@ are gated on `players.length > 2`).
   left the game. The *viewed* opponent additionally keeps a full-size life orb in the
   center HUD (seat-tinted to match their chip) — the familiar, biggest click target for
   targeting and defender assignment. Anchors (`data-player-id` / `data-life-id` /
-  `data-life-display`) are carried by the orb for the viewed opponent and by the rail chip
-  for everyone else — never both, so arrows, damage floats, and player-target clicks
-  resolve unambiguously.
+  `data-life-display`) are carried by exactly one element per player: the orb for the
+  viewed opponent, the cell's name plate for every other board visible in a shared-strip
+  view (the plate is also a defender-assignment / player-target click target), and the
+  rail chip only while the board is off-screen — never more than one, so arrows, damage
+  floats, and player-target clicks resolve unambiguously.
 - **Board switching**: rail-chip click (pins; re-click unpins), keyboard `1`/`2`/`3`,
   horizontal swipe. Follow-the-action (`useMultiplayerView` + the `boardView` slice:
   `viewedOpponentId`, `viewPinned`, `followAction`) slides automatically on coarse
   boundaries — an opponent's turn starting, the attacker's board when you're attacked, the
   priority seat in hotseat — and is refused inside `followViewTo` while any input is
   pending (the camera never moves under an in-progress selection).
-- **Table overview** (`boardView.overviewMode`, rail toggle or key `0`): every living
-  opponent's board shares the strip side-by-side instead of the one-board camera — cells
-  split the width evenly (padded clear of the fixed rail via `railReservedWidth`), hand
-  fans hide (chips carry the counts), and the per-slot card sizer shrinks cards to fit.
+- **Table overview** (`boardView.overviewMode`, rail toggle or key `0`; desktop/tablet
+  only — phones keep the focused camera): every living opponent's board shares the strip
+  side-by-side instead of the one-board camera — cells split the width evenly (padded
+  clear of the fixed rail via `railReservedWidth` and of the Fullscreen/Concede row),
+  hand fans hide (chips carry the counts), and the per-slot card sizer shrinks cards to
+  fit. Each visible cell gets a seat-colored **name plate** (`BoardNamePlate` — the
+  board's "face": name + life) and the viewed cell a subtle seat-colored inset ring.
   Hidden boards stay mounted after the visible cells at full width, overflowing
   off-screen right, so their card anchors keep remapping to rail chips. Selecting a
   single board (chip click / `1`-`9`) exits back to the focused camera.
@@ -280,7 +285,7 @@ are gated on `players.length > 2`).
   attacked (phrased with the lobby's `attackMode` when known) and rail chips of
   unattackable living seats dim with a 🚫 marker. Arrows against the viewed defender render
   per-creature in the defender's seat color; attacks on boards visible in a shared-strip
-  view aim near the top of the defender's board cell; attacks on off-screen boards bundle
+  view end on the defender's name plate; attacks on off-screen boards bundle
   into one arrow to the defender's rail chip with a creature-count badge (`CombatArrows`),
   and any card anchor on an off-screen board remaps to its controller's chip (also in
   `TargetingArrows`). While you declare blocks, attackers aimed at other defenders render

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -178,13 +178,29 @@ export default function App() {
         ? [...attackersAction.mandatoryAttackers]
         : []
 
+      // Multiplayer with exactly one legal attack target that is a player (attack
+      // left/right, last opponent standing — and no attackable planeswalkers):
+      // pre-assign it as the sticky defender so every selected attacker gets it
+      // and the "Attack which player?" popup never needs to ask.
+      const playerIdSet = new Set(gameState?.players.map((p) => p.playerId) ?? [])
+      const soleDefenderId =
+        (gameState?.players.length ?? 0) > 2 &&
+        validAttackTargets.length === 1 &&
+        playerIdSet.has(validAttackTargets[0]!)
+          ? validAttackTargets[0]!
+          : null
+
       // Enter combat mode — pre-select mandatory attackers
       startCombat({
         mode: 'declareAttackers',
         actingSeat: attackersAction?.action.type === 'DeclareAttackers' ? attackersAction.action.playerId : null,
-        stickyDefenderId: null,
+        stickyDefenderId: soleDefenderId,
         selectedAttackers: [...mandatoryAttackers],
-        attackerTargets: {},
+        // Mandatory attackers are pre-selected, so give them the sole defender too —
+        // otherwise the defender popup would still ask about them.
+        attackerTargets: soleDefenderId
+          ? Object.fromEntries(mandatoryAttackers.map((id) => [id, soleDefenderId]))
+          : {},
         validAttackTargets,
         blockerAssignments: {},
         validCreatures,
@@ -411,6 +427,7 @@ function GameOverlay() {
   const lastError = useGameStore((state) => state.lastError)
   const clearError = useGameStore((state) => state.clearError)
   const returnToMenu = useGameStore((state) => state.returnToMenu)
+  const enterEliminatedSpectate = useGameStore((state) => state.enterEliminatedSpectate)
   const navigate = useNavigate()
 
   // Auto-dismiss is handled centrally in the store (setError schedules clearError), so it
@@ -437,6 +454,16 @@ function GameOverlay() {
           </h1>
           <p style={overlayStyles.subtitle}>{reasonText}</p>
           <div style={overlayStyles.buttonRow}>
+            {/* Eliminated from a multiplayer game that plays on: offer to stay and
+                spectate the rest of it (board overview, action UI hidden). */}
+            {gameOverState.eliminated && (
+              <button
+                onClick={enterEliminatedSpectate}
+                style={overlayStyles.replayButton}
+              >
+                Keep Watching
+              </button>
+            )}
             <button
               onClick={returnToMenu}
               style={overlayStyles.button}

--- a/web-client/src/components/combat/CombatArrows.tsx
+++ b/web-client/src/components/combat/CombatArrows.tsx
@@ -221,19 +221,17 @@ function isOnScreen(p: Point): boolean {
 }
 
 /**
- * A player's board cell in the multiplayer strip, when it is actually visible: in the
- * table overview / combat defender-focus split several boards share the strip, so
- * "on screen" can't be inferred from the viewed opponent alone. Returns the cell rect
- * when the board is on-screen with real width (hidden cells sit off-screen to the
- * right at full width), else null.
+ * The name plate ("face") of a player's board cell in a shared-strip view (table
+ * overview / combat defender-focus split). Its presence on-screen is what marks the
+ * board as visible — several boards can share the strip, so visibility can't be
+ * inferred from the viewed opponent alone. Arrows targeting the player end here.
  */
-function getVisibleBoardRect(playerId: EntityId): DOMRect | null {
-  const element = document.querySelector(`[data-opponent-board="${playerId}"]`)
+function getBoardPlateCenter(playerId: EntityId): Point | null {
+  const element = document.querySelector(`[data-board-plate="${playerId}"]`)
   if (!element) return null
   const rect = element.getBoundingClientRect()
-  if (rect.width < 40) return null
-  const midX = rect.left + rect.width / 2
-  return midX >= 0 && midX <= window.innerWidth ? rect : null
+  const p = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+  return isOnScreen(p) ? p : null
 }
 
 /**
@@ -467,9 +465,9 @@ export function CombatArrows() {
         const isOtherOpponent =
           isMulti && defenderId !== viewingPlayerId && defenderId !== viewedOpponentId
         // A defender board sharing the strip (table overview / combat defender-focus
-        // split) is a real on-screen anchor — no bundling.
-        const visibleBoard = isOtherOpponent ? getVisibleBoardRect(defenderId) : null
-        if (isOtherOpponent && !visibleBoard) {
+        // split) shows its name plate — a real on-screen anchor, so no bundling.
+        const platePos = isOtherOpponent ? getBoardPlateCenter(defenderId) : null
+        if (isOtherOpponent && !platePos) {
           // Off-screen defender → bundle to their rail chip.
           const chip = getPlayerLifeCenter(defenderId)
           if (!chip) return
@@ -481,12 +479,9 @@ export function CombatArrows() {
         }
         const cardPos = targetCard ? getCardCenter(targetId) : null
         const targetPos = (cardPos && (!isMulti || isOnScreen(cardPos)) ? cardPos : null)
-          // Player attacked on a visible shared-strip board: aim near the top of their
-          // board cell (their "face"); their center-HUD orb belongs to the viewed
-          // opponent and their rail chip would drag the arrow across the screen.
-          ?? (visibleBoard
-            ? { x: visibleBoard.left + visibleBoard.width / 2, y: visibleBoard.top + Math.min(60, visibleBoard.height * 0.18) }
-            : null)
+          // Player attacked on a visible shared-strip board: their cell's name plate is
+          // the "face" of the board (and also carries their data-life-id anchors).
+          ?? platePos
           ?? getPlayerLifeCenter(defenderId)
         if (!targetPos) return
         newAttackerArrows.push({

--- a/web-client/src/components/combat/CombatArrows.tsx
+++ b/web-client/src/components/combat/CombatArrows.tsx
@@ -221,6 +221,22 @@ function isOnScreen(p: Point): boolean {
 }
 
 /**
+ * A player's board cell in the multiplayer strip, when it is actually visible: in the
+ * table overview / combat defender-focus split several boards share the strip, so
+ * "on screen" can't be inferred from the viewed opponent alone. Returns the cell rect
+ * when the board is on-screen with real width (hidden cells sit off-screen to the
+ * right at full width), else null.
+ */
+function getVisibleBoardRect(playerId: EntityId): DOMRect | null {
+  const element = document.querySelector(`[data-opponent-board="${playerId}"]`)
+  if (!element) return null
+  const rect = element.getBoundingClientRect()
+  if (rect.width < 40) return null
+  const midX = rect.left + rect.width / 2
+  return midX >= 0 && midX <= window.innerWidth ? rect : null
+}
+
+/**
  * Combat arrows overlay - draws arrows between blockers and attackers.
  *
  * Shows arrows in three scenarios:
@@ -448,7 +464,12 @@ export function CombatArrows() {
         // is the planeswalker's controller (CR 802.2a) or the player themself.
         const targetCard = cards?.[targetId]
         const defenderId = targetCard ? targetCard.controllerId : targetId
-        if (isMulti && defenderId !== viewingPlayerId && defenderId !== viewedOpponentId) {
+        const isOtherOpponent =
+          isMulti && defenderId !== viewingPlayerId && defenderId !== viewedOpponentId
+        // A defender board sharing the strip (table overview / combat defender-focus
+        // split) is a real on-screen anchor — no bundling.
+        const visibleBoard = isOtherOpponent ? getVisibleBoardRect(defenderId) : null
+        if (isOtherOpponent && !visibleBoard) {
           // Off-screen defender → bundle to their rail chip.
           const chip = getPlayerLifeCenter(defenderId)
           if (!chip) return
@@ -460,6 +481,12 @@ export function CombatArrows() {
         }
         const cardPos = targetCard ? getCardCenter(targetId) : null
         const targetPos = (cardPos && (!isMulti || isOnScreen(cardPos)) ? cardPos : null)
+          // Player attacked on a visible shared-strip board: aim near the top of their
+          // board cell (their "face"); their center-HUD orb belongs to the viewed
+          // opponent and their rail chip would drag the arrow across the screen.
+          ?? (visibleBoard
+            ? { x: visibleBoard.left + visibleBoard.width / 2, y: visibleBoard.top + Math.min(60, visibleBoard.height * 0.18) }
+            : null)
           ?? getPlayerLifeCenter(defenderId)
         if (!targetPos) return
         newAttackerArrows.push({

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -184,15 +184,19 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // defending seats during combat between two other players.
   const visibleStripIds = useMemo<readonly EntityId[]>(() => {
     if (!isMulti) return []
+    const single = viewedOpponent ? [viewedOpponent.playerId] : []
+    // Phones: the shared-strip views split into ~33% cells that are unusable in
+    // portrait — keep the focused one-board camera only.
+    if (responsive.isMobile) return single
     if (overviewActive) return stripOpponents.map((o) => o.playerId)
     if (!viewedOpponent) return []
     const stripIds = new Set(stripOpponents.map((o) => o.playerId))
     const extras = defenderFocusIds.filter((id) => id !== viewedOpponent.playerId && stripIds.has(id))
-    if (extras.length === 0) return [viewedOpponent.playerId]
+    if (extras.length === 0) return single
     // Keep strip (turn) order so boards don't jump when defenders change.
     const visible = new Set([viewedOpponent.playerId, ...extras])
     return stripOpponents.filter((o) => visible.has(o.playerId)).map((o) => o.playerId)
-  }, [isMulti, overviewActive, stripOpponents, viewedOpponent, defenderFocusIds])
+  }, [isMulti, responsive.isMobile, overviewActive, stripOpponents, viewedOpponent, defenderFocusIds])
   const multiView = visibleStripIds.length > 1
   // In a shared-strip view the visible boards come first (each with an equal width
   // share) and the hidden ones follow at full width, overflowing off-screen to the
@@ -601,7 +605,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       )}
       {isMulti && (
         <>
-          <OpponentRail spectatorMode={spectatorMode} />
+          <OpponentRail spectatorMode={spectatorMode} visibleBoardIds={visibleStripIds} />
           <div
             data-opponent-strip
             style={{
@@ -611,8 +615,11 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
               minHeight: 0,
               minWidth: 0,
               // Shared-strip views: keep the leftmost board clear of the fixed rail
-              // column (single view centers one full-width board, so no clash there).
+              // column, and every cell's top (name plates, zone piles) clear of the
+              // Fullscreen/Concede button row (single view centers one full-width
+              // board below the hand reservation, so no clash there).
               paddingLeft: multiView ? railReservedWidth(responsive) : 0,
+              paddingTop: multiView ? 48 : 0,
               boxSizing: 'border-box',
             }}
             onTouchStart={(e) => {
@@ -653,6 +660,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                     ? 100 / visibleStripIds.length
                     : 100
                   : 100
+                const isViewedCell = o.playerId === viewedOpponent?.playerId
                 return (
                   <OpponentBoardArea
                     key={o.playerId}
@@ -662,6 +670,12 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                     handReservation={oppHandReservation}
                     stripWidthPct={widthPct}
                     hideHand={multiView}
+                    // The viewed board's anchors stay on the center-HUD orb; every other
+                    // visible board's plate takes over from its rail chip.
+                    plateCarriesAnchors={multiView && !isViewedCell && visibleStripIds.includes(o.playerId)}
+                    {...(multiView && isViewedCell
+                      ? { viewedRingColor: identitySeatColor(teamMap, o.playerId, gameState.players.findIndex((p) => p.playerId === o.playerId)).base }
+                      : {})}
                     spectatorMode={spectatorMode}
                     isHijacking={hijackControlledOpponentId === o.playerId}
                     hijackedSurfaceStyle={hijackedSurfaceStyle}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -2,9 +2,10 @@ import { useMemo, useCallback, useRef } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
 import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor } from '@/store/selectors'
-import { useMultiplayerView } from '@/hooks/useMultiplayerView'
-import { OpponentRail } from './OpponentRail'
+import { useMultiplayerView, useCombatDefenderFocus } from '@/hooks/useMultiplayerView'
+import { OpponentRail, railReservedWidth } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
+import type { EntityId } from '@/types'
 import { StepStrip } from '../ui/StepStrip'
 import { ManaPool } from '../ui/ManaPool'
 import { ActionMenu } from '../ui/ActionMenu'
@@ -75,6 +76,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // A multi-phase cast/activation in progress (convoke, waterbend, harmonize, targeting, …). While
   // one is mid-flight the player must finish or cancel it, not pass priority / move to combat.
   const pipelineState = useGameStore((state) => state.pipelineState)
+  // Lobby settings — only for phrasing the attack-restriction banner ("attack left/right").
+  // The actual legality always comes from the server's validAttackTargets.
+  const lobbyState = useGameStore((state) => state.lobbyState)
   const cancelManaSelection = useGameStore((state) => state.cancelManaSelection)
   const { executeAction } = useInteraction()
 
@@ -95,6 +99,13 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     0,
     stripOpponents.findIndex((o) => o.playerId === viewedOpponent?.playerId),
   )
+  // Multiplayer camera extensions: the all-boards table overview (toggle / key 0), the
+  // eliminated-spectator layout, and the combat defender-focus split (combat between two
+  // *other* players shows attacker and defender side by side).
+  const overviewModeOn = useGameStore((state) => state.overviewMode)
+  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const returnToMenu = useGameStore((state) => state.returnToMenu)
+  const defenderFocusIds = useCombatDefenderFocus(isMulti && !spectatorMode)
   // In a Two-Headed Giant game the orb/edge tints follow the *team* hue (both teammates share
   // it); otherwise they keep the per-seat hue. The team map is empty in every non-team game.
   const teamMap = useGameStore(selectTeamMap)
@@ -160,6 +171,40 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const opponent = useOpponent()
   const stackCards = useStackCards()
   const ghostCards = useGhostCards(playerId ?? null)
+
+  // Eliminated-spectator layout: the local player is out of a multiplayer game and chose
+  // "Keep watching" — their dead bottom half collapses and all action UI hides.
+  const isEliminatedSpectator =
+    isMulti && !spectatorMode && eliminatedSpectating && (viewingPlayer?.hasLost ?? false)
+  // Table overview: every living opponent's board shares the strip. Entering the
+  // eliminated-spectator layout turns it on; a chip click focuses one board again.
+  const overviewActive = isMulti && overviewModeOn
+  // Which opponent boards share the strip this frame. One (the viewed board, sliding
+  // camera) normally; all living opponents in the overview; the viewed board plus the
+  // defending seats during combat between two other players.
+  const visibleStripIds = useMemo<readonly EntityId[]>(() => {
+    if (!isMulti) return []
+    if (overviewActive) return stripOpponents.map((o) => o.playerId)
+    if (!viewedOpponent) return []
+    const stripIds = new Set(stripOpponents.map((o) => o.playerId))
+    const extras = defenderFocusIds.filter((id) => id !== viewedOpponent.playerId && stripIds.has(id))
+    if (extras.length === 0) return [viewedOpponent.playerId]
+    // Keep strip (turn) order so boards don't jump when defenders change.
+    const visible = new Set([viewedOpponent.playerId, ...extras])
+    return stripOpponents.filter((o) => visible.has(o.playerId)).map((o) => o.playerId)
+  }, [isMulti, overviewActive, stripOpponents, viewedOpponent, defenderFocusIds])
+  const multiView = visibleStripIds.length > 1
+  // In a shared-strip view the visible boards come first (each with an equal width
+  // share) and the hidden ones follow at full width, overflowing off-screen to the
+  // right — so card anchors on hidden boards keep resolving to rail chips.
+  const orderedStrip = useMemo(() => {
+    if (!multiView) return stripOpponents
+    const visible = new Set(visibleStripIds)
+    return [
+      ...stripOpponents.filter((o) => visible.has(o.playerId)),
+      ...stripOpponents.filter((o) => !visible.has(o.playerId)),
+    ]
+  }, [multiView, stripOpponents, visibleStripIds])
 
   // Mindslaver-style hijack indicators (Phase 2C). Spectators don't get the UX promotions.
   const youAreHijacking = !spectatorMode ? (gameState?.youAreHijacking ?? null) : null
@@ -371,6 +416,37 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     return { satisfied, total, entries, colorSatisfied }
   }, [manaSelectionState, viewingPlayer?.manaPool])
 
+  // Attack restriction ("can only attack left/right", 2HG, …): during declare-attackers,
+  // some living non-ally opponent is not a legal attack target. Drives the explainer
+  // banner; the rail chips independently dim the unattackable seats. Teammates are
+  // excluded — "you can't attack your ally" needs no banner.
+  const attackRestriction = (() => {
+    if (!isMulti || spectatorMode || combatState?.mode !== 'declareAttackers' || !gameState) return null
+    // Candidates are relative to the *acting* seat — normally the viewing player, but a
+    // hotseat/hijack declaration acts for another seat, whose own chip must not read as
+    // "restricted" and whose enemies differ.
+    const actingSeat = combatState.actingSeat ?? viewingPlayer?.playerId ?? null
+    const actingTeam = actingSeat != null ? teamMap[actingSeat] : undefined
+    const enemies = gameState.players.filter(
+      (p) =>
+        !p.hasLost &&
+        p.playerId !== actingSeat &&
+        !(actingTeam != null && teamMap[p.playerId] === actingTeam),
+    )
+    const attackable = enemies.filter((o) => combatState.validAttackTargets.includes(o.playerId))
+    const restricted = enemies.filter((o) => !combatState.validAttackTargets.includes(o.playerId))
+    if (attackable.length === 0 || restricted.length === 0) return null
+    const lobbyMode =
+      lobbyState?.settings.gameMode === 'FREE_FOR_ALL' ? lobbyState.settings.attackMode : undefined
+    const direction = lobbyMode === 'LEFT' ? 'left' : lobbyMode === 'RIGHT' ? 'right' : null
+    return { attackable, direction }
+  })()
+  const defenderPopupVisible =
+    !spectatorMode &&
+    isMulti &&
+    combatState?.mode === 'declareAttackers' &&
+    combatState.selectedAttackers.some((id) => !combatState.attackerTargets[id])
+
   const counterTotalAllocated = counterDistributionState
     ? Object.values(counterDistributionState.distribution).reduce<number>(
         (sum, byType) => sum + Object.values(byType).reduce<number>((s, v) => s + v, 0),
@@ -435,9 +511,13 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // Hand reservation rows (1 and 5) keep the battlefield rows from sliding
       // under the position:fixed hand overlays. Both 1fr rows then receive
       // identical heights → symmetric card sizes for player and opponent.
-      gridTemplateRows: `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
-        (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
-      }px`,
+      // Eliminated spectator: the dead bottom half (rows 4-5) collapses — the freed
+      // space flows to the opponent strip (row 2, the only remaining 1fr).
+      gridTemplateRows: isEliminatedSpectator
+        ? `${oppHandReservation}px minmax(0, 1fr) auto 0px 0px`
+        : `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
+            (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
+          }px`,
     }}>
       {/* Fullscreen button (top-left) */}
       <FullscreenButton />
@@ -446,8 +526,63 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       {!spectatorMode && <SpectatorCountBadge />}
 
       {/* Concede button (top-right) - hidden in spectator mode. Stays live for the
-          affected player even when the rest of the UI is disabled by hijack. */}
-      {!spectatorMode && <ConcedeButton />}
+          affected player even when the rest of the UI is disabled by hijack. An
+          eliminated spectator has nothing to concede — they get a Leave button. */}
+      {!spectatorMode && !isEliminatedSpectator && <ConcedeButton />}
+      {isEliminatedSpectator && (
+        <>
+          <button
+            onClick={returnToMenu}
+            title="Leave the game and return to the menu"
+            style={{
+              position: 'fixed',
+              top: responsive.isMobile ? 8 : 12,
+              right: responsive.isMobile ? 8 : 12,
+              zIndex: 120,
+              height: 28,
+              padding: '0 12px',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              borderRadius: 6,
+              border: '1px solid #555',
+              background: 'rgba(18, 18, 26, 0.85)',
+              color: '#ccc',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Leave Game
+          </button>
+          {/* Spectating banner — sits where the (now empty) hand used to be. */}
+          <div
+            role="status"
+            style={{
+              position: 'fixed',
+              bottom: 12,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              zIndex: 90,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '5px 14px',
+              borderRadius: 999,
+              border: '1px solid #3a3a44',
+              background: 'rgba(10, 12, 20, 0.9)',
+              color: '#9fb0d0',
+              fontSize: 12,
+              fontWeight: 600,
+              whiteSpace: 'nowrap',
+              userSelect: 'none',
+            }}
+          >
+            <span aria-hidden>💀</span>
+            You've been eliminated — spectating the rest of the game
+          </div>
+        </>
+      )}
 
 
       {/* Opponent half. 2-player: today's exact markup (fixed hand at the top +
@@ -475,6 +610,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
               overflow: 'hidden',
               minHeight: 0,
               minWidth: 0,
+              // Shared-strip views: keep the leftmost board clear of the fixed rail
+              // column (single view centers one full-width board, so no clash there).
+              paddingLeft: multiView ? railReservedWidth(responsive) : 0,
+              boxSizing: 'border-box',
             }}
             onTouchStart={(e) => {
               stripTouchX.current = e.touches[0]?.clientX ?? null
@@ -482,6 +621,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             onTouchEnd={(e) => {
               const start = stripTouchX.current
               stripTouchX.current = null
+              // Swiping between boards only applies to the one-board sliding camera.
+              if (multiView) return
               const end = e.changedTouches[0]?.clientX ?? null
               if (start == null || end == null) return
               const store = useGameStore.getState()
@@ -498,13 +639,20 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 display: 'flex',
                 width: '100%',
                 height: '100%',
-                transform: `translateX(-${viewedStripIndex * 100}%)`,
+                transform: multiView ? 'none' : `translateX(-${viewedStripIndex * 100}%)`,
                 transition: 'transform 220ms cubic-bezier(0.4, 0, 0.2, 1)',
               }}
             >
-              {stripOpponents.map((o) => {
+              {orderedStrip.map((o) => {
                 // Two-Headed Giant: your teammate's board is an ally (face-up hand + marker).
                 const oIsAlly = viewerTeam != null && teamMap[o.playerId] === viewerTeam
+                // Shared-strip views: visible boards split the width evenly; hidden ones
+                // keep full width and overflow off-screen (see orderedStrip).
+                const widthPct = multiView
+                  ? visibleStripIds.includes(o.playerId)
+                    ? 100 / visibleStripIds.length
+                    : 100
+                  : 100
                 return (
                   <OpponentBoardArea
                     key={o.playerId}
@@ -512,6 +660,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                     layout="strip"
                     topOffset={effectiveTopOffset}
                     handReservation={oppHandReservation}
+                    stripWidthPct={widthPct}
+                    hideHand={multiView}
                     spectatorMode={spectatorMode}
                     isHijacking={hijackControlledOpponentId === o.playerId}
                     hijackedSurfaceStyle={hijackedSurfaceStyle}
@@ -522,7 +672,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
               })}
             </div>
             {/* Seat-colored edge flash on board arrival */}
-            {viewedOpponent && (
+            {!multiView && viewedOpponent && (
               <div
                 key={viewedOpponent.playerId}
                 aria-hidden
@@ -691,8 +841,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
 
       {/* Player area (grid row 4) — player-hand reservation lives in row 5,
-          so no padding here. Equal-height with row 2 → symmetric cards. */}
-      <div style={styles.playerArea}>
+          so no padding here. Equal-height with row 2 → symmetric cards.
+          Collapsed (row is 0px) for an eliminated spectator — their permanents
+          left the game with them. */}
+      {!isEliminatedSpectator && <div style={styles.playerArea}>
         <div style={styles.playerRowWithZones}>
           {/* Player command zone (left side) — Commander format only; renders nothing otherwise. */}
           {effectiveViewingPlayer && <CommandZone player={effectiveViewingPlayer} />}
@@ -709,7 +861,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           {/* Player deck/graveyard (right side) */}
           {effectiveViewingPlayer && <ZonePile player={effectiveViewingPlayer} />}
         </div>
-      </div>
+      </div>}
 
       {/* Spectator mode: floating player name label for bottom player */}
       {spectatorMode && effectiveViewingPlayer && (
@@ -725,8 +877,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         </div>
       )}
 
-      {/* Player hand - fixed at bottom of screen */}
-      <div
+      {/* Player hand - fixed at bottom of screen (gone for an eliminated spectator) */}
+      {!isEliminatedSpectator && <div
         data-zone="hand"
         data-hijack-controlled={isHijacked || undefined}
         data-hijack-dim={(isHijacking && !isHijacked) || undefined}
@@ -791,10 +943,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             ghostCards={isHijacked ? [] : ghostCards}
           />
         ) : null}
-      </div>
+      </div>}
 
       {/* Floating pass/resolve button (bottom-right) - always present, disabled when unavailable */}
-      {!spectatorMode && viewingPlayer && !isInManaSelectionMode && !isInCounterDistMode && (() => {
+      {!spectatorMode && !isEliminatedSpectator && viewingPlayer && !isInManaSelectionMode && !isInCounterDistMode && (() => {
         const passEnabled = canAct && !isHijacked && !isInCombatMode && !isInDistributeMode && !isInCounterDistMode && !isInManaSelectionMode && !delveSelectionState && !tapForPowerSelectionState && !targetingState && !pipelineState
         return (
           <div style={{
@@ -847,7 +999,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       })()}
 
       {/* Undo, priority mode icons (bottom-right, above pass button) */}
-      {!spectatorMode && viewingPlayer && !isInManaSelectionMode && !isInCounterDistMode && (
+      {!spectatorMode && !isEliminatedSpectator && viewingPlayer && !isInManaSelectionMode && !isInCounterDistMode && (
         <div style={{
           position: 'fixed',
           bottom: responsive.isMobile ? 50 : 66,
@@ -922,6 +1074,48 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
              serverPriorityMode === 'stops' ? 'Stops' :
              'Auto'}
           </button>
+        </div>
+      )}
+
+      {/* Attack-restriction explainer — "attack left/right" (CR 803.1) and similar
+          restrictions are invisible on the board itself, so say exactly who can be
+          attacked. Sits above the defender popup / combat buttons. */}
+      {attackRestriction && (
+        <div
+          role="status"
+          style={{
+            position: 'fixed',
+            bottom: defenderPopupVisible ? 196 : 110,
+            right: 16,
+            zIndex: 108,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '5px 12px',
+            borderRadius: 999,
+            border: '1px solid rgba(239, 83, 80, 0.55)',
+            background: 'rgba(26, 10, 10, 0.92)',
+            color: '#ffb3b3',
+            fontSize: responsive.isMobile ? 11 : 12,
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+            userSelect: 'none',
+          }}
+        >
+          <span aria-hidden>⚔</span>
+          <span>
+            {attackRestriction.direction ? `Attack ${attackRestriction.direction} — you can only attack ` : 'You can only attack '}
+            {attackRestriction.attackable.map((o, i) => {
+              const idx = gameState.players.findIndex((p) => p.playerId === o.playerId)
+              const seat = identitySeatColor(teamMap, o.playerId, idx)
+              return (
+                <span key={o.playerId}>
+                  {i > 0 ? ', ' : ''}
+                  <span style={{ color: seat.bright, fontWeight: 800 }}>{o.name}</span>
+                </span>
+              )
+            })}
+          </span>
         </div>
       )}
 

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -17,6 +17,15 @@ import type { ClientCard, ClientPlayer } from '@/types'
 import { useResponsiveContext } from './board/shared'
 
 /**
+ * Total viewport width claimed by the fixed rail column (chip width + left offset + a
+ * small gap). The table overview pads the board strip by this much so the leftmost
+ * board never renders under the rail.
+ */
+export function railReservedWidth(responsive: { isMobile: boolean; isTablet: boolean; isShortDesktop: boolean }): number {
+  return chipSizing(responsive).width + (responsive.isMobile ? 8 : 12) + 8
+}
+
+/**
  * Chip dimensions by screen size. The rail is a fixed-width column, so every chip shares one
  * size; large desktops get noticeably bigger chips (the small default felt cramped there).
  */
@@ -61,6 +70,8 @@ export function OpponentRail({
   const viewPinned = useGameStore((state) => state.viewPinned)
   const followAction = useGameStore((state) => state.followAction)
   const toggleFollowAction = useGameStore((state) => state.toggleFollowAction)
+  const overviewMode = useGameStore((state) => state.overviewMode)
+  const toggleOverviewMode = useGameStore((state) => state.toggleOverviewMode)
 
   // Two-Headed Giant (CR 810): when a team game is in progress, the rail splits into two
   // team sections — your team (you + ally) and the opposing team — colored by team with one
@@ -179,9 +190,42 @@ export function OpponentRail({
       )}
       {!spectatorMode && (
         <>
-          {/* Divider — the Follow control is a camera *setting*, not a player, so set it apart
+          {/* Divider — the camera controls below are *settings*, not players, so set them apart
               from the chip list above. */}
           <div aria-hidden style={{ alignSelf: 'stretch', height: 1, margin: '4px 6px 2px', background: 'rgba(255, 255, 255, 0.1)' }} />
+          <button
+            onClick={toggleOverviewMode}
+            title={
+              overviewMode
+                ? 'Table overview: every opponent board is shown side-by-side. Click (or press 0) to focus one board.'
+                : 'Focused camera: one opponent board at a time. Click (or press 0) to see the whole table at once.'
+            }
+            style={{
+              alignSelf: 'flex-start',
+              pointerEvents: 'auto',
+              height: 20,
+              padding: '0 9px',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 5,
+              borderRadius: 6,
+              border: `1px solid ${overviewMode ? 'rgba(180, 160, 255, 0.55)' : '#3a3a44'}`,
+              background: overviewMode ? 'rgba(50, 35, 90, 0.7)' : 'rgba(18, 18, 26, 0.7)',
+              color: overviewMode ? '#cbb8ff' : '#888',
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            <span aria-hidden style={{ fontSize: 11 }}>⊞</span>
+            Overview
+            <span style={{ fontWeight: 800, color: overviewMode ? '#e4daff' : '#666' }}>
+              {overviewMode ? 'On' : 'Off'}
+            </span>
+          </button>
           <button
             onClick={toggleFollowAction}
             title={
@@ -637,6 +681,15 @@ function RailChip({
       .map((id) => gameState.cards[id])
       .filter((c): c is ClientCard => !!c && c.controllerId === playerId)
   }, [declaringAttackers, combatState, gameState, playerId])
+  // Attack restriction: while declaring attackers, this living seat can't be attacked at
+  // all — neither the player (attack left/right, teammate) nor any of their
+  // planeswalkers. Dimmed with a 🚫 marker so who's legal reads at a glance.
+  const isAttackRestricted =
+    !spectatorMode &&
+    !opponent.hasLost &&
+    declaringAttackers &&
+    !isDefenderTarget &&
+    attackablePlaneswalkers.length === 0
   const [hovered, setHovered] = useState(false)
 
   /* ── Attention pulse on life / hand changes ─────────────────────────── */
@@ -746,7 +799,7 @@ function RailChip({
             }
           : {})}
         role="button"
-        title={chipTitle(opponent)}
+        title={chipTitle(opponent) + (isAttackRestricted ? "\nCan't be attacked this combat" : '')}
         onClick={handleChipClick}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
@@ -766,8 +819,8 @@ function RailChip({
           cursor: tomb && !spectatorMode ? 'default' : 'pointer',
           userSelect: 'none',
           whiteSpace: 'nowrap',
-          filter: tomb ? 'grayscale(1)' : 'none',
-          opacity: tomb ? 0.6 : 1,
+          filter: tomb ? 'grayscale(1)' : isAttackRestricted ? 'saturate(0.5)' : 'none',
+          opacity: tomb ? 0.6 : isAttackRestricted ? 0.5 : 1,
           transition: 'border-color 150ms, background 150ms, opacity 200ms',
           ...(ringShadow ? { boxShadow: ringShadow } : {}),
           // Active turn wins the animation slot (clearest signal); otherwise the
@@ -837,6 +890,13 @@ function RailChip({
         >
           {tomb ? '💀' : ''}
         </span>
+
+        {/* Attack-restriction marker — this seat can't be attacked this combat. */}
+        {isAttackRestricted && (
+          <span aria-hidden style={{ fontSize: compact ? 9 : 10, lineHeight: 1, flexShrink: 0 }}>
+            🚫
+          </span>
+        )}
 
         {/* Name (hidden on phones — the seat dot + position carries identity). Flexes to fill
             the fixed chip width and truncates, so every chip is the same size. An ally (your

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -13,7 +13,7 @@ import {
   useViewerTeamIndex,
 } from '@/store/selectors'
 import { teamColor, type SeatColor } from '@/styles/seatColors'
-import type { ClientCard, ClientPlayer } from '@/types'
+import type { ClientCard, ClientPlayer, EntityId } from '@/types'
 import { useResponsiveContext } from './board/shared'
 
 /**
@@ -60,8 +60,15 @@ function chipSizing(responsive: { isMobile: boolean; isTablet: boolean; isShortD
  */
 export function OpponentRail({
   spectatorMode = false,
+  visibleBoardIds = [],
 }: {
   spectatorMode?: boolean
+  /**
+   * Boards currently visible in the strip (the viewed board, plus every cell of a
+   * shared-strip view). A chip whose board is visible drops its player anchors — the
+   * center-HUD orb (viewed) or the cell's name plate (shared-strip) carries them instead.
+   */
+  visibleBoardIds?: readonly EntityId[]
 }) {
   const responsive = useResponsiveContext()
   const opponents = useOpponents()
@@ -152,6 +159,7 @@ export function OpponentRail({
                 key={opponent.playerId}
                 opponent={opponent}
                 isViewed={viewedOpponent?.playerId === opponent.playerId}
+                isBoardVisible={visibleBoardIds.includes(opponent.playerId)}
                 viewPinned={viewPinned}
                 spectatorMode={spectatorMode}
                 isAlly
@@ -165,6 +173,7 @@ export function OpponentRail({
                 key={opponent.playerId}
                 opponent={opponent}
                 isViewed={viewedOpponent?.playerId === opponent.playerId}
+                isBoardVisible={visibleBoardIds.includes(opponent.playerId)}
                 viewPinned={viewPinned}
                 spectatorMode={spectatorMode}
               />
@@ -182,6 +191,7 @@ export function OpponentRail({
               key={opponent.playerId}
               opponent={opponent}
               isViewed={viewedOpponent?.playerId === opponent.playerId}
+              isBoardVisible={visibleBoardIds.includes(opponent.playerId)}
               viewPinned={viewPinned}
               spectatorMode={spectatorMode}
             />
@@ -193,7 +203,9 @@ export function OpponentRail({
           {/* Divider — the camera controls below are *settings*, not players, so set them apart
               from the chip list above. */}
           <div aria-hidden style={{ alignSelf: 'stretch', height: 1, margin: '4px 6px 2px', background: 'rgba(255, 255, 255, 0.1)' }} />
-          <button
+          {/* Overview is desktop/tablet-landscape only — three ~33% board cells are
+              unusable on a portrait phone (GameBoard ignores the mode on isMobile too). */}
+          {!responsive.isMobile && <button
             onClick={toggleOverviewMode}
             title={
               overviewMode
@@ -225,7 +237,7 @@ export function OpponentRail({
             <span style={{ fontWeight: 800, color: overviewMode ? '#e4daff' : '#666' }}>
               {overviewMode ? 'On' : 'Off'}
             </span>
-          </button>
+          </button>}
           <button
             onClick={toggleFollowAction}
             title={
@@ -583,12 +595,15 @@ function HandCountIcon({ color = '#8899bb' }: { color?: string }) {
 function RailChip({
   opponent,
   isViewed,
+  isBoardVisible,
   viewPinned,
   spectatorMode,
   isAlly = false,
 }: {
   opponent: ClientPlayer
   isViewed: boolean
+  /** This opponent's board is on screen (viewed, or a cell of a shared-strip view). */
+  isBoardVisible: boolean
   viewPinned: boolean
   spectatorMode: boolean
   /** Two-Headed Giant: this seat is the viewing player's teammate (ally treatment, no own life). */
@@ -786,12 +801,12 @@ function RailChip({
     <div style={{ position: 'relative', pointerEvents: 'auto', width: '100%' }}>
       <div
         data-rail-chip={playerId}
-        // The viewed opponent's full-size life orb (center HUD) carries the
-        // player anchors while their board is in view — the chip only anchors
-        // arrows / damage floats / target clicks for off-screen opponents.
-        // Duplicate anchors would make querySelector pick whichever comes
-        // first in the DOM.
-        {...(!isViewed
+        // Exactly one element per player carries the anchors: the center-HUD life orb
+        // for the *viewed* opponent, the cell's name plate for every other board
+        // visible in a shared-strip view, and this chip only while the board is
+        // off-screen. Duplicate anchors would make querySelector pick whichever
+        // comes first in the DOM.
+        {...(!isBoardVisible
           ? {
               'data-player-id': playerId,
               'data-life-id': playerId,

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react'
 import type React from 'react'
+import { useGameStore } from '@/store/gameStore'
 import type { ClientPlayer } from '@/types'
 import { hand } from '@/types'
-import { useRevealedLibraryTopCard } from '@/store/selectors'
+import { useRevealedLibraryTopCard, useIdentityColor } from '@/store/selectors'
 import { Battlefield } from './Battlefield'
 import { CardRow } from './HandZone'
 import { CommandZone } from './CommandZone'
@@ -29,6 +30,8 @@ export function OpponentBoardArea({
   handReservation = 0,
   stripWidthPct = 100,
   hideHand = false,
+  plateCarriesAnchors = false,
+  viewedRingColor,
   spectatorMode,
   isHijacking,
   hijackedSurfaceStyle,
@@ -47,11 +50,24 @@ export function OpponentBoardArea({
    */
   stripWidthPct?: number
   /**
-   * Strip layout only: hide the opponent hand fan and its reservation band. Used when
-   * several boards share the strip — the fans would overlap across the narrow cells,
-   * and the rail chips already carry every hand count.
+   * Strip layout only: shared-strip view (table overview / combat defender-focus split).
+   * Hides the opponent hand fan and its reservation band (the fans would overlap across
+   * the narrow cells; rail chips carry the hand counts) and renders a seat-colored name
+   * plate at the top of the cell instead — the board's "face".
    */
   hideHand?: boolean
+  /**
+   * Shared-strip view only: the name plate carries this player's anchors
+   * (`data-life-id` etc.) so arrows, damage floats, and player-target clicks land on it.
+   * False for the *viewed* board, whose anchors stay on the center-HUD life orb —
+   * exactly one element per player may carry the anchors (see the OpponentRail comment).
+   */
+  plateCarriesAnchors?: boolean
+  /**
+   * Shared-strip view only: seat color for a persistent inset ring marking this cell as
+   * the *viewed* board (the one the center-HUD orb and keys 1-9 track). Undefined = no ring.
+   */
+  viewedRingColor?: string
   spectatorMode: boolean
   /** This opponent's seat is currently driven by this client (Mindslaver / hotseat). */
   isHijacking: boolean
@@ -194,12 +210,211 @@ export function OpponentBoardArea({
       {/* A hijack-controlled hand must stay visible even in shared-strip views —
           this client is playing from it. */}
       {(!hideHand || isHijacking) && handBlock}
+      {/* Shared-strip view: the board's "face" — name + life at the top of the cell.
+          Sits below the hand when a hijack forces the fan visible. */}
+      {hideHand && (
+        <BoardNamePlate
+          player={opponent}
+          carriesAnchors={plateCarriesAnchors}
+          top={(isHijacking ? handReservation : 0) + 6}
+        />
+      )}
+      {/* Persistent inset ring marking the viewed cell in a shared-strip view. */}
+      {viewedRingColor && (
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 2,
+            pointerEvents: 'none',
+            borderRadius: 10,
+            boxShadow: `inset 0 0 0 2px ${viewedRingColor}55, inset 0 0 18px ${viewedRingColor}22`,
+          }}
+        />
+      )}
       {/* Reservation band mirrors grid row 1 so the board area below aligns
-          exactly with the 2-player opponent area (grid row 2). With the hand
-          hidden (shared-strip views) a slim margin replaces it — the board
-          gets the vertical space back. */}
-      <div style={{ height: !hideHand || isHijacking ? handReservation : 8, flexShrink: 0 }} aria-hidden />
+          exactly with the 2-player opponent area (grid row 2). Shared-strip views
+          replace it with room for the name plate — the board gets the rest of the
+          vertical space back. */}
+      <div
+        style={{
+          height: hideHand ? (isHijacking ? handReservation : 0) + 34 : handReservation,
+          flexShrink: 0,
+        }}
+        aria-hidden
+      />
       {boardBlock}
+    </div>
+  )
+}
+
+/**
+ * The board's "face" in a shared-strip view: a compact seat-colored pill (name + life)
+ * pinned to the top of the cell. When [carriesAnchors] it holds this player's anchor
+ * attributes, so attack/targeting arrows and damage floats land on it instead of the
+ * board's lands, and it doubles as the player-level click target — defender assignment
+ * while declaring attackers, player targeting during a selection (same handling as the
+ * rail chip's crosshair).
+ */
+function BoardNamePlate({
+  player,
+  carriesAnchors,
+  top,
+}: {
+  player: ClientPlayer
+  carriesAnchors: boolean
+  top: number
+}) {
+  const seat = useIdentityColor(player.playerId)
+  const playerId = player.playerId
+
+  const combatState = useGameStore((state) => state.combatState)
+  const assignDefender = useGameStore((state) => state.assignDefenderToSelectedAttackers)
+  const draggingAttackerId = useGameStore((state) => state.draggingAttackerId)
+  const targetingState = useGameStore((state) => state.targetingState)
+  const addTarget = useGameStore((state) => state.addTarget)
+  const removeTarget = useGameStore((state) => state.removeTarget)
+  const pendingDecision = useGameStore((state) => state.pendingDecision)
+  const submitTargetsDecision = useGameStore((state) => state.submitTargetsDecision)
+  const decisionSelectionState = useGameStore((state) => state.decisionSelectionState)
+  const toggleDecisionSelection = useGameStore((state) => state.toggleDecisionSelection)
+
+  // Defender assignment (mirrors RailChip): legal while declaring attackers with a
+  // selection or an attacker drag in flight.
+  const declaringAttackers = combatState?.mode === 'declareAttackers'
+  const isDefenderTarget =
+    declaringAttackers && (combatState?.validAttackTargets.includes(playerId) ?? false)
+  const isDefenderAssignTarget =
+    isDefenderTarget &&
+    ((combatState?.selectedAttackers.length ?? 0) > 0 || draggingAttackerId !== null)
+
+  // Player-as-target (mirrors RailChip's crosshair handling).
+  const isTargetingSelected = targetingState?.selectedTargets.includes(playerId) ?? false
+  const isValidTargetingTarget = targetingState?.validTargets.includes(playerId) ?? false
+  const isChooseTargetsDecision = pendingDecision?.type === 'ChooseTargetsDecision'
+  const isValidDecisionTarget =
+    isChooseTargetsDecision &&
+    pendingDecision.targetRequirements.length === 1 &&
+    (pendingDecision.legalTargets[0] ?? []).includes(playerId)
+  const isValidDecisionSelection = decisionSelectionState?.validOptions.includes(playerId) ?? false
+  const isSelectedDecisionOption = decisionSelectionState?.selectedOptions.includes(playerId) ?? false
+  const isPlayerTargetable = isValidTargetingTarget || isValidDecisionTarget || isValidDecisionSelection
+  const isPlayerTargetSelected = isTargetingSelected || isSelectedDecisionOption
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (isDefenderTarget && (combatState?.selectedAttackers.length ?? 0) > 0) {
+      assignDefender(playerId)
+      return
+    }
+    if (isTargetingSelected) {
+      removeTarget(playerId)
+      return
+    }
+    if (isValidTargetingTarget) {
+      addTarget(playerId)
+      return
+    }
+    if (isValidDecisionTarget) {
+      submitTargetsDecision({ 0: [playerId] })
+      return
+    }
+    if (isValidDecisionSelection) {
+      toggleDecisionSelection(playerId)
+    }
+  }
+
+  const interactive = isDefenderAssignTarget || isPlayerTargetable || isPlayerTargetSelected
+  const lifeDanger = player.life <= 5
+  const borderColor = isDefenderAssignTarget
+    ? '#ff4444'
+    : isPlayerTargetSelected
+      ? '#ffff00'
+      : isPlayerTargetable
+        ? '#ff4444'
+        : seat.base
+
+  return (
+    <div
+      data-board-plate={playerId}
+      {...(carriesAnchors
+        ? {
+            'data-player-id': playerId,
+            'data-life-id': playerId,
+            'data-life-display': playerId,
+          }
+        : {})}
+      role={interactive ? 'button' : undefined}
+      title={
+        isDefenderAssignTarget
+          ? `Attack ${player.name}`
+          : isPlayerTargetable || isPlayerTargetSelected
+            ? (isPlayerTargetSelected ? `Unselect ${player.name}` : `Target ${player.name}`)
+            : player.name
+      }
+      onClick={interactive ? handleClick : undefined}
+      style={{
+        position: 'absolute',
+        top,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 56,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        height: 24,
+        padding: '0 11px',
+        borderRadius: 999,
+        border: `${interactive ? 2 : 1}px solid ${borderColor}`,
+        background: 'rgba(10, 12, 20, 0.9)',
+        color: '#dde3f0',
+        fontSize: 12,
+        fontWeight: 700,
+        whiteSpace: 'nowrap',
+        userSelect: 'none',
+        cursor: interactive ? 'pointer' : 'default',
+        pointerEvents: 'auto',
+        boxShadow: isDefenderAssignTarget
+          ? '0 0 12px rgba(255, 68, 68, 0.6)'
+          : isPlayerTargetSelected
+            ? '0 0 10px rgba(255, 255, 0, 0.6)'
+            : 'none',
+        transition: 'border-color 150ms, box-shadow 150ms',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 9,
+          height: 9,
+          borderRadius: '50%',
+          background: seat.base,
+          boxShadow: `0 0 5px ${seat.base}`,
+          flexShrink: 0,
+        }}
+      />
+      <span
+        style={{
+          maxWidth: 140,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          color: seat.bright,
+        }}
+      >
+        {player.name}
+      </span>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 3,
+          fontVariantNumeric: 'tabular-nums',
+          color: lifeDanger ? '#ff5555' : '#ffffff',
+        }}
+      >
+        <span aria-hidden style={{ color: '#ff6b6b', fontSize: 11 }}>❤</span>
+        {player.life}
+      </span>
     </div>
   )
 }

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -27,6 +27,8 @@ export function OpponentBoardArea({
   layout,
   topOffset,
   handReservation = 0,
+  stripWidthPct = 100,
+  hideHand = false,
   spectatorMode,
   isHijacking,
   hijackedSurfaceStyle,
@@ -38,6 +40,18 @@ export function OpponentBoardArea({
   topOffset: number
   /** Strip layout only: height of the hand reservation band (grid row 1 height). */
   handReservation?: number
+  /**
+   * Strip layout only: this cell's share of the strip width. 100 (default) for the
+   * one-board sliding camera; a fraction of 100 when several boards share the strip
+   * (table overview / combat defender-focus split) — card sizing self-measures per slot.
+   */
+  stripWidthPct?: number
+  /**
+   * Strip layout only: hide the opponent hand fan and its reservation band. Used when
+   * several boards share the strip — the fans would overlap across the narrow cells,
+   * and the rail chips already carry every hand count.
+   */
+  hideHand?: boolean
   spectatorMode: boolean
   /** This opponent's seat is currently driven by this client (Mindslaver / hotseat). */
   isHijacking: boolean
@@ -137,13 +151,14 @@ export function OpponentBoardArea({
       data-opponent-board={opponent.playerId}
       data-ally={isAlly || undefined}
       style={{
-        flex: '0 0 100%',
-        minWidth: '100%',
+        flex: `0 0 ${stripWidthPct}%`,
+        minWidth: `${stripWidthPct}%`,
         height: '100%',
         position: 'relative',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        transition: 'flex-basis 220ms cubic-bezier(0.4, 0, 0.2, 1), min-width 220ms cubic-bezier(0.4, 0, 0.2, 1)',
       }}
     >
       {/* Two-Headed Giant ally marker — a team-colored corner badge so a teammate's board (with
@@ -176,10 +191,14 @@ export function OpponentBoardArea({
           Ally · {opponent.name}
         </div>
       )}
-      {handBlock}
+      {/* A hijack-controlled hand must stay visible even in shared-strip views —
+          this client is playing from it. */}
+      {(!hideHand || isHijacking) && handBlock}
       {/* Reservation band mirrors grid row 1 so the board area below aligns
-          exactly with the 2-player opponent area (grid row 2). */}
-      <div style={{ height: handReservation, flexShrink: 0 }} aria-hidden />
+          exactly with the 2-player opponent area (grid row 2). With the hand
+          hidden (shared-strip views) a slim margin replaces it — the board
+          gets the vertical space back. */}
+      <div style={{ height: !hideHand || isHijacking ? handReservation : 8, flexShrink: 0 }} aria-hidden />
       {boardBlock}
     </div>
   )

--- a/web-client/src/components/game/board/ZonePiles.tsx
+++ b/web-client/src/components/game/board/ZonePiles.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useZoneCards, useStackCards, useZone, selectGameState } from '@/store/selectors.ts'
 import { graveyard, exile, library } from '@/types'
@@ -50,6 +51,10 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
   const hasPlotted = plottedCards.length > 0
   const hasParadigm = paradigmCards.length > 0
   const pileCount = BASE_PILE_COUNT + (hasPlotted ? 1 : 0) + (hasParadigm ? 1 : 0)
+
+  // Browser titles carry the owner's name — "Opponent's Graveyard" is ambiguous at a
+  // multiplayer table.
+  const ownerLabel = (zone: string) => (isOpponent ? `${player.name}'s ${zone}` : `Your ${zone}`)
 
   // Shrink piles to fit the column's actual height. The viewport-derived
   // pileWidth doesn't know about (a) the opponent's Concede button, which
@@ -290,32 +295,50 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
         </div>
       )}
 
-      {browsingGraveyard && (
-        <GraveyardBrowser cards={graveyardCards} onClose={() => setBrowsingGraveyard(false)} />
+      {/* The browsers are position:fixed full-screen overlays, but an opponent's
+          ZonePile sits inside the multiplayer board strip whose translateX transform
+          makes `fixed` resolve against the (overflow-hidden, possibly off-screen)
+          strip cell instead of the viewport. Portal them to <body> so browsing an
+          opponent's graveyard/exile/library works identically in every layout. */}
+      {browsingGraveyard && createPortal(
+        <GraveyardBrowser
+          cards={graveyardCards}
+          ownerLabel={ownerLabel('Graveyard')}
+          onClose={() => setBrowsingGraveyard(false)}
+        />,
+        document.body,
       )}
-      {browsingExile && (
-        <ExileBrowser cards={exileCards} onClose={() => setBrowsingExile(false)} />
+      {browsingExile && createPortal(
+        <ExileBrowser
+          cards={exileCards}
+          ownerLabel={ownerLabel('Exile')}
+          onClose={() => setBrowsingExile(false)}
+        />,
+        document.body,
       )}
-      {browsingPlotted && (
+      {browsingPlotted && createPortal(
         <PlottedBrowser
           cards={plottedCards}
-          ownerLabel={isOpponent ? "Opponent's Plotted Spells" : 'Your Plotted Spells'}
+          ownerLabel={ownerLabel('Plotted Spells')}
           onClose={() => setBrowsingPlotted(false)}
-        />
+        />,
+        document.body,
       )}
-      {browsingParadigm && (
+      {browsingParadigm && createPortal(
         <ParadigmBrowser
           cards={paradigmCards}
-          ownerLabel={isOpponent ? "Opponent's Paradigm Cards" : 'Your Paradigm Cards'}
+          ownerLabel={ownerLabel('Paradigm Cards')}
           onClose={() => setBrowsingParadigm(false)}
-        />
+        />,
+        document.body,
       )}
-      {browsingLibrary && (
+      {browsingLibrary && createPortal(
         <LibraryBrowser
-          ownerLabel={isOpponent ? "Opponent's Library" : 'Your Library'}
+          ownerLabel={ownerLabel('Library')}
           entityIds={libraryEntityIds}
           onClose={() => setBrowsingLibrary(false)}
-        />
+        />,
+        document.body,
       )}
     </div>
   )
@@ -324,7 +347,7 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
 /**
  * Full-screen overlay for browsing graveyard cards.
  */
-function GraveyardBrowser({ cards, onClose }: { cards: readonly ClientCard[], onClose: () => void }) {
+function GraveyardBrowser({ cards, ownerLabel, onClose }: { cards: readonly ClientCard[], ownerLabel: string, onClose: () => void }) {
   const hoverCard = useGameStore((state) => state.hoverCard)
   const responsive = useResponsiveContext()
   const [minimized, setMinimized] = useState(false)
@@ -380,7 +403,7 @@ function GraveyardBrowser({ cards, onClose }: { cards: readonly ClientCard[], on
     <div style={styles.graveyardOverlay} onClick={onClose}>
       <div style={styles.graveyardBrowserContent} onClick={(e) => e.stopPropagation()}>
         <div style={styles.graveyardBrowserHeader}>
-          <h2 style={styles.graveyardBrowserTitle}>Graveyard ({cards.length})</h2>
+          <h2 style={styles.graveyardBrowserTitle}>{ownerLabel} ({cards.length})</h2>
           <button style={styles.graveyardCloseButton} onClick={onClose}>✕</button>
         </div>
         <div style={styles.graveyardCardGrid}>
@@ -439,7 +462,7 @@ function GraveyardBrowser({ cards, onClose }: { cards: readonly ClientCard[], on
 /**
  * Full-screen overlay for browsing exile cards.
  */
-function ExileBrowser({ cards, onClose }: { cards: readonly ClientCard[], onClose: () => void }) {
+function ExileBrowser({ cards, ownerLabel, onClose }: { cards: readonly ClientCard[], ownerLabel: string, onClose: () => void }) {
   const hoverCard = useGameStore((state) => state.hoverCard)
   const responsive = useResponsiveContext()
   const [minimized, setMinimized] = useState(false)
@@ -503,7 +526,7 @@ function ExileBrowser({ cards, onClose }: { cards: readonly ClientCard[], onClos
       <div style={styles.exileBrowserContent} onClick={(e) => e.stopPropagation()}>
         <div style={styles.exileBrowserHeader}>
           <h2 style={styles.exileBrowserTitle}>
-            Exile ({cards.length})
+            {ownerLabel} ({cards.length})
             {plottedCount > 0 && (
               <span style={styles.exilePlottedCount}> · {plottedCount} plotted</span>
             )}

--- a/web-client/src/hooks/useMultiplayerView.ts
+++ b/web-client/src/hooks/useMultiplayerView.ts
@@ -1,7 +1,8 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useGameStore } from '@/store/gameStore'
-import { selectGameState, selectViewingPlayerId } from '@/store/selectors'
-import type { ClientPlayer } from '@/types'
+import { selectGameState, selectViewingPlayerId, useViewedOpponent } from '@/store/selectors'
+import { hasPendingInputSelection } from '@/store/slices/ui/boardViewSlice'
+import type { ClientPlayer, EntityId } from '@/types'
 
 /**
  * Multiplayer camera controls: follow-the-action and keyboard board switching.
@@ -12,7 +13,8 @@ import type { ClientPlayer } from '@/types'
  * pending input (the camera never moves under an in-progress selection) or has
  * pinned the view.
  *
- * Keyboard: 1..9 select the Nth living opponent (in rail order); Esc unpins.
+ * Keyboard: 1..9 select the Nth living opponent (in rail order); 0 toggles the
+ * table overview; Esc unpins.
  */
 export function useMultiplayerView(enabled: boolean, opponents: readonly ClientPlayer[]) {
   const gameState = useGameStore(selectGameState)
@@ -65,6 +67,9 @@ export function useMultiplayerView(enabled: boolean, opponents: readonly ClientP
         const living = opponents.filter((o) => !o.hasLost)
         const picked = living[Number(e.key) - 1]
         if (picked) store.viewOpponent(picked.playerId)
+      } else if (e.key === '0') {
+        if (store.selectedCardId) return
+        store.toggleOverviewMode()
       } else if (e.key === 'Escape') {
         // Esc means "cancel" inside selection modes; only unpin when idle.
         if (
@@ -80,4 +85,76 @@ export function useMultiplayerView(enabled: boolean, opponents: readonly ClientP
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [enabled, opponents])
+}
+
+const NO_EXTRA_BOARDS: readonly EntityId[] = Object.freeze([])
+
+/**
+ * Combat between two *other* players: the extra defending seats whose boards should be
+ * shown alongside the viewed board so the fight is visible as real arrows between real
+ * boards instead of a bundled arrow onto a rail chip.
+ *
+ * Active only while the server's confirmed combat has attackers, the viewing player is
+ * neither the attacker nor among the defenders (those cases keep today's behavior — your
+ * own half is always visible), and follow-the-action is on and unpinned. Entering the
+ * split view is refused while the player has any pending input (the camera never moves
+ * under an in-progress selection), but once active it stays for the whole combat so the
+ * boards don't shift mid-fight.
+ */
+export function useCombatDefenderFocus(enabled: boolean): readonly EntityId[] {
+  const gameState = useGameStore(selectGameState)
+  const viewingPlayerId = useGameStore(selectViewingPlayerId)
+  const viewedOpponent = useViewedOpponent()
+  const viewedOpponentId = viewedOpponent?.playerId ?? null
+  const [extras, setExtras] = useState<readonly EntityId[]>(NO_EXTRA_BOARDS)
+
+  const combat = gameState?.combat ?? null
+
+  useEffect(() => {
+    const reset = () => setExtras((prev) => (prev.length === 0 ? prev : NO_EXTRA_BOARDS))
+    if (!enabled || !gameState || !combat || combat.attackers.length === 0 || !viewingPlayerId) {
+      reset()
+      return
+    }
+    if (combat.attackingPlayerId === viewingPlayerId) {
+      reset()
+      return
+    }
+    const defenders = new Set<EntityId>()
+    for (const a of combat.attackers) {
+      const d =
+        a.attackingTarget.type === 'Player'
+          ? a.attackingTarget.playerId
+          : gameState.cards[a.attackingTarget.permanentId]?.controllerId
+      if (d) defenders.add(d)
+    }
+    // You're among the defenders → the attacker slides into view (useMultiplayerView)
+    // and your own half is already on screen. No split needed.
+    if (defenders.has(viewingPlayerId)) {
+      reset()
+      return
+    }
+    // Both sides of the fight must be on screen: the attacker and every defending
+    // seat, minus whichever of them already occupies the viewed slot.
+    const combatants = new Set<EntityId>(defenders)
+    combatants.add(combat.attackingPlayerId)
+    const next = gameState.players
+      .filter((p) => !p.hasLost && combatants.has(p.playerId))
+      .map((p) => p.playerId)
+      .filter((id) => id !== viewedOpponentId)
+    if (next.length === 0) {
+      reset()
+      return
+    }
+    setExtras((prev) => {
+      // Entering (not updating) the split view respects the camera guards.
+      if (prev.length === 0) {
+        const store = useGameStore.getState()
+        if (!store.followAction || store.viewPinned || hasPendingInputSelection(store)) return prev
+      }
+      return prev.length === next.length && prev.every((id, i) => id === next[i]) ? prev : next
+    })
+  }, [enabled, gameState, combat, viewingPlayerId, viewedOpponentId])
+
+  return extras
 }

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -674,6 +674,7 @@ export function createGameplayHandlers(set: SetState, get: GetState): Pick<Messa
           result: 'lose',
           message: 'You are out of the game — the table plays on without you.',
           gameId: msg.gameId,
+          eliminated: true,
         },
       })
     },

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -168,6 +168,12 @@ export interface GameOverState {
   result: 'win' | 'lose' | 'draw'
   message?: string | undefined
   gameId?: string | undefined
+  /**
+   * True when this is a personal elimination from a multiplayer game that continues
+   * without the player — the overlay then offers "Keep watching" (spectate the rest
+   * of the game) alongside the exit buttons.
+   */
+  eliminated?: boolean
 }
 
 /**
@@ -970,12 +976,16 @@ export type GameStore = {
   viewedOpponentId: EntityId | null
   viewPinned: boolean
   followAction: boolean
+  overviewMode: boolean
+  eliminatedSpectating: boolean
   spectatorBottomSeatId: EntityId | null
   teamByPlayerId: Readonly<Record<EntityId, number>>
   teamSharedLife: boolean
   viewOpponent: (playerId: EntityId, opts?: { pin?: boolean }) => void
   unpinView: () => void
   toggleFollowAction: () => void
+  toggleOverviewMode: () => void
+  enterEliminatedSpectate: () => void
   followViewTo: (playerId: EntityId) => void
   setSpectatorBottomSeat: (playerId: EntityId | null) => void
   setSeatTeams: (teamByPlayerId: Record<EntityId, number>, sharedLife?: boolean) => void

--- a/web-client/src/store/slices/ui/boardViewSlice.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.ts
@@ -6,9 +6,29 @@
  * rules. In a 2-player game none of this state is consulted — the sole opponent is
  * always the viewed board and the rail doesn't render.
  */
-import type { SliceCreator, EntityId } from '../types'
+import type { SliceCreator, EntityId, GameStore } from '../types'
 
 const FOLLOW_ACTION_KEY = 'argentum-follow-action'
+
+/**
+ * True while the player has any pending input or in-progress selection. The camera —
+ * whether follow-the-action, the combat defender-focus split, or any other automatic
+ * view change — must never move under an in-progress selection (stale-UI suppression
+ * applies to camera movement). Shared by `followViewTo` and the render-time camera hooks.
+ */
+export function hasPendingInputSelection(state: GameStore): boolean {
+  return !!(
+    state.targetingState ||
+    state.decisionSelectionState ||
+    state.pendingDecision ||
+    state.distributeState ||
+    state.counterDistributionState ||
+    state.manaSelectionState ||
+    state.delveSelectionState ||
+    state.tapForPowerSelectionState ||
+    state.pipelineState
+  )
+}
 
 function loadFollowAction(): boolean {
   try {
@@ -32,6 +52,18 @@ export interface BoardViewSliceState {
   viewPinned: boolean
   /** Follow-the-action camera setting (persisted). Default on. */
   followAction: boolean
+  /**
+   * Table overview: every living opponent's board is shown side-by-side (cards shrink to
+   * fit) instead of the one-board sliding camera. Toggled from the rail or the `0` key;
+   * selecting a single board (chip click / 1-9) exits back to the focused camera.
+   */
+  overviewMode: boolean
+  /**
+   * The local player was eliminated from a multiplayer game and chose "Keep watching"
+   * on the defeat overlay: their dead bottom half collapses, the freed space goes to the
+   * opponent boards, and all action UI hides. Cleared on reset (new game / leave).
+   */
+  eliminatedSpectating: boolean
   /**
    * Spectator/replay: which seat anchors the bottom half of the board. Null =
    * the stream's default (`spectatingState.player1Id`). Set by the spectator
@@ -60,6 +92,13 @@ export interface BoardViewSliceActions {
   unpinView: () => void
   /** Toggle the follow-the-action setting (persisted). */
   toggleFollowAction: () => void
+  /** Toggle the all-boards table overview. */
+  toggleOverviewMode: () => void
+  /**
+   * "Keep watching" after being eliminated from a multiplayer game: dismisses the defeat
+   * overlay and enters the spectator layout (overview on, dead bottom half collapsed).
+   */
+  enterEliminatedSpectate: () => void
   /**
    * Follow-the-action write. Refused at the handler (not at render time) when the
    * view is pinned, following is off, or the player has any pending input — the
@@ -84,6 +123,8 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
   viewedOpponentId: null,
   viewPinned: false,
   followAction: loadFollowAction(),
+  overviewMode: false,
+  eliminatedSpectating: false,
   spectatorBottomSeatId: null,
   teamByPlayerId: {},
   teamSharedLife: false,
@@ -96,7 +137,13 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     const pin = opts?.pin ?? true
     // Pinning a board and follow-the-action are mutually exclusive: pinning turns follow off
     // (the camera is locked), so the Follow toggle reflects that rather than lying "on".
-    set({ viewedOpponentId: playerId, viewPinned: pin, ...(pin ? { followAction: false } : {}) })
+    // Picking a single board also exits the table overview — it *is* the focus gesture.
+    set({
+      viewedOpponentId: playerId,
+      viewPinned: pin,
+      overviewMode: false,
+      ...(pin ? { followAction: false } : {}),
+    })
   },
 
   unpinView: () => set({ viewPinned: false }),
@@ -112,6 +159,15 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     set({ followAction: next, ...(next ? { viewPinned: false } : {}) })
   },
 
+  toggleOverviewMode: () => {
+    // Entering the overview releases any pin (there is no single board to pin).
+    const next = !get().overviewMode
+    set({ overviewMode: next, ...(next ? { viewPinned: false } : {}) })
+  },
+
+  enterEliminatedSpectate: () =>
+    set({ eliminatedSpectating: true, overviewMode: true, viewPinned: false, gameOverState: null }),
+
   followViewTo: (playerId) => {
     const state = get()
     if (!state.followAction || state.viewPinned) return
@@ -121,18 +177,7 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     // declare-blockers is the one exception: sliding the attacker's board in is
     // exactly what a defender needs, and blocking happens on your own (always
     // visible) half — so only an in-progress *attack* declaration blocks it.
-    if (
-      state.targetingState ||
-      state.decisionSelectionState ||
-      state.pendingDecision ||
-      state.combatState?.mode === 'declareAttackers' ||
-      state.distributeState ||
-      state.counterDistributionState ||
-      state.manaSelectionState ||
-      state.delveSelectionState ||
-      state.tapForPowerSelectionState ||
-      state.pipelineState
-    ) {
+    if (hasPendingInputSelection(state) || state.combatState?.mode === 'declareAttackers') {
       return
     }
     set({ viewedOpponentId: playerId })
@@ -145,5 +190,13 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     set({ teamByPlayerId, teamSharedLife: sharedLife }),
 
   resetBoardView: () =>
-    set({ viewedOpponentId: null, viewPinned: false, spectatorBottomSeatId: null, teamByPlayerId: {}, teamSharedLife: false }),
+    set({
+      viewedOpponentId: null,
+      viewPinned: false,
+      overviewMode: false,
+      eliminatedSpectating: false,
+      spectatorBottomSeatId: null,
+      teamByPlayerId: {},
+      teamSharedLife: false,
+    }),
 })

--- a/web-client/src/store/slices/ui/combatSlice.ts
+++ b/web-client/src/store/slices/ui/combatSlice.ts
@@ -369,10 +369,23 @@ export const createCombatSlice: SliceCreator<CombatSlice> = (set, get) => ({
     if (combatState.mode !== 'declareAttackers') return
     if (combatState.validCreatures.length === 0) return
 
+    // Sticky defender applies to the whole selection (multiplayer) — same rule as
+    // toggling attackers one by one, so "Attack All" never reopens the defender pick
+    // when a defender is already chosen (or was pre-assigned as the sole legal one).
+    const newAttackers = [...combatState.validCreatures]
+    const newTargets = { ...combatState.attackerTargets }
+    if (combatState.stickyDefenderId) {
+      for (const id of newAttackers) {
+        if (!newTargets[id]) newTargets[id] = combatState.stickyDefenderId
+      }
+    }
+    getWebSocket()?.send(createUpdateAttackerTargetsMessage(newAttackers, newTargets))
+
     set({
       combatState: {
         ...combatState,
-        selectedAttackers: [...combatState.validCreatures],
+        selectedAttackers: newAttackers,
+        attackerTargets: newTargets,
       },
     })
   },


### PR DESCRIPTION
Addresses the multiplayer UI pain points: no way to see the whole table, combat between two other players being invisible, nothing to do after being eliminated, unclear attack-left/right legality — plus broken zone browsing in multiplayer. Also implements follow-up items #2 and #3 from `backlog/multiplayer-ui-followups.md` (added in this PR).

## Table overview (zoom out)

Rail toggle or key `0` (desktop/tablet only): every living opponent's board shares the strip side-by-side. Cells split the width evenly, clear of the rail and the Fullscreen/Concede row; hand fans hide (rail chips carry the counts) and the per-slot card sizer shrinks cards to fit. Each cell gets a seat-colored **name plate** (the board's "face") and the viewed cell an inset ring. Chip click / `1`–`9` focuses one board again.

![overview](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-screenshots/overview.png)

## Combat between two other players

When confirmed combat is between two *other* players, the attacker's and defenders' boards share the strip so the fight renders as real per-creature arrows (defender's seat color) ending on the defender's name plate — instead of one bundled arrow onto a rail chip. Entering the split respects the camera guards (follow-the-action on, unpinned, no pending input); once active it holds for the whole combat.

![combat split](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-screenshots/combat-split.png)

## Eliminated spectating

A personal elimination now offers **Keep Watching** on the defeat overlay: the dead bottom half collapses (the space flows to the opponent boards in overview), all action UI hides, and a banner + Leave Game button appear. ⚠️ Not live-verified: hotseat connections never receive `PlayerEliminatedMessage`, so this path needs a real multi-connection FFA game — flagged as item #1 in the backlog doc.

## Attack-direction clarity (attack left/right, 2HG)

- Banner during declare-attackers naming exactly who can legally be attacked (phrased with the lobby's attack mode when known; legality always from the server's `validAttackTargets`).
- Rail chips of unattackable living seats dim with a 🚫 marker.
- A sole legal defender is pre-assigned as the sticky defender, so the "Attack which player?" popup never has to ask; **Attack All** honors the sticky defender too.

![declare attackers](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-screenshots/declare-attackers.png)

## Zone browsing fix

The graveyard/exile/library/plotted/paradigm browsers are `position: fixed` overlays, but an opponent's `ZonePile` sits inside the strip whose `translateX` transform made `fixed` resolve against the clipped (possibly off-screen) cell — broken in multiplayer only. They now portal to `document.body`, and titles name the owner ("Carol's Graveyard").

![graveyard browser](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-screenshots/graveyard-browser.png)

## Anchor handoff rule

Exactly one element per player carries the `data-life-id`/`data-player-id` anchors: the center-HUD orb for the *viewed* opponent, the cell's name plate for every other visible shared-strip board, and the rail chip only while the board is off-screen. The plate is also a defender-assignment / player-target click target.

## Notes

- 2-player games are untouched (everything is gated on `players.length > 2`); the single-view multiplayer camera behaves exactly as before when no shared-strip view is active.

  ![single view](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-screenshots/single-view.png)

- Docs updated: `docs/web-client-architecture.md` (multiplayer section) + new `backlog/multiplayer-ui-followups.md` (remaining follow-ups, incl. the deferred MTGO-style per-opponent collapse).
- Verified with `npm run typecheck` + `npm run build` and driven live via 4-player hotseat scenarios (screenshots above); the `multiplayer-ui-screenshots` branch is throwaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)