### PR TITLE
Multiplayer UI follow-ups: per-board collapse, eliminated bottom seat, transform-trap audit

### DIFF
--- a/backlog/multiplayer-ui-followups.md
+++ b/backlog/multiplayer-ui-followups.md
@@ -46,10 +46,11 @@ when no plate is on screen and otherwise ends player arrows on the plate.
   (`viewedRingColor` on `OpponentBoardArea`).
 - ~~**Phones**~~ — shared-strip views are disabled on `isMobile` (focused camera only; the rail
   hides the Overview toggle). A 1×N vertically scrollable phone overview remains an idea.
-- **MTGO-style per-opponent collapse** (bigger lift, still open): instead of all-or-one, let
-  each opponent cell be individually collapsed (+/-) so the remaining boards grow — MTGO's
-  model. The `stripWidthPct` plumbing already supports arbitrary shares; needs UI + state
-  (`collapsedSeats: Set<EntityId>` in `boardViewSlice`).
+- ~~**MTGO-style per-opponent collapse**~~ — DONE (2026-07-24): each overview cell has a
+  "−" button folding it to a narrow seat-colored tab (`CollapsedBoardTab`); the remaining
+  boards split the freed width and the collapsed board joins the off-screen group so its
+  anchors bundle back to the rail chip. State: `collapsedSeats` in `boardViewSlice`
+  (overview-only; focused camera and combat split ignore it).
 
 ## 4. Combat split-view refinements
 
@@ -92,19 +93,26 @@ died (`spectatorBottomSeatId` machinery already exists in `boardViewSlice`).
 
 ## 7. Eliminated-spectator layout polish
 
-- The center HUD's right orb still shows the dead player's last life total; replace with a
-  tombstone treatment or repurpose the slot (e.g. whose turn / turn number).
-- Optionally let an eliminated spectator put a *chosen living player* in the (now empty) bottom
-  half instead of collapsing it — closer to how spectating renders a bottom seat.
+- The center HUD's right orb still shows the dead player's last life total (when no bottom
+  board is chosen); replace with a tombstone treatment or repurpose the slot (e.g. whose
+  turn / turn number).
+- ~~Chosen living player in the bottom half~~ — DONE (2026-07-24): the spectating banner
+  carries a bottom-board picker (`eliminatedBottomSeatId` in `boardViewSlice`); the chosen
+  seat's board renders read-only in the bottom half (spectator-style face-down hand), takes
+  over the right center-HUD orb, and leaves the opponent strip. Click the active seat again
+  to clear; self-heals if the seat dies.
 
-## 8. Overlay-inside-strip audit (transform trap)
+## 8. ~~Overlay-inside-strip audit (transform trap)~~ — DONE (2026-07-24)
 
-The strip track's `translateX` turns `position: fixed` descendants into cell-relative boxes —
-that's what broke multiplayer zone browsing (fixed by portalling the `ZonePiles` browsers to
-`document.body`). Audit the remaining subtree rendered under `OpponentBoardArea` for other
-fixed/full-screen elements (card context menus, yield menus, any future in-board overlay) and
-portal or hoist them. A lint-ish guard is hard; a checklist note in
-`web-client-architecture.md` may be enough.
+Audited everything rendered under `OpponentBoardArea` for `position: fixed` /
+viewport-coordinate elements. Two live bugs found and portalled to `document.body`:
+the attachments browser (`Battlefield.tsx` `AttachmentsBrowser`, a full-screen
+`styles.exileOverlay`) and the active-effect badge tooltip (`CardOverlays.tsx`,
+`styles.cardEffectTooltip` — also broken under a tapped card's rotation transform).
+Everything else in the subtree was clean: the zone browsers and the copy-of hover
+preview were already portalled; the yield context menu, decision modals, stack, and
+action menu render from `GameBoard`, outside the strip. A checklist note now lives in
+`web-client-architecture.md` § *the transform trap*.
 
 ## 9. Overview performance sanity check
 

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -256,7 +256,13 @@ are gated on `players.length > 2`).
   board's "face": name + life) and the viewed cell a subtle seat-colored inset ring.
   Hidden boards stay mounted after the visible cells at full width, overflowing
   off-screen right, so their card anchors keep remapping to rail chips. Selecting a
-  single board (chip click / `1`-`9`) exits back to the focused camera.
+  single board (chip click / `1`-`9`) exits back to the focused camera. Each cell can
+  also be individually folded to a narrow seat-colored tab (MTGO-style: the "−" button
+  next to the plate; the tab re-expands on click — `boardView.collapsedSeats`): the
+  remaining boards split the freed width, and a collapsed seat's full board moves to
+  the off-screen group so its anchors bundle back to the rail chip. Collapse state is
+  overview-only — the focused camera and the combat split ignore it — and persists
+  across overview toggles until the game resets.
 - **Combat defender-focus split** (`useCombatDefenderFocus`): when the server's confirmed
   combat is between two *other* players, the attacker's and defenders' boards share the
   strip so the fight renders as real arrows between real boards instead of a bundled
@@ -268,7 +274,12 @@ are gated on `players.length > 2`).
   adds a "Keep Watching" button. It dismisses the overlay, forces the table overview, and
   collapses the dead bottom half (grid rows 4-5 → 0, hand/pass/undo/concede hidden) with
   a "spectating" banner + Leave Game button; the freed height flows to the opponent
-  strip.
+  strip. The banner also carries a **bottom-board picker**
+  (`boardView.eliminatedBottomSeatId`): choosing a living player anchors their board in
+  the empty bottom half the way spectating renders a bottom seat — read-only board +
+  face-down hand, their life on the right center-HUD orb (which takes over their
+  anchors from the rail chip), and their cell leaves the opponent strip. Clicking the
+  active seat again clears it; the choice self-heals to "collapsed" if that player dies.
 - **Seat identity**: `styles/seatColors.ts` (Okabe-Ito, by seat index = turn-order index in
   `gameState.players`) colors rail chips, combat arrows and chevrons, stack item borders
   (caster), and log entry names.
@@ -291,12 +302,20 @@ are gated on `players.length > 2`).
   `TargetingArrows`). While you declare blocks, attackers aimed at other defenders render
   dimmed (CR 509.1b — `CombatState.actingSeat` scopes `attackingCreatures` to attacks on
   you).
