### PR TITLE
Add Omniscience, Ramos, and Teach by Example to Foundations

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RamosDragonEngine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RamosDragonEngine.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Ramos, Dragon Engine — Commander 2017 #55.
+ *
+ * The cast trigger counts the triggering spell's colors, not the colors of mana spent to cast it.
+ */
+val RamosDragonEngine = card("Ramos, Dragon Engine") {
+    manaCost = "{6}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Artifact Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate only once each turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmounts.colorCountOf(EntityReference.Triggering),
+            target = EffectTarget.Self
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.PLUS_ONE_PLUS_ONE, 5)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.Composite(
+            Effects.AddMana(Color.WHITE, 2),
+            Effects.AddMana(Color.BLUE, 2),
+            Effects.AddMana(Color.BLACK, 2),
+            Effects.AddMana(Color.RED, 2),
+            Effects.AddMana(Color.GREEN, 2)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "55"
+        artist = "Joseph Meehan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e747ef1-a1ad-4859-a70c-3f935f017310.jpg?1783935930"
+
+        ruling("2024-11-08", "Ramos's triggered ability counts the number of colors a spell has (from zero to five), not how many colored mana symbols are there in its mana cost or how many colors of mana you spent.")
+        ruling("2024-11-08", "If you cast a colorless spell, Ramos's triggered ability triggers, but it won't get any +1/+1 counters.")
+        ruling("2024-11-08", "Ramos's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered or otherwise leaves the stack without resolving. In that case, use its last known information to determine what colors it was.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RamosDragonEngineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RamosDragonEngineReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ramos, Dragon Engine reprint in Commander Legends. The canonical card definition lives in Commander 2017.
+ */
+val RamosDragonEngineReprint = Printing(
+    oracleId = "3ed41d2d-211b-4013-8562-8c64d54cc43a",
+    name = "Ramos, Dragon Engine",
+    setCode = "CMR",
+    collectorNumber = "545",
+    scryfallId = "5865c39e-847e-4dc6-8e6c-a4200124f21f",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/5865c39e-847e-4dc6-8e6c-a4200124f21f.jpg?1783928658",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.MYTHIC,
+    frameEffects = listOf("inverted", "etched", "legendary")
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OmniscienceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OmniscienceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omniscience reprint in Foundations. The canonical card definition lives in Magic 2013.
+ */
+val OmniscienceReprint = Printing(
+    oracleId = "730e39e6-c61d-48b5-8827-bfd952bf1be7",
+    name = "Omniscience",
+    setCode = "FDN",
+    collectorNumber = "161",
+    scryfallId = "d33d91d0-1506-45e4-9def-975bf901815e",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d33d91d0-1506-45e4-9def-975bf901815e.jpg?1783909079",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RamosDragonEngineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RamosDragonEngineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ramos, Dragon Engine reprint in Foundations. The canonical card definition lives in Commander 2017.
+ */
+val RamosDragonEngineReprint = Printing(
+    oracleId = "3ed41d2d-211b-4013-8562-8c64d54cc43a",
+    name = "Ramos, Dragon Engine",
+    setCode = "FDN",
+    collectorNumber = "678",
+    scryfallId = "8f95f753-bbaa-4282-9cd9-f1737136fc9e",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8f95f753-bbaa-4282-9cd9-f1737136fc9e.jpg?1783908904",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TeachByExampleReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TeachByExampleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Teach by Example reprint in Foundations. The canonical card definition lives in Strixhaven.
+ */
+val TeachByExampleReprint = Printing(
+    oracleId = "d85ba214-fa05-44ca-a7f9-ab2c5dc07962",
+    name = "Teach by Example",
+    setCode = "FDN",
+    collectorNumber = "666",
+    scryfallId = "516baae5-f7bf-4a90-a80d-192ff19dbae5",
+    artist = "Johan Grenier",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/516baae5-f7bf-4a90-a80d-192ff19dbae5.jpg?1783908908",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Omniscience.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Omniscience.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+
+/**
+ * Omniscience — Magic 2013 #63.
+ *
+ * The permission is controller-only and otherwise unrestricted: it applies to every spell
+ * cast from the controller's hand while Omniscience remains on the battlefield.
+ */
+val Omniscience = card("Omniscience") {
+    manaCost = "{7}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "You may cast spells from your hand without paying their mana costs."
+
+    staticAbility {
+        ability = MayCastWithoutPayingManaCost(controllerOnly = true)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "63"
+        artist = "Jason Chan"
+        flavorText = "\"The things I once imagined would be my greatest achievements were only the first steps toward a future I can only begin to fathom.\"\n—Jace Beleren"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg?1783940505"
+
+        ruling("2018-07-13", "You must follow the normal timing permissions and restrictions of each spell you cast.")
+        ruling("2018-07-13", "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the spell.")
+        ruling("2018-07-13", "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OmniscienceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OmniscienceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omniscience reprint in Core Set 2019. The canonical card definition lives in Magic 2013.
+ */
+val OmniscienceReprint = Printing(
+    oracleId = "730e39e6-c61d-48b5-8827-bfd952bf1be7",
+    name = "Omniscience",
+    setCode = "M19",
+    collectorNumber = "65",
+    scryfallId = "db534b4e-8bff-4924-baea-9988d195fb25",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db534b4e-8bff-4924-baea-9988d195fb25.jpg?1783934583",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.MYTHIC
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/RamosDragonEngineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/RamosDragonEngineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ramos, Dragon Engine Treasure Chest printing. The canonical card definition lives in Commander 2017.
+ */
+val RamosDragonEngineReprint = Printing(
+    oracleId = "3ed41d2d-211b-4013-8562-8c64d54cc43a",
+    name = "Ramos, Dragon Engine",
+    setCode = "PZ2",
+    collectorNumber = "65749",
+    scryfallId = "cba697aa-9f33-4048-98a6-45175c4ed95d",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cba697aa-9f33-4048-98a6-45175c4ed95d.jpg?1783935572",
+    releaseDate = "2017-11-15",
+    rarity = Rarity.MYTHIC
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/C17.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C17.json
@@ -1,1 +1,127 @@
-
+// Ramos, Dragon Engine
+{
+    "name": "Ramos, Dragon Engine",
+    "manaCost": "{6}",
+    "typeLine": "Legendary Artifact Creature — Dragon",
+    "oracleText": "Flying\nWhenever you cast a spell, put a +1/+1 counter on Ramos for each of that spell's colors.\nRemove five +1/+1 counters from Ramos: Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Activate only once each turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "ColorCount"
+                    },
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "+1/+1",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "WHITE",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "BLUE",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "BLACK",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "GREEN",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "restrictions": [
+                    "OncePerTurn"
+                ],
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "MYTHIC",
+        "artist": "Joseph Meehan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e747ef1-a1ad-4859-a70c-3f935f017310.jpg?1783935930",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Ramos's triggered ability counts the number of colors a spell has (from zero to five), not how many colored mana symbols are there in its mana cost or how many colors of mana you spent."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If you cast a colorless spell, Ramos's triggered ability triggers, but it won't get any +1/+1 counters."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Ramos's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered or otherwise leaves the stack without resolving. In that case, use its last known information to determine what colors it was."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -275,6 +275,46 @@
     ]
 }
 
+// Omniscience
+{
+    "name": "Omniscience",
+    "manaCost": "{7}{U}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "You may cast spells from your hand without paying their mana costs.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "MayCastWithoutPayingManaCost",
+                "controllerOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "MYTHIC",
+        "artist": "Jason Chan",
+        "flavorText": "\"The things I once imagined would be my greatest achievements were only the first steps toward a future I can only begin to fathom.\"\n—Jace Beleren",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1088f33e-cb5f-4248-ae8e-280c4e41f291.jpg?1783940505",
+        "rulings": [
+            {
+                "date": "2018-07-13",
+                "text": "You must follow the normal timing permissions and restrictions of each spell you cast."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, such as that of Tormenting Voice, those must be paid to cast the spell."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sentinel Spider
 {
     "name": "Sentinel Spider",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmniscienceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmniscienceScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+import io.kotest.matchers.shouldBe
+
+class OmniscienceScenarioTest : ScenarioTestBase() {
+
+    private val calculator = CostCalculator(cardRegistry)
+
+    private fun com.wingedsheep.engine.state.GameState.cardInHand(playerId: EntityId, name: String): EntityId =
+        getHand(playerId).first { getEntity(it)?.get<CardComponent>()?.name == name }
+
+    init {
+        context("Omniscience free-cast permission") {
+
+            test("its controller may cast a spell from hand without paying its mana cost") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Omniscience")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .build()
+                val player = game.player1Id
+                val bears = game.state.cardInHand(player, "Grizzly Bears")
+
+                calculator.hasFreeCastPermission(
+                    game.state,
+                    player,
+                    cardRegistry.requireCard("Grizzly Bears")
+                ) shouldBe true
+
+                game.execute(CastSpell(player, bears, useWithoutPayingManaCost = true)).error shouldBe null
+                game.state.stack.contains(bears) shouldBe true
+            }
+
+            test("it neither benefits an opponent nor applies while absent from the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Omniscience")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .build()
+
+                calculator.hasFreeCastPermission(
+                    game.state,
+                    game.player2Id,
+                    cardRegistry.requireCard("Grizzly Bears")
+                ) shouldBe false
+
+                val withoutOmniscience = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .build()
+
+                calculator.hasFreeCastPermission(
+                    withoutOmniscience.state,
+                    withoutOmniscience.player1Id,
+                    cardRegistry.requireCard("Grizzly Bears")
+                ) shouldBe false
+            }
+
+            test("the card uses the unrestricted controller-only static") {
+                val ability = cardRegistry.requireCard("Omniscience").script.staticAbilities
+                    .filterIsInstance<MayCastWithoutPayingManaCost>()
+                    .single()
+
+                ability.controllerOnly shouldBe true
+                ability.firstSpellOfTurnOnly shouldBe false
+                ability.oncePerTurn shouldBe false
+                ability.fromExileOnly shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RamosDragonEngineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RamosDragonEngineScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.Ornithopter
+import com.wingedsheep.mtg.sets.definitions.c17.cards.RamosDragonEngine
+import com.wingedsheep.mtg.sets.definitions.rav.cards.LightningHelix
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class RamosDragonEngineScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RamosDragonEngine, LightningHelix, Ornithopter))
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun counters(driver: GameTestDriver, ramos: EntityId): Int =
+        driver.state.getEntity(ramos)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("the cast trigger counts the spell's colors and gives a colorless spell zero counters") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val ramos = driver.putCreatureOnBattlefield(player, "Ramos, Dragon Engine")
+
+        val helix = driver.putCardInHand(player, "Lightning Helix")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.castSpell(player, helix, targets = listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass() // Ramos trigger
+
+        counters(driver, ramos) shouldBe 2
+        driver.bothPass() // Lightning Helix
+
+        val ornithopter = driver.putCardInHand(player, "Ornithopter")
+        driver.castSpell(player, ornithopter).isSuccess shouldBe true
+        driver.bothPass() // Ramos trigger
+
+        counters(driver, ramos) shouldBe 2
+    }
+
+    test("removing five counters adds two mana of each color and is limited to once each turn") {
+        val driver = setup()
+        val player = driver.activePlayer!!
+        val ramos = driver.putCreatureOnBattlefield(player, "Ramos, Dragon Engine")
+        driver.replaceState(
+            driver.state.updateEntity(ramos) {
+                it.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 10))
+            }
+        )
+        val abilityId = RamosDragonEngine.activatedAbilities.single().id
+
+        driver.submitSuccess(ActivateAbility(player, ramos, abilityId))
+
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        pool.white shouldBe 2
+        pool.blue shouldBe 2
+        pool.black shouldBe 2
+        pool.red shouldBe 2
+        pool.green shouldBe 2
+        counters(driver, ramos) shouldBe 5
+
+        driver.submit(ActivateAbility(player, ramos, abilityId)).isSuccess shouldBe false
+        counters(driver, ramos) shouldBe 5
+    }
+})


### PR DESCRIPTION
## Summary

- implement Omniscience in its canonical Magic 2013 set and add its Foundations printing
- implement Ramos, Dragon Engine in Commander 2017, including spell-color counter scaling and its once-per-turn mana ability, and add its Foundations printing
- add the Foundations printing of the existing Teach by Example implementation
- fill required printing metadata for scaffolded historical sets
- add focused scenario coverage and card snapshots

## Testing

- `just test-class OmniscienceScenarioTest`
- `just test-class RamosDragonEngineScenarioTest`
- `./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true`
- `just check-card-printing "Omniscience"`
- `just check-card-printing "Ramos, Dragon Engine"`
- `just check-card-printing "Teach by Example"`
- `just build`