### PR TITLE
Add four Foundations cards: Giada, Garna, Mazemind Tome, Fishing Pole

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -276,6 +276,23 @@ excluded.
     top in `canPay`, enumeration, and payment. The legal action still ships one flat material list
     (min = max = slot count); an illegal set that can't fill every slot is rejected at payment time
     (no per-slot selection UI).
+- `Costs.PutCounterOnSelf(counterType, count = 1)` — "Put a [kind] counter on this permanent" as
+  part of the activation cost (Mazemind Tome: "{T}, Put a page counter on this artifact: Scry 1").
+  The *accruing* mirror of `Costs.RemoveCounterFromSelf`, and the only cost that adds something
+  rather than spending it: it is **always payable**, which is exactly what lets Mazemind Tome reach
+  the fourth page counter that exiles it. Paid at activation (so the counter lands before the
+  ability resolves, and stays even if the ability is countered), and routed through the normal
+  counter-placement chokepoint — the "can't have counters put on it" gate and the placement
+  replacements (Hardened Scales, Doubling Season) all apply. Activated-ability scoped: there is no
+  additional-cost or `PayCost` form, since a spell on the stack has no permanent to accrue them on.
+- `Costs.TapGrantingPermanent` — tap the permanent whose static ability *granted* this activated
+  ability, the third member of the granter-cost family alongside `Costs.ExileGrantingPermanent` and
+  `Costs.SacrificeGrantingPermanent`. Use for an Equipment/Aura whose granted ability names the
+  Equipment itself: Fishing Pole's "Equipped creature has '{1}, {T}, **Tap Fishing Pole**: …'",
+  where `Costs.Tap` taps the *host creature* and this taps the *Equipment* — compose both in a
+  `Costs.Composite`. Per CR 201.5a the name refers only to the granting permanent, so an
+  already-tapped (or departed) granter makes the ability unactivatable even with another same-named
+  Equipment untapped elsewhere; the enumerator and `ActivateAbilityHandler` both gate on it.
 - `Costs.Composite(c1, c2, ...)` — multiple costs paid together.
 - `Costs.RemoveCounters(count = 1, counterType = null, filter = Any)` — remove `count` counters
   from among permanents matching `filter` you control. When `counterType` is set (e.g. `"+1/+1"`),