-- **Zone browsers portal to `<body>`**: the graveyard/exile/library/plotted/paradigm
-  browsers are `position: fixed` overlays, but an opponent's `ZonePile` sits inside the
-  strip whose `translateX` transform would make `fixed` resolve against the (clipped,
-  possibly off-screen) cell — so `ZonePiles.tsx` renders them through `createPortal`.
-  Titles carry the owner's name ("Carol's Graveyard") since "Opponent's" is ambiguous at
-  a multiplayer table.
+- **The transform trap — overlays inside the strip portal to `<body>`**: the strip
+  track's `translateX` (and any other transformed ancestor, e.g. a tapped card's
+  rotation) turns a `position: fixed` descendant's containing block into that ancestor —
+  the "fixed" element then renders relative to the (clipped, possibly off-screen) cell
+  instead of the viewport. **Checklist: anything rendered under `OpponentBoardArea`
+  (hand `CardRow`, `CommandZone`, `Battlefield`, `ZonePile`, and everything inside
+  `GameCard`) that is full-screen or positioned in viewport coordinates must go through
+  `createPortal(..., document.body)`.** Current portals: the
+  graveyard/exile/library/plotted/paradigm browsers (`ZonePiles.tsx` — titles carry the
+  owner's name, "Carol's Graveyard", since "Opponent's" is ambiguous at a multiplayer
+  table), the attachments browser (`Battlefield.tsx`), the copy-of hover preview and the
+  active-effect badge tooltip (`GameCard.tsx` / `CardOverlays.tsx`). Overlays rendered
+  from `GameBoard` itself (stack, action menu, decision modals, yield menu) sit outside
+  the strip and don't need it.
 - **Spectator/replay** reuse the same layout anchored to a chosen bottom seat
   (`spectatorBottomSeatId`, cycled from the spectator header); replays render through the
   same `GameBoard spectatorMode` path.

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -23,7 +23,7 @@ import { useResponsive } from '@/hooks/useResponsive'
 import { ManaSymbol } from '../ui/ManaSymbols'
 
 // Import extracted components
-import { Battlefield, CardRow, CommandZone, OpponentBoardArea, StackDisplay, ZonePile, ResponsiveContext } from './board'
+import { Battlefield, CardRow, CommandZone, OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH, StackDisplay, ZonePile, ResponsiveContext } from './board'
 import { RenderProfiler } from '@/utils/renderProfiler'
 import { CardPreview } from './card'
 import { TargetingOverlay, ManaColorSelectionOverlay, LifeDisplay, ActiveEffectsBadges, ConcedeButton, FullscreenButton, SpectatorCountBadge } from './overlay'
@@ -94,17 +94,38 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // not a reserved full-width band — so it no longer pushes the board down.
   const effectiveTopOffset = topOffset
   useMultiplayerView(isMulti, opponents)
-  const stripOpponents = useMemo(() => opponents.filter((o) => !o.hasLost), [opponents])
+  // Multiplayer camera extensions: the all-boards table overview (toggle / key 0) with
+  // MTGO-style per-board collapse, the eliminated-spectator layout, and the combat
+  // defender-focus split (combat between two *other* players shows attacker and defender
+  // side by side).
+  const overviewModeOn = useGameStore((state) => state.overviewMode)
+  const collapsedSeats = useGameStore((state) => state.collapsedSeats)
+  const toggleSeatCollapsed = useGameStore((state) => state.toggleSeatCollapsed)
+  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const eliminatedBottomSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
+  const setEliminatedBottomSeat = useGameStore((state) => state.setEliminatedBottomSeat)
+  const returnToMenu = useGameStore((state) => state.returnToMenu)
+  const viewingPlayer = useViewingPlayer()
+  // Eliminated-spectator layout: the local player is out of a multiplayer game and chose
+  // "Keep watching" — their dead bottom half collapses and all action UI hides.
+  const isEliminatedSpectator =
+    isMulti && !spectatorMode && eliminatedSpectating && (viewingPlayer?.hasLost ?? false)
+  // Eliminated spectator's chosen bottom seat: a living player whose board fills the
+  // (otherwise collapsed) bottom half, the way spectating anchors a bottom seat. Their
+  // board leaves the opponent strip while anchored here. Self-heals if the seat dies.
+  const eliminatedBottomSeat = useMemo(() => {
+    if (!isEliminatedSpectator || !eliminatedBottomSeatId) return null
+    const p = gameState?.players.find((pp) => pp.playerId === eliminatedBottomSeatId)
+    return p && !p.hasLost ? p : null
+  }, [isEliminatedSpectator, eliminatedBottomSeatId, gameState])
+  const stripOpponents = useMemo(
+    () => opponents.filter((o) => !o.hasLost && o.playerId !== eliminatedBottomSeat?.playerId),
+    [opponents, eliminatedBottomSeat],
+  )
   const viewedStripIndex = Math.max(
     0,
     stripOpponents.findIndex((o) => o.playerId === viewedOpponent?.playerId),
   )
-  // Multiplayer camera extensions: the all-boards table overview (toggle / key 0), the
-  // eliminated-spectator layout, and the combat defender-focus split (combat between two
-  // *other* players shows attacker and defender side by side).
-  const overviewModeOn = useGameStore((state) => state.overviewMode)
-  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
-  const returnToMenu = useGameStore((state) => state.returnToMenu)
   const defenderFocusIds = useCombatDefenderFocus(isMulti && !spectatorMode)
   // In a Two-Headed Giant game the orb/edge tints follow the *team* hue (both teammates share
   // it); otherwise they keep the per-seat hue. The team map is empty in every non-team game.
@@ -167,15 +188,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     executeAction(modifiedActionInfo)
   }, [manaSelectionState, cancelManaSelection, executeAction])
 
-  const viewingPlayer = useViewingPlayer()
   const opponent = useOpponent()
   const stackCards = useStackCards()
   const ghostCards = useGhostCards(playerId ?? null)
 
-  // Eliminated-spectator layout: the local player is out of a multiplayer game and chose
-  // "Keep watching" — their dead bottom half collapses and all action UI hides.
-  const isEliminatedSpectator =
-    isMulti && !spectatorMode && eliminatedSpectating && (viewingPlayer?.hasLost ?? false)
   // Table overview: every living opponent's board shares the strip. Entering the
   // eliminated-spectator layout turns it on; a chip click focuses one board again.
   const overviewActive = isMulti && overviewModeOn
