### PR TITLE
Add LCI graveyard-caves batch (Echoing Deeps, Intrepid Paleontologist, Pit of Offerings,
  Starving Revenant)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 272 / 286
+**Implemented:** 273 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -236,7 +236,7 @@
 - [x] Squirming Emergence
 - [x] Staggering Size
 - [x] Stalactite Stalker
-- [ ] Starving Revenant
+- [x] Starving Revenant
 - [x] Staunch Crewmate
 - [x] Stinging Cave Crawler
 - [x] Subterranean Schooner

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -88,7 +88,7 @@
 - [x] Earthshaker Dreadmaw
 - [x] Eaten by Piranhas
 - [x] Echo of Dusk
-- [ ] Echoing Deeps
+- [x] Echoing Deeps
 - [x] Enterprising Scallywag
 - [x] Envoy of Okinec Ahau
 - [x] Etali's Favor

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 269 / 286
+**Implemented:** 270 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -131,7 +131,7 @@
 - [x] Idol of the Deep King
 - [x] In the Presence of Ages
 - [x] Inti, Seneschal of the Sun
-- [ ] Intrepid Paleontologist
+- [x] Intrepid Paleontologist
 - [x] Inverted Iceberg
 - [x] Ironpaw Aspirant
 - [x] Itzquinth, Firstborn of Gishath

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 270 / 286
+**Implemented:** 272 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -183,7 +183,7 @@
 - [x] Pathfinding Axejaw
 - [x] Petrify
 - [x] Pirate Hat
-- [ ] Pit of Offerings
+- [x] Pit of Offerings
 - [x] Plundering Pirate
 - [x] Poetic Ingenuity
 - [x] Poison Dart Frog

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7451,7 +7451,10 @@ levels, saga chapters, faces — is covered automatically. What it checks:
   `ChooseOption` / a cast-time additional cost, …) in the same resolution scope. A read written
   *nowhere* on the card is an **error** (typo → silent no-op); read-before-write and
   cross-resolution reads are warnings, as are stores nothing reads. A collection write `x`