@@ -1441,6 +1458,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     "{2}, {T}: Target opponent gains control of another target permanent you control. If they do, you
     draw a card" → `IfYouDoEffect(GiveControlToTargetPlayer(permanent, opponent), DrawCards(1),
     successCriterion = ControlChanged)`.
+    `SuccessCriterion.CountersRemoved` gates on whether the action **actually took a counter off**
+    something (a positive-amount `CountersRemovedEvent`) — a removal against a permanent carrying no
+    such counter, or one that has already left the battlefield, emits none and counts as "didn't
+    happen" (`RemoveCountersExecutor` reports the amount genuinely removed, clamped to what was
+    there). Use for the "Remove a [kind] counter from [permanent]. If you do, …" shape, where
+    `Auto` can't infer (no zone move) and `Always` would wrongly fire on an empty permanent.
+    Fishing Pole: "Whenever equipped creature becomes untapped, remove a bait counter from this
+    Equipment. If you do, create a 1/1 blue Fish creature token" → `IfYouDoEffect(
+    RemoveCounters(Counters.BAIT, 1, Self), CreateToken(...), successCriterion = CountersRemoved)`.
     `CollectionNonEmpty` gates on the action's actual pipeline collection
     (`storedCollections[name].size >= min` after the action runs) — the collections propagate onto
     the gate frame via `exposeCollectionsToNextFrame`, in both the synchronous and the
@@ -2602,7 +2628,12 @@ work for abilities-on-stack (which carry no `CardComponent`).
 
 - `IsTapped` — currently tapped.
 - `IsUntapped` — currently untapped.
-- `IsAttacking` — declared as attacker this combat.
+- `IsAttacking` — declared as attacker this combat. **Last-known-information aware** (CR 608.2h): once
+  the permanent has left the battlefield the live attack is gone, so the predicate falls back to the
+  battlefield-exit snapshot (`EntitySnapshot.wasAttacking`). That is what lets a dies trigger ask
+  "was it attacking?" after the creature is already in the graveyard — Garna, Bloodfist of Keld:
+  `Conditions.EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Any.attacking())`.
+  Battlefield reads are unchanged; the fallback can only fire for an entity outside the battlefield.
 - `IsBlocking` — declared as blocker this combat.
 - `HasLockedDoor` (filter builder `hasLockedDoor()`) — a Room permanent (CR 709.5) with at least one locked
   door, i.e. a half lacking its "unlocked" designation (CR 709.5c). Reads the engine's
@@ -3069,6 +3100,9 @@ in the repo today):
   `Triggers.attacks(binding = TriggerBinding.ATTACHED)`
 - *Enchanted permanent becomes tapped* (Uncontrolled Infestation, Cryoshatter):
   `Triggers.becomesTapped(binding = TriggerBinding.ATTACHED)`
+- *Equipped creature becomes untapped* (Fishing Pole):
+  `Triggers.becomesUntapped(binding = TriggerBinding.ATTACHED)` — the factory form of the SELF-only
+  `Triggers.BecomesUntapped`. `UntapEvent` carries no filter, so binding is the only axis.
 - *Enchanted creature is turned face up* (Fatal Mutation):
   `Triggers.turnedFaceUp(binding = TriggerBinding.ATTACHED)`
 - *At the beginning of enchanted creature's controller's `<step>`* (Custody Battle,
@@ -6972,7 +7006,7 @@ substitution.
 - `charge`, `time`, `level`, `quest`, `shield`, `fade`, `vanishing`, `experience`, `age`, `velocity`, `awakening`,
   `blood`, `cage`, `doom`, `storage`, `divinity`, `charm`, `music`, `crumble`, `corpse`, `germ`, `ink`, `growth`,
   `hour`, `energy`, `scry`, `aura`, `chapter`, `citation`, `rune`, `scar`, `crux`, `omen`, `secret`, `feather`,
-  `hourglass`, `hope`, `verse`, `influence`, `burden`, `loot`, `soul` — assorted printed counter kinds. (`hourglass`: Temporal Distortion
+  `hourglass`, `hope`, `verse`, `influence`, `burden`, `loot`, `soul`, `bait` — assorted printed counter kinds. (`hourglass`: Temporal Distortion
   — a permanent with one doesn't untap during its controller's untap step; model the restriction with
   `GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, GroupFilter(... .withCounter(Counters.HOURGLASS)))` so it stays
   projection-scoped.) (`hope` / `verse` / `influence` / `burden`: LTR — Dawn of a New Age / Lost Isle Calling /
@@ -7011,6 +7045,11 @@ substitution.
   "that many" via `AddDynamicCounters(Counters.INCUBATION, DynamicAmount.ContextProperty(TRIGGER_DAMAGE_AMOUNT), Self)`;
   an activated ability spends three via `Costs.RemoveCounterFromSelf(Counters.INCUBATION, 3)` to hatch a Drake token) —
   a pure passive resource counter with no inherent rule. Not MTG's Incubate/incubator-token mechanic.
+  `bait` (`Counters.BAIT`): FDN — Fishing Pole (the Equipment's *granted* ability accrues one via
+  `Costs.PutCounterOnSelf(Counters.BAIT)` + `AddCountersEffect(..., EffectTarget.GrantingSource)`;
+  its "equipped creature becomes untapped" trigger spends one through an `IfYouDoEffect` gated on
+  `SuccessCriterion.CountersRemoved` to make a Fish token) — another pure passive resource counter
+  with no inherent rule.
   `fellowship` (`Counters.FELLOWSHIP`): FDN — Banner of Kinship (enters with one per creature you control of
   the as-enters chosen type via `EntersWithDynamicCounters(CounterTypeFilter.Named(Counters.FELLOWSHIP),
   DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.withChosenSubtype()))`; a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -70,6 +70,7 @@ enum class CounterType {
     SPORE,
     INCUBATION,
     FELLOWSHIP,
+    BAIT,
     BORE;
 
     companion object {
@@ -201,6 +202,13 @@ object Counters {
      * count to reduce an activated ability's cost. No inherent rule.
      */
     const val PAGE = "page"
+
+    /**
+     * Bait counter (FDN — Fishing Pole). Passive storage counter with no inherent rule; the
+     * Equipment's granted activated ability accumulates one and its "equipped creature becomes
+     * untapped" trigger spends one to reel in a Fish token. No inherent rule.
+     */
+    const val BAIT = "bait"
 
     /**
      * Rev counter (DSK — Chainsaw). Passive storage counter with no inherent rule; the card's own

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -186,6 +186,13 @@ object Costs {
     val SacrificeGrantingPermanent: AbilityCost = AbilityCost.SacrificeGrantingPermanent
 
     /**
+     * Tap the permanent that granted this activated ability — "Tap Fishing Pole" inside the
+     * ability the Equipment grants its equipped creature. Compose with [Tap] when the printed cost
+     * taps both the host (`{T}`) and the granter.
+     */
+    val TapGrantingPermanent: AbilityCost = AbilityCost.TapGrantingPermanent
+
+    /**
      * Sacrifice a creature of the type chosen when this permanent entered the battlefield.
      * Used by cards like Doom Cannon.
      */
@@ -283,6 +290,14 @@ object Costs {
      */
     fun RemoveCounterFromSelf(counterType: String?, count: Int = 1): AbilityCost =
         AbilityCost.Atom(CostAtom.RemoveCounters(counterType, DynamicAmount.Fixed(count), self = true))
+
+    /**
+     * Put [count] counters of [counterType] on this permanent as part of the activation cost —
+     * "{T}, Put a page counter on this artifact: Scry 1" (Mazemind Tome). The accruing mirror of
+     * [RemoveCounterFromSelf]; always payable, since it costs the player nothing they must have.
+     */
+    fun PutCounterOnSelf(counterType: String, count: Int = 1): AbilityCost =
+        AbilityCost.Atom(CostAtom.PutCountersOnSelf(counterType, count))
 
     /**
      * Remove [count] counters of the specified [counterType] (or any type when null)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1353,6 +1353,14 @@ object Triggers {
         TriggerSpec(event = TapEvent(filter), binding = binding)
 
     /**
+     * Generic "becomes untapped" factory — use [BecomesUntapped] for SELF; reach for this factory
+     * for ATTACHED ("whenever equipped creature becomes untapped", Fishing Pole). [UntapEvent]
+     * carries no filter, so binding is the only axis.
+     */
+    fun becomesUntapped(binding: TriggerBinding = TriggerBinding.SELF): TriggerSpec =
+        TriggerSpec(event = UntapEvent, binding = binding)
+
+    /**
      * Whenever one or more permanents matching [filter] become tapped — a **batching** trigger
      * (CR 603.2c) that fires at most once per simultaneous tap batch, not once per tapped permanent.
      * Use for the "Whenever one or more … become tapped" wording (Deeproot Pilgrimage: "Whenever one

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -311,6 +311,23 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
+     * Tap the permanent that granted this activated ability to the source — the third member of
+     * the granter-cost family alongside [ExileGrantingPermanent] and [SacrificeGrantingPermanent],
+     * and the granter-scoped sibling of the plain [Tap] (which taps the ability's *host*).
+     *
+     * Fishing Pole grants the equipped creature "{1}, {T}, **Tap Fishing Pole**: Put a bait counter
+     * on Fishing Pole" — two different permanents tap: `{T}` taps the creature that has the
+     * ability, this taps the Equipment. Per CR 201.5a (and the printed ruling) the name refers only
+     * to the specific granting permanent, so an already-tapped granter makes the cost unpayable
+     * even with another same-named Equipment untapped elsewhere.
+     */
+    @SerialName("CostTapGrantingPermanent")
+    @Serializable
+    data object TapGrantingPermanent : AbilityCost {
+        override val description: String = "Tap the granting permanent"
+    }
+
+    /**
      * Sacrifice a creature of the type chosen when this permanent entered the battlefield.
      * Used by cards like Doom Cannon that choose a creature type on entry and reference it in costs.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -235,6 +235,30 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
         }
     }
 
+    /**
+     * Put [count] counters of [counterType] on the permanent the cost belongs to — "Put a page
+     * counter on this artifact" (Mazemind Tome), the *accruing* mirror of [RemoveCounters] with
+     * `self = true`.
+     *
+     * Self-scoped by design: every printed counter-adding cost puts the counters on the very
+     * permanent whose ability is being activated, so there is nothing to select and nothing to
+     * choose ([selectionCount] stays 0). It is also **always payable** — unlike every other atom
+     * this one takes nothing away, which is exactly what makes the printed cards work (Mazemind
+     * Tome stays activatable right up to the counter that exiles it).
+     */
+    @SerialName("AtomPutCountersOnSelf")
+    @Serializable
+    data class PutCountersOnSelf(
+        val counterType: String,
+        val count: Int = 1,
+    ) : CostAtom {
+        override val description: String get() = buildString {
+            append("put ")
+            append(quantify(count, "$counterType counter"))
+            append(" on this permanent")
+        }
+    }
+
     /** Reveal [count] cards matching [filter] from your hand (the cards stay in hand). */
     @SerialName("AtomRevealFromHand")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -445,6 +445,21 @@ sealed interface SuccessCriterion {
     @SerialName("SuccessCriterion.ControlChanged")
     @Serializable
     data object ControlChanged : SuccessCriterion
+
+    /**
+     * Action succeeded iff the gated action actually *removed a counter* — at least one
+     * `CountersRemovedEvent` with a positive amount was emitted during the action. Use for the
+     * "Remove a [kind] counter from [permanent]. If you do, …" shape, where the removal silently
+     * does nothing when the permanent carries no such counter (or has left the battlefield):
+     * counter removal is not a zone move, so `Auto` can't infer it, and `Always` would wrongly
+     * fire the payoff on an empty permanent.
+     *
+     * Fishing Pole: "Whenever equipped creature becomes untapped, remove a bait counter from this
+     * Equipment. If you do, create a 1/1 blue Fish creature token." — no bait counter means no Fish.
+     */
+    @SerialName("SuccessCriterion.CountersRemoved")
+    @Serializable
+    data object CountersRemoved : SuccessCriterion
 }
 
 /**

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -37,7 +37,8 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.RevealFromHand(GameObjectFilter.Any, count = 1),
         CostAtom.RemoveCounters(Counters.PLUS_ONE_PLUS_ONE, filter = GameObjectFilter.Creature),
         CostAtom.RemoveCounters("charge", self = true),
-        CostAtom.RemoveCounters(counterType = null, filter = GameObjectFilter.Creature)
+        CostAtom.RemoveCounters(counterType = null, filter = GameObjectFilter.Creature),
+        CostAtom.PutCountersOnSelf(Counters.PAGE, count = 1)
     )
 
     test("every concrete CostAtom subtype has a representative in this test") {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GarnaBloodfistOfKeld.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GarnaBloodfistOfKeld.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Garna, Bloodfist of Keld
+ * {1}{B}{R}{R}
+ * Legendary Creature — Human Berserker
+ * 4/3
+ *
+ * Whenever another creature you control dies, draw a card if it was attacking.
+ * Otherwise, Garna deals 1 damage to each opponent.
+ *
+ * One trigger, one branch: the two clauses are mutually exclusive halves of a single ability, so
+ * this is a [ConditionalEffect] on the dying creature's combat status rather than two triggers
+ * with mirrored intervening-if clauses (which would each check at both trigger and resolution
+ * time, CR 603.4, and could diverge).
+ *
+ * "It was attacking" is last-known information (CR 608.2h): by the time the ability resolves the
+ * creature is in the graveyard and its `AttackingComponent` has been torn down by the battlefield
+ * exit. `StatePredicate.IsAttacking` (via `GameObjectFilter.attacking()`) reads the frozen
+ * `EntitySnapshot.wasAttacking` for an entity that has left the battlefield, so the branch sees
+ * the creature as it last existed. The filter is left unrestricted (`Any`) because the trigger
+ * has already scoped the event to creatures you control — re-asserting `Creature` here would
+ * re-derive a type from a projection that no longer covers the dead permanent.
+ */
+val GarnaBloodfistOfKeld = card("Garna, Bloodfist of Keld") {
+    manaCost = "{1}{B}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Berserker"
+    oracleText = "Whenever another creature you control dies, draw a card if it was attacking. " +
+        "Otherwise, Garna deals 1 damage to each opponent."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.EntityMatches(
+                EffectTarget.TriggeringEntity,
+                GameObjectFilter.Any.attacking(),
+            ),
+            effect = Effects.DrawCards(1),
+            elseEffect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "200"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Let's see who gets more kills, Radha.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg?1783921286"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FishingPole.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FishingPole.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fishing Pole
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature has "{1}, {T}, Tap Fishing Pole: Put a bait counter on Fishing Pole."
+ * Whenever equipped creature becomes untapped, remove a bait counter from this Equipment.
+ * If you do, create a 1/1 blue Fish creature token.
+ * Equip {2}
+ *
+ * Three different objects are involved in the granted ability, which is why it needs the
+ * granter-scoped cost and target rather than plain `Self`:
+ *  - `{T}` taps the **equipped creature** (the ability's host, [Costs.Tap]),
+ *  - "Tap Fishing Pole" taps the **Equipment** ([Costs.TapGrantingPermanent]),
+ *  - "Put a bait counter on Fishing Pole" puts them on the **Equipment**
+ *    ([EffectTarget.GrantingSource]).
+ *
+ * Per the printed ruling (below) each of those names the *granting* Fishing Pole specifically
+ * (CR 201.5a), so a second Fishing Pole on the battlefield is untouched — which is exactly what
+ * the granter-relative cost and target give, as opposed to a name/type filter.
+ *
+ * The counters are spent by an ATTACHED-bound "becomes untapped" trigger. Tapping the Equipment
+ * to bait it means the pole can only be baited once per untap cycle, and the trigger's
+ * [IfYouDoEffect] correctly makes no Fish when there is no bait counter to remove.
+ */
+val FishingPole = card("Fishing Pole") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has \"{1}, {T}, Tap Fishing Pole: Put a bait counter on " +
+        "Fishing Pole.\"\n" +
+        "Whenever equipped creature becomes untapped, remove a bait counter from this Equipment. " +
+        "If you do, create a 1/1 blue Fish creature token.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(
+                    Costs.Mana("{1}"),
+                    Costs.Tap,
+                    Costs.TapGrantingPermanent,
+                ),
+                effect = AddCountersEffect(Counters.BAIT, 1, EffectTarget.GrantingSource),
+            )
+            // filter defaults to GroupFilter.attachedCreature() — "equipped creature has ..."
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.becomesUntapped(binding = TriggerBinding.ATTACHED)
+        effect = IfYouDoEffect(
+            action = Effects.RemoveCounters(Counters.BAIT, 1, EffectTarget.Self),
+            // A counter removal is not a zone move, so Auto can't infer it — and "if you do" here
+            // really can fail: no bait counter means no Fish.
+            successCriterion = SuccessCriterion.CountersRemoved,
+            ifYouDo = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf(Subtype.FISH.value),
+                imageUri = "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg?1783908592",
+            ),
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "128"
+        artist = "Franz Vohwinkel"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg?1783909089"
+        ruling(
+            "2024-11-08",
+            "The ability granted by Fishing Pole's first ability refers only to the Fishing Pole " +
+                "granting that ability, not any other permanent on the battlefield named Fishing Pole."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GarnaBloodfistOfKeldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GarnaBloodfistOfKeldReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Garna, Bloodfist of Keld reprint in FDN. Canonical CardDefinition lives in DMU
+ * (earliest printing).
+ */
+val GarnaBloodfistOfKeldReprint = Printing(
+    oracleId = "3fb83218-e18d-405d-91c8-46b5e4e672a9",
+    name = "Garna, Bloodfist of Keld",
+    setCode = "FDN",
+    collectorNumber = "658",
+    scryfallId = "5d7fcd03-fffe-467a-88a5-e583e32afd7a",
+    artist = "Andrey Kuzinskiy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5d7fcd03-fffe-467a-88a5-e583e32afd7a.jpg?1783908912",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GiadaFontOfHopeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GiadaFontOfHopeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Giada, Font of Hope reprint in FDN. Canonical CardDefinition lives in SNC (earliest printing).
+ */
+val GiadaFontOfHopeReprint = Printing(
+    oracleId = "48e6d3d8-2f27-4017-acdd-40bce8cdbc02",
+    name = "Giada, Font of Hope",
+    setCode = "FDN",
+    collectorNumber = "141",
+    scryfallId = "8ae6fc26-cfad-4da8-98d9-49c27c24d293",
+    artist = "Kai Carpenter",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8ae6fc26-cfad-4da8-98d9-49c27c24d293.jpg?1783909085",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MazemindTomeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MazemindTomeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mazemind Tome reprint in FDN. Canonical CardDefinition lives in M21 (earliest printing).
+ */
+val MazemindTomeReprint = Printing(
+    oracleId = "800fb917-8898-4eba-9f94-aec6e9d75236",
+    name = "Mazemind Tome",
+    setCode = "FDN",
+    collectorNumber = "676",
+    scryfallId = "f45072cd-e3f2-4090-b984-50ec8d360bf2",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f45072cd-e3f2-4090-b984-50ec8d360bf2.jpg?1783908904",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MazemindTome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MazemindTome.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mazemind Tome
+ * {2}
+ * Artifact — Book
+ *
+ * {T}, Put a page counter on this artifact: Scry 1.
+ * {2}, {T}, Put a page counter on this artifact: Draw a card.
+ * When there are four or more page counters on this artifact, exile it. If you do, you gain 4 life.
+ *
+ * The counter is an *accruing activation cost* ([Costs.PutCounterOnSelf]), not a resolution
+ * effect — it is paid whether or not the ability resolves, and it is always payable, which is
+ * what lets the fourth activation happen at all before the state trigger exiles the Tome.
+ *
+ * The third ability is state-triggered (CR 603.8): there is no event to hang it on, the engine
+ * polls the counter count and fires on the false → true transition. The exile is scoped
+ * `fromZone = BATTLEFIELD` so a Tome that has already left while the trigger sits on the stack
+ * isn't dragged out of its new zone — and because `IfYouDoEffect`'s `Auto` criterion measures the
+ * exile zone's growth, a skipped exile also means no life (Scryfall ruling below).
+ */
+val MazemindTome = card("Mazemind Tome") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Book"
+    oracleText = "{T}, Put a page counter on this artifact: Scry 1. (Look at the top card of your " +
+        "library. You may put that card on the bottom.)\n" +
+        "{2}, {T}, Put a page counter on this artifact: Draw a card.\n" +
+        "When there are four or more page counters on this artifact, exile it. If you do, you gain 4 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PutCounterOnSelf(Counters.PAGE))
+        effect = Patterns.Library.scry(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.PutCounterOnSelf(Counters.PAGE))
+        effect = Effects.DrawCards(1)
+    }
+
+    stateTriggeredAbility {
+        condition = Conditions.SourceCounterCountAtLeast(Counters.PAGE, 4)
+        effect = IfYouDoEffect(
+            action = Effects.Move(
+                target = EffectTarget.Self,
+                destination = Zone.EXILE,
+                fromZone = Zone.BATTLEFIELD,
+            ),
+            ifYouDo = Effects.GainLife(4, EffectTarget.Controller),
+        )
+        description = "When there are four or more page counters on this artifact, exile it. " +
+            "If you do, you gain 4 life"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg?1783930659"
+        ruling(
+            "2020-06-23",
+            "If Mazemind Tome leaves the battlefield while its triggered ability is on the stack, " +
+                "you can't exile it from the zone it's put into."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/GiadaFontOfHope.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/GiadaFontOfHope.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Giada, Font of Hope
+ * {1}{W}
+ * Legendary Creature — Angel
+ * 2/2
+ *
+ * Flying, vigilance
+ * Each other Angel you control enters with an additional +1/+1 counter on it for each Angel
+ * you already control.
+ * {T}: Add {W}. Spend this mana only to cast an Angel spell.
+ *
+ * "Each Angel you already control" is the board *excluding the entering Angel* but
+ * *including Giada herself* (Scryfall ruling below) — modelled as an
+ * [EntersWithDynamicCounters] with `otherOnly = true` whose count is an
+ * `AggregateBattlefield(excludeSelf = true)`. The global enters-with pass evaluates the count
+ * with `sourceId`/`affectedEntityId` set to the *entering* permanent (the counters describe it,
+ * CR 614), so `excludeSelf` drops exactly the new Angel while `Player.You` still resolves to
+ * Giada's controller.
+ */
+val GiadaFontOfHope = card("Giada, Font of Hope") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Angel"
+    oracleText = "Flying, vigilance\n" +
+        "Each other Angel you control enters with an additional +1/+1 counter on it for each " +
+        "Angel you already control.\n" +
+        "{T}: Add {W}. Spend this mana only to cast an Angel spell."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature.withSubtype(Subtype.ANGEL),
+                excludeSelf = true,
+            ),
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.withSubtype(Subtype.ANGEL).youControl(),
+                to = Zone.BATTLEFIELD,
+            ),
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(
+            Color.WHITE,
+            1,
+            restriction = ManaRestriction.SubtypeSpellsOnly(setOf(Subtype.ANGEL.value)),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "14"
+        artist = "Eric Deschamps"
+        flavorText = "The source of the Cabaretti's Halo turned out to be a single teenage girl."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg?1783923158"
+        ruling(
+            "2024-11-08",
+            "\"Each Angel you already control\" means each Angel you control other than the Angel " +
+                "entering, including Giada. It doesn't matter if some or all of the Angels on the " +
+                "battlefield entered after Giada did."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -193,6 +193,72 @@
     ]
 }
 
+// Garna, Bloodfist of Keld
+{
+    "name": "Garna, Bloodfist of Keld",
+    "manaCost": "{1}{B}{R}{R}",
+    "typeLine": "Legendary Creature — Human Berserker",
+    "oracleText": "Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "TriggeringEntity",
+                            "filter": "attacking"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "otherwise": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "UNCOMMON",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Let's see who gets more kills, Radha.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/294c5f08-08e7-458f-8838-ff321dc5d9f2.jpg?1783921286"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Haughty Djinn
 {
     "name": "Haughty Djinn",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -3167,6 +3167,120 @@
     ]
 }
 
+// Fishing Pole
+{
+    "name": "Fishing Pole",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has \"{1}, {T}, Tap Fishing Pole: Put a bait counter on Fishing Pole.\"\nWhenever equipped creature becomes untapped, remove a bait counter from this Equipment. If you do, create a 1/1 blue Fish creature token.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "UntapEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "RemoveCounters",
+                            "counterType": "bait",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        "successCriterion": "SuccessCriterion.CountersRemoved"
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Fish"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44057462-40b7-4709-afac-2ce03d53d525.jpg?1783908592"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}"
+                                }
+                            },
+                            "CostTap",
+                            "CostTapGrantingPermanent"
+                        ]
+                    },
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "bait",
+                        "count": 1,
+                        "target": "GrantingSource"
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c95ab836-3277-4223-9aaa-ef2c77256b65.jpg?1783909089",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "The ability granted by Fishing Pole's first ability refers only to the Fishing Pole granting that ability, not any other permanent on the battlefield named Fishing Pole."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Fleeting Flight
 {
     "name": "Fleeting Flight",

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -171,6 +171,125 @@
     ]
 }
 
+// Mazemind Tome
+{
+    "name": "Mazemind Tome",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Book",
+    "oracleText": "{T}, Put a page counter on this artifact: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{2}, {T}, Put a page counter on this artifact: Draw a card.\nWhen there are four or more page counters on this artifact, exile it. If you do, you gain 4 life.",
+    "script": {
+        "stateTriggeredAbilities": [
+            {
+                "id": "ability_1",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "page"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Exile",
+                            "fromZone": "Battlefield"
+                        }
+                    },
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                },
+                "descriptionOverride": "When there are four or more page counters on this artifact, exile it. If you do, you gain 4 life"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPutCountersOnSelf",
+                                "counterType": "page"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPutCountersOnSelf",
+                                "counterType": "page"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fd761f3-6b43-4150-8595-dc3abd85b06c.jpg?1783930659",
+        "rulings": [
+            {
+                "date": "2020-06-23",
+                "text": "If Mazemind Tome leaves the battlefield while its triggered ability is on the stack, you can't exile it from the zone it's put into."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Primal Might
 {
     "name": "Primal Might",

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -118,6 +118,75 @@
     ]
 }
 
+// Giada, Font of Hope
+{
+    "name": "Giada, Font of Hope",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flying, vigilance\nEach other Angel you control enters with an additional +1/+1 counter on it for each Angel you already control.\n{T}: Add {W}. Spend this mana only to cast an Angel spell.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE",
+                    "restriction": {
+                        "type": "SubtypeSpellsOnly",
+                        "subtypes": [
+                            "Angel"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "creature Angel",
+                    "excludeSelf": true
+                },
+                "otherOnly": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Angel ctrl:you",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "RARE",
+        "artist": "Eric Deschamps",
+        "flavorText": "The source of the Cabaretti's Halo turned out to be a single teenage girl.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bae077bd-fc8d-44d7-8c75-8dc8699c168e.jpg?1783923158",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "\"Each Angel you already control\" means each Angel you control other than the Angel entering, including Giada. It doesn't matter if some or all of the Angels on the battlefield entered after Giada did."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Inspiring Overseer
 {
     "name": "Inspiring Overseer",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
 import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.TurnFaceUpEvent
+import com.wingedsheep.engine.core.UntappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.core.Zone
@@ -82,6 +83,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             is AttackersDeclaredEvent -> event.attackers
             is TurnFaceUpEvent -> listOf(event.entityId)
             is TappedEvent -> listOf(event.entityId)
+            is UntappedEvent -> listOf(event.entityId)
             // "an ability of enchanted artifact … was activated" (Artifact Possession) — the
             // activated ability's source is the enchanted permanent.
             is AbilityActivatedEvent -> listOf(event.sourceId)
@@ -121,6 +123,11 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             }
             is EventPattern.TapEvent -> {
                 event is TappedEvent && event.entityId == attachedEntityId
+            }
+            // "Whenever equipped creature becomes untapped" (Fishing Pole). UntapEvent carries no
+            // filter, so identity with the attached permanent is the whole match.
+            is EventPattern.UntapEvent -> {
+                event is UntappedEvent && event.entityId == attachedEntityId
             }
             is EventPattern.AbilityActivatedEvent -> {
                 if (event !is AbilityActivatedEvent) return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.CastFromHandComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredViaAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageToPlayerComponent
@@ -640,6 +641,22 @@ class ConditionEvaluator(
                     // watching "that Equipment"). Match against projected state so state predicates
                     // (attachment) and the controller predicate ("a creature you control") resolve;
                     // "you" is the ability's controller carried in the effect context.
+                    PredicateEvaluator().matches(
+                        state,
+                        state.projectedState,
+                        triggeringId,
+                        condition.filter,
+                        PredicateContext.fromEffectContext(it.effectContext)
+                    )
+                } else if (triggeringId != null &&
+                    state.getEntity(triggeringId)?.has<LastKnownPermanentComponent>() == true
+                ) {
+                    // The triggering object is a permanent that has *left* the battlefield — the
+                    // dies/leaves-trigger case. "It" still means the permanent as it last existed
+                    // (CR 608.2h), so run the real predicate evaluator: the LKI-aware predicates
+                    // (e.g. IsAttacking, which reads the battlefield-exit snapshot) resolve there,
+                    // whereas the static-card-characteristics path below can't see them at all and
+                    // would vacuously match. Garna, Bloodfist of Keld's "if it was attacking".
                     PredicateEvaluator().matches(
                         state,
                         state.projectedState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
@@ -65,6 +66,13 @@ class CostHandler {
         controllerId: EntityId,
         manaPool: ManaPool,
         abilityContext: SpellPaymentContext? = null,
+        /**
+         * The permanent whose static ability granted [cost]'s ability to [sourceId], when this is a
+         * granted ability. Only [AbilityCost.TapGrantingPermanent] needs it — the granter has to be
+         * untapped for that cost to be payable. Null (the default) means "granter unknown", which
+         * defers the check to payment time, matching the Exile/Sacrifice granter costs.
+         */
+        granterId: EntityId? = null,
     ): Boolean {
         return when (cost) {
             is AbilityCost.Free -> true
@@ -126,6 +134,17 @@ class CostHandler {
                 // Same granter-resolution contract as ExileGrantingPermanent above.
                 true
             }
+            is AbilityCost.TapGrantingPermanent -> {
+                // Unlike its exile/sacrifice siblings this one has a real payability gate: a
+                // granter that is already tapped can't be tapped again, which is what stops a
+                // Fishing Pole from being milked more than once per untap. When the caller
+                // couldn't resolve the granter we fall through to payment-time validation.
+                if (granterId == null) true
+                else {
+                    val granter = state.getEntity(granterId)
+                    granter != null && granterId in state.getBattlefield() && !granter.has<TappedComponent>()
+                }
+            }
             is AbilityCost.TapXPermanents -> {
                 // X can be 0, so this is always payable
                 // maxAffordableX is capped by untapped permanent count in LegalActionsCalculator
@@ -173,7 +192,7 @@ class CostHandler {
                 true
             }
             is AbilityCost.Composite -> {
-                cost.costs.all { canPayAbilityCost(state, it, sourceId, controllerId, manaPool, abilityContext) }
+                cost.costs.all { canPayAbilityCost(state, it, sourceId, controllerId, manaPool, abilityContext, granterId) }
             }
             is AbilityCost.Loyalty -> {
                 // Check if we have enough loyalty to pay the cost
@@ -341,6 +360,22 @@ class CostHandler {
                 )
 
                 CostPaymentResult.success(transitionResult.state, manaPool, transitionResult.events)
+            }
+            is AbilityCost.TapGrantingPermanent -> {
+                val granterId = choices.granterId
+                    ?: return CostPaymentResult.failure("Granting permanent not provided for cost")
+                val granter = state.getEntity(granterId)
+                    ?: return CostPaymentResult.failure("Granting permanent not found")
+                if (granterId !in state.getBattlefield()) {
+                    return CostPaymentResult.failure("Granting permanent is not on the battlefield")
+                }
+                if (granter.has<TappedComponent>()) {
+                    return CostPaymentResult.failure("Granting permanent is already tapped")
+                }
+                // Through the shared tap helper so the TappedEvent fires — a "whenever this becomes
+                // tapped" trigger must see an Equipment tapped to pay a granted ability's cost.
+                val (newState, event) = tap(state, granterId)
+                CostPaymentResult.success(newState, manaPool, listOfNotNull(event))
             }
             is AbilityCost.SacrificeGrantingPermanent -> {
                 val granterId = choices.granterId
@@ -530,6 +565,9 @@ class CostHandler {
             val handZone = ZoneKey(controllerId, Zone.HAND)
             findMatchingCardsUnified(state, state.getZone(handZone), atom.filter, controllerId).size >= atom.count
         }
+        // Adding counters takes nothing away, so there is never a reason it can't be paid — this
+        // is what keeps Mazemind Tome activatable on the very activation that exiles it.
+        is CostAtom.PutCountersOnSelf -> true
         is CostAtom.RemoveCounters -> {
             if (atom.self) {
                 val counters = state.getEntity(sourceId)?.get<CountersComponent>() ?: return false
@@ -612,6 +650,37 @@ class CostHandler {
             // is a no-op success kept for atom exhaustiveness (the PayCost reveal path emits the
             // CardsRevealedEvent through CostPaymentService).
             CostPaymentResult.success(state, manaPool)
+        is CostAtom.PutCountersOnSelf -> {
+            // Counters put on as a cost are an ordinary counter placement (CR 121.6), so they run
+            // through the same chokepoint as the AddCounters effect: the "can't have counters put
+            // on it" gate (CR 614.1 / Solemnity), the placement replacements (Hardened Scales,
+            // Doubling Season), and the first-placement-this-turn marker. A permanent that can't
+            // receive counters still pays the cost — nothing is owed and the activation stands.
+            val counterType = resolveNamedCounterType(atom.counterType)
+            if (!state.projectedState.canReceiveCounters(sourceId)) {
+                CostPaymentResult.success(state, manaPool)
+            } else {
+                val current = state.getEntity(sourceId)?.get<CountersComponent>() ?: CountersComponent()
+                val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
+                    state, sourceId, counterType, atom.count, placerId = controllerId
+                )
+                val firstThisTurn = DamageUtils.isFirstCounterThisTurn(state, sourceId)
+                val newState = state.updateEntity(sourceId) { c ->
+                    c.with(current.withAdded(counterType, modifiedCount))
+                }.let { DamageUtils.markCounterPlacedOnCreature(it, controllerId, sourceId) }
+                val entityName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: ""
+                CostPaymentResult.success(
+                    newState,
+                    manaPool,
+                    events = listOf(
+                        CountersAddedEvent(
+                            sourceId, atom.counterType, modifiedCount, entityName,
+                            firstThisTurn, placedBy = controllerId,
+                        )
+                    ),
+                )
+            }
+        }
         is CostAtom.RemoveCounters -> {
             val counterType = atom.counterType?.let { resolveNamedCounterType(it) }
             val requiredCount = getAtomCount(atom.count, choices)
@@ -886,8 +955,11 @@ class CostHandler {
                         total >= needed
                     }
                 }
-                // Mana / return-to-hand / reveal are not produced as spell additional costs today.
-                is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand -> false
+                // Mana / return-to-hand / reveal / put-counters-on-self are not produced as spell
+                // additional costs today (the last is inherently ability-scoped — a spell on the
+                // stack has no permanent to put the counters on).
+                is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand,
+                is CostAtom.PutCountersOnSelf -> false
             }
             is AdditionalCost.PayLifePerTarget -> {
                 // Always payable: choosing zero targets pays zero life. Per-target life

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -906,8 +906,17 @@ class PredicateEvaluator {
             StatePredicate.IsTapped -> container.has<TappedComponent>()
             StatePredicate.IsUntapped -> !container.has<TappedComponent>()
 
-            // Combat state
-            StatePredicate.IsAttacking -> container.has<AttackingComponent>()
+            // Combat state.
+            //
+            // On the battlefield this is the live "declared as attacker this combat" check. Once
+            // the permanent has left, the live component is gone (the exit's combat cleanup tears
+            // down the attack), so we fall back to the frozen last-known snapshot (CR 608.2h) —
+            // that is exactly what "draw a card if it was attacking" (Garna, Bloodfist of Keld)
+            // needs from a dies trigger that resolves after the death. The fallback can only fire
+            // for an entity outside the battlefield, so live battlefield reads are unchanged.
+            StatePredicate.IsAttacking ->
+                container.get<AttackingComponent>() != null ||
+                    container.get<LastKnownPermanentComponent>()?.snapshot?.wasAttacking == true
             StatePredicate.IsBlocking -> container.has<BlockingComponent>()
             StatePredicate.IsBlocked -> {
                 // Check if this attacking creature has any blockers assigned

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -363,7 +363,11 @@ class ActivateAbilityHandler(
 
         val abilityPaymentContext = buildAbilityPaymentContext(cardComponent, state.projectedState, action.sourceId)
 
-        if (action.paymentStrategy !is PaymentStrategy.Explicit && !canPayAbilityCostWithSources(state, costAfterConvokeReduction, action.sourceId, action.playerId, abilityPaymentContext)) {
+        // The granter of a statically-granted ability, so AbilityCost.TapGrantingPermanent can be
+        // checked against the *Equipment's* tap state rather than the host creature's.
+        val validationGranterId = staticGrants.firstOrNull { it.first.id == action.abilityId }?.second
+
+        if (action.paymentStrategy !is PaymentStrategy.Explicit && !canPayAbilityCostWithSources(state, costAfterConvokeReduction, action.sourceId, action.playerId, abilityPaymentContext, validationGranterId)) {
             return when (effectiveCost) {
                 is AbilityCost.Tap -> "This permanent is already tapped"
                 is AbilityCost.TapAttachedCreature -> "Enchanted creature is tapped"
@@ -1707,6 +1711,7 @@ class ActivateAbilityHandler(
         sourceId: com.wingedsheep.sdk.model.EntityId,
         playerId: com.wingedsheep.sdk.model.EntityId,
         abilityContext: SpellPaymentContext? = null,
+        granterId: com.wingedsheep.sdk.model.EntityId? = null,
     ): Boolean {
         val poolComponent = state.getEntity(playerId)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
         val manaPool = ManaPool(
@@ -1722,7 +1727,7 @@ class ActivateAbilityHandler(
             is AbilityCost.Atom -> {
                 val mana = cost.manaCostOrNull
                 if (mana != null) manaSolver.canPay(state, playerId, mana, spellContext = abilityContext)
-                else costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext)
+                else costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext, granterId)
             }
             is AbilityCost.Composite -> {
                 // If composite cost includes Tap, the source itself can't also be used as a mana source
@@ -1730,10 +1735,10 @@ class ActivateAbilityHandler(
                 cost.costs.all { subCost ->
                     val subMana = subCost.manaCostOrNull
                     if (subMana != null) manaSolver.canPay(state, playerId, subMana, excludeSources = excludeSources, spellContext = abilityContext)
-                    else costHandler.canPayAbilityCost(state, subCost, sourceId, playerId, manaPool, abilityContext)
+                    else costHandler.canPayAbilityCost(state, subCost, sourceId, playerId, manaPool, abilityContext, granterId)
                 }
             }
-            else -> costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext)
+            else -> costHandler.canPayAbilityCost(state, cost, sourceId, playerId, manaPool, abilityContext, granterId)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1496,8 +1496,9 @@ class CastSpellHandler(
                             }
                         }
                     }
-                    // Mana / reveal are not produced as spell additional costs today.
-                    is CostAtom.Mana, is CostAtom.RevealFromHand -> {}
+                    // Mana / reveal are not produced as spell additional costs today, and
+                    // put-counters-on-self is ability-scoped (no permanent to accrue them on).
+                    is CostAtom.Mana, is CostAtom.RevealFromHand, is CostAtom.PutCountersOnSelf -> {}
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> c.amount
@@ -2278,8 +2279,11 @@ class CastSpellHandler(
                                 events.addAll(tr.events)
                             }
                         }
-                        // PayLife is auto-paid in the loop above; mana / reveal aren't spell additional costs.
-                        is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand -> {}
+                        // PayLife is auto-paid in the loop above; mana / reveal aren't spell additional
+                        // costs, and put-counters-on-self is ability-scoped (a spell on the stack has no
+                        // permanent to accrue them on).
+                        is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand,
+                        is CostAtom.PutCountersOnSelf -> {}
                         is CostAtom.RemoveCounters -> {
                             val resolvedRemovals = resolveDistributedCounterRemovalsForPayment(action)
                             for (removal in resolvedRemovals) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -64,6 +64,10 @@ class CostPaymentContinuationResumer(
                 } else {
                     resumeSelection(state, continuation, cost, response, checkForMore)
                 }
+            // Ability-scoped only; never reaches a PayCost prompt, but it is a yes/no shape
+            // (nothing to select) if one is ever built.
+            is CostAtom.PutCountersOnSelf ->
+                resumeYesNo(state, continuation, cost, response, checkForMore)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -158,6 +158,7 @@ object ZoneTransitionService {
         var lastKnownLostAllAbilities = false
         var lastKnownAttachedTo = options.lastKnownAttachedTo
         var lastKnownBlockingOrBlockedByIds: List<EntityId> = emptyList()
+        var lastKnownWasAttacking = false
         var lastKnownWasToken = false
         var lastKnownDamageDealtByPlayers: Map<EntityId, Int> = emptyMap()
         var lastKnownDamageSources: Set<com.wingedsheep.engine.state.components.battlefield.DamageSourceLki> = emptySet()
@@ -199,6 +200,11 @@ object ZoneTransitionService {
                 val blockedByThis = container.get<BlockingComponent>()?.blockedAttackerIds ?: emptyList()
                 lastKnownBlockingOrBlockedByIds = (blockingThis + blockedByThis).distinct()
             }
+            // Whether it was still an attacking creature as it left (CR 506.4), captured before
+            // cleanupCombatReferences strips the live AttackingComponent — "draw a card if it was
+            // attacking" (Garna, Bloodfist of Keld) resolves after the death, so it can only read
+            // last known information (CR 608.2h).
+            lastKnownWasAttacking = container.has<AttackingComponent>()
             lastKnownWasToken = container.has<TokenComponent>()
             lastKnownDamageDealtByPlayers =
                 container.get<DamageDealtByPlayersThisTurnComponent>()?.perPlayer ?: emptyMap()
@@ -271,6 +277,7 @@ object ZoneTransitionService {
                 cardDefinitionId = cardComponent.cardDefinitionId,
                 attachedTo = lastKnownAttachedTo,
                 blockingOrBlockedByIds = lastKnownBlockingOrBlockedByIds,
+                wasAttacking = lastKnownWasAttacking,
                 wasToken = lastKnownWasToken,
                 damageDealtByPlayers = lastKnownDamageDealtByPlayers,
                 damageSources = lastKnownDamageSources,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -688,6 +688,7 @@ class GatedEffectExecutor(
                 (effectContext.pipeline.storedCollections[criterion.name]?.size ?: 0) >= criterion.min
             is SuccessCriterion.DamageDealt -> evaluateDamageDealt(criterion, effectContext, priorEvents)
             is SuccessCriterion.ControlChanged -> evaluateControlChanged(priorEvents)
+            is SuccessCriterion.CountersRemoved -> evaluateCountersRemoved(priorEvents)
         }
 
         /**
@@ -699,6 +700,15 @@ class GatedEffectExecutor(
          * new controller, and a control change that never happened (illegal/missing permanent target
          * at resolution) emits no such event at all.
          */
+        /**
+         * Did the gated action actually take a counter off something? Scans the action's own
+         * events for a positive-amount [CountersRemovedEvent] — a removal against a permanent with
+         * no such counter (or one that has left the battlefield) emits none, which is exactly the
+         * "you didn't do it" case the gate must catch.
+         */
+        private fun evaluateCountersRemoved(priorEvents: List<GameEvent>): Boolean =
+            priorEvents.any { event -> event is CountersRemovedEvent && event.amount > 0 }
+
         private fun evaluateControlChanged(priorEvents: List<GameEvent>): Boolean =
             priorEvents.any { event ->
                 event is ControlChangedEvent && event.oldControllerId != event.newControllerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveCountersExecutor.kt
@@ -30,15 +30,23 @@ class RemoveCountersExecutor : EffectExecutor<RemoveCountersEffect> {
 
         val current = state.getEntity(targetId)?.get<CountersComponent>() ?: CountersComponent()
 
+        // Report what was *actually* taken off, not what was asked for: a permanent carrying fewer
+        // counters than the effect names (or none at all — it may have left the battlefield and had
+        // its counters stripped) has that many removed and no more. Emitting the requested amount
+        // regardless would tell "whenever a counter is removed" observers, and the
+        // SuccessCriterion.CountersRemoved "if you do" gate, that something happened when nothing did.
+        val removed = minOf(current.getCount(counterType), effect.count)
+        if (removed <= 0) return EffectResult.success(state, emptyList())
+
         val newState = state.updateEntity(targetId) { container ->
-            container.with(current.withRemoved(counterType, effect.count))
+            container.with(current.withRemoved(counterType, removed))
         }
 
         val entityName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
 
         return EffectResult.success(
             newState,
-            listOf(CountersRemovedEvent(targetId, effect.counterType, effect.count, entityName))
+            listOf(CountersRemovedEvent(targetId, effect.counterType, removed, entityName))
         )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -86,6 +86,7 @@ class PayOrSufferExecutor(
                 is CostAtom.TapPermanents -> handleTapCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
                 is CostAtom.ReturnToHand -> EffectResult.error(state, "ReturnToHand payment for PayOrSuffer not yet implemented")
                 is CostAtom.RevealFromHand -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
+                is CostAtom.PutCountersOnSelf -> EffectResult.error(state, "PutCountersOnSelf is an activated-ability cost, not a PayOrSuffer cost")
                 is CostAtom.RemoveCounters -> handleRemoveCountersCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
             }
         }
@@ -710,6 +711,7 @@ class PayOrSufferExecutor(
                 is CostAtom.TapPermanents -> findValidUntappedPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
                 is CostAtom.ReturnToHand -> false
                 is CostAtom.RevealFromHand -> false
+                is CostAtom.PutCountersOnSelf -> false
                 is CostAtom.RemoveCounters -> {
                     // Can pay if there are permanents matching the filter with enough counters.
                     // Don't exclude the source — removing counters from the source itself is a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -65,7 +65,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             val grantedAbilities = state.grantedActivatedAbilities
                 .filter { it.entityId == entityId }
                 .map { it.ability }
-            val staticAbilities = context.castPermissionUtils.getStaticGrantedActivatedAbilities(entityId, state)
+            val staticGrants = context.castPermissionUtils.getStaticGrantedAbilitiesWithGranter(entityId, state)
+            val staticAbilities = staticGrants.map { it.ability }
+            // Which permanent granted each statically-granted ability, so a cost that names the
+            // granter (AbilityCost.TapGrantingPermanent) can be gated on *its* state, not the host's.
+            val granterByAbilityId = staticGrants.associate { it.ability.id to it.granterId }
             val allAbilities = grantedAbilities + staticAbilities
 
             // If no card definition (e.g., tokens) and no granted/static abilities, skip
@@ -199,6 +203,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             if (hasSummoningSickness && !hasHaste) continue
                         }
                     }
+                    // "Tap <the granting Equipment>" — an already-tapped (or departed) granter makes
+                    // the whole granted ability unactivatable (Fishing Pole).
+                    is AbilityCost.TapGrantingPermanent -> {
+                        if (!granterIsUntapped(state, granterByAbilityId[ability.id])) continue
+                    }
                     is AbilityCost.Atom -> when (val atom = effectiveCost.atom) {
                         is CostAtom.Mana -> {
                             if (!context.manaSolver.canPay(state, playerId, atom.cost, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {
@@ -258,8 +267,9 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         }
                         // Pay-life / reveal carry no enumeration-time selection or affordability gate
                         // here (life payability is validated at payment time, matching the prior
-                        // fall-through behavior for these costs).
-                        is CostAtom.PayLife, is CostAtom.RevealFromHand -> {}
+                        // fall-through behavior for these costs). Putting counters on the source
+                        // costs nothing the player must have, so it never gates enumeration either.
+                        is CostAtom.PayLife, is CostAtom.RevealFromHand, is CostAtom.PutCountersOnSelf -> {}
                         is CostAtom.RemoveCounters -> {
                             val needed = when (val count = atom.count) {
                                 is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> count.amount
@@ -405,9 +415,10 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                             discardTargets = targets
                                         }
                                     }
-                                    // Pay-life / reveal carry no enumeration-time gate here (matching
-                                    // the prior else fall-through for these sub-costs).
-                                    is CostAtom.PayLife, is CostAtom.RevealFromHand -> {}
+                                    // Pay-life / reveal / put-counters-on-self carry no enumeration-time
+                                    // gate here (matching the prior else fall-through for these sub-costs).
+                                    is CostAtom.PayLife, is CostAtom.RevealFromHand,
+                                    is CostAtom.PutCountersOnSelf -> {}
                                     is CostAtom.RemoveCounters -> {
                                         val needed = when (val count = atom.count) {
                                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> count.amount
@@ -465,6 +476,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                             costCanBePaid = false
                                             break
                                         }
+                                    }
+                                }
+                                // "Tap <the granting Equipment>" as one sub-cost of a composite —
+                                // "{1}, {T}, Tap Fishing Pole:".
+                                is AbilityCost.TapGrantingPermanent -> {
+                                    if (!granterIsUntapped(state, granterByAbilityId[ability.id])) {
+                                        costCanBePaid = false
+                                        break
                                     }
                                 }
                                 is AbilityCost.Forage -> {
@@ -1248,6 +1267,18 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             )
             evaluator.evaluate(state, reduction, targetContext)
         }
+    }
+
+    /**
+     * Is [granterId] a permanent that is on the battlefield and untapped? The payability gate for
+     * [AbilityCost.TapGrantingPermanent]; an unresolved granter (null) is treated as unpayable,
+     * since the cost names a specific permanent that must still be there to tap (CR 201.5a).
+     */
+    private fun granterIsUntapped(state: com.wingedsheep.engine.state.GameState, granterId: EntityId?): Boolean {
+        if (granterId == null) return false
+        val granter = state.getEntity(granterId) ?: return false
+        if (granterId !in state.getBattlefield()) return false
+        return !granter.has<TappedComponent>()
     }
 
     private fun reduceGenericInAbilityCost(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -138,6 +138,10 @@ class CostPaymentService(private val services: EngineServices) {
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
                 is CostAtom.TapPermanents ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null), atom.count, useTargetingUI = true)
+                // Activated-ability-scoped (see canAfford below, which reports it unaffordable as a
+                // PayCost) — unreachable, but a yes/no is its shape if it is ever wired up.
+                is CostAtom.PutCountersOnSelf ->
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "${atom.description}?", atom.description)
                 is CostAtom.RemoveCounters -> {
                     val count = when (val c = atom.count) {
                         is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> c.amount
@@ -306,6 +310,9 @@ class CostPaymentService(private val services: EngineServices) {
             is CostAtom.Sacrifice -> sacrificeSelected(state, payerId, selected.keys.toList())
             is CostAtom.ReturnToHand -> returnSelected(state, selected.keys.toList())
             is CostAtom.TapPermanents -> tapSelected(state, selected.keys.toList())
+            // Not offered as a PayCost (canAfford reports it unaffordable) — an activated-ability
+            // cost is paid through CostHandler.payAtom, which owns the counter-placement path.
+            is CostAtom.PutCountersOnSelf -> CostPaymentExecution(state, emptyList(), success = false)
             is CostAtom.RemoveCounters -> performRemoveCounters(state, payerId, atom, sourceId, selected)
         }
     }
@@ -623,6 +630,9 @@ class CostPaymentService(private val services: EngineServices) {
                     }
                     is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
                     is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null).size >= atom.count
+                    // Activated-ability cost only: no printed morph / "unless you …" cost puts
+                    // counters on a permanent, and CostHandler owns the placement path.
+                    is CostAtom.PutCountersOnSelf -> false
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> c.amount

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -101,6 +101,15 @@ data class EntitySnapshot(
     val attachedTo: EntityId? = null,
     /** Creatures blocking, or blocked by, this one when it left (CR 509; Abu Ja'far). */
     val blockingOrBlockedByIds: List<EntityId> = emptyList(),
+    /**
+     * True if this permanent was an attacking creature (CR 506.4) at the moment it left the
+     * battlefield. Frozen here because the live `AttackingComponent` is torn down by the exit's
+     * combat cleanup, so a dies/leaves trigger asking "was it attacking?" has to read last known
+     * information (CR 608.2h) — Garna, Bloodfist of Keld ("draw a card if it was attacking").
+     * Backs the last-known leg of
+     * [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttacking].
+     */
+    val wasAttacking: Boolean = false,
     /** True if the leaving entity was a token (CR 704.5d — suppress persist-style return triggers). */
     val wasToken: Boolean = false,
     /** Per-player damage dealt to this entity this turn, keyed by source-controller (Grothama). */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FishingPoleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FishingPoleScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Fishing Pole — the granted "{1}, {T}, Tap Fishing Pole: Put a bait counter on Fishing Pole"
+ * plus the "whenever equipped creature becomes untapped" payoff.
+ *
+ * Three separate objects are touched by one activation: `{T}` taps the *creature*,
+ * "Tap Fishing Pole" taps the *Equipment*
+ * ([com.wingedsheep.sdk.scripting.AbilityCost.TapGrantingPermanent]), and the counter goes on the
+ * *Equipment* ([com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource]). These tests
+ * pin all three, plus the "if you do" gate that makes no Fish without a bait counter.
+ */
+class FishingPoleScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.baitCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.BAIT) ?: 0
+
+    /** The bait ability the Fishing Pole's static grants to its equipped creature. */
+    private val baitAbilityId by lazy {
+        cardRegistry.requireCard("Fishing Pole").script.staticAbilities
+            .filterIsInstance<GrantActivatedAbility>().first().ability.id
+    }
+
+    init {
+        test("the granted ability taps both the creature and the Equipment, and baits the pole") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardAttachedTo(1, "Fishing Pole", "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val pole = game.findPermanent("Fishing Pole")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = bears,
+                    abilityId = baitAbilityId,
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.state.getEntity(bears)!!.has<TappedComponent>() shouldBe true
+            game.state.getEntity(pole)!!.has<TappedComponent>() shouldBe true
+            game.baitCounters(pole) shouldBe 1
+        }
+
+        test("the ability can't be activated again while the Equipment is tapped") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardAttachedTo(1, "Fishing Pole", "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 4)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val pole = game.findPermanent("Fishing Pole")!!
+            val abilityId = baitAbilityId
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = bears, abilityId = abilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Untap only the creature: the {T} half would be payable again, but the pole is tapped.
+            game.state = game.state.updateEntity(bears) { it.without<TappedComponent>() }
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = bears, abilityId = abilityId)
+            ).error shouldNotBe null
+            game.baitCounters(pole) shouldBe 1
+        }
+
+        test("the equipped creature untapping spends a bait counter for a 1/1 blue Fish") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                .withCardAttachedTo(1, "Fishing Pole", "Grizzly Bears")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Island")
+                // Start on the opponent's turn so the next untap step is ours.
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .build()
+
+            val pole = game.findPermanent("Fishing Pole")!!
+            game.state = game.state.updateEntity(pole) { container ->
+                val existing = container.get<CountersComponent>() ?: CountersComponent()
+                container.with(existing.withAdded(CounterType.BAIT, 1))
+            }
+
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            game.resolveStack()
+
+            game.baitCounters(pole) shouldBe 0
+            game.findPermanent("Fish Token") shouldNotBe null
+        }
+
+        test("no bait counter means no Fish") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                .withCardAttachedTo(1, "Fishing Pole", "Grizzly Bears")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                .build()
+
+            val pole = game.findPermanent("Fishing Pole")!!
+            game.baitCounters(pole) shouldBe 0
+
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            game.resolveStack()
+
+            // The trigger still fires; the "if you do" gate withholds the token.
+            game.findPermanent("Fish Token") shouldBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarnaBloodfistOfKeldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarnaBloodfistOfKeldScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Garna, Bloodfist of Keld — "Whenever another creature you control dies, draw a card if it was
+ * attacking. Otherwise, Garna deals 1 damage to each opponent."
+ *
+ * The branch is decided from last-known information (CR 608.2h): by resolution the dead creature
+ * is in the graveyard with its `AttackingComponent` gone, so `StatePredicate.IsAttacking` has to
+ * read the battlefield-exit snapshot. These tests pin both legs plus the "another" scoping.
+ */
+class GarnaBloodfistOfKeldScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("a non-attacking creature dying deals 1 damage to each opponent") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Garna, Bloodfist of Keld")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.handSize(1)
+            val opponentLifeBefore = game.getLifeTotal(2)
+
+            // Shock the Bears: 2 damage kills a 2/2 that isn't attacking.
+            game.castSpell(1, "Shock", game.findPermanent("Grizzly Bears")!!)
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            game.getLifeTotal(2) shouldBe opponentLifeBefore - 1
+            // Shock left hand, nothing was drawn.
+            game.handSize(1) shouldBe handBefore - 1
+        }
+
+        test("an attacking creature dying draws a card instead") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Garna, Bloodfist of Keld")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Serra Angel")
+                .withCardInLibrary(1, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.handSize(1)
+            val opponentLifeBefore = game.getLifeTotal(2)
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            // The 4/4 Angel blocks and kills the 2/2 while it is attacking.
+            game.declareBlockers(mapOf("Serra Angel" to listOf("Grizzly Bears")))
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            game.handSize(1) shouldBe handBefore + 1
+            // The draw leg fired, so no damage was dealt to the opponent.
+            game.getLifeTotal(2) shouldBe opponentLifeBefore
+        }
+
+        test("Garna's own death does not trigger her ability") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Garna, Bloodfist of Keld")
+                .withCardInHand(1, "Murder")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val opponentLifeBefore = game.getLifeTotal(2)
+
+            game.castSpell(1, "Murder", game.findPermanent("Garna, Bloodfist of Keld")!!)
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Garna, Bloodfist of Keld") shouldBe true
+            // "another creature you control" — the source's own death is excluded.
+            game.getLifeTotal(2) shouldBe opponentLifeBefore
+        }
+
+        test("an opponent's creature dying does not trigger it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Garna, Bloodfist of Keld")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val opponentLifeBefore = game.getLifeTotal(2)
+
+            game.castSpell(1, "Shock", game.findPermanent("Grizzly Bears")!!)
+            game.resolveStack()
+
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            // "a creature you control" — an opponent's death is out of scope.
+            game.getLifeTotal(2) shouldBe opponentLifeBefore
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiadaFontOfHopeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiadaFontOfHopeScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+
+/**
+ * Giada, Font of Hope — "Each other Angel you control enters with an additional +1/+1 counter on
+ * it for each Angel you already control."
+ *
+ * The Scryfall ruling is the interesting part: the count is every Angel you control *other than*
+ * the one entering, and it *includes* Giada. So Giada alone gives the next Angel one counter, and
+ * Giada plus one other Angel gives the next Angel two.
+ */
+class GiadaFontOfHopeScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        test("another Angel enters with one +1/+1 counter when Giada is the only Angel") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Giada, Font of Hope")
+                .withCardInHand(1, "Serra Angel")
+                .withLandsOnBattlefield(1, "Plains", 5)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Serra Angel")
+            game.resolveStack()
+
+            val serra = game.findPermanent("Serra Angel")!!
+            // Giada herself is the one Angel "already controlled".
+            game.plusOneCounters(serra) shouldBe 1
+        }
+
+        test("the count includes every other Angel, not just Giada") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Giada, Font of Hope")
+                .withCardOnBattlefield(1, "Serra Angel")
+                .withCardInHand(1, "Angel of Mercy")
+                .withLandsOnBattlefield(1, "Plains", 6)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Angel of Mercy")
+            game.resolveStack()
+
+            val mercy = game.findPermanent("Angel of Mercy")!!
+            // Giada + Serra Angel = two Angels already controlled; the entering Angel isn't counted.
+            game.plusOneCounters(mercy) shouldBe 2
+        }
+
+        test("Giada does not give herself counters, and non-Angels get none") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Giada, Font of Hope")
+                .withCardInHand(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.plusOneCounters(game.findPermanent("Giada, Font of Hope")!!) shouldBe 0
+
+            game.castSpell(1, "Grizzly Bears")
+            game.resolveStack()
+
+            game.plusOneCounters(game.findPermanent("Grizzly Bears")!!) shouldBe 0
+        }
+
+        test("an opponent's Angel is unaffected") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Giada, Font of Hope")
+                .withCardInHand(2, "Serra Angel")
+                .withLandsOnBattlefield(2, "Plains", 5)
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(2, "Serra Angel")
+            game.resolveStack()
+
+            game.plusOneCounters(game.findPermanent("Serra Angel")!!) shouldBe 0
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazemindTomeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazemindTomeScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Mazemind Tome — the "{T}, Put a page counter on this artifact:" cost
+ * ([com.wingedsheep.sdk.dsl.Costs.PutCounterOnSelf]) plus the state-triggered
+ * "four or more page counters → exile it, gain 4 life".
+ *
+ * The cost is the novel piece: unlike every other cost it *adds* something, so it is always
+ * payable, and it is paid whether or not the ability resolves.
+ */
+class MazemindTomeScenarioTest : ScenarioTestBase() {
+
+    private val scryAbilityId by lazy {
+        cardRegistry.requireCard("Mazemind Tome").activatedAbilities[0].id
+    }
+    private val drawAbilityId by lazy {
+        cardRegistry.requireCard("Mazemind Tome").activatedAbilities[1].id
+    }
+
+    private fun TestGame.pageCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PAGE) ?: 0
+
+    private fun TestGame.seedPageCounters(id: EntityId, count: Int) {
+        state = state.updateEntity(id) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(CounterType.PAGE, count))
+        }
+    }
+
+    init {
+        test("the scry ability taps the Tome and puts a page counter on it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mazemind Tome")
+                .withCardInLibrary(1, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val tome = game.findPermanent("Mazemind Tome")!!
+            game.pageCounters(tome) shouldBe 0
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = tome, abilityId = scryAbilityId)
+            ).error shouldBe null
+
+            // The counter is part of the cost, so it lands immediately — before resolution.
+            game.pageCounters(tome) shouldBe 1
+            game.state.getEntity(tome)!!.has<TappedComponent>() shouldBe true
+        }
+
+        test("the draw ability costs {2} and also accrues a page counter") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mazemind Tome")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInLibrary(1, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val tome = game.findPermanent("Mazemind Tome")!!
+            val handBefore = game.handSize(1)
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = tome, abilityId = drawAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.pageCounters(tome) shouldBe 1
+            game.handSize(1) shouldBe handBefore + 1
+        }
+
+        test("the draw ability is unaffordable without the {2}") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mazemind Tome")
+                .withCardInLibrary(1, "Mountain")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val tome = game.findPermanent("Mazemind Tome")!!
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = tome, abilityId = drawAbilityId)
+            ).error shouldNotBe null
+            game.pageCounters(tome) shouldBe 0
+        }
+
+        test("the fourth page counter exiles the Tome and gains 4 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mazemind Tome")
+                .withCardInLibrary(1, "Mountain")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withLifeTotal(1, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val tome = game.findPermanent("Mazemind Tome")!!
+            // Three already there; the activation's own cost counter is the fourth. The draw
+            // ability is used rather than scry so resolution doesn't pause for a scry decision.
+            game.seedPageCounters(tome, 3)
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = tome, abilityId = drawAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.isInExile(1, "Mazemind Tome") shouldBe true
+            game.isOnBattlefield("Mazemind Tome") shouldBe false
+            game.getLifeTotal(1) shouldBe 24
+        }
+
+        test("the state trigger stays quiet below four counters") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Mazemind Tome")
+                .withCardInLibrary(1, "Mountain")
+                .withLifeTotal(1, 20)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val tome = game.findPermanent("Mazemind Tome")!!
+            game.seedPageCounters(tome, 2)
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = tome, abilityId = scryAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.pageCounters(tome) shouldBe 3
+            game.isOnBattlefield("Mazemind Tome") shouldBe true
+            game.getLifeTotal(1) shouldBe 20
+        }
+    }
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -124,4 +124,5 @@ export const counterManaClass: Record<string, string> = {
   DREAD: 'counter-doom',
   INCUBATION: 'counter-slime',
   FELLOWSHIP: 'counter-devotion',
+  BAIT: 'counter-fungus',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -683,6 +683,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.DREAD,
   CounterType.INCUBATION,
   CounterType.FELLOWSHIP,
+  CounterType.BAIT,
   CounterType.BORE,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1896,6 +1896,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   DREAD: { bg: 'rgba(25, 15, 35, 0.95)', border: 'rgba(120, 90, 160, 0.7)', color: '#b59ad0', glow: 'rgba(120, 90, 160, 0.55)' },
   INCUBATION: { bg: 'rgba(20, 45, 65, 0.95)', border: 'rgba(110, 190, 220, 0.65)', color: '#a0d4e8', glow: 'rgba(110, 190, 220, 0.5)' },
   FELLOWSHIP: { bg: 'rgba(58, 44, 20, 0.95)', border: 'rgba(214, 178, 96, 0.65)', color: '#e8d3a0', glow: 'rgba(214, 178, 96, 0.5)' },
+  BAIT: { bg: 'rgba(18, 48, 62, 0.95)', border: 'rgba(96, 186, 214, 0.65)', color: '#9ed4e8', glow: 'rgba(96, 186, 214, 0.5)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -403,6 +403,7 @@ export enum CounterType {
   DREAD = 'DREAD',
   INCUBATION = 'INCUBATION',
   FELLOWSHIP = 'FELLOWSHIP',
+  BAIT = 'BAIT',
   BORE = 'BORE',
 }
 
@@ -463,6 +464,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.DREAD]: 'Dread',
   [CounterType.INCUBATION]: 'Incubation',
   [CounterType.FELLOWSHIP]: 'Fellowship',
+  [CounterType.BAIT]: 'Bait',
   [CounterType.BORE]: 'Bore',
 }
 


### PR DESCRIPTION
Four Foundations cards, each canonical in its earliest real printing with a `Printing` row in FDN for the reprints. `just check-card-printing` is clean for all four.

| Card | Canonical | FDN role |
|---|---|---|
| Giada, Font of Hope | SNC | printing row |
| Garna, Bloodfist of Keld | DMU | printing row |
| Mazemind Tome | M21 | printing row |
| Fishing Pole | **FDN** | canonical (FDN original) |

## Giada — no new SDK

`EntersWithDynamicCounters(otherOnly = true)` whose count is an `AggregateBattlefield(excludeSelf = true)` is exactly "each Angel you **already** control": the global enters-with pass evaluates the count with the *entering* permanent as the source, so `excludeSelf` drops the new Angel while still counting Giada herself — which is what the Scryfall ruling says. The mana ability is a plain `ManaRestriction.SubtypeSpellsOnly`.

## Three new general primitives

**"Was attacking" as last known information (CR 608.2h)** — Garna's branch is decided after the creature is already in the graveyard with its `AttackingComponent` torn down. `EntitySnapshot` grows a `wasAttacking` flag captured on battlefield exit, and `StatePredicate.IsAttacking` falls back to it once the permanent has left. Battlefield reads are unchanged; the fallback can only fire off-battlefield.

This also uncovered a real bug: `ConditionEvaluator`'s `EntityMatches(TriggeringEntity, …)` routed a *departed permanent* to the spell-characteristics path, which can't see state predicates at all and so matched vacuously. It now runs the real predicate evaluator whenever the triggering object carries a `LastKnownPermanentComponent`.

**`CostAtom.PutCountersOnSelf` / `Costs.PutCounterOnSelf`** — "Put a page counter on this artifact" as part of an activation cost. The accruing mirror of `RemoveCounterFromSelf`, and the only cost that *adds* rather than spends, so it is always payable — which is what lets Mazemind Tome reach the fourth counter that exiles it. Placement runs through the normal chokepoint, so Solemnity / Hardened Scales / Doubling Season all still apply. Ability-scoped only; the other cost contexts get explicit "not this shape" branches.

**`AbilityCost.TapGrantingPermanent`** — "Tap Fishing Pole" inside the ability the Equipment grants its equipped creature, joining the existing `ExileGrantingPermanent` / `SacrificeGrantingPermanent`. One activation touches three objects: `{T}` taps the creature, this taps the Equipment, and the counter lands on the Equipment via `EffectTarget.GrantingSource`. Gated in both the enumerator and `ActivateAbilityHandler`, so an already-tapped granter makes the ability unactivatable — CR 201.5a and the printed ruling both say the name means *that* Equipment, not any same-named one.

## Supporting additions

- `bait` counter type (SDK enum + `Counters` constant + client badge/palette/icon wiring).
- `Triggers.becomesUntapped(binding)` plus `UntapEvent` handling in `AttachmentTriggerDetector`, for "whenever equipped creature becomes untapped".
- `SuccessCriterion.CountersRemoved` for the "remove a counter. If you do, …" gate — `Auto` can't infer it (no zone move) and `Always` would wrongly fire on an empty permanent.
- `RemoveCountersExecutor` now reports the amount **actually** removed (clamped to what was there) instead of the amount requested. Emitting the requested amount told the new gate — and any "whenever a counter is removed" observer — that something happened when nothing did.

## Testing

`just test` green (7742 tests). Scenario tests for all four cards cover both branches of Garna's trigger plus its "another"/"you control" scoping, Mazemind's cost-vs-resolution timing and the state trigger firing exactly at four counters, Fishing Pole's three-object activation and the no-bait-no-Fish gate, and Giada's counter arithmetic including the opponent-Angel and non-Angel cases. Card snapshots re-blessed — diff is additions only, no unrelated card moved. `npm run typecheck` clean.

## Not done

Step 4.11 of the add-card skill (teaching the mtgish generator the new building blocks via bridge + emitter entries) is explicitly best-effort and was skipped; the emitter is untouched, so existing coverage is unaffected. Worth a follow-up if the counter-cost and granter-cost shapes turn up in other sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)