@@ -198,17 +214,44 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     return stripOpponents.filter((o) => visible.has(o.playerId)).map((o) => o.playerId)
   }, [isMulti, responsive.isMobile, overviewActive, stripOpponents, viewedOpponent, defenderFocusIds])
   const multiView = visibleStripIds.length > 1
-  // In a shared-strip view the visible boards come first (each with an equal width
-  // share) and the hidden ones follow at full width, overflowing off-screen to the
-  // right — so card anchors on hidden boards keep resolving to rail chips.
-  const orderedStrip = useMemo(() => {
-    if (!multiView) return stripOpponents
-    const visible = new Set(visibleStripIds)
-    return [
-      ...stripOpponents.filter((o) => visible.has(o.playerId)),
-      ...stripOpponents.filter((o) => !visible.has(o.playerId)),
-    ]
-  }, [multiView, stripOpponents, visibleStripIds])
+  // MTGO-style per-board collapse — table overview only; the focused camera and the
+  // combat defender-focus split ignore it (their board sets are already deliberate).
+  const collapsedStripIds = useMemo<readonly EntityId[]>(
+    () => (overviewActive && multiView ? visibleStripIds.filter((id) => collapsedSeats.includes(id)) : []),
+    [overviewActive, multiView, visibleStripIds, collapsedSeats],
+  )
+  // Boards whose cards + plate are actually on screen: the shared-strip cells minus the
+  // collapsed ones. Drives which rail chips drop their player anchors.
+  const expandedStripIds = useMemo<readonly EntityId[]>(
+    () => visibleStripIds.filter((id) => !collapsedStripIds.includes(id)),
+    [visibleStripIds, collapsedStripIds],
+  )
+  // In a shared-strip view the strip renders the visible cells in turn order (expanded
+  // boards splitting the width, collapsed boards as narrow tabs), then the hidden *and*
+  // collapsed full boards at full width, overflowing off-screen to the right — so card
+  // anchors on boards without an expanded cell keep resolving to rail chips.
+  const visibleStripCells = useMemo(
+    () => stripOpponents.filter((o) => visibleStripIds.includes(o.playerId)),
+    [stripOpponents, visibleStripIds],
+  )
+  const offscreenStripBoards = useMemo(
+    () =>
+      stripOpponents.filter(
+        (o) => !visibleStripIds.includes(o.playerId) || collapsedStripIds.includes(o.playerId),
+      ),
+    [stripOpponents, visibleStripIds, collapsedStripIds],
+  )
+  // Expanded cells share the width left over by the collapsed tabs.
+  const expandedCellBasis =
+    collapsedStripIds.length > 0
+      ? `calc((100% - ${collapsedStripIds.length * COLLAPSED_TAB_WIDTH}px) / ${Math.max(1, expandedStripIds.length)})`
+      : `${100 / Math.max(1, expandedStripIds.length)}%`
+  // The rail chips also cover the eliminated spectator's bottom-anchored board, whose
+  // anchors live on the bottom life orb while it is on screen.
+  const anchorVisibleBoardIds = useMemo<readonly EntityId[]>(
+    () => (eliminatedBottomSeat ? [...expandedStripIds, eliminatedBottomSeat.playerId] : expandedStripIds),
+    [expandedStripIds, eliminatedBottomSeat],
+  )
 
   // Mindslaver-style hijack indicators (Phase 2C). Spectators don't get the UX promotions.
   const youAreHijacking = !spectatorMode ? (gameState?.youAreHijacking ?? null) : null
@@ -261,6 +304,11 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // seat color everyone else sees for you (and that the rail's self chip uses), instead of the
   // fixed 2-player blue.
   const selfSeatColor = useIdentityColor(effectiveViewingPlayer?.playerId ?? null)
+
+  // The seat anchoring the bottom HUD (right life orb + bottom half of the board): the
+  // eliminated spectator's chosen living seat when one is set, else the viewing player.
+  const bottomHudPlayer = eliminatedBottomSeat ?? effectiveViewingPlayer
+  const bottomHudSeatColor = useIdentityColor(bottomHudPlayer?.playerId ?? null)
 
   if (!gameState || (!spectatorMode && (!playerId || !viewingPlayer))) {
     return null
@@ -516,9 +564,15 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // under the position:fixed hand overlays. Both 1fr rows then receive
       // identical heights → symmetric card sizes for player and opponent.
       // Eliminated spectator: the dead bottom half (rows 4-5) collapses — the freed
-      // space flows to the opponent strip (row 2, the only remaining 1fr).
+      // space flows to the opponent strip (row 2, the only remaining 1fr) — unless a
+      // living player's board is anchored there, which restores the spectator-shaped
+      // rows (small face-down hand at the bottom).
       gridTemplateRows: isEliminatedSpectator
-        ? `${oppHandReservation}px minmax(0, 1fr) auto 0px 0px`
+        ? eliminatedBottomSeat
+          ? `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
+              responsive.smallCardHeight + responsive.handBattlefieldGap
+            }px`
+          : `${oppHandReservation}px minmax(0, 1fr) auto 0px 0px`
         : `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
             (spectatorMode ? responsive.smallCardHeight : responsive.cardHeight) + responsive.handBattlefieldGap
           }px`,
@@ -559,12 +613,16 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           >
             Leave Game
           </button>
-          {/* Spectating banner — sits where the (now empty) hand used to be. */}
+          {/* Spectating banner — top center, in the chrome row between the Fullscreen
+              and Leave Game buttons (the bottom of the screen belongs to the step strip
+              or the anchored bottom board). It also carries the bottom-board picker:
+              put a living player's board in the empty bottom half (click the active
+              seat again to clear it). */}
           <div
             role="status"
             style={{
               position: 'fixed',
-              bottom: 12,
+              top: responsive.isMobile ? 8 : 12,
               left: '50%',
               transform: 'translateX(-50%)',
               zIndex: 90,
@@ -583,7 +641,47 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             }}
           >
             <span aria-hidden>💀</span>
-            You've been eliminated — spectating the rest of the game
+            You've been eliminated — spectating
+            <span aria-hidden style={{ width: 1, height: 14, background: '#3a3a44' }} />
+            <span style={{ color: '#7c8aa8', fontWeight: 600 }}>Board below:</span>
+            {opponents.filter((o) => !o.hasLost).map((o) => {
+              const idx = gameState.players.findIndex((p) => p.playerId === o.playerId)
+              const seat = identitySeatColor(teamMap, o.playerId, idx)
+              const active = eliminatedBottomSeat?.playerId === o.playerId
+              return (
+                <button
+                  key={o.playerId}
+                  onClick={() => setEliminatedBottomSeat(active ? null : o.playerId)}
+                  title={active
+                    ? `Stop showing ${o.name}'s board at the bottom`
+                    : `Show ${o.name}'s board in the bottom half`}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    height: 22,
+                    padding: '0 9px',
+                    borderRadius: 999,
+                    border: `${active ? 2 : 1}px solid ${active ? seat.bright : seat.base}`,
+                    background: active ? seat.soft : 'rgba(10, 12, 20, 0.85)',
+                    color: seat.bright,
+                    fontSize: 11,
+                    fontWeight: 700,
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <span aria-hidden style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: '50%',
+                    background: seat.base,
+                    boxShadow: `0 0 4px ${seat.base}`,
+                  }} />
+                  {o.name}
+                </button>
+              )
+            })}
           </div>
         </>
       )}