-  also satisfies the numeric read `x_count`.
+  also satisfies the numeric read `x_count`. Macro effects that the engine expands into a
+  pipeline count as writers of the collections that expansion seeds: `Scry` writes `toTop` /
+  `toBottom` and `Surveil` writes `toTop` / `toGraveyard`, so a sibling effect may read the
+  kept-on-top cards (e.g. Starving Revenant's `DistinctEntitiesInCollections("toTop")`).
 - **Target bindings per owning ability** — `ContextTarget(i)` must fit the owning ability's
   flattened target slots (a `count = 2` requirement spans two indices); `BoundVariable(name)`
   must match a requirement `id` (indexed form `id[i]` allowed). Modes inherit the card-level

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4528,7 +4528,7 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   in your graveyard has flashback … equal to that card's mana cost") and one for
   `InstantOrSorcery.withSubtype(Lesson)` with `cost = {1}` ("each Lesson card in your graveyard has
   flashback {1}"), both `duringYourTurnOnly = true`.
-- `GrantMayCastFromLinkedExile(filter = Nonland, duringYourTurnOnly = false, additionalCost = null, ownedByYou = false, withoutPayingManaCost = false, oncePerTurn = false, maxManaValue = null, exiledThisTurnOnly = false)`
+- `GrantMayCastFromLinkedExile(filter = Nonland, duringYourTurnOnly = false, additionalCost = null, ownedByYou = false, withoutPayingManaCost = false, oncePerTurn = false, maxManaValue = null, exiledThisTurnOnly = false, entersWithCounter = null)`
   — "you may cast cards exiled with this permanent" — reads the source's `LinkedExileComponent` (Rona,
   Disciple of Gix; Maralen, Fae Ascendant; Dawnhand Dissident). Casting spells from linked exile is
   enumerated by `CastFromZoneEnumerator.enumerateLinkedExile`; the cast path deliberately skips lands.
@@ -4538,6 +4538,14 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   (e.g. `GameObjectFilter.Any`, no `IsNonland` predicate), the permission also covers *playing* land
   cards from the linked exile — surfaced by `PlayLandEnumerator` and authorized by `PlayLandHandler`
   (lands cost no life). Pair with a `RedirectZoneChange(linkToSource = true)` to fill the exile pile.
+  **Cast-this-way entry rider:** `entersWithCounter` (a `CounterType`) mirrors
+  `MayCastFromGraveyard.entersWithCounter` for the linked-exile path — a permanent cast from this pile
+  *under this grant* enters the battlefield with one such counter (`CastSpellHandler` freezes the same
+  `GraveyardCastRiderComponent` it uses for graveyard casts, applied at resolution by `StackResolver`).
+  Intrepid Paleontologist = `GrantMayCastFromLinkedExile(filter = Creature.withSubtype("Dinosaur"),
+  ownedByYou = true, entersWithCounter = CounterType.FINALITY)` — "You may cast Dinosaur creature spells
+  from among cards you own exiled with this creature. If you cast a spell this way, that creature enters
+  with a finality counter on it."
 - `GraveyardCreaturesHaveSneak(cost)` — "Creature cards in your graveyard have sneak `cost`. You may
   cast creature spells from your graveyard using their sneak abilities." (Ninja Teen level 3.) While
   the controller has this static active, their graveyard creature cards become castable via the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -906,6 +906,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `AddManaOfColorAmongGraveyard(filter)` — one mana of any color among cards in your graveyard matching
   `filter` (reads each card's base colors; sugar for `ManaColorSet.AmongCardsInGraveyard(filter)`). The
   Grey Havens ("any color among legendary creature cards in your graveyard").
+- `AddManaOfColorAmongLinkedExile()` — one mana of any color among the cards currently exiled *with*
+  the source permanent (its `LinkedExileComponent`, still in the exile zone; reads each card's base
+  colors; sugar for `ManaColorSet.AmongLinkedExiledCards`). Pit of Offerings ("any of the exiled
+  cards' colors"). Pair with a `MoveToZoneEffect(linkToSource = true)` that records the exiled pile.
 - `AddManaOfColorLandsCouldProduce(scope)` — sugar for `AddManaOfChoice(ManaColorSet.LandsCouldProduce(scope))`. Fellwar Stone / Exotic Orchard / Reflecting Pool shape.
 - `AddManaOfColorInCommanderColorIdentity()` — sugar for `AddManaOfChoice(ManaColorSet.CommanderIdentity)`. Arcane Signet / Command Tower shape.
 - `AddAnyColorManaSpendOnChosenType(typeName)` — mana that can only pay for a specific card type (kept separate because it derives a runtime [ManaRestriction] from the source's chosen subtype).
@@ -6294,6 +6298,7 @@ solver picks if there's only one), and that color is added to the pool.
 - `ManaColorSet.AmongPermanents(filter)` — colors of permanents matching `filter`, read via projected state so type/color-changing effects are honored. Mox Amber shape.
 - `ManaColorSet.LandsCouldProduce(scope)` — colors any land in `scope` could produce; tapped state and activation costs are ignored (CR 106.7). `scope` is `LandControllerScope.{YOU, OPPONENTS, ANY}`. Fellwar Stone / Exotic Orchard / Reflecting Pool shape.
 - `ManaColorSet.SourceChosenColor` — the single color stored on the source's `ChosenColorComponent` (set via `EntersWithChoice(ChoiceType.COLOR)`). Uncharted Haven / Ashling Rekindled shape.
+- `ManaColorSet.AmongLinkedExiledCards` — union of the base colors of the cards currently exiled *with* the source permanent — the ids in its `LinkedExileComponent` (set by `MoveToZoneEffect(linkToSource = true)`) that are still in the exile zone. A card that has since left exile drops out of the pool; colorless-only or empty piles produce no mana. Pit of Offerings shape ("any of the exiled cards' colors").
 
 ### `ManaRestriction`
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6921,17 +6921,24 @@ replacementEffect {
   trigger itself. Used by Worldwalker Helm (`TokenCreationEvent(You, Artifact)`, add `Map`, `inheritTapped = true`)
   and Peregrin Took (`additionalTokenType = "Food"`, "those tokens plus an additional Food token are created instead")
   and Quina, Qu Gourmet (`additionalTokenType = "Frog"`, default `appliesTo` = any token you create, adds a 1/1 green Frog).
-- `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
-  "enter as a copy of …". As the permanent resolves, the controller picks an object matching
+- `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard, tappedIfCopied)` —
+  "enter as a copy of …". As the permanent enters, the controller picks an object matching
   `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides
   applied. `copyFromZone` selects the candidate pool: `Zone.BATTLEFIELD` (default — Clone, Clever
-  Impersonator, Mockingbird) copies a permanent in play; `Zone.GRAVEYARD` copies a creature *card*
-  from any graveyard (Superior Spider-Man) via the modal card-list overlay. `additionalSubtypes` /
+  Impersonator, Mockingbird) copies a permanent in play; `Zone.GRAVEYARD` copies a *card*
+  from any graveyard (Superior Spider-Man; Echoing Deeps copies a land card) via the modal card-list
+  overlay. `additionalSubtypes` /
   `additionalKeywords` are added "in addition to its other types"; `nameOverride` keeps a fixed name;
   `powerOverride` / `toughnessOverride` force base P/T; `exileCopiedCard` exiles the copied card after
   the copy ("When you do, exile that card"). `filterByTotalManaSpent` restricts copy targets to mana
-  value ≤ total mana spent (Mockingbird). The copy snapshots a `CopyOfComponent` so it reverts to its
-  printed identity when it leaves the battlefield (CR 400.7 / 707.2).
+  value ≤ total mana spent (Mockingbird). `tappedIfCopied` makes the permanent enter **tapped** only
+  when it actually enters as a copy — the "enter tapped as a copy" rider on the land-copy cycle
+  (Echoing Deeps; Vesuva / Thespian's Stage copying a land on the battlefield); declining the copy
+  enters it untapped as its printed self. The copy snapshots a `CopyOfComponent` so it reverts to its
+  printed identity when it leaves the battlefield (CR 400.7 / 707.2). Works both when the source is
+  cast as a spell (resolved off the stack) **and** when it enters the battlefield directly — a land
+  played (Echoing Deeps) pauses via `PermanentEntryReplacements.pauseForEntersAsCopy`, its resumer
+  `CloneEntersOnBattlefieldContinuation` copying onto the already-placed permanent in place.
 - `ModifyDrawAmount(modifier, restrictions, appliesTo)` — modify the number of cards a draw
   instruction announces by a fixed amount, optionally gated by extra `restrictions: List<Condition>`
   evaluated against the drawing player as controller. Applied **once** per draw instruction at the

--- a/manual-scenarios/sets/lci/graveyard-caves.json
+++ b/manual-scenarios/sets/lci/graveyard-caves.json
@@ -1,0 +1,70 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Intrepid Paleontologist",
+      "Echoing Deeps",
+      "Pit of Offerings",
+      "Starving Revenant"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Island"}
+    ],
+    "graveyard": [
+      "Forest",
+      "Swamp",
+      "Island",
+      "Plains",
+      "Mountain",
+      "Belligerent Yearling",
+      "Bedrock Tortoise",
+      "Basking Capybara",
+      "Armored Kincaller"
+    ],
+    "library": [
+      "Forest",
+      "Swamp",
+      "Island",
+      "Plains",
+      "Mountain",
+      "Belligerent Yearling",
+      "Abrade",
+      "Bitter Triumph"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [
+      "Mountain",
+      "Plains",
+      "Basking Capybara",
+      "Bedrock Tortoise"
+    ],
+    "library": [
+      "Forest",
+      "Island",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1990,6 +1990,15 @@ object Effects {
         AddManaOfChoiceEffect(ManaColorSet.AmongCardsInGraveyard(filter), DynamicAmount.Fixed(1), restriction)
 
     /**
+     * Add one mana of any color among the cards currently exiled with the source permanent
+     * (its `LinkedExileComponent`, still in the exile zone; base colors). "Add one mana of any
+     * of the exiled cards' colors." (Pit of Offerings). Sugar for
+     * `AddManaOfChoice(ManaColorSet.AmongLinkedExiledCards)`.
+     */
+    fun AddManaOfColorAmongLinkedExile(restriction: ManaRestriction? = null): Effect =
+        AddManaOfChoiceEffect(ManaColorSet.AmongLinkedExiledCards, DynamicAmount.Fixed(1), restriction)
+
+    /**
      * For each color among permanents matching a filter, add one mana of that color.
      * Used for cards like Bloom Tender — produces one mana of every color present (0–5 total).
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1199,6 +1199,10 @@ data class LifeLossFloor(
  * @param toughnessOverride When non-null, the copy's base toughness is set to this value.
  * @param exileCopiedCard When true, the copied card is exiled after the copy is applied
  *                   ("When you do, exile that card"). Only meaningful with [copyFromZone] = graveyard.
+ * @param tappedIfCopied When true, the permanent enters **tapped** if (and only if) it enters as a
+ *                   copy — the "enter tapped as a copy" rider on the land-copy cycle (Vesuva,
+ *                   Thespian's Stage, Echoing Deeps). If the copy is declined (or no candidate
+ *                   exists) the permanent enters untapped as its printed self.
  */
 @SerialName("EntersAsCopy")
 @Serializable
@@ -1213,6 +1217,7 @@ data class EntersAsCopy(
     val powerOverride: Int? = null,
     val toughnessOverride: Int? = null,
     val exileCopiedCard: Boolean = false,
+    val tappedIfCopied: Boolean = false,
     override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
         filter = GameObjectFilter.Any,
         to = Zone.BATTLEFIELD
@@ -1221,10 +1226,12 @@ data class EntersAsCopy(
     override val description: String = run {
         val filterDesc = copyFilter.description
         val where = if (copyFromZone == Zone.GRAVEYARD) "$filterDesc card in a graveyard" else "$filterDesc on the battlefield"
+        val subject = if (copyFilter == GameObjectFilter.Land) "this land" else "this creature"
+        val tappedWord = if (tappedIfCopied) "tapped " else ""
         val lead = if (optional) {
-            "You may have this creature enter as a copy of any $where"
+            "You may have $subject enter ${tappedWord}as a copy of any $where"
         } else {
-            "This creature enters as a copy of any $where"
+            "$subject enters ${tappedWord}as a copy of any $where"
         }
         buildString {
             append(lead)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -134,7 +134,17 @@ data class GrantMayCastFromLinkedExile(
      * When true, only cards exiled this turn are eligible (Maralen). Checked via
      * [com.wingedsheep.engine.state.components.battlefield.ExileEntryTurnComponent].
      */
-    val exiledThisTurnOnly: Boolean = false
+    val exiledThisTurnOnly: Boolean = false,
+    /**
+     * Cast-this-way entry rider (CR 614-style): when set, a permanent cast from this linked-exile
+     * pile *under this grant* enters the battlefield with one counter of that type on it. Mirrors
+     * [MayCastFromGraveyard.entersWithCounter], but for the linked-exile cast path. Defaults to null
+     * (no rider), so existing linked-exile cast cards are unaffected.
+     *
+     * Intrepid Paleontologist: `entersWithCounter = CounterType.FINALITY` — "If you cast a spell this
+     * way, that creature enters with a finality counter on it."
+     */
+    val entersWithCounter: com.wingedsheep.sdk.core.CounterType? = null
 ) : StaticAbility {
     override val description: String = buildString {
         // "pay life equal to its mana value rather than pay its mana cost" — Valgavoth, Terror Eater
@@ -159,6 +169,9 @@ data class GrantMayCastFromLinkedExile(
         if (additionalCost != null) append(" by ${additionalCost.description.lowercase()} in addition to paying their other costs")
         if (oncePerTurn) append(". This ability may be used only once each turn")
         append(".")
+        if (entersWithCounter != null) {
+            append(" If you cast a spell this way, that permanent enters with a ${entersWithCounter.name.lowercase()} counter on it.")
+        }
     }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ManaColorSet.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ManaColorSet.kt
@@ -89,6 +89,20 @@ sealed interface ManaColorSet {
     }
 
     /**
+     * The union of colors among the cards currently exiled *with* the source permanent — the
+     * cards recorded in its `LinkedExileComponent` (set by `MoveToZoneEffect(linkToSource = true)`)
+     * that are still in the exile zone. Colors are read from each exiled card's base colors
+     * (exile-zone cards aren't projected). Empty if the source exiled no cards, they've all since
+     * left exile, or every exiled card is colorless — in which case no mana is produced. Used by
+     * Pit of Offerings: "Add one mana of any of the exiled cards' colors."
+     */
+    @SerialName("ManaColorSet.AmongLinkedExiledCards")
+    @Serializable
+    data object AmongLinkedExiledCards : ManaColorSet {
+        override val description: String = "any of the exiled cards' colors"
+    }
+
+    /**
      * The single color recorded on the source permanent's `CastChoicesComponent`
      * (set when it entered the battlefield, e.g., via `EntersWithChoice(COLOR)`).
      * If no color was chosen, no mana is produced. Used by Unchartered Haven and

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -272,6 +272,23 @@ object CardLinter {
             type == "CreateToken" || type == "CreatePredefinedToken" ||
                 type == "CreateTokenCopyOfTarget" || type == "CreateTokenCopyOfSource" ->
                 listOf(Kind.WRITE to (Space.COLLECTION to "createdTokens"))
+            // The scry / surveil macros are opaque nodes on the card, but the engine expands each
+            // into a Gather → Select → Move pipeline (LibraryPatterns.scryPipeline /
+            // surveilPipeline) whose selected/remainder collections seed the *same* EffectContext.
+            // Sibling effects can therefore read the cards kept on top / put below — e.g. Starving
+            // Revenant draws and drains per card left on top via
+            // DistinctEntitiesInCollections("toTop"). Surface those writes so such reads resolve
+            // instead of looking unwired. (Collection names mirror the two pipelines above.)
+            type == "Scry" ->
+                listOf(
+                    Kind.WRITE to (Space.COLLECTION to "toBottom"),
+                    Kind.WRITE to (Space.COLLECTION to "toTop"),
+                )
+            type == "Surveil" ->
+                listOf(
+                    Kind.WRITE to (Space.COLLECTION to "toGraveyard"),
+                    Kind.WRITE to (Space.COLLECTION to "toTop"),
+                )
             else -> emptyList()
         }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EchoingDeeps.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EchoingDeeps.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Echoing Deeps
+ * Land — Cave
+ * You may have this land enter tapped as a copy of any land card in a graveyard, except it's a Cave
+ * in addition to its other types.
+ * {T}: Add {C}.
+ *
+ * The copy is an as-enters replacement (CR 707.2): a graveyard-sourced [EntersAsCopy] with
+ * `tappedIfCopied` (the "enter tapped as a copy" rider) and `additionalSubtypes = ["Cave"]` for the
+ * "it's a Cave in addition to its other types" clause. If the copy is declined (or no land card is
+ * in any graveyard) the land enters untapped as its printed self — a Cave that taps for {C}.
+ */
+val EchoingDeeps = card("Echoing Deeps") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land — Cave"
+    oracleText = "You may have this land enter tapped as a copy of any land card in a graveyard, " +
+        "except it's a Cave in addition to its other types.\n{T}: Add {C}."
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            copyFilter = GameObjectFilter.Land,
+            copyFromZone = Zone.GRAVEYARD,
+            additionalSubtypes = listOf("Cave"),
+            tappedIfCopied = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "271"
+        artist = "Mauricio Calle"
+        flavorText = "The still, silent waters reflect what was, not what is."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg?1782694396"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IntrepidPaleontologist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IntrepidPaleontologist.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
+
+/**
+ * Intrepid Paleontologist
+ * {1}{G}
+ * Creature — Human Druid
+ * 2/2
+ *
+ * {T}: Add one mana of any color.
+ * {2}: Exile target card from a graveyard.
+ * You may cast Dinosaur creature spells from among cards you own exiled with this creature.
+ * If you cast a spell this way, that creature enters with a finality counter on it. (If a
+ * creature with a finality counter on it would die, exile it instead.)
+ */
+val IntrepidPaleontologist = card("Intrepid Paleontologist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Add one mana of any color.\n" +
+        "{2}: Exile target card from a graveyard.\n" +
+        "You may cast Dinosaur creature spells from among cards you own exiled with this creature. " +
+        "If you cast a spell this way, that creature enters with a finality counter on it. " +
+        "(If a creature with a finality counter on it would die, exile it instead.)"
+
+    // {T}: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    // {2}: Exile target card from a graveyard, linked to this creature so the Dinosaur-cast
+    // permission below can find it.
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val graveyardTarget = target("target card in a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Move(
+            target = graveyardTarget,
+            destination = Zone.EXILE,
+            linkToSource = true
+        )
+    }
+
+    // You may cast Dinosaur creature spells from among cards you own exiled with this creature.
+    // A creature cast this way enters with a finality counter on it (the entersWithCounter rider).
+    staticAbility {
+        ability = GrantMayCastFromLinkedExile(
+            filter = GameObjectFilter.Creature.withSubtype("Dinosaur"),
+            ownedByYou = true,
+            entersWithCounter = CounterType.FINALITY
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg?1782694454"
+
+        ruling("2023-11-10", "Finality counters aren't a keyword ability. A finality counter doesn't give any abilities to the permanent it's on.")
+        ruling("2023-11-10", "You cast the exiled Dinosaur creature spell using the permission Intrepid Paleontologist grants. You must still pay that spell's costs and follow its normal timing permissions (usually sorcery speed).")
+        ruling("2023-11-10", "If Intrepid Paleontologist leaves the battlefield, the cards exiled with it remain exiled and can no longer be cast.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PitOfOfferings.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PitOfOfferings.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pit of Offerings
+ * Land — Cave
+ *
+ * This land enters tapped.
+ * When this land enters, exile up to three target cards from graveyards.
+ * {T}: Add {C}.
+ * {T}: Add one mana of any of the exiled cards' colors.
+ *
+ * The exiled cards are linked to this land via `MoveToZoneEffect(linkToSource = true)`, so the
+ * fourth ability's color pool ([Effects.AddManaOfColorAmongLinkedExile] →
+ * `ManaColorSet.AmongLinkedExiledCards`) is the union of the base colors of the cards still exiled
+ * with this land. Colorless-only or empty piles produce no mana (per the printed rulings). Because
+ * the link lives on the source permanent, a new Pit of Offerings (or this land leaving and
+ * returning) is a fresh object with no remembered cards.
+ */
+val PitOfOfferings = card("Pit of Offerings") {
+    typeLine = "Land — Cave"
+    colorIdentity = ""
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, exile up to three target cards from graveyards.\n" +
+        "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any of the exiled cards' colors."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "cards from graveyards",
+            TargetObject(count = 3, optional = true, filter = TargetFilter.CardInGraveyard)
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE, linkToSource = true))
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfColorAmongLinkedExile()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "278"
+        artist = "Martin de Diego Sádaba"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg?1782694390"
+        ruling(
+            "2023-11-10",
+            "The five colors are white, blue, black, red, and green. The last ability of Pit of " +
+                "Offerings can't produce {C}."
+        )
+        ruling(
+            "2023-11-10",
+            "If no cards are exiled with Pit of Offerings, its last ability can't add mana."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/StarvingRevenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/StarvingRevenant.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Starving Revenant (LCI #123) — {2}{B}{B} Creature — Spirit Horror (rare), 4/4.
+ *
+ * When this creature enters, surveil 2. Then for each card you put on top of your library, you
+ * draw a card and you lose 3 life.
+ * Descend 8 — Whenever you draw a card, if there are eight or more permanent cards in your
+ * graveyard, target opponent loses 1 life and you gain 1 life.
+ *
+ * ETB "surveil-then-draw-per-card-kept" — composed entirely from existing primitives:
+ *  - [Effects.Surveil] (2) runs the sanctioned surveil macro, whose expanded pipeline stores the
+ *    cards the controller keeps ON TOP under the pipeline collection `"toTop"` (the surveil
+ *    remainder) and fires "whenever you surveil" triggers. The macro executes in the *same*
+ *    [com.wingedsheep.engine.handlers.EffectContext], so `"toTop"` is visible to the sibling
+ *    effects that follow it in this Composite (CompositeEffectExecutor threads storedCollections
+ *    across children, including across the surveil selection pause).
+ *  - The count of cards kept on top is read with [DynamicAmount.DistinctEntitiesInCollections]
+ *    over `"toTop"`. `MoveCollection` never clears its source collection, so the value is still
+ *    correct after those cards have been moved onto the library. That count drives both the draw
+ *    (`draw that many`) and, via [DynamicAmount.Multiply] × 3, the life loss (`lose 3 per card`).
+ *  - Keeping zero on top ⇒ count 0 ⇒ draw 0 and lose 0 (both no-op), matching the rules.
+ *
+ * The ETB draws feed the card's own descend trigger below: each drawn card that resolves while
+ * eight-or-more permanent cards sit in the graveyard puts a drain on the stack.
+ *
+ * Descend 8 (draw drain) — a "whenever you draw a card" ([Triggers.YouDraw], fires once per card
+ * drawn) triggered ability gated by an intervening-if ([TriggeredAbilityBuilder.triggerCondition]
+ * = [Conditions.CardsInGraveyardMatchingAtLeast] (8, [GameObjectFilter.Permanent])). Per CR 603.4
+ * the condition is checked both when the ability would trigger and again on resolution, so it does
+ * nothing if the graveyard drops below eight permanent cards in between. "target opponent loses 1
+ * life" is a fixed [Effects.LoseLife] on the bound opponent target; "you gain 1 life" is a fixed
+ * [Effects.GainLife] on the controller — two separate fixed amounts, not a drain.
+ */
+val StarvingRevenant = card("Starving Revenant") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit Horror"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, surveil 2. Then for each card you put on top of your " +
+        "library, you draw a card and you lose 3 life.\n" +
+        "Descend 8 — Whenever you draw a card, if there are eight or more permanent cards in your " +
+        "graveyard, target opponent loses 1 life and you gain 1 life."
+
+    // ETB: surveil 2, then for each card kept on top, draw one and lose 3 life.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                Effects.Surveil(2),
+                Effects.DrawCards(DynamicAmount.DistinctEntitiesInCollections(listOf("toTop"))),
+                Effects.LoseLife(
+                    DynamicAmount.Multiply(DynamicAmount.DistinctEntitiesInCollections(listOf("toTop")), 3),
+                    EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    // Descend 8: whenever you draw a card, if eight or more permanent cards are in your graveyard,
+    // target opponent loses 1 life and you gain 1 life.
+    triggeredAbility {
+        trigger = Triggers.YouDraw
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(8, GameObjectFilter.Permanent)
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            listOf(
+                Effects.LoseLife(1, opponent),
+                Effects.GainLife(1)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Fesbra"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg?1783913770"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6066,6 +6066,54 @@
     ]
 }
 
+// Echoing Deeps
+{
+    "name": "Echoing Deeps",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "You may have this land enter tapped as a copy of any land card in a graveyard, except it's a Cave in addition to its other types.\n{T}: Add {C}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "copyFilter": {
+                    "cardPredicates": [
+                        "IsLand"
+                    ]
+                },
+                "copyFromZone": "Graveyard",
+                "additionalSubtypes": [
+                    "Cave"
+                ],
+                "tappedIfCopied": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "RARE",
+        "artist": "Mauricio Calle",
+        "flavorText": "The still, silent waters reflect what was, not what is.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/244c06b3-532d-426e-8bee-ee9461d092a6.jpg?1782694396"
+    },
+    "colorIdentityOverride": []
+}
+
 // Enterprising Scallywag
 {
     "name": "Enterprising Scallywag",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -12787,6 +12787,93 @@
     ]
 }
 
+// Pit of Offerings
+{
+    "name": "Pit of Offerings",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\nWhen this land enters, exile up to three target cards from graveyards.\n{T}: Add {C}.\n{T}: Add one mana of any of the exiled cards' colors.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile",
+                        "linkToSource": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 3,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "cards from graveyards"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": "ManaColorSet.AmongLinkedExiledCards"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "278",
+        "rarity": "UNCOMMON",
+        "artist": "Martin de Diego Sádaba",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc7d3957-b483-4a1f-a244-293c90032f5e.jpg?1782694390",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "The five colors are white, blue, black, red, and green. The last ability of Pit of Offerings can't produce {C}."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "If no cards are exiled with Pit of Offerings, its last ability can't add mana."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Plundering Pirate
 {
     "name": "Plundering Pirate",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -8761,6 +8761,88 @@
     ]
 }
 
+// Intrepid Paleontologist
+{
+    "name": "Intrepid Paleontologist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "{T}: Add one mana of any color.\n{2}: Exile target card from a graveyard.\nYou may cast Dinosaur creature spells from among cards you own exiled with this creature. If you cast a spell this way, that creature enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card in a graveyard"
+                    },
+                    "destination": "Exile",
+                    "linkToSource": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card in a graveyard"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantMayCastFromLinkedExile",
+                "filter": "creature Dinosaur",
+                "ownedByYou": true,
+                "entersWithCounter": "FINALITY"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "RARE",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/871a164a-0fe6-480e-a1be-cbffce884bd3.jpg?1782694454",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "Finality counters aren't a keyword ability. A finality counter doesn't give any abilities to the permanent it's on."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "You cast the exiled Dinosaur creature spell using the permission Intrepid Paleontologist grants. You must still pay that spell's costs and follow its normal timing permissions (usually sorcery speed)."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "If Intrepid Paleontologist leaves the battlefield, the cards exiled with it remain exiled and can no longer be cast."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Inverted Iceberg
 {
     "name": "Inverted Iceberg",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -16402,6 +16402,116 @@
     ]
 }
 
+// Starving Revenant
+{
+    "name": "Starving Revenant",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Spirit Horror",
+    "oracleText": "When this creature enters, surveil 2. Then for each card you put on top of your library, you draw a card and you lose 3 life.\nDescend 8 — Whenever you draw a card, if there are eight or more permanent cards in your graveyard, target opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Surveil",
+                            "count": 2
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "DistinctEntitiesInCollections",
+                                "collections": [
+                                    "toTop"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Multiply",
+                                "amount": {
+                                    "type": "DistinctEntitiesInCollections",
+                                    "collections": [
+                                        "toTop"
+                                    ]
+                                },
+                                "multiplier": 3
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "DrawEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Fesbra",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f25ea466-eb48-4c4c-b5d4-35f58e46ebe1.jpg?1783913770"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Staunch Crewmate
 {
     "name": "Staunch Crewmate",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -207,6 +207,40 @@ data class CloneEntersContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after a player chooses (or declines) a card/permanent to copy for an
+ * [com.wingedsheep.sdk.scripting.EntersAsCopy] replacement on a permanent that has *already* been
+ * placed on the battlefield **directly** — a land played (Echoing Deeps / Vesuva / Thespian's Stage)
+ * or a token/put-onto-battlefield permanent — rather than a spell resolving off the stack (which uses
+ * [CloneEntersContinuation]).
+ *
+ * The resumer copies the chosen object's copiable characteristics (CR 707.2) onto the entity, adds
+ * any [additionalSubtypes] / [additionalKeywords] and overrides, taps the entity if
+ * [tappedIfCopied] and a copy was actually made, optionally exiles the copied card, then fires the
+ * entry's ETB triggers off a synthesized [ZoneChangeEvent] (so the copied identity's landfall /
+ * "when ~ enters" triggers see the final characteristics). Declining leaves the permanent as its
+ * printed self, untapped.
+ *
+ * @property entityId The permanent already on the battlefield.
+ * @property controllerId Its controller (also the copy chooser).
+ * @property fromZone The zone the permanent came from, used to synthesize the entry event.
+ * @property tappedIfCopied Tap the permanent iff it entered as a copy ("enter tapped as a copy").
+ */
+@Serializable
+data class CloneEntersOnBattlefieldContinuation(
+    override val decisionId: String,
+    val entityId: EntityId,
+    val controllerId: EntityId,
+    val fromZone: Zone? = null,
+    val additionalSubtypes: List<String> = emptyList(),
+    val additionalKeywords: List<Keyword> = emptyList(),
+    val nameOverride: String? = null,
+    val powerOverride: Int? = null,
+    val toughnessOverride: Int? = null,
+    val exileCopiedCard: Boolean = false,
+    val tappedIfCopied: Boolean = false
+) : ContinuationFrame
+
+/**
  * Resume after player makes an "as enters" choice for a spell being resolved.
  *
  * Handles all choice types (color, creature type, creature on battlefield) via

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -237,6 +237,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ModalPreChosenContinuation::class)
         subclass(ModalChosenModeTailContinuation::class)
         subclass(CloneEntersContinuation::class)
+        subclass(CloneEntersOnBattlefieldContinuation::class)
         subclass(EntersWithChoiceSpellContinuation::class)
         subclass(EntersWithChoiceOnBattlefieldContinuation::class)
         subclass(PayLifeOrEnterTappedLandContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -301,19 +301,15 @@ class PlayLandHandler(
                     .entersAsCopyCandidates(newState, action.cardId, action.playerId, entersAsCopy)
                     .isNotEmpty()
             ) {
-                // Use up a land drop and emit the entry event before pausing.
+                // Use up a land drop before pausing. The entry ZoneChangeEvent is emitted by the
+                // resumer once the copy choice is made, so it carries the final (copied) identity
+                // and `copyOfOriginalName` — see CloneEntersOnBattlefieldContinuation's resumer.
+                // Emitting a printed-name event here too would double the entry and hide the copy.
+                // Only the play-from-permission rider event (if any) is surfaced now.
                 newState = newState.updateEntity(action.playerId) { c ->
                     val landDrops = c.get<LandDropsComponent>() ?: LandDropsComponent()
                     c.with(landDrops.use())
                 }
-                val zoneChangeEvent = ZoneChangeEvent(
-                    action.cardId,
-                    cardComponent.name,
-                    fromZone,
-                    Zone.BATTLEFIELD,
-                    action.playerId
-                )
-                val events = listOf(zoneChangeEvent) + listOfNotNull(riderPlayEvent)
                 newState = newState.tick()
 
                 val result = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
@@ -324,7 +320,7 @@ class PlayLandHandler(
                         cardComponent = cardComponent,
                         effect = entersAsCopy,
                         fromZone = fromZone,
-                        carryEvents = events,
+                        carryEvents = listOfNotNull(riderPlayEvent),
                     )
                 if (result != null) return result
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersWithChoice
@@ -281,6 +282,51 @@ class PlayLandHandler(
                     return ExecutionResult.success(triggerResult.newState, allEvents)
                 }
                 return ExecutionResult.success(newState, onEnterEvents)
+            }
+        }
+
+        // EntersAsCopy — "you may have this land enter [tapped] as a copy of a land card in a
+        // graveyard, except it's a Cave …" (Echoing Deeps; also Vesuva / Thespian's Stage copying a
+        // land on the battlefield). This is an as-enters replacement (CR 707.2): pause for the copy
+        // choice; [CloneEntersOnBattlefieldContinuation]'s resumer copies the chosen land's copiable
+        // characteristics onto this land, adds the extra subtype, taps it if the rider says so, and
+        // fires the entry's ETB triggers. Only engaged when a candidate exists — otherwise the land
+        // just enters as its printed self via the normal finish below.
+        if (cardDef != null) {
+            val entersAsCopy = cardDef.script.replacementEffects
+                .filterIsInstance<EntersAsCopy>()
+                .firstOrNull()
+            if (entersAsCopy != null &&
+                com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                    .entersAsCopyCandidates(newState, action.cardId, action.playerId, entersAsCopy)
+                    .isNotEmpty()
+            ) {
+                // Use up a land drop and emit the entry event before pausing.
+                newState = newState.updateEntity(action.playerId) { c ->
+                    val landDrops = c.get<LandDropsComponent>() ?: LandDropsComponent()
+                    c.with(landDrops.use())
+                }
+                val zoneChangeEvent = ZoneChangeEvent(
+                    action.cardId,
+                    cardComponent.name,
+                    fromZone,
+                    Zone.BATTLEFIELD,
+                    action.playerId
+                )
+                val events = listOf(zoneChangeEvent) + listOfNotNull(riderPlayEvent)
+                newState = newState.tick()
+
+                val result = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                    .pauseForEntersAsCopy(
+                        state = newState,
+                        entityId = action.cardId,
+                        controllerId = action.playerId,
+                        cardComponent = cardComponent,
+                        effect = entersAsCopy,
+                        fromZone = fromZone,
+                        carryEvents = events,
+                    )
+                if (result != null) return result
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -3010,9 +3010,14 @@ class CastSpellHandler(
         //    added subtype), from the specific grant that authorized this cast.
         //  - Osteomancer Adept's forage permission: "that creature enters with a finality counter on
         //    it" (finality only, no added subtype) — reusing the same entry-rider plumbing.
+        //  - Intrepid Paleontologist: a rider-bearing GrantMayCastFromLinkedExile ("If you cast a
+        //    spell this way, that creature enters with a finality counter on it") — same plumbing,
+        //    but the authorizing grant is the linked-exile cast permission captured pre-cast.
         val riderCounter: CounterType? = when {
             graveyardCastRiderGrant?.hasEntryRider == true -> graveyardCastRiderGrant.entersWithCounter
             isForageCast -> CounterType.FINALITY
+            linkedExileGranterEntry?.ability?.entersWithCounter != null ->
+                linkedExileGranterEntry.ability.entersWithCounter
             else -> null
         }
         val riderSubtype: String? =

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -646,7 +646,11 @@ class CastZoneResolver(
         }
 
         private fun matchesCardPredicate(card: CardComponent, predicate: CardPredicate): Boolean {
+            val cmc = card.manaCost.cmc
+            val power = card.baseStats?.basePower
+            val toughness = card.baseStats?.baseToughness
             return when (predicate) {
+                // --- Card types ---
                 is CardPredicate.IsInstant -> card.typeLine.isInstant
                 is CardPredicate.IsSorcery -> card.typeLine.isSorcery
                 is CardPredicate.IsCreature -> card.typeLine.isCreature
@@ -657,21 +661,105 @@ class CastZoneResolver(
                 is CardPredicate.IsNonartifact -> !card.typeLine.isArtifact
                 is CardPredicate.IsLand -> card.typeLine.isLand
                 is CardPredicate.IsNonland -> !card.typeLine.isLand
+                is CardPredicate.IsPlaneswalker -> card.isPlaneswalker
                 is CardPredicate.IsPermanent -> card.typeLine.isPermanent
-                // Subtype gating — required for e.g. "Dinosaur creature spells" (Intrepid
-                // Paleontologist). Without these branches a subtype filter silently matched
-                // every card via the conservative `else`.
+                is CardPredicate.IsBasicLand -> card.typeLine.isBasicLand
+                is CardPredicate.HasAdventure -> card.hasAdventure
+                // --- Supertypes ---
+                is CardPredicate.IsLegendary -> card.typeLine.isLegendary
+                is CardPredicate.IsNonlegendary -> !card.typeLine.isLegendary
+                // --- Colors ---
+                is CardPredicate.HasColor -> predicate.color in card.colors
+                is CardPredicate.NotColor -> predicate.color !in card.colors
+                is CardPredicate.IsColorless -> card.colors.isEmpty()
+                is CardPredicate.IsColored -> card.colors.isNotEmpty()
+                is CardPredicate.IsMulticolored -> card.colors.size >= 2
+                is CardPredicate.IsMonocolored -> card.colors.size == 1
+                // --- Subtypes ---
                 is CardPredicate.HasSubtype -> card.typeLine.hasSubtype(predicate.subtype)
                 is CardPredicate.HasAnyOfSubtypes ->
                     predicate.subtypes.any { card.typeLine.hasSubtype(it) }
                 is CardPredicate.NotSubtype -> !card.typeLine.hasSubtype(predicate.subtype)
-                is CardPredicate.ManaValueAtLeast -> card.manaCost.cmc >= predicate.min
-                is CardPredicate.ManaValueAtMost -> card.manaCost.cmc <= predicate.max
-                is CardPredicate.ManaValueEquals -> card.manaCost.cmc == predicate.value
+                is CardPredicate.HasBasicLandType ->
+                    card.typeLine.hasSubtype(com.wingedsheep.sdk.core.Subtype(predicate.landType))
+                // --- Name / origin ---
+                is CardPredicate.NameEquals -> card.name == predicate.name
+                is CardPredicate.OriginallyPrintedInSet ->
+                    card.originalSetCode?.equals(predicate.setCode, ignoreCase = true) == true
+                // --- Keywords ---
+                is CardPredicate.HasKeyword -> predicate.keyword in card.baseKeywords
+                is CardPredicate.NotKeyword -> predicate.keyword !in card.baseKeywords
+                // --- Mana value ---
+                is CardPredicate.ManaValueEquals -> cmc == predicate.value
+                is CardPredicate.ManaValueAtMost -> cmc <= predicate.max
+                is CardPredicate.ManaValueAtLeast -> cmc >= predicate.min
+                is CardPredicate.ManaValueIsEven -> cmc % 2 == 0
+                is CardPredicate.ManaValueIsOdd -> cmc % 2 != 0
+                is CardPredicate.HasXInManaCost -> card.manaCost.hasX
+                // --- Power / toughness (null base P/T — e.g. */noncreature — never matches) ---
+                is CardPredicate.PowerEquals -> power == predicate.value
+                is CardPredicate.PowerAtMost -> power != null && power <= predicate.max
+                is CardPredicate.PowerAtLeast -> power != null && power >= predicate.min
+                is CardPredicate.ToughnessEquals -> toughness == predicate.value
+                is CardPredicate.ToughnessAtMost -> toughness != null && toughness <= predicate.max
+                is CardPredicate.ToughnessAtLeast -> toughness != null && toughness >= predicate.min
+                is CardPredicate.PowerOrToughnessAtLeast ->
+                    (power != null && power >= predicate.min) || (toughness != null && toughness >= predicate.min)
+                is CardPredicate.PowerOrToughnessAtMost ->
+                    (power != null && power <= predicate.max) || (toughness != null && toughness <= predicate.max)
+                is CardPredicate.TotalPowerAndToughnessAtMost ->
+                    power != null && toughness != null && power + toughness <= predicate.max
+                is CardPredicate.ToughnessGreaterThanPower ->
+                    power != null && toughness != null && toughness > power
+                // --- Intrinsic activated abilities (precomputed flags) ---
+                is CardPredicate.HasActivatedAbility -> card.hasActivatedAbility
+                is CardPredicate.HasNonManaActivatedAbility -> card.hasNonManaActivatedAbility
+                // --- Combinators ---
                 is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(card, it) }
                 is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(card, it) }
                 is CardPredicate.Not -> !matchesCardPredicate(card, predicate.predicate)
-                else -> true // Conservative: allow unknown predicates
+                // Predicates that can't be judged from a card's static characteristics alone —
+                // they need runtime/interaction context (a chosen value, another entity, X, a
+                // pipeline variable/stored group, the recipient/source of an effect), or describe
+                // a stack ability rather than a castable card. No cast-from-zone filter uses them,
+                // and matching a condition we can't verify would silently widen the grant, so they
+                // fail closed. This `when` is exhaustive: adding a CardPredicate forces a decision
+                // here rather than leaking through a permissive `else`.
+                is CardPredicate.IsToken,
+                is CardPredicate.IsNontoken,
+                is CardPredicate.HasChosenColor,
+                is CardPredicate.HasChosenSubtype,
+                is CardPredicate.SharesChosenColorWithSource,
+                is CardPredicate.NameEqualsChosen,
+                is CardPredicate.NameEqualsChosenComponent,
+                is CardPredicate.NameNotSharedWithControlledRoom,
+                is CardPredicate.ManaValueEqualsX,
+                is CardPredicate.ManaValueAtMostX,
+                is CardPredicate.ManaValueAtMostEntity,
+                is CardPredicate.ManaValueAtMostEntityManaSpent,
+                is CardPredicate.ManaValueAtMostColorsSpent,
+                is CardPredicate.ManaValueAtMostDynamic,
+                is CardPredicate.PowerEqualsX,
+                is CardPredicate.ToughnessAtMostX,
+                is CardPredicate.PowerAtMostEntity,
+                is CardPredicate.PowerGreaterThanEntity,
+                is CardPredicate.PowerLessThanEntity,
+                is CardPredicate.HasSubtypeFromVariable,
+                is CardPredicate.HasSubtypeInStoredList,
+                is CardPredicate.HasSubtypeInEachStoredGroup,
+                is CardPredicate.NotOfSourceChosenType,
+                is CardPredicate.SharesCreatureTypeWithSource,
+                is CardPredicate.SharesCreatureTypeWithTriggeringEntity,
+                is CardPredicate.SharesCreatureTypeWith,
+                is CardPredicate.SharesColorWith,
+                is CardPredicate.SharesColorWithRecipient,
+                is CardPredicate.SharesColorWithPermanentYouControl,
+                is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
+                is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl,
+                is CardPredicate.TargetsMatching,
+                is CardPredicate.IsActivatedOrTriggeredAbility,
+                is CardPredicate.IsTriggeredAbility,
+                is CardPredicate.IsActivatedAbility -> false
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -650,9 +650,21 @@ class CastZoneResolver(
                 is CardPredicate.IsInstant -> card.typeLine.isInstant
                 is CardPredicate.IsSorcery -> card.typeLine.isSorcery
                 is CardPredicate.IsCreature -> card.typeLine.isCreature
+                is CardPredicate.IsNoncreature -> !card.typeLine.isCreature
                 is CardPredicate.IsEnchantment -> card.typeLine.isEnchantment
+                is CardPredicate.IsNonenchantment -> !card.typeLine.isEnchantment
                 is CardPredicate.IsArtifact -> card.typeLine.isArtifact
+                is CardPredicate.IsNonartifact -> !card.typeLine.isArtifact
                 is CardPredicate.IsLand -> card.typeLine.isLand
+                is CardPredicate.IsNonland -> !card.typeLine.isLand
+                is CardPredicate.IsPermanent -> card.typeLine.isPermanent
+                // Subtype gating — required for e.g. "Dinosaur creature spells" (Intrepid
+                // Paleontologist). Without these branches a subtype filter silently matched
+                // every card via the conservative `else`.
+                is CardPredicate.HasSubtype -> card.typeLine.hasSubtype(predicate.subtype)
+                is CardPredicate.HasAnyOfSubtypes ->
+                    predicate.subtypes.any { card.typeLine.hasSubtype(it) }
+                is CardPredicate.NotSubtype -> !card.typeLine.hasSubtype(predicate.subtype)
                 is CardPredicate.ManaValueAtLeast -> card.manaCost.cmc >= predicate.min
                 is CardPredicate.ManaValueAtMost -> card.manaCost.cmc <= predicate.max
                 is CardPredicate.ManaValueEquals -> card.manaCost.cmc == predicate.value

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -223,6 +223,63 @@ class ModalAndCloneContinuationResumer(
     }
 
     /**
+     * Apply an `EntersAsCopy` copy onto [entityId] in place (CR 707.2): overwrite its
+     * [CardComponent] with [targetCardComponent]'s copiable characteristics (re-homed to [newOwnerId]),
+     * add any [additionalSubtypes] / [additionalKeywords] and name / P-T overrides, and snapshot a
+     * [com.wingedsheep.engine.state.components.identity.CopyOfComponent] so the permanent reverts to
+     * its printed identity when it leaves the battlefield (CR 400.7 / 707.2).
+     *
+     * Shared by both copy-enters paths — the spell resolution ([resumeCloneEnters], where the entity
+     * is still a spell on the stack) and the already-on-battlefield direct entry
+     * ([resumeCloneEntersOnBattlefield], a land played / token). Returns the updated state; callers
+     * read the copied [CardComponent] back off it.
+     */
+    private fun applyCopyToEntity(
+        state: GameState,
+        entityId: EntityId,
+        originalCardComponent: CardComponent,
+        targetCardComponent: CardComponent,
+        newOwnerId: EntityId?,
+        additionalSubtypes: List<String>,
+        additionalKeywords: List<com.wingedsheep.sdk.core.Keyword>,
+        nameOverride: String?,
+        powerOverride: Int?,
+        toughnessOverride: Int?,
+    ): GameState {
+        var copiedCardComponent = targetCardComponent.copy(ownerId = newOwnerId)
+        if (additionalSubtypes.isNotEmpty()) {
+            val newSubtypes = copiedCardComponent.typeLine.subtypes +
+                additionalSubtypes.map { com.wingedsheep.sdk.core.Subtype(it) }
+            copiedCardComponent = copiedCardComponent.copy(
+                typeLine = copiedCardComponent.typeLine.copy(subtypes = newSubtypes)
+            )
+        }
+        if (additionalKeywords.isNotEmpty()) {
+            copiedCardComponent = copiedCardComponent.copy(
+                baseKeywords = copiedCardComponent.baseKeywords + additionalKeywords
+            )
+        }
+        if (nameOverride != null) {
+            copiedCardComponent = copiedCardComponent.copy(name = nameOverride)
+        }
+        if (powerOverride != null || toughnessOverride != null) {
+            val basePower = powerOverride ?: copiedCardComponent.baseStats?.basePower ?: 0
+            val baseToughness = toughnessOverride ?: copiedCardComponent.baseStats?.baseToughness ?: 0
+            copiedCardComponent = copiedCardComponent.copy(
+                baseStats = com.wingedsheep.sdk.model.CreatureStats(basePower, baseToughness)
+            )
+        }
+        return state.updateEntity(entityId) { c ->
+            c.with(copiedCardComponent)
+                .with(com.wingedsheep.engine.state.components.identity.CopyOfComponent(
+                    originalCardDefinitionId = originalCardComponent.cardDefinitionId,
+                    copiedCardDefinitionId = targetCardComponent.cardDefinitionId,
+                    originalCardComponent = originalCardComponent
+                ))
+        }
+    }
+
+    /**
      * Resume after player selects a creature to copy for Clone-style effects.
      */
     fun resumeCloneEnters(
@@ -262,49 +319,21 @@ class ModalAndCloneContinuationResumer(
 
             if (targetCardComponent != null) {
                 copyApplied = true
-                // Create a copy of the target's CardComponent, keeping Clone's ownerId
-                // Apply additional subtypes and keywords if specified (e.g., Mockingbird adds Bird + flying)
-                var copiedCardComponent = targetCardComponent.copy(
-                    ownerId = ownerId
+                // Copy the target's copiable characteristics onto the spell (keeping Clone's own
+                // ownerId), plus any Mockingbird/Superior-Spider-Man overrides — shared with the
+                // land-copy path via applyCopyToEntity.
+                newState = applyCopyToEntity(
+                    state = newState,
+                    entityId = spellId,
+                    originalCardComponent = originalCardComponent,
+                    targetCardComponent = targetCardComponent,
+                    newOwnerId = ownerId,
+                    additionalSubtypes = continuation.additionalSubtypes,
+                    additionalKeywords = continuation.additionalKeywords,
+                    nameOverride = continuation.nameOverride,
+                    powerOverride = continuation.powerOverride,
+                    toughnessOverride = continuation.toughnessOverride,
                 )
-                if (continuation.additionalSubtypes.isNotEmpty()) {
-                    val newSubtypes = copiedCardComponent.typeLine.subtypes +
-                        continuation.additionalSubtypes.map { com.wingedsheep.sdk.core.Subtype(it) }
-                    copiedCardComponent = copiedCardComponent.copy(
-                        typeLine = copiedCardComponent.typeLine.copy(subtypes = newSubtypes)
-                    )
-                }
-                if (continuation.additionalKeywords.isNotEmpty()) {
-                    copiedCardComponent = copiedCardComponent.copy(
-                        baseKeywords = copiedCardComponent.baseKeywords + continuation.additionalKeywords
-                    )
-                }
-                // Name override (e.g., Superior Spider-Man keeps his own name)
-                if (continuation.nameOverride != null) {
-                    copiedCardComponent = copiedCardComponent.copy(name = continuation.nameOverride)
-                }
-                // Power/toughness override (e.g., Superior Spider-Man is always 4/4)
-                if (continuation.powerOverride != null || continuation.toughnessOverride != null) {
-                    val basePower = continuation.powerOverride
-                        ?: copiedCardComponent.baseStats?.basePower ?: 0
-                    val baseToughness = continuation.toughnessOverride
-                        ?: copiedCardComponent.baseStats?.baseToughness ?: 0
-                    copiedCardComponent = copiedCardComponent.copy(
-                        baseStats = com.wingedsheep.sdk.model.CreatureStats(basePower, baseToughness)
-                    )
-                }
-
-                // Update entity with copied card component and copy tracking.
-                // Snapshot the pre-copy CardComponent so the permanent reverts to its
-                // printed identity when it leaves the battlefield (CR 400.7 / 707.2).
-                newState = newState.updateEntity(spellId) { c ->
-                    c.with(copiedCardComponent)
-                        .with(com.wingedsheep.engine.state.components.identity.CopyOfComponent(
-                            originalCardDefinitionId = originalCardComponent.cardDefinitionId,
-                            copiedCardDefinitionId = targetCardComponent.cardDefinitionId,
-                            originalCardComponent = originalCardComponent
-                        ))
-                }
 
                 // Look up the card definition for the copied creature
                 copiedCardDef = services.cardRegistry.getCard(targetCardComponent.cardDefinitionId)
@@ -389,43 +418,20 @@ class ModalAndCloneContinuationResumer(
             val targetCardComponent = newState.getEntity(selectedId)?.get<CardComponent>()
             if (targetCardComponent != null) {
                 copyApplied = true
-                // Copy the chosen object's copiable characteristics (CR 707.2), keeping this
-                // permanent's own owner. Apply additional subtypes/keywords and overrides.
-                var copiedCardComponent = targetCardComponent.copy(ownerId = originalCardComponent.ownerId)
-                if (continuation.additionalSubtypes.isNotEmpty()) {
-                    val newSubtypes = copiedCardComponent.typeLine.subtypes +
-                        continuation.additionalSubtypes.map { com.wingedsheep.sdk.core.Subtype(it) }
-                    copiedCardComponent = copiedCardComponent.copy(
-                        typeLine = copiedCardComponent.typeLine.copy(subtypes = newSubtypes)
-                    )
-                }
-                if (continuation.additionalKeywords.isNotEmpty()) {
-                    copiedCardComponent = copiedCardComponent.copy(
-                        baseKeywords = copiedCardComponent.baseKeywords + continuation.additionalKeywords
-                    )
-                }
-                if (continuation.nameOverride != null) {
-                    copiedCardComponent = copiedCardComponent.copy(name = continuation.nameOverride)
-                }
-                if (continuation.powerOverride != null || continuation.toughnessOverride != null) {
-                    val basePower = continuation.powerOverride
-                        ?: copiedCardComponent.baseStats?.basePower ?: 0
-                    val baseToughness = continuation.toughnessOverride
-                        ?: copiedCardComponent.baseStats?.baseToughness ?: 0
-                    copiedCardComponent = copiedCardComponent.copy(
-                        baseStats = com.wingedsheep.sdk.model.CreatureStats(basePower, baseToughness)
-                    )
-                }
-                // Snapshot the pre-copy CardComponent so the permanent reverts to its printed
-                // identity when it leaves the battlefield (CR 400.7 / 707.2).
-                newState = newState.updateEntity(entityId) { c ->
-                    c.with(copiedCardComponent)
-                        .with(com.wingedsheep.engine.state.components.identity.CopyOfComponent(
-                            originalCardDefinitionId = originalCardComponent.cardDefinitionId,
-                            copiedCardDefinitionId = targetCardComponent.cardDefinitionId,
-                            originalCardComponent = originalCardComponent
-                        ))
-                }
+                // Copy the chosen object's copiable characteristics (CR 707.2) onto this permanent,
+                // keeping its own owner — shared with the spell-resolution path via applyCopyToEntity.
+                newState = applyCopyToEntity(
+                    state = newState,
+                    entityId = entityId,
+                    originalCardComponent = originalCardComponent,
+                    targetCardComponent = targetCardComponent,
+                    newOwnerId = originalCardComponent.ownerId,
+                    additionalSubtypes = continuation.additionalSubtypes,
+                    additionalKeywords = continuation.additionalKeywords,
+                    nameOverride = continuation.nameOverride,
+                    powerOverride = continuation.powerOverride,
+                    toughnessOverride = continuation.toughnessOverride,
+                )
             }
         }
 
@@ -449,8 +455,10 @@ class ModalAndCloneContinuationResumer(
             originalCardComponent.name
         } else null
 
-        // Fire any ETB triggers off a synthesized entry event now that the final (copied) identity
-        // is in place, mirroring resumeEntersWithChoiceOnBattlefield.
+        // Emit the entry event now that the final (copied) identity is in place — this is the
+        // single ZoneChangeEvent the client sees for this land play (PlayLandHandler deliberately
+        // does not carry one), so it carries the copied name and `copyOfOriginalName`. It also
+        // drives ETB triggers (landfall / "when ~ enters"), mirroring resumeCloneEnters.
         val zoneChangeEvent = ZoneChangeEvent(
             entityId,
             finalCardComponent.name,
@@ -466,13 +474,13 @@ class ModalAndCloneContinuationResumer(
                 return ExecutionResult.paused(
                     triggerResult.state,
                     triggerResult.pendingDecision!!,
-                    outEvents + triggerResult.events
+                    outEvents + zoneChangeEvent + triggerResult.events
                 )
             }
-            return checkForMore(triggerResult.newState, outEvents + triggerResult.events)
+            return checkForMore(triggerResult.newState, outEvents + zoneChangeEvent + triggerResult.events)
         }
 
-        return checkForMore(newState, outEvents)
+        return checkForMore(newState, outEvents + zoneChangeEvent)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -24,6 +24,7 @@ class ModalAndCloneContinuationResumer(
         resumer(ModalContinuation::class, ::resumeModal),
         resumer(ModalTargetContinuation::class, ::resumeModalTarget),
         resumer(CloneEntersContinuation::class, ::resumeCloneEnters),
+        resumer(CloneEntersOnBattlefieldContinuation::class, ::resumeCloneEntersOnBattlefield),
         resumer(EntersWithChoiceSpellContinuation::class, ::resumeEntersWithChoiceSpell),
         resumer(EntersWithChoiceOnBattlefieldContinuation::class, ::resumeEntersWithChoiceOnBattlefield),
         resumer(PayLifeOrEnterTappedLandContinuation::class, ::resumePayLifeOrEnterTappedLand),
@@ -353,6 +354,125 @@ class ModalAndCloneContinuationResumer(
         }
 
         return checkForMore(newState, events)
+    }
+
+    /**
+     * Resume after a player chooses (or declines) a card/permanent to copy for an
+     * [com.wingedsheep.sdk.scripting.EntersAsCopy] replacement on a permanent that has already been
+     * placed on the battlefield **directly** (a land played — Echoing Deeps / Vesuva / Thespian's
+     * Stage — or a token). Unlike [resumeCloneEnters], the entity is already a battlefield permanent,
+     * so we copy onto it in place, tap it if [CloneEntersOnBattlefieldContinuation.tappedIfCopied]
+     * and a copy was made, then fire the entry's ETB triggers off a synthesized [ZoneChangeEvent].
+     */
+    fun resumeCloneEntersOnBattlefield(
+        state: GameState,
+        continuation: CloneEntersOnBattlefieldContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card selection response for clone-enters-on-battlefield")
+        }
+
+        val entityId = continuation.entityId
+        val entityContainer = state.getEntity(entityId)
+            ?: return ExecutionResult.error(state, "Clone-enters entity not found: $entityId")
+        val originalCardComponent = entityContainer.get<CardComponent>()
+            ?: return ExecutionResult.error(state, "Clone-enters entity has no CardComponent")
+
+        var newState = state
+        var copyApplied = false
+        val outEvents = mutableListOf<GameEvent>()
+        val selectedId = response.selectedCards.firstOrNull()
+
+        if (selectedId != null) {
+            val targetCardComponent = newState.getEntity(selectedId)?.get<CardComponent>()
+            if (targetCardComponent != null) {
+                copyApplied = true
+                // Copy the chosen object's copiable characteristics (CR 707.2), keeping this
+                // permanent's own owner. Apply additional subtypes/keywords and overrides.
+                var copiedCardComponent = targetCardComponent.copy(ownerId = originalCardComponent.ownerId)
+                if (continuation.additionalSubtypes.isNotEmpty()) {
+                    val newSubtypes = copiedCardComponent.typeLine.subtypes +
+                        continuation.additionalSubtypes.map { com.wingedsheep.sdk.core.Subtype(it) }
+                    copiedCardComponent = copiedCardComponent.copy(
+                        typeLine = copiedCardComponent.typeLine.copy(subtypes = newSubtypes)
+                    )
+                }
+                if (continuation.additionalKeywords.isNotEmpty()) {
+                    copiedCardComponent = copiedCardComponent.copy(
+                        baseKeywords = copiedCardComponent.baseKeywords + continuation.additionalKeywords
+                    )
+                }
+                if (continuation.nameOverride != null) {
+                    copiedCardComponent = copiedCardComponent.copy(name = continuation.nameOverride)
+                }
+                if (continuation.powerOverride != null || continuation.toughnessOverride != null) {
+                    val basePower = continuation.powerOverride
+                        ?: copiedCardComponent.baseStats?.basePower ?: 0
+                    val baseToughness = continuation.toughnessOverride
+                        ?: copiedCardComponent.baseStats?.baseToughness ?: 0
+                    copiedCardComponent = copiedCardComponent.copy(
+                        baseStats = com.wingedsheep.sdk.model.CreatureStats(basePower, baseToughness)
+                    )
+                }
+                // Snapshot the pre-copy CardComponent so the permanent reverts to its printed
+                // identity when it leaves the battlefield (CR 400.7 / 707.2).
+                newState = newState.updateEntity(entityId) { c ->
+                    c.with(copiedCardComponent)
+                        .with(com.wingedsheep.engine.state.components.identity.CopyOfComponent(
+                            originalCardDefinitionId = originalCardComponent.cardDefinitionId,
+                            copiedCardDefinitionId = targetCardComponent.cardDefinitionId,
+                            originalCardComponent = originalCardComponent
+                        ))
+                }
+            }
+        }
+
+        // "enter tapped as a copy" — only tap when a copy was actually made.
+        if (copyApplied && continuation.tappedIfCopied) {
+            newState = newState.updateEntity(entityId) { c ->
+                c.with(com.wingedsheep.engine.state.components.battlefield.TappedComponent)
+            }
+        }
+
+        // "When you do, exile that card." (graveyard copies) — exile the copied card afterward.
+        if (copyApplied && continuation.exileCopiedCard && selectedId != null) {
+            val exileResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                .moveToZone(newState, selectedId, Zone.EXILE)
+            newState = exileResult.state
+            outEvents.addAll(exileResult.events)
+        }
+
+        val finalCardComponent = newState.getEntity(entityId)?.get<CardComponent>() ?: originalCardComponent
+        val copyOfOriginalName = if (copyApplied && finalCardComponent.name != originalCardComponent.name) {
+            originalCardComponent.name
+        } else null
+
+        // Fire any ETB triggers off a synthesized entry event now that the final (copied) identity
+        // is in place, mirroring resumeEntersWithChoiceOnBattlefield.
+        val zoneChangeEvent = ZoneChangeEvent(
+            entityId,
+            finalCardComponent.name,
+            continuation.fromZone,
+            Zone.BATTLEFIELD,
+            continuation.controllerId,
+            copyOfOriginalName = copyOfOriginalName
+        )
+        val triggers = services.triggerDetector.detectTriggers(newState, listOf(zoneChangeEvent))
+        if (triggers.isNotEmpty()) {
+            val triggerResult = services.triggerProcessor.processTriggers(newState, triggers)
+            if (triggerResult.isPaused) {
+                return ExecutionResult.paused(
+                    triggerResult.state,
+                    triggerResult.pendingDecision!!,
+                    outEvents + triggerResult.events
+                )
+            }
+            return checkForMore(triggerResult.newState, outEvents + triggerResult.events)
+        }
+
+        return checkForMore(newState, outEvents)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -6,12 +6,15 @@ import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.ContinuationFrame
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.CloneEntersOnBattlefieldContinuation
 import com.wingedsheep.engine.core.EntersWithChoiceOnBattlefieldContinuation
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.OptionMetadata
 import com.wingedsheep.engine.core.PendingDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
@@ -19,6 +22,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.sdk.scripting.EntersWithChoice
 import com.wingedsheep.sdk.scripting.references.Player
 
@@ -45,6 +49,100 @@ import com.wingedsheep.sdk.scripting.references.Player
  * [carryEvents], or the triggers fire twice.
  */
 object PermanentEntryReplacements {
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * Copy candidates for an [EntersAsCopy] on a permanent already on the battlefield: land/permanent
+     * cards in graveyards ([Zone.GRAVEYARD]) or permanents on the battlefield matching
+     * [EntersAsCopy.copyFilter], excluding [entityId] itself. Exposed so callers (e.g.
+     * `PlayLandHandler`) can guard resource consumption before committing to a pause.
+     */
+    fun entersAsCopyCandidates(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        effect: EntersAsCopy,
+    ): List<EntityId> {
+        val pool = if (effect.copyFromZone == Zone.GRAVEYARD) {
+            state.turnOrder.flatMap { state.getGraveyard(it) }
+        } else {
+            state.getBattlefield()
+        }
+        return pool.filter { candidateId ->
+            candidateId != entityId &&
+                predicateEvaluator.matches(
+                    state, state.projectedState, candidateId, effect.copyFilter,
+                    PredicateContext(controllerId = controllerId)
+                )
+        }
+    }
+
+    /**
+     * Build the paused [ExecutionResult] for a permanent's [EntersAsCopy] replacement (CR 707.2) on
+     * a permanent already placed on the battlefield **directly** — a land played (Echoing Deeps /
+     * Vesuva / Thespian's Stage) or a token/put-onto-battlefield permanent. The spell-resolution
+     * path keeps its own pre-battlefield variant
+     * ([com.wingedsheep.engine.mechanics.stack.StackResolver.resolvePermanentSpell]) because there
+     * the entity is still on the stack.
+     *
+     * Gathers copy candidates — land/permanent cards in graveyards ([Zone.GRAVEYARD]) or permanents
+     * on the battlefield — matching [EntersAsCopy.copyFilter], excluding the entering permanent
+     * itself, then pauses for a [SelectCardsDecision] (min 0 when [EntersAsCopy.optional], so "may"
+     * declines are expressible). [CloneEntersOnBattlefieldContinuation]'s resumer applies the copy,
+     * taps if [EntersAsCopy.tappedIfCopied], and fires the entry's ETB triggers.
+     *
+     * @return a paused [ExecutionResult], or `null` if there are no candidates to copy — the caller
+     *   then completes entry normally (the permanent stays its printed self).
+     */
+    fun pauseForEntersAsCopy(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        cardComponent: CardComponent,
+        effect: EntersAsCopy,
+        fromZone: Zone?,
+        carryEvents: List<GameEvent> = emptyList(),
+    ): ExecutionResult? {
+        val copyFromGraveyard = effect.copyFromZone == Zone.GRAVEYARD
+        val candidates = entersAsCopyCandidates(state, entityId, controllerId, effect)
+        if (candidates.isEmpty()) return null
+
+        val filterDesc = effect.copyFilter.description
+        val whereDesc = if (copyFromGraveyard) "$filterDesc card in a graveyard" else filterDesc
+        val decisionId = "clone-enters-bf-${entityId.value}"
+        val decision = SelectCardsDecision(
+            id = decisionId,
+            playerId = controllerId,
+            prompt = if (effect.optional) "You may choose a $whereDesc to copy" else "Choose a $whereDesc to copy",
+            context = DecisionContext(
+                sourceId = entityId,
+                sourceName = cardComponent.name,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = candidates,
+            minSelections = if (effect.optional) 0 else 1,
+            maxSelections = 1,
+            // Battlefield copies click permanents in-place; graveyard copies use the modal
+            // card-list overlay (graveyards aren't on the battlefield).
+            useTargetingUI = !copyFromGraveyard
+        )
+        val continuation = CloneEntersOnBattlefieldContinuation(
+            decisionId = decisionId,
+            entityId = entityId,
+            controllerId = controllerId,
+            fromZone = fromZone,
+            additionalSubtypes = effect.additionalSubtypes,
+            additionalKeywords = effect.additionalKeywords,
+            nameOverride = effect.nameOverride,
+            powerOverride = effect.powerOverride,
+            toughnessOverride = effect.toughnessOverride,
+            exileCopiedCard = effect.exileCopiedCard,
+            tappedIfCopied = effect.tappedIfCopied,
+        )
+        val paused = state.pushContinuation(continuation).withPendingDecision(decision)
+        return ExecutionResult.paused(paused, decision, carryEvents)
+    }
 
     /**
      * Build the paused [ExecutionResult] for a permanent's first/next [EntersWithChoice].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -36,7 +36,6 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.MayCastFromGraveyard
 import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
-import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.WarpGrants
@@ -742,16 +741,12 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 // Mana-value cap (Maralen)
                 if (maxManaValueCap != null && exiledCard.manaCost.cmc > maxManaValueCap) continue
 
-                // Check filter (e.g., nonland)
-                val passesFilter = grantAbility.filter.cardPredicates.all { pred ->
-                    when (pred) {
-                        is CardPredicate.IsNonland -> !exiledCard.typeLine.isLand
-                        is CardPredicate.IsCreature -> exiledCard.typeLine.isCreature
-                        is CardPredicate.IsArtifact -> exiledCard.typeLine.isArtifact
-                        is CardPredicate.IsNonartifact -> !exiledCard.typeLine.isArtifact
-                        else -> true
-                    }
-                }
+                // Check filter (e.g., nonland, or "Dinosaur creature" for Intrepid
+                // Paleontologist). Delegate to the shared matcher so legal-action
+                // enumeration and cast-time validation (CastZoneResolver.matchesCardFilter)
+                // agree on subtype/type gating.
+                val passesFilter = com.wingedsheep.engine.handlers.actions.spell.CastZoneResolver
+                    .matchesCardFilter(exiledCard, grantAbility.filter)
                 if (!passesFilter) continue
 
                 // Verify card is actually in exile

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/LandManaColorInspector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/LandManaColorInspector.kt
@@ -140,6 +140,7 @@ object LandManaColorInspector {
             is ManaColorSet.CommanderIdentity,
             is ManaColorSet.AmongPermanents,
             is ManaColorSet.AmongCardsInGraveyard,
+            is ManaColorSet.AmongLinkedExiledCards,
             is ManaColorSet.LandsCouldProduce -> out.addAll(Color.entries)
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaColorSetResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaColorSetResolver.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.CommanderRegistryComponent
 import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.values.LandControllerScope
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
@@ -156,9 +155,13 @@ object ManaColorSetResolver {
         val exiledIds = source.get<LinkedExileComponent>()?.exiledIds ?: return emptySet()
         val colors = mutableSetOf<Color>()
         for (id in exiledIds) {
-            val stillInExile = state.zones.any { (zone, cards) -> zone.zoneType == Zone.EXILE && id in cards }
-            if (!stillInExile) continue
-            colors.addAll(state.getEntity(id)?.get<CardComponent>()?.colors.orEmpty())
+            // An exiled card lives in its owner's exile zone (ZoneTransitionService keys every
+            // non-battlefield zone by owner), so a direct membership check confirms it's still
+            // exiled — a card that has since left exile drops out of the color pool.
+            val card = state.getEntity(id)?.get<CardComponent>() ?: continue
+            val ownerId = card.ownerId ?: continue
+            if (id !in state.getExile(ownerId)) continue
+            colors.addAll(card.colors)
         }
         return colors
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaColorSetResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaColorSetResolver.kt
@@ -6,9 +6,11 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.CommanderRegistryComponent
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.values.LandControllerScope
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
@@ -51,6 +53,7 @@ object ManaColorSetResolver {
         is ManaColorSet.AmongCardsInGraveyard -> amongCardsInGraveyard(colorSet, state, projected, controllerId)
         is ManaColorSet.LandsCouldProduce -> landsCouldProduce(colorSet, state, projected, controllerId, cardRegistry)
         is ManaColorSet.SourceChosenColor -> sourceChosenColor(state, sourceId)
+        is ManaColorSet.AmongLinkedExiledCards -> amongLinkedExiledCards(state, sourceId)
     }
 
     /**
@@ -136,5 +139,27 @@ object ManaColorSetResolver {
     private fun sourceChosenColor(state: GameState, sourceId: EntityId?): Set<Color> {
         val source = sourceId?.let { state.getEntity(it) } ?: return emptySet()
         return setOfNotNull(source.chosenColor())
+    }
+
+    /**
+     * Union of the base colors of the cards currently exiled with the source permanent.
+     *
+     * The candidate ids come from the source's [LinkedExileComponent] (stamped by
+     * `MoveToZoneEffect(linkToSource = true)`); each is counted only while it is *still in the
+     * exile zone* — a card that has since left exile is no longer "exiled with" the source, so it
+     * drops out of the color pool (matching the still-in-exile filter used by the linked-exile
+     * return executors). Colors are read from each card's base [CardComponent.colors]; exile-zone
+     * cards aren't projected. Colorless-only or empty piles yield an empty set → no mana produced.
+     */
+    private fun amongLinkedExiledCards(state: GameState, sourceId: EntityId?): Set<Color> {
+        val source = sourceId?.let { state.getEntity(it) } ?: return emptySet()
+        val exiledIds = source.get<LinkedExileComponent>()?.exiledIds ?: return emptySet()
+        val colors = mutableSetOf<Color>()
+        for (id in exiledIds) {
+            val stillInExile = state.zones.any { (zone, cards) -> zone.zoneType == Zone.EXILE && id in cards }
+            if (!stillInExile) continue
+            colors.addAll(state.getEntity(id)?.get<CardComponent>()?.colors.orEmpty())
+        }
+        return colors
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchoingDeepsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchoingDeepsScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Echoing Deeps (LCI #271) — Land — Cave
+ * "You may have this land enter tapped as a copy of any land card in a graveyard, except it's a Cave
+ *  in addition to its other types.
+ *  {T}: Add {C}."
+ *
+ * Exercises the [com.wingedsheep.sdk.scripting.EntersAsCopy] replacement wired into the direct
+ * land-play entry path, with the "enter tapped as a copy" rider (`tappedIfCopied`) and the extra
+ * "Cave" subtype. Covers: copy chosen (CR 707.2), copy declined ("may"), and no candidate present.
+ */
+class EchoingDeepsScenarioTest : ScenarioTestBase() {
+
+    private fun com.wingedsheep.engine.support.ScenarioTestBase.TestGame.handCardId(name: String) =
+        state.getHand(player1Id).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    init {
+        context("Echoing Deeps — enters as a copy of a graveyard land") {
+
+            test("choosing a graveyard land copies it, adds Cave, and enters tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Echoing Deeps")
+                    .withCardInGraveyard(1, "Island")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val deeps = game.handCardId("Echoing Deeps")
+                val played = game.execute(PlayLand(game.player1Id, deeps))
+                withClue("Playing Echoing Deeps should succeed: ${played.error}") { played.error shouldBe null }
+
+                withClue("An EntersAsCopy selection should be pending") {
+                    game.hasPendingDecision().shouldBeTrue()
+                }
+
+                // Choose the graveyard Island to copy.
+                val islandInGrave = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Island"
+                }
+                val resolved = game.selectCards(listOf(islandInGrave))
+                withClue("Resolving the copy choice should succeed: ${resolved.error}") { resolved.error shouldBe null }
+
+                val land = game.state.getBattlefield(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Island"
+                }
+                withClue("Copy took the Island's name") {
+                    game.state.getEntity(land)?.get<CardComponent>()?.name shouldBe "Island"
+                }
+                val subtypes = game.state.projectedState.getSubtypes(land)
+                withClue("Copy keeps Island's subtype and gains Cave (subtypes=$subtypes)") {
+                    subtypes.any { it.equals("Island", ignoreCase = true) }.shouldBeTrue()
+                    subtypes.any { it.equals("Cave", ignoreCase = true) }.shouldBeTrue()
+                }
+                withClue("Enters tapped when it enters as a copy") {
+                    game.state.getEntity(land)?.has<TappedComponent>()?.shouldBeTrue()
+                }
+            }
+
+            test("declining the copy enters untapped as a Cave named Echoing Deeps") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Echoing Deeps")
+                    .withCardInGraveyard(1, "Island")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val deeps = game.handCardId("Echoing Deeps")
+                game.execute(PlayLand(game.player1Id, deeps)).error shouldBe null
+                game.hasPendingDecision().shouldBeTrue()
+
+                val resolved = game.skipSelection()
+                withClue("Declining should succeed: ${resolved.error}") { resolved.error shouldBe null }
+
+                val land = game.state.getBattlefield(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Echoing Deeps"
+                }
+                withClue("Stays Echoing Deeps (its printed self)") {
+                    game.state.getEntity(land)?.get<CardComponent>()?.name shouldBe "Echoing Deeps"
+                }
+                val subtypes = game.state.projectedState.getSubtypes(land)
+                withClue("Still a Cave, not an Island (subtypes=$subtypes)") {
+                    subtypes.any { it.equals("Cave", ignoreCase = true) }.shouldBeTrue()
+                    subtypes.any { it.equals("Island", ignoreCase = true) }.shouldBeFalse()
+                }
+                withClue("Enters untapped when the copy is declined") {
+                    game.state.getEntity(land)?.has<TappedComponent>()?.shouldBeFalse()
+                }
+            }
+
+            test("no land in any graveyard enters normally with no decision") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Echoing Deeps")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val deeps = game.handCardId("Echoing Deeps")
+                val played = game.execute(PlayLand(game.player1Id, deeps))
+                withClue("Playing should succeed: ${played.error}") { played.error shouldBe null }
+                withClue("No copy candidate, so no decision is presented") {
+                    game.hasPendingDecision().shouldBeFalse()
+                }
+
+                val land = game.state.getBattlefield(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Echoing Deeps"
+                }
+                withClue("Enters untapped as its printed self") {
+                    game.state.getEntity(land)?.has<TappedComponent>()?.shouldBeFalse()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntrepidPaleontologistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntrepidPaleontologistScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.Colossadactyl
+import com.wingedsheep.mtg.sets.definitions.lci.cards.IntrepidPaleontologist
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Intrepid Paleontologist (LCI #193):
+ *   {T}: Add one mana of any color.
+ *   {2}: Exile target card from a graveyard.
+ *   You may cast Dinosaur creature spells from among cards you own exiled with this creature.
+ *   If you cast a spell this way, that creature enters with a finality counter on it.
+ *
+ * Exercises the {2} linked-exile activated ability, the Dinosaur-only cast permission
+ * (GrantMayCastFromLinkedExile with ownedByYou), and the new cast-this-way finality-counter
+ * entry rider on that grant.
+ */
+class IntrepidPaleontologistScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IntrepidPaleontologist, Colossadactyl))
+        return driver
+    }
+
+    // The {2} exile ability is the second activated ability (index 0 is the mana ability).
+    val exileAbilityId = IntrepidPaleontologist.activatedAbilities[1].id
+
+    fun linkedExileOf(driver: GameTestDriver, sourceId: EntityId): List<EntityId> =
+        driver.state.getEntity(sourceId)?.get<LinkedExileComponent>()?.exiledIds ?: emptyList()
+
+    test("{2}: Exile target card from a graveyard links it to the Paleontologist") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val paleo = driver.putCreatureOnBattlefield(you, "Intrepid Paleontologist")
+        val dino = driver.putCardInGraveyard(you, "Colossadactyl")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = paleo,
+                abilityId = exileAbilityId,
+                targets = listOf(ChosenTarget.Card(dino, ownerId = you, zone = Zone.GRAVEYARD))
+            )
+        )
+        driver.bothPass() // resolve the exile ability
+
+        driver.getGraveyard(you) shouldNotContain dino
+        driver.getExile(you) shouldContain dino
+        linkedExileOf(driver, paleo) shouldContain dino
+    }
+
+    test("A Dinosaur cast from linked exile resolves onto the battlefield with a finality counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val paleo = driver.putCreatureOnBattlefield(you, "Intrepid Paleontologist")
+        val dino = driver.putCardInGraveyard(you, "Colossadactyl")
+
+        // {2}: exile the Dinosaur, linked to the Paleontologist.
+        driver.giveMana(you, Color.GREEN, 2)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = paleo,
+                abilityId = exileAbilityId,
+                targets = listOf(ChosenTarget.Card(dino, ownerId = you, zone = Zone.GRAVEYARD))
+            )
+        )
+        driver.bothPass()
+        driver.getExile(you) shouldContain dino
+
+        // Cast Colossadactyl ({2}{G}{G}) from exile via the granted permission.
+        driver.giveMana(you, Color.GREEN, 4)
+        driver.castSpell(you, dino).isSuccess shouldBe true
+
+        // Resolve it onto the battlefield.
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        val perm = driver.findPermanent(you, "Colossadactyl")
+        perm shouldNotBe null
+        // "If you cast a spell this way, that creature enters with a finality counter on it."
+        driver.state.getEntity(perm!!)!!.get<CountersComponent>()
+            ?.getCount(CounterType.FINALITY) shouldBe 1
+        // The exile pile no longer holds it.
+        linkedExileOf(driver, paleo) shouldNotContain dino
+    }
+
+    test("A non-Dinosaur card exiled with the Paleontologist cannot be cast from exile") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val paleo = driver.putCreatureOnBattlefield(you, "Intrepid Paleontologist")
+        // Grizzly Bears is a 2/2 Bear — not a Dinosaur, so the grant's filter excludes it.
+        val bears = driver.putCardInGraveyard(you, "Grizzly Bears")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = paleo,
+                abilityId = exileAbilityId,
+                targets = listOf(ChosenTarget.Card(bears, ownerId = you, zone = Zone.GRAVEYARD))
+            )
+        )
+        driver.bothPass()
+        driver.getExile(you) shouldContain bears
+
+        // No permission to cast a non-Dinosaur from the linked exile.
+        driver.giveMana(you, Color.GREEN, 2)
+        driver.castSpell(you, bears).isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitOfOfferingsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitOfOfferingsScenarioTest.kt
@@ -1,0 +1,183 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.PitOfOfferings
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Pit of Offerings (LCI #278) — Land — Cave.
+ *
+ *   This land enters tapped.
+ *   When this land enters, exile up to three target cards from graveyards.
+ *   {T}: Add {C}.
+ *   {T}: Add one mana of any of the exiled cards' colors.
+ *
+ * Covers the new `ManaColorSet.AmongLinkedExiledCards` mana-color pool: the fourth ability
+ * offers exactly the union of the base colors of the cards still exiled *with* this land (its
+ * `LinkedExileComponent`, set by the ETB trigger's `MoveToZoneEffect(linkToSource = true)`).
+ * Edge cases: colorless-only pile, empty pile, and a card that has since left exile all shrink
+ * the pool. Plus the full ETB flow — exiling across multiple graveyards and linking the cards.
+ */
+class PitOfOfferingsScenarioTest : FunSpec({
+
+    val whiteCreature = CardDefinition.creature(
+        name = "White Test Bear",
+        manaCost = ManaCost.parse("{W}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+    )
+    val blueCreature = CardDefinition.creature(
+        name = "Blue Test Bear",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+    )
+    val colorlessCreature = CardDefinition.creature(
+        name = "Colorless Test Golem",
+        manaCost = ManaCost.parse("{2}"),
+        subtypes = setOf(Subtype("Golem")),
+        power = 2,
+        toughness = 2,
+    )
+
+    val colorAbilityId = PitOfOfferings.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(PitOfOfferings, whiteCreature, blueCreature, colorlessCreature))
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    /** Put the pit on the battlefield (untapped) with [names] exiled and linked to it. */
+    fun GameTestDriver.pitWithLinkedExile(owner: EntityId, names: List<String>): Pair<EntityId, List<EntityId>> {
+        val pit = putPermanentOnBattlefield(owner, "Pit of Offerings")
+        val exiled = names.map { putCardInExile(owner, it) }
+        replaceState(state.updateEntity(pit) { it.with(LinkedExileComponent(exiled)) })
+        return pit to exiled
+    }
+
+    test("color ability offers exactly the exiled cards' colors (pauses to choose)") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val (pit, _) = d.pitWithLinkedExile(you, listOf("White Test Bear", "Blue Test Bear"))
+
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe true
+        val decision = d.pendingDecision
+        decision.shouldBeInstanceOf<ChooseColorDecision>()
+        decision.availableColors.toSet() shouldBe setOf(Color.WHITE, Color.BLUE)
+
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.BLUE))
+        val pool = d.state.getEntity(you)?.get<ManaPoolComponent>()!!
+        pool.getAmount(Color.BLUE) shouldBe 1
+        pool.getAmount(Color.WHITE) shouldBe 0
+    }
+
+    test("single exiled color needs no choice") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val (pit, _) = d.pitWithLinkedExile(you, listOf("White Test Bear"))
+
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe false
+        d.state.getEntity(you)?.get<ManaPoolComponent>()!!.getAmount(Color.WHITE) shouldBe 1
+    }
+
+    test("colorless-only exiled cards produce no mana") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val (pit, _) = d.pitWithLinkedExile(you, listOf("Colorless Test Golem"))
+
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe false
+        val pool = d.state.getEntity(you)?.get<ManaPoolComponent>()
+        Color.entries.sumOf { pool?.getAmount(it) ?: 0 } shouldBe 0
+    }
+
+    test("no exiled cards produce no mana") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pit = d.putPermanentOnBattlefield(you, "Pit of Offerings")
+
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe false
+        val pool = d.state.getEntity(you)?.get<ManaPoolComponent>()
+        Color.entries.sumOf { pool?.getAmount(it) ?: 0 } shouldBe 0
+    }
+
+    test("a card that has left exile no longer contributes its color") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val (pit, exiled) = d.pitWithLinkedExile(you, listOf("White Test Bear", "Blue Test Bear"))
+        // The blue card leaves exile (e.g., cast/returned): still in LinkedExileComponent ids,
+        // but no longer in the exile zone → drops out of the color pool.
+        d.moveToGraveyard(exiled[1])
+
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe false // only white remains → auto-picked
+        d.state.getEntity(you)?.get<ManaPoolComponent>()!!.getAmount(Color.WHITE) shouldBe 1
+    }
+
+    test("ETB exiles up to three cards across graveyards, links them, and enters tapped") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.state.turnOrder.first { it != you }
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myCard = d.putCardInGraveyard(you, "White Test Bear")
+        val oppCard = d.putCardInGraveyard(opponent, "Blue Test Bear")
+
+        val pit = d.putCardInHand(you, "Pit of Offerings")
+        d.playLand(you, pit)
+
+        // The ETB trigger targets up to three cards from graveyards.
+        d.pendingDecision.shouldNotBeNull()
+        d.submitTargetSelection(you, listOf(myCard, oppCard))
+        while (d.stackSize > 0) d.bothPass()
+
+        // "This land enters tapped."
+        d.isTapped(pit) shouldBe true
+        // Both cards exiled and linked to the land.
+        d.getExile(you) shouldContainExactlyInAnyOrder listOf(myCard)
+        d.getExile(opponent) shouldContainExactlyInAnyOrder listOf(oppCard)
+        d.state.getEntity(pit)?.get<LinkedExileComponent>()?.exiledIds?.toSet() shouldBe
+            setOf(myCard, oppCard)
+
+        // The color ability now offers both exiled colors.
+        d.untapPermanent(pit)
+        val result = d.submit(ActivateAbility(playerId = you, sourceId = pit, abilityId = colorAbilityId))
+        result.isPaused shouldBe true
+        val decision = d.pendingDecision as ChooseColorDecision
+        decision.availableColors.toSet() shouldBe setOf(Color.WHITE, Color.BLUE)
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.WHITE))
+        d.state.getEntity(you)?.get<ManaPoolComponent>()!!.getAmount(Color.WHITE) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StarvingRevenantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StarvingRevenantScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+
+/**
+ * Starving Revenant (LCI #123) — {2}{B}{B} Creature — Spirit Horror 4/4.
+ *
+ * "When this creature enters, surveil 2. Then for each card you put on top of your library, you
+ *  draw a card and you lose 3 life.
+ *  Descend 8 — Whenever you draw a card, if there are eight or more permanent cards in your
+ *  graveyard, target opponent loses 1 life and you gain 1 life."
+ *
+ * The ETB is composed from the surveil macro (which stores the kept-on-top cards under the "toTop"
+ * pipeline collection) plus a draw and a life-loss whose amounts are driven by
+ * `DistinctEntitiesInCollections("toTop")`. The descend trigger is a "whenever you draw" trigger
+ * gated by an intervening-if on eight-or-more permanent cards in the graveyard.
+ */
+class StarvingRevenantScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Cast Starving Revenant from hand and resolve until the ETB surveil selection pauses. */
+    fun GameTestDriver.castRevenant(you: EntityId) {
+        val spell = putCardInHand(you, "Starving Revenant")
+        giveMana(you, Color.BLACK, 4)
+        castSpell(you, spell)
+        var guard = 0
+        while (guard++ < 50 && !(isPaused && pendingDecision is SelectCardsDecision)) {
+            if (!isPaused && state.stack.isNotEmpty()) bothPass() else break
+        }
+    }
+
+    /** Resolve the rest of the ETB: any top-order pause, then all triggers on the stack. */
+    fun GameTestDriver.finishResolution(you: EntityId) {
+        var guard = 0
+        while (guard++ < 50) {
+            val pd = pendingDecision
+            when {
+                isPaused && pd is ReorderLibraryDecision -> submitOrderedResponse(you, pd.cards)
+                !isPaused && state.stack.isNotEmpty() -> bothPass()
+                else -> return
+            }
+        }
+    }
+
+    test("keeping both surveiled cards on top draws two and loses six life") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.getOpponent(you)
+
+        val bottom = d.putCardOnTopOfLibrary(you, "Swamp")
+        val top = d.putCardOnTopOfLibrary(you, "Swamp")
+
+        d.castRevenant(you)
+        val select = d.pendingDecision as SelectCardsDecision
+        select.options.toSet() shouldBe setOf(top, bottom)
+
+        // Put nothing into the graveyard — keep both cards on top.
+        d.submitCardSelection(you, emptyList())
+        d.finishResolution(you)
+
+        d.isPaused shouldBe false
+        // Drew both kept cards; lost 3 life each (empty graveyard ⇒ descend does not fire).
+        d.getHand(you) shouldContainAll listOf(top, bottom)
+        d.getLifeTotal(you) shouldBe 14
+        d.getLifeTotal(opp) shouldBe 20
+    }
+
+    test("putting both surveiled cards into the graveyard draws nothing and loses no life") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.getOpponent(you)
+
+        val bottom = d.putCardOnTopOfLibrary(you, "Swamp")
+        val top = d.putCardOnTopOfLibrary(you, "Swamp")
+
+        d.castRevenant(you)
+        d.submitCardSelection(you, listOf(top, bottom))
+        d.finishResolution(you)
+
+        d.isPaused shouldBe false
+        // No card put on top ⇒ no draw, no life loss.
+        d.getGraveyard(you) shouldContainAll listOf(top, bottom)
+        d.getLifeTotal(you) shouldBe 20
+        d.getLifeTotal(opp) shouldBe 20
+    }
+
+    test("descend 8 drains once per drawn card when eight permanent cards are in the graveyard") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.getOpponent(you)
+
+        // Eight permanent cards (lands) already in the graveyard satisfies descend 8.
+        repeat(8) { d.putCardInGraveyard(you, "Swamp") }
+        d.putCardOnTopOfLibrary(you, "Swamp")
+        d.putCardOnTopOfLibrary(you, "Swamp")
+
+        d.castRevenant(you)
+        d.submitCardSelection(you, emptyList()) // keep both on top ⇒ draw two
+        d.finishResolution(you)
+
+        d.isPaused shouldBe false
+        // Two draws: lose 3 each (−6) and gain 1 each from descend (+2) ⇒ 20 − 6 + 2 = 16.
+        d.getLifeTotal(you) shouldBe 16
+        // Descend fires once per draw ⇒ opponent loses 2.
+        d.getLifeTotal(opp) shouldBe 18
+    }
+
+    test("descend 8 does not fire when fewer than eight permanent cards are in the graveyard") {
+        val d = driver()
+        val you = d.player1
+        val opp = d.getOpponent(you)
+
+        // Only seven permanent cards in the graveyard — below the descend-8 threshold.
+        repeat(7) { d.putCardInGraveyard(you, "Swamp") }
+        d.putCardOnTopOfLibrary(you, "Swamp")
+        d.putCardOnTopOfLibrary(you, "Swamp")
+
+        d.castRevenant(you)
+        d.submitCardSelection(you, emptyList()) // keep both on top ⇒ draw two
+        d.finishResolution(you)
+
+        d.isPaused shouldBe false
+        // Two draws lose 6 life; descend never fires (7 < 8), so no life swing.
+        d.getLifeTotal(you) shouldBe 14
+        d.getLifeTotal(opp) shouldBe 20
+    }
+})


### PR DESCRIPTION
## LCI graveyard-caves batch — four cards + engine support

Implements four Lost Caverns of Ixalan cards (LCI 269 → 273 / 286) sharing a graveyard/exile
and Caves theme, plus the engine/SDK primitives they need. Each card has a scenario test; a
manual self-play scenario bundles all four.

### Cards

- **Starving Revenant** (#123) — `{2}{B}{B}` 4/4. ETB surveil-2-then-draw-per-kept + Descend 8
  draw drain. **Composed entirely from existing primitives** — no new SDK type (Surveil →
  `DistinctEntitiesInCollections("toTop")` driving the draw and `Multiply(...,3)` life loss; a
  `YouDraw` trigger gated by an intervening-if on eight permanent cards in the graveyard).
- **Pit of Offerings** (#278) — Land — Cave. ETB exiles up to three cards from graveyards
  (linked to the land); a mana ability adds one of the exiled cards' colors. New
  `ManaColorSet.AmongLinkedExiledCards`.
- **Intrepid Paleontologist** (#193) — `{1}{G}` 2/2. `{2}` exile-and-link a graveyard card;
  cast Dinosaur creatures from that linked exile, entering with a finality counter. New
  `entersWithCounter` rider on `GrantMayCastFromLinkedExile` (mirrors
  `MayCastFromGraveyard.entersWithCounter`) + subtype-aware cast filtering.
- **Echoing Deeps** (#271) — Land — Cave. Enters tapped as a copy of a graveyard land, plus
  Cave. New `EntersAsCopy.tappedIfCopied` and a direct-entry clone path
  (`CloneEntersOnBattlefieldContinuation`) for lands played onto the battlefield.

### Engine / SDK

- `ManaColorSet.AmongLinkedExiledCards` — colors among the source's still-in-exile linked pile.
- `EntersAsCopy.tappedIfCopied` + `PlayLandHandler` / `CloneEntersOnBattlefieldContinuation` —
  as-enters copy (CR 707.2) applied to a permanent already placed on the battlefield directly.
- `GrantMayCastFromLinkedExile.entersWithCounter` — cast-this-way finality-counter rider.
- `CastZoneResolver.matchesCardFilter` unified for both legal-action enumeration and cast-time
  validation; made exhaustive over `CardPredicate` (fixes subtype gating and a latent
  `PowerOrToughnessAtMost` widening).
- SDK reference and the per-set card snapshot golden updated.

### Review + follow-up

The branch was self-reviewed (SDK-elegance + correctness lens). One important item (duplicated
clone-enters resumers) and three minor items were raised and **all fixed in the final commit**
(`Address review feedback …`): shared `applyCopyToEntity` helper, exhaustive `matchesCardFilter`,
a single enriched entry `ZoneChangeEvent` for the copy path, and a direct owner-keyed exile
lookup. The full review is posted as a PR comment.

### Testing

`rules-engine` scenario tests for all four cards pass, plus a regression net over the touched
clone/copy and cast-from-zone paths (`CloneTest`, `SharkShredderKillerCloneTest`,
`ValgavothTerrorEaterScenarioTest`, `DawnhandDissidentTest`, `GraveyardCastGrantChoiceTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
