### PR TITLE
Add Progenitus to Foundations

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Progenitus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/Progenitus.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Progenitus — Conflux #121 (canonical printing; reprinted in Foundations #244).
+ *
+ * Protection from everything is a single parameterized keyword ability. Its graveyard
+ * replacement is intrinsic to the card, so it applies from every zone, including when
+ * Progenitus is discarded, milled, countered, or would die.
+ */
+val Progenitus = card("Progenitus") {
+    manaCost = "{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Creature — Hydra Avatar"
+    oracleText = "Protection from everything\n" +
+        "If Progenitus would be put into a graveyard from anywhere, reveal Progenitus and " +
+        "shuffle it into its owner's library instead."
+    power = 10
+    toughness = 10
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Everything))
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.LIBRARY,
+            appliesTo = EventPattern.ZoneChangeEvent(to = Zone.GRAVEYARD),
+            selfOnly = true,
+            shuffleIntoLibrary = true,
+            reveal = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "121"
+        artist = "Jaime Jones"
+        flavorText = "The Soul of the World has returned."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg?1783942466"
+        ruling(
+            "2009-02-01",
+            "\"Protection from everything\" means Progenitus can't be blocked, enchanted or " +
+                "equipped, targeted, or dealt damage."
+        )
+        ruling(
+            "2009-02-01",
+            "Progenitus can still be affected by effects that neither target it nor deal damage to it."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ProgenitusReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ProgenitusReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Foundations printing; the canonical definition lives in Conflux. */
+val ProgenitusReprint = Printing(
+    oracleId = "2d7e00b6-12f0-4b03-82a6-50e3d1b5395e",
+    name = "Progenitus",
+    setCode = "FDN",
+    collectorNumber = "244",
+    scryfallId = "e77fbc87-d78e-4602-baa0-da9b0d464dfb",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e77fbc87-d78e-4602-baa0-da9b0d464dfb.jpg?1783909051",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -104,6 +104,63 @@
     "colorIdentityOverride": []
 }
 
+// Progenitus
+{
+    "name": "Progenitus",
+    "manaCost": "{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}",
+    "typeLine": "Legendary Creature — Hydra Avatar",
+    "oracleText": "Protection from everything\nIf Progenitus would be put into a graveyard from anywhere, reveal Progenitus and shuffle it into its owner's library instead.",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 10
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": "ProtectionScope.Everything"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChange",
+                "newDestination": "Library",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Graveyard"
+                },
+                "selfOnly": true,
+                "shuffleIntoLibrary": true,
+                "reveal": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "MYTHIC",
+        "artist": "Jaime Jones",
+        "flavorText": "The Soul of the World has returned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcc764b0-3046-4bde-b424-c0f4e1a6169b.jpg?1783942466",
+        "rulings": [
+            {
+                "date": "2009-02-01",
+                "text": "\"Protection from everything\" means Progenitus can't be blocked, enchanted or equipped, targeted, or dealt damage."
+            },
+            {
+                "date": "2009-02-01",
+                "text": "Progenitus can still be affected by effects that neither target it nor deal damage to it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Reliquary Tower
 {
     "name": "Reliquary Tower",


### PR DESCRIPTION
## Summary
- add the canonical Progenitus definition to Conflux
- add the Foundations #244 printing metadata
- model protection from everything and the intrinsic graveyard-to-library replacement
- update the Conflux card snapshot

## Verification
- `just coverage-fidelity --emit "Progenitus"`
- Scryfall canonical and Foundations metadata rechecked
- all canonical and reprint image URLs return HTTP 200
- `just check-card-printing "Progenitus"`
- `just build`

## Scope note
The remaining Foundations backlog is mechanics-heavy. Demonic Pact was evaluated but intentionally excluded because its targeted recurring modal trigger requires mode/history selection timing that the current reusable primitive does not faithfully support at trigger placement.