@@ -605,7 +703,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       )}
       {isMulti && (
         <>
-          <OpponentRail spectatorMode={spectatorMode} visibleBoardIds={visibleStripIds} />
+          <OpponentRail spectatorMode={spectatorMode} visibleBoardIds={anchorVisibleBoardIds} />
           <div
             data-opponent-strip
             style={{
@@ -650,40 +748,60 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 transition: 'transform 220ms cubic-bezier(0.4, 0, 0.2, 1)',
               }}
             >
-              {orderedStrip.map((o) => {
-                // Two-Headed Giant: your teammate's board is an ally (face-up hand + marker).
-                const oIsAlly = viewerTeam != null && teamMap[o.playerId] === viewerTeam
-                // Shared-strip views: visible boards split the width evenly; hidden ones
-                // keep full width and overflow off-screen (see orderedStrip).
-                const widthPct = multiView
-                  ? visibleStripIds.includes(o.playerId)
-                    ? 100 / visibleStripIds.length
-                    : 100
-                  : 100
-                const isViewedCell = o.playerId === viewedOpponent?.playerId
+              {(() => {
+                const renderStripBoard = (o: (typeof stripOpponents)[number], expandedCell: boolean) => {
+                  // Two-Headed Giant: your teammate's board is an ally (face-up hand + marker).
+                  const oIsAlly = viewerTeam != null && teamMap[o.playerId] === viewerTeam
+                  const isViewedCell = o.playerId === viewedOpponent?.playerId
+                  return (
+                    <OpponentBoardArea
+                      key={o.playerId}
+                      opponent={o}
+                      layout="strip"
+                      topOffset={effectiveTopOffset}
+                      handReservation={oppHandReservation}
+                      // Shared-strip views: expanded cells split the width left over by
+                      // the collapsed tabs; hidden/collapsed full boards keep full width
+                      // and overflow off-screen (see offscreenStripBoards).
+                      stripBasis={multiView && expandedCell ? expandedCellBasis : '100%'}
+                      hideHand={multiView}
+                      // The viewed board's anchors stay on the center-HUD orb; every other
+                      // expanded board's plate takes over from its rail chip.
+                      plateCarriesAnchors={multiView && expandedCell && !isViewedCell}
+                      {...(multiView && expandedCell && isViewedCell
+                        ? { viewedRingColor: identitySeatColor(teamMap, o.playerId, gameState.players.findIndex((p) => p.playerId === o.playerId)).base }
+                        : {})}
+                      // Fold-away control — table overview only; the combat split and the
+                      // focused camera keep their deliberate board sets.
+                      {...(overviewActive && multiView && expandedCell
+                        ? { onToggleCollapse: () => toggleSeatCollapsed(o.playerId) }
+                        : {})}
+                      spectatorMode={spectatorMode}
+                      isHijacking={hijackControlledOpponentId === o.playerId}
+                      hijackedSurfaceStyle={hijackedSurfaceStyle}
+                      isAlly={oIsAlly}
+                      {...(oIsAlly && viewerTeam != null ? { allyColor: selfSeatColor.base } : {})}
+                    />
+                  )
+                }
+                if (!multiView) return stripOpponents.map((o) => renderStripBoard(o, false))
                 return (
-                  <OpponentBoardArea
-                    key={o.playerId}
-                    opponent={o}
-                    layout="strip"
-                    topOffset={effectiveTopOffset}
-                    handReservation={oppHandReservation}
-                    stripWidthPct={widthPct}
-                    hideHand={multiView}
-                    // The viewed board's anchors stay on the center-HUD orb; every other
-                    // visible board's plate takes over from its rail chip.
-                    plateCarriesAnchors={multiView && !isViewedCell && visibleStripIds.includes(o.playerId)}
-                    {...(multiView && isViewedCell
-                      ? { viewedRingColor: identitySeatColor(teamMap, o.playerId, gameState.players.findIndex((p) => p.playerId === o.playerId)).base }
-                      : {})}
-                    spectatorMode={spectatorMode}
-                    isHijacking={hijackControlledOpponentId === o.playerId}
-                    hijackedSurfaceStyle={hijackedSurfaceStyle}
-                    isAlly={oIsAlly}
-                    {...(oIsAlly && viewerTeam != null ? { allyColor: selfSeatColor.base } : {})}
-                  />
+                  <>
+                    {visibleStripCells.map((o) =>
+                      collapsedStripIds.includes(o.playerId) ? (
+                        <CollapsedBoardTab
+                          key={`${o.playerId}-collapsed-tab`}
+                          player={o}
+                          onExpand={() => toggleSeatCollapsed(o.playerId)}
+                        />
+                      ) : (
+                        renderStripBoard(o, true)
+                      ),
+                    )}
+                    {offscreenStripBoards.map((o) => renderStripBoard(o, false))}
+                  </>
                 )
-              })}
+              })()}
             </div>
             {/* Seat-colored edge flash on board arrival */}
             {!multiView && viewedOpponent && (
@@ -822,7 +940,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           activeSide={
             spectatorMode
               ? (gameState.activePlayerId === effectiveViewingPlayer?.playerId ? 'bottom' : 'top')
-              : (isMyTurn ? 'bottom' : 'top')
+              : (isMyTurn || (eliminatedBottomSeat != null && gameState.activePlayerId === eliminatedBottomSeat.playerId)
+                  ? 'bottom'
+                  : 'top')
           }
           stopOverrides={stopOverrides}
           onToggleStop={toggleStopOverride}
@@ -830,13 +950,16 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         />
         </div>
 
-        {/* Player life (right side) */}
+        {/* Player life (right side) — the eliminated spectator's chosen bottom seat
+            takes this orb over (their board fills the bottom half). */}
         <div style={{ ...styles.centerLifeSection, ...styles.centerLifeSectionRight }}>
-          {effectiveViewingPlayer && (
+          {bottomHudPlayer && (
             <>
-              <LifeDisplay life={effectiveViewingPlayer.life} isPlayer playerId={effectiveViewingPlayer.playerId} playerName={effectiveViewingPlayer.name} spectatorMode={spectatorMode} poisonCounters={effectiveViewingPlayer.poisonCounters} commanderDamage={effectiveViewingPlayer.commanderDamage ?? []} handSize={effectiveViewingPlayer.handSize} maxHandSize={effectiveViewingPlayer.maxHandSize} {...(isMulti ? { seatColor: selfSeatColor.base } : {})} />
-              {!responsive.isMobile && <ActiveEffectsBadges effects={effectiveViewingPlayer.activeEffects} />}
-              {!responsive.isMobile && effectiveViewingPlayer.manaPool && <ManaPool manaPool={effectiveViewingPlayer.manaPool} />}
+              {/* When another seat is anchored here (eliminated spectator), the orb is
+                  spectator-shaped: no "You" role tag, no player-click handling. */}
+              <LifeDisplay life={bottomHudPlayer.life} isPlayer playerId={bottomHudPlayer.playerId} playerName={bottomHudPlayer.name} spectatorMode={spectatorMode || eliminatedBottomSeat != null} poisonCounters={bottomHudPlayer.poisonCounters} commanderDamage={bottomHudPlayer.commanderDamage ?? []} handSize={bottomHudPlayer.handSize} maxHandSize={bottomHudPlayer.maxHandSize} {...(isMulti ? { seatColor: bottomHudSeatColor.base } : {})} />
+              {!responsive.isMobile && <ActiveEffectsBadges effects={bottomHudPlayer.activeEffects} />}
+              {!responsive.isMobile && bottomHudPlayer.manaPool && <ManaPool manaPool={bottomHudPlayer.manaPool} />}
             </>
           )}
         </div>
@@ -858,6 +981,34 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           so no padding here. Equal-height with row 2 → symmetric cards.
           Collapsed (row is 0px) for an eliminated spectator — their permanents
           left the game with them. */}
+      {/* Eliminated spectator with a chosen bottom seat: that living player's board fills
+          the bottom half, rendered read-only the way spectating renders a bottom seat. */}
+      {isEliminatedSpectator && eliminatedBottomSeat && (
+        <div style={styles.playerArea}>
+          <div style={styles.playerRowWithZones}>
+            <CommandZone player={eliminatedBottomSeat} />
+            <div style={styles.playerMainArea}>
+              <Battlefield isOpponent={false} playerId={eliminatedBottomSeat.playerId} spectatorMode />
+            </div>
+            <ZonePile player={eliminatedBottomSeat} />
+          </div>
+        </div>
+      )}
+      {isEliminatedSpectator && eliminatedBottomSeat && (
+        <div
+          data-zone="hand"
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 50,
+          }}
+        >
+          <CardRow zoneId={hand(eliminatedBottomSeat.playerId)} faceDown small />
+        </div>
+      )}
+
       {!isEliminatedSpectator && <div style={styles.playerArea}>
         <div style={styles.playerRowWithZones}>
           {/* Player command zone (left side) — Commander format only; renders nothing otherwise. */}

--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useBattlefieldCards, groupCards, visibleStackDepth, useSplitOutTargetIds, selectViewingPlayerId } from '@/store/selectors.ts'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
@@ -43,15 +44,16 @@ const ATTACHMENT_COLLAPSE_THRESHOLD = 3
 export function Battlefield({ isOpponent, playerId, spectatorMode = false }: {
   isOpponent: boolean
   /**
-   * Scope an opponent battlefield to one seat's permanents (multiplayer opponent
-   * boards). Omitted → all non-viewing-player permanents (the 2-player shape; in a
-   * 2-player game the two are identical).
+   * Scope this battlefield to one seat's permanents. For an opponent board (multiplayer
+   * strip cells): omitted → all non-viewing-player permanents (the 2-player shape; in a
+   * 2-player game the two are identical). For the player side it renders another seat's
+   * board in the bottom half (eliminated spectator's chosen bottom seat).
    */
   playerId?: EntityId
   spectatorMode?: boolean
 }) {
   const slotRef = useRef<HTMLDivElement>(null)
-  const cards = useBattlefieldCards(isOpponent ? playerId : undefined)
+  const cards = useBattlefieldCards(isOpponent ? playerId : undefined, isOpponent ? undefined : playerId)
   const lands = isOpponent ? cards.opponentLands : cards.playerLands
   const creatures = isOpponent ? cards.opponentCreatures : cards.playerCreatures
   const planeswalkers = isOpponent ? cards.opponentPlaneswalkers : cards.playerPlaneswalkers
@@ -822,7 +824,11 @@ function AttachmentsBrowser({
     )
   }
 
-  return (
+  // Portalled to <body>: this fixed full-screen overlay renders from inside a
+  // battlefield that may sit in the multiplayer board strip, whose translateX
+  // transform would otherwise make `fixed` resolve against the (clipped, possibly
+  // off-screen) cell — same trap the ZonePiles browsers portal around.
+  return createPortal(
     <div style={styles.exileOverlay} onClick={onClose}>
       <div style={styles.exileBrowserContent} onClick={(e) => e.stopPropagation()}>
         <div style={styles.exileBrowserHeader}>
@@ -834,6 +840,7 @@ function AttachmentsBrowser({
           {renderSection('linkedExile', linkedExile)}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -28,10 +28,11 @@ export function OpponentBoardArea({
   layout,
   topOffset,
   handReservation = 0,
-  stripWidthPct = 100,
+  stripBasis = '100%',
   hideHand = false,
   plateCarriesAnchors = false,
   viewedRingColor,
+  onToggleCollapse,
   spectatorMode,
   isHijacking,
   hijackedSurfaceStyle,
@@ -44,11 +45,12 @@ export function OpponentBoardArea({
   /** Strip layout only: height of the hand reservation band (grid row 1 height). */
   handReservation?: number
   /**
-   * Strip layout only: this cell's share of the strip width. 100 (default) for the
-   * one-board sliding camera; a fraction of 100 when several boards share the strip
+   * Strip layout only: this cell's share of the strip width as a CSS width value.
+   * '100%' (default) for the one-board sliding camera; an equal fraction (or a
+   * `calc(...)` share around collapsed tabs) when several boards share the strip
    * (table overview / combat defender-focus split) — card sizing self-measures per slot.
    */
-  stripWidthPct?: number
+  stripBasis?: string
   /**
    * Strip layout only: shared-strip view (table overview / combat defender-focus split).
    * Hides the opponent hand fan and its reservation band (the fans would overlap across
@@ -68,6 +70,12 @@ export function OpponentBoardArea({
    * the *viewed* board (the one the center-HUD orb and keys 1-9 track). Undefined = no ring.
    */
   viewedRingColor?: string
+  /**
+   * Table overview only: fold this cell down to a narrow tab (MTGO-style per-board
+   * collapse) so the other boards split the freed width. Rendered as a small "−"
+   * button next to the name plate; the collapsed tab itself is [CollapsedBoardTab].
+   */
+  onToggleCollapse?: () => void
   spectatorMode: boolean
   /** This opponent's seat is currently driven by this client (Mindslaver / hotseat). */
   isHijacking: boolean
@@ -167,8 +175,8 @@ export function OpponentBoardArea({
       data-opponent-board={opponent.playerId}
       data-ally={isAlly || undefined}
       style={{
-        flex: `0 0 ${stripWidthPct}%`,
-        minWidth: `${stripWidthPct}%`,
+        flex: `0 0 ${stripBasis}`,
+        minWidth: stripBasis,
         height: '100%',
         position: 'relative',
         display: 'flex',
@@ -219,6 +227,36 @@ export function OpponentBoardArea({
           top={(isHijacking ? handReservation : 0) + 6}
         />
       )}
+      {/* Fold-away control (table overview): collapse this cell to a tab so the
+          other boards grow. Top-right corner, clear of the centered name plate. */}
+      {onToggleCollapse && (
+        <button
+          onClick={onToggleCollapse}
+          title={`Collapse ${opponent.name}'s board`}
+          style={{
+            position: 'absolute',
+            top: (isHijacking ? handReservation : 0) + 6,
+            right: 8,
+            zIndex: 56,
+            width: 24,
+            height: 24,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 6,
+            border: '1px solid #3a3a44',
+            background: 'rgba(10, 12, 20, 0.85)',
+            color: '#9fb0d0',
+            fontSize: 14,
+            fontWeight: 800,
+            lineHeight: 1,
+            cursor: 'pointer',
+            padding: 0,
+          }}
+        >
+          −
+        </button>
+      )}
       {/* Persistent inset ring marking the viewed cell in a shared-strip view. */}
       {viewedRingColor && (
         <div
@@ -247,6 +285,101 @@ export function OpponentBoardArea({
     </div>
   )
 }
+
+/**
+ * A collapsed board's stand-in in the table overview (MTGO-style per-board collapse):
+ * a narrow full-height tab with the seat color, a "+" affordance, and the player's name
+ * running vertically. The whole tab is one click target that re-expands the board. The
+ * seat's real board stays mounted off-screen (with the other hidden boards) so its card
+ * anchors keep bundling to the rail chip, which also carries the player anchors — the
+ * tab itself carries none.
+ */
+export function CollapsedBoardTab({
+  player,
+  onExpand,
+}: {
+  player: ClientPlayer
+  onExpand: () => void
+}) {
+  const seat = useIdentityColor(player.playerId)
+  const tomb = player.hasLost
+  return (
+    <div
+      data-collapsed-board={player.playerId}
+      role="button"
+      title={`Expand ${player.name}'s board`}
+      onClick={onExpand}
+      style={{
+        flex: `0 0 ${COLLAPSED_TAB_WIDTH}px`,
+        minWidth: COLLAPSED_TAB_WIDTH,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px 0',
+        boxSizing: 'border-box',
+        borderRadius: 8,
+        border: `1px solid ${seat.base}55`,
+        background: `linear-gradient(180deg, ${seat.soft}, rgba(10, 12, 20, 0.85))`,
+        cursor: 'pointer',
+        userSelect: 'none',
+        overflow: 'hidden',
+        transition: 'flex-basis 220ms cubic-bezier(0.4, 0, 0.2, 1), min-width 220ms cubic-bezier(0.4, 0, 0.2, 1)',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 20,
+          height: 20,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: 5,
+          border: `1px solid ${seat.base}`,
+          color: seat.bright,
+          fontSize: 13,
+          fontWeight: 800,
+          lineHeight: 1,
+          flexShrink: 0,
+        }}
+      >
+        +
+      </span>
+      <span
+        aria-hidden
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: seat.base,
+          boxShadow: `0 0 5px ${seat.base}`,
+          flexShrink: 0,
+          filter: tomb ? 'grayscale(1)' : 'none',
+        }}
+      />
+      <span
+        style={{
+          writingMode: 'vertical-rl',
+          fontSize: 12,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          color: seat.bright,
+          maxHeight: '55%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {player.name}
+      </span>
+    </div>
+  )
+}
+
+/** Width of a collapsed board's tab in the table overview. */
+export const COLLAPSED_TAB_WIDTH = 30
 
 /**
  * The board's "face" in a shared-strip view: a compact seat-colored pill (name + life)

--- a/web-client/src/components/game/board/index.ts
+++ b/web-client/src/components/game/board/index.ts
@@ -1,5 +1,5 @@
 export { Battlefield } from './Battlefield'
-export { OpponentBoardArea } from './OpponentBoardArea'
+export { OpponentBoardArea, CollapsedBoardTab, COLLAPSED_TAB_WIDTH } from './OpponentBoardArea'
 export { CardRow, HandFan } from './HandZone'
 export { CommandZone } from './CommandZone'
 export { StackDisplay } from './StackZone'

--- a/web-client/src/components/game/card/CardOverlays.tsx
+++ b/web-client/src/components/game/card/CardOverlays.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import type { Keyword, AbilityFlag, ClientCardEffect, Color } from '@/types'
 import { keywordManaClass, keywordSvgIcon, displayableKeywords } from '@/assets/icons/keywords'
 import { SvgGlyph } from '@/assets/icons/SvgGlyph'
@@ -363,7 +364,11 @@ export function ActiveEffectBadges({ effects, sizing }: {
           </div>
         ))}
       </div>
-      {hoveredEffect && tooltipPos && hoveredEffectData?.description && (
+      {/* Portalled to <body>: the tooltip is position:fixed with viewport coordinates,
+          but it renders from inside a card that may sit under a transform (tapped-card
+          rotation, the multiplayer board strip's translateX) — a transformed ancestor
+          would re-anchor `fixed` to itself and misplace the tooltip. */}
+      {hoveredEffect && tooltipPos && hoveredEffectData?.description && createPortal(
         <div style={{
           ...styles.cardEffectTooltip,
           left: tooltipPos.x,
@@ -371,7 +376,8 @@ export function ActiveEffectBadges({ effects, sizing }: {
           borderColor: getTooltipBorderColor(hoveredEffectData.icon),
         }}>
           <AbilityText text={hoveredEffectData.description} size={13} />
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   )

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -242,16 +242,22 @@ export function useOpponents(): readonly ClientPlayer[] {
  * The opponent whose board occupies the viewed slot. Resolves the boardView
  * selection with fallbacks: an eliminated or unknown selection falls back to the
  * first opponent still in the game (or the first opponent, if all have lost).
+ * The eliminated spectator's chosen bottom seat never occupies the viewed slot —
+ * its board is already fully visible at the bottom of the screen.
  */
 export function useViewedOpponent(): ClientPlayer | null {
   const opponents = useOpponents()
   const viewedOpponentId = useGameStore((state) => state.viewedOpponentId)
+  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const eliminatedBottomSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
   return useMemo(() => {
-    if (opponents.length === 0) return null
-    const selected = opponents.find((p) => p.playerId === viewedOpponentId)
+    const bottomSeatId = eliminatedSpectating ? eliminatedBottomSeatId : null
+    const candidates = bottomSeatId ? opponents.filter((p) => p.playerId !== bottomSeatId) : opponents
+    if (candidates.length === 0) return null
+    const selected = candidates.find((p) => p.playerId === viewedOpponentId)
     if (selected && !selected.hasLost) return selected
-    return opponents.find((p) => !p.hasLost) ?? opponents[0] ?? null
-  }, [opponents, viewedOpponentId])
+    return candidates.find((p) => !p.hasLost) ?? candidates[0] ?? null
+  }, [opponents, viewedOpponentId, eliminatedSpectating, eliminatedBottomSeatId])
 }
 
 /**
@@ -519,10 +525,19 @@ function battlefieldCardsEqual(a: BattlefieldCards, b: BattlefieldCards): boolea
  * `opponentId` scopes the opponent* groups to one seat's permanents (a multiplayer
  * opponent board). When omitted, the opponent groups hold everything the viewing
  * player doesn't control — the 2-player shape, unchanged.
+ *
+ * `playerIdOverride` makes the player* groups hold another seat's permanents instead of
+ * the viewing player's — the eliminated spectator's chosen bottom board (spectating
+ * proper doesn't need it: there `selectViewingPlayerId` already resolves to the bottom
+ * seat).
  */
-export function useBattlefieldCards(opponentId?: EntityId | null): BattlefieldCards {
+export function useBattlefieldCards(
+  opponentId?: EntityId | null,
+  playerIdOverride?: EntityId | null,
+): BattlefieldCards {
   const gameState = useGameStore(selectGameState)
-  const playerId = useGameStore(selectViewingPlayerId)
+  const viewerId = useGameStore(selectViewingPlayerId)
+  const playerId = playerIdOverride ?? viewerId
   const previousRef = useRef<BattlefieldCards | null>(null)
 
   return useMemo(() => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -986,7 +986,9 @@ export type GameStore = {
   viewPinned: boolean
   followAction: boolean
   overviewMode: boolean
+  collapsedSeats: readonly EntityId[]
   eliminatedSpectating: boolean
+  eliminatedBottomSeatId: EntityId | null
   spectatorBottomSeatId: EntityId | null
   teamByPlayerId: Readonly<Record<EntityId, number>>
   teamSharedLife: boolean
@@ -994,7 +996,9 @@ export type GameStore = {
   unpinView: () => void
   toggleFollowAction: () => void
   toggleOverviewMode: () => void
+  toggleSeatCollapsed: (playerId: EntityId) => void
   enterEliminatedSpectate: () => void
+  setEliminatedBottomSeat: (playerId: EntityId | null) => void
   followViewTo: (playerId: EntityId) => void
   setSpectatorBottomSeat: (playerId: EntityId | null) => void
   setSeatTeams: (teamByPlayerId: Record<EntityId, number>, sharedLife?: boolean) => void

--- a/web-client/src/store/slices/ui/boardViewSlice.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.ts
@@ -59,11 +59,25 @@ export interface BoardViewSliceState {
    */
   overviewMode: boolean
   /**
+   * MTGO-style per-opponent collapse in the table overview: seats whose cell is folded
+   * to a narrow tab so the remaining boards split the freed width. Only consulted while
+   * the overview is on; the focused camera and the combat split ignore it. Seats stay
+   * collapsed across overview toggles until reset (new game / leave).
+   */
+  collapsedSeats: readonly EntityId[]
+  /**
    * The local player was eliminated from a multiplayer game and chose "Keep watching"
    * on the defeat overlay: their dead bottom half collapses, the freed space goes to the
    * opponent boards, and all action UI hides. Cleared on reset (new game / leave).
    */
   eliminatedSpectating: boolean
+  /**
+   * Eliminated spectator's chosen bottom seat: a *living* player whose board fills the
+   * (otherwise collapsed) bottom half, the way spectating anchors a bottom seat. Null =
+   * no bottom board (the freed height flows to the opponent strip). Ignored outside the
+   * eliminated-spectating layout; self-heals to null rendering-side if the seat dies.
+   */
+  eliminatedBottomSeatId: EntityId | null
   /**
    * Spectator/replay: which seat anchors the bottom half of the board. Null =
    * the stream's default (`spectatingState.player1Id`). Set by the spectator
@@ -94,11 +108,18 @@ export interface BoardViewSliceActions {
   toggleFollowAction: () => void
   /** Toggle the all-boards table overview. */
   toggleOverviewMode: () => void
+  /** Fold/unfold one opponent's overview cell (MTGO-style per-board collapse). */
+  toggleSeatCollapsed: (playerId: EntityId) => void
   /**
    * "Keep watching" after being eliminated from a multiplayer game: dismisses the defeat
    * overlay and enters the spectator layout (overview on, dead bottom half collapsed).
    */
   enterEliminatedSpectate: () => void
+  /**
+   * Eliminated spectator: anchor the bottom half to a living player's board
+   * (null = collapse the bottom half again).
+   */
+  setEliminatedBottomSeat: (playerId: EntityId | null) => void
   /**
    * Follow-the-action write. Refused at the handler (not at render time) when the
    * view is pinned, following is off, or the player has any pending input — the
@@ -124,7 +145,9 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
   viewPinned: false,
   followAction: loadFollowAction(),
   overviewMode: false,
+  collapsedSeats: [],
   eliminatedSpectating: false,
+  eliminatedBottomSeatId: null,
   spectatorBottomSeatId: null,
   teamByPlayerId: {},
   teamSharedLife: false,
@@ -134,6 +157,9 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     // Only opponents occupy the viewed slot — your half is sacred.
     if (playerId === ownId && !get().spectatingState) return
     if (gameState && !gameState.players.some((p) => p.playerId === playerId)) return
+    // The eliminated spectator's chosen bottom board is already fully visible at the
+    // bottom — it never also occupies the viewed strip slot.
+    if (get().eliminatedSpectating && playerId === get().eliminatedBottomSeatId) return
     const pin = opts?.pin ?? true
     // Pinning a board and follow-the-action are mutually exclusive: pinning turns follow off
     // (the camera is locked), so the Follow toggle reflects that rather than lying "on".
@@ -165,8 +191,19 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     set({ overviewMode: next, ...(next ? { viewPinned: false } : {}) })
   },
 
+  toggleSeatCollapsed: (playerId) => {
+    const prev = get().collapsedSeats
+    set({
+      collapsedSeats: prev.includes(playerId)
+        ? prev.filter((id) => id !== playerId)
+        : [...prev, playerId],
+    })
+  },
+
   enterEliminatedSpectate: () =>
     set({ eliminatedSpectating: true, overviewMode: true, viewPinned: false, gameOverState: null }),
+
+  setEliminatedBottomSeat: (playerId) => set({ eliminatedBottomSeatId: playerId }),
 
   followViewTo: (playerId) => {
     const state = get()
@@ -194,7 +231,9 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
       viewedOpponentId: null,
       viewPinned: false,
       overviewMode: false,
+      collapsedSeats: [],
       eliminatedSpectating: false,
+      eliminatedBottomSeatId: null,
       spectatorBottomSeatId: null,
       teamByPlayerId: {},
       teamSharedLife: false,


### PR DESCRIPTION
Three items from `backlog/multiplayer-ui-followups.md` (all client-only).

## 1. MTGO-style per-opponent collapse (§3)

In the table overview every opponent cell gets a "−" button that folds it to a narrow seat-colored tab (`CollapsedBoardTab`); the remaining boards split the freed width, and clicking the tab re-expands it.

- State: `boardView.collapsedSeats` — overview-only (the focused camera and the combat defender-focus split keep their deliberate board sets), persists across overview toggles, reset with the game.
- A collapsed seat's full board moves to the off-screen group (like hidden boards in the focused camera), so its card anchors keep resolving and arrows bundle back to its rail chip, which also takes the player anchors back.
- `OpponentBoardArea`'s width prop is now a CSS basis string (`stripBasis`), so expanded cells can share `calc((100% − tabs) / n)`.

| Overview | One board collapsed |
|---|---|
| ![overview](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-followups-2-screenshots/01-overview.png) | ![collapsed](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-followups-2-screenshots/02-collapsed.png) |

## 2. Eliminated spectator: chosen bottom board (§7)

The spectating banner (moved from the bottom — which now belongs to the step strip / bottom board — to the top chrome row) carries a **Board below** picker: choosing a living player anchors their board in the empty bottom half, the way spectating renders a bottom seat.

- Read-only battlefield (`Battlefield` accepts a player-side seat override) + face-down small hand, their life/name on the right center-HUD orb (spectator-shaped: no "You" tag, no click handling), and their cell leaves the opponent strip while anchored.
- Anchors stay unambiguous: the bottom orb carries the seat's `data-life-id`, so its rail chip drops them.
- Click the active seat again to clear; the choice self-heals to the collapsed layout if that player dies. State: `boardView.eliminatedBottomSeatId`.

| Spectating (banner + picker) | Carol's board anchored below |
|---|---|
| ![spectating](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-followups-2-screenshots/03-eliminated-spectating.png) | ![bottom board](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-ui-followups-2-screenshots/04-eliminated-bottom-board.png) |

## 3. Overlay-inside-strip audit — transform trap (§8)

Audited everything rendered under `OpponentBoardArea` for `position: fixed` / viewport-coordinate elements (the strip track's `translateX` re-anchors `fixed` descendants to the cell). Two live bugs found, both portalled to `document.body`:

- **Attachments browser** (`Battlefield.tsx` `AttachmentsBrowser`) — full-screen `styles.exileOverlay`, same class of bug as the zone browsers fixed earlier.
- **Active-effect badge tooltip** (`CardOverlays.tsx`) — fixed-position tooltip with `getBoundingClientRect` coords; was also broken under a tapped card's rotation transform even in 2-player.

Everything else was clean (zone browsers + copy-of preview already portalled; yield menu / decision modals / stack render from `GameBoard`, outside the strip). A checklist note now lives in `web-client-architecture.md` § *the transform trap*.

## Verification

- `npm run typecheck` clean, `npm test` 180/180.
- Live-verified in a 4-player hotseat scenario (screenshots above). The eliminated-spectator shots simulate the elimination client-side (hotseat connections never receive `PlayerEliminatedMessage` — backlog §1's e2e fixture remains open).
- The `multiplayer-ui-followups-2-screenshots` branch is throwaway (images only, off the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)