### PR TITLE
Add Redcap Gutter-Dweller and Ovika, Enigma Goliath (FDN reprints)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OvikaEnigmaGoliathReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/OvikaEnigmaGoliathReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ovika, Enigma Goliath reprint in Foundations. Canonical CardDefinition lives in
+ * Phyrexia: All Will Be One's `cards/` package; this file contributes only presentation data.
+ */
+val OvikaEnigmaGoliathReprint = Printing(
+    oracleId = "b05a2b5f-1b5c-4f1b-8a6b-525c5c8b8ba1",
+    name = "Ovika, Enigma Goliath",
+    setCode = "FDN",
+    collectorNumber = "663",
+    scryfallId = "54819d7a-eec6-49e6-a0bb-d9d07d42b4a6",
+    artist = "Antonio José Manzanedo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54819d7a-eec6-49e6-a0bb-d9d07d42b4a6.jpg?1783908910",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RedcapGutterDwellerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RedcapGutterDwellerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Redcap Gutter-Dweller reprint in Foundations. Canonical CardDefinition lives in
+ * Wilds of Eldraine's `cards/` package; this file contributes only presentation data.
+ */
+val RedcapGutterDwellerReprint = Printing(
+    oracleId = "ada48353-4c86-44d6-83a5-e7e3c703b948",
+    name = "Redcap Gutter-Dweller",
+    setCode = "FDN",
+    collectorNumber = "631",
+    scryfallId = "c6c7f55a-bcc7-4ca3-853d-fc6e260d9429",
+    artist = "Alexey Kruglov",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c6c7f55a-bcc7-4ca3-853d-fc6e260d9429.jpg?1783908920",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/OvikaEnigmaGoliath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/OvikaEnigmaGoliath.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Ovika, Enigma Goliath
+ * {5}{U}{R}
+ * Legendary Creature — Phyrexian Nightmare
+ * 6/6
+ *
+ * Flying
+ * Ward—{3}, Pay 3 life.
+ * Whenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature
+ * tokens, where X is the mana value of that spell. They gain haste until end of turn.
+ *
+ * Implementation notes:
+ * - Ward—{3}, Pay 3 life is a single composite ward cost ([WardCost.Composite] of a mana
+ *   part and a life part), the Gisa, the Hellraiser shape (CR 702.21a).
+ * - The token count reads the triggering spell's mana value via
+ *   [EntityReference.Triggering]; for {X} spells CR 202.3e fixes the X portion to the
+ *   chosen value while the spell is on the stack, matching the 2024-11-08 ruling.
+ * - "They gain haste" iterates the [CREATED_TOKENS] pipeline collection the create-token
+ *   executor publishes, so only the tokens made by this trigger are granted haste — and
+ *   only until end of turn, so a later control change doesn't inherit permanent haste.
+ */
+val OvikaEnigmaGoliath = card("Ovika, Enigma Goliath") {
+    manaCost = "{5}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Phyrexian Nightmare"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\n" +
+        "Ward—{3}, Pay 3 life.\n" +
+        "Whenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature " +
+        "tokens, where X is the mana value of that spell. They gain haste until end of turn."
+
+    keywords(Keyword.FLYING)
+    keywordAbility(
+        KeywordAbility.wardComposite(WardCost.Mana("{3}"), WardCost.Life(3))
+    )
+
+    // Whenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin tokens,
+    // where X is the mana value of that spell. They gain haste until end of turn.
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Composite(listOf(
+            Effects.CreateToken(
+                count = DynamicAmount.EntityProperty(
+                    EntityReference.Triggering,
+                    EntityNumericProperty.ManaValue,
+                ),
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Phyrexian", "Goblin"),
+                imageUri = "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg?1783918169",
+            ),
+            ForEachInCollectionEffect(
+                CREATED_TOKENS,
+                Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self),
+            ),
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "213"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg?1783917997"
+        ruling(
+            "2024-11-08",
+            "If a spell on the stack has {X} in its cost, use the value chosen for X to determine its mana value."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedcapGutterDweller.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RedcapGutterDweller.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Redcap Gutter-Dweller
+ * {2}{R}{R}
+ * Creature — Goblin Warrior
+ * 3/3
+ *
+ * Menace
+ * When this creature enters, create two 1/1 black Rat creature tokens with
+ * "This token can't block."
+ * At the beginning of your upkeep, you may sacrifice another creature. If you do,
+ * put a +1/+1 counter on this creature and exile the top card of your library.
+ * You may play that card this turn.
+ *
+ * Implementation notes:
+ * - The upkeep trigger is an [OptionalCostEffect]: the sacrifice is the optional
+ *   cost (`excludeSource` enforces "another"), and paying it runs the counter +
+ *   impulse rewards. Per the 2024-11-08 ruling, if Redcap leaves the battlefield
+ *   before the trigger resolves, the sacrifice and impulse still happen — the
+ *   [Effects.AddCounters] on the departed source simply no-ops while the rest of
+ *   the composite continues.
+ */
+val RedcapGutterDweller = card("Redcap Gutter-Dweller") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Menace\n" +
+        "When this creature enters, create two 1/1 black Rat creature tokens with \"This token can't block.\"\n" +
+        "At the beginning of your upkeep, you may sacrifice another creature. If you do, " +
+        "put a +1/+1 counter on this creature and exile the top card of your library. " +
+        "You may play that card this turn."
+
+    keywords(Keyword.MENACE)
+
+    // When this creature enters, create two 1/1 black Rat tokens with "This token can't block."
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = woeRatToken(count = DynamicAmount.Fixed(2))
+    }
+
+    // At the beginning of your upkeep, you may sacrifice another creature. If you do,
+    // put a +1/+1 counter on this creature and impulse the top card of your library.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = OptionalCostEffect(
+            cost = SacrificeEffect(
+                filter = GameObjectFilter.Creature,
+                count = 1,
+                excludeSource = true,
+            ),
+            ifPaid = Effects.Composite(listOf(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                Patterns.Exile.impulse(count = 1, storeAs = "redcapImpulseExiled"),
+            )),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "146"
+        artist = "Alexey Kruglov"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg?1783915091"
+        ruling(
+            "2024-11-08",
+            "If Redcap Gutter-Dweller leaves the battlefield after its last ability has triggered, " +
+                "you can still sacrifice a creature and exile the top card of your library, even though " +
+                "you won't put a +1/+1 counter on Redcap Gutter-Dweller."
+        )
+        ruling(
+            "2024-11-08",
+            "You pay all costs and follow all normal timing rules for cards played with the permission " +
+                "granted by Redcap Gutter-Dweller's last ability. For example, if the exiled card is a " +
+                "land card, you may play it only during your main phase while the stack is empty."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ONE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONE.json
@@ -322,6 +322,107 @@
     ]
 }
 
+// Ovika, Enigma Goliath
+{
+    "name": "Ovika, Enigma Goliath",
+    "manaCost": "{5}{U}{R}",
+    "typeLine": "Legendary Creature — Phyrexian Nightmare",
+    "oracleText": "Flying\nWard—{3}, Pay 3 life.\nWhenever you cast a noncreature spell, create X 1/1 red Phyrexian Goblin creature tokens, where X is the mana value of that spell. They gain haste until end of turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Composite",
+                "parts": [
+                    {
+                        "type": "WardCost.Mana",
+                        "manaCost": "{3}"
+                    },
+                    {
+                        "type": "WardCost.Life",
+                        "amount": 3
+                    }
+                ]
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "ManaValue"
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "RED"
+                            ],
+                            "creatureTypes": [
+                                "Phyrexian",
+                                "Goblin"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/3/6/3663e79b-2bf9-44af-a638-c0ad9067d8d4.jpg?1783918169"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "createdTokens"
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "RARE",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b298cf34-7aa5-4f97-a86c-7f28d2113b87.jpg?1783917997",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If a spell on the stack has {X} in its cost, use the value chosen for X to determine its mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Razorverge Thicket
 {
     "name": "Razorverge Thicket",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3989,6 +3989,128 @@
     ]
 }
 
+// Redcap Gutter-Dweller
+{
+    "name": "Redcap Gutter-Dweller",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Menace\nWhen this creature enters, create two 1/1 black Rat creature tokens with \"This token can't block.\"\nAt the beginning of your upkeep, you may sacrifice another creature. If you do, put a +1/+1 counter on this creature and exile the top card of your library. You may play that card this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "creature",
+                            "excludeSource": true
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeAs": "redcapImpulseExiled"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "redcapImpulseExiled",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantMayPlayFromExile",
+                                        "from": "redcapImpulseExiled"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "RARE",
+        "artist": "Alexey Kruglov",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96bcd5f0-da79-47ab-83cf-976198b458d1.jpg?1783915091",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If Redcap Gutter-Dweller leaves the battlefield after its last ability has triggered, you can still sacrifice a creature and exile the top card of your library, even though you won't put a +1/+1 counter on Redcap Gutter-Dweller."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You pay all costs and follow all normal timing rules for cards played with the permission granted by Redcap Gutter-Dweller's last ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Redcap Thief
 {
     "name": "Redcap Thief",


### PR DESCRIPTION
## Summary

Implements two of the remaining Foundations cards. Both are reprints, so per the printing rules the canonical `CardDefinition` lives in each card's earliest real set and FDN gets a `Printing` row:

- **Redcap Gutter-Dweller** — canonical in **WOE**, `Printing` row in FDN (#631).
  - ETB reuses the shared `woeRatToken` helper (1/1 black Rat, "This token can't block", WOE token art).
  - The upkeep trigger is an `OptionalCostEffect`: sacrificing another creature (the optional cost) gates a +1/+1 counter on the source plus a `Patterns.Exile.impulse`. Matches the 2024-11-08 ruling — if Redcap leaves the battlefield first, the sacrifice and impulse still happen while the counter placement no-ops.
- **Ovika, Enigma Goliath** — canonical in **ONE**, `Printing` row in FDN (#663).
  - Ward—{3}, Pay 3 life as a single composite ward cost (`KeywordAbility.wardComposite`, the Gisa, the Hellraiser shape).
  - The noncreature-cast trigger creates X 1/1 red Phyrexian Goblin tokens where X reads the triggering spell's mana value (`EntityReference.Triggering` + `ManaValue`; CR 202.3e fixes {X} to the chosen value on the stack), then grants haste **until end of turn** to exactly the created tokens via the `CREATED_TOKENS` pipeline collection.

Both cards compose existing SDK primitives only — no engine changes. Card snapshots for WOE and ONE re-blessed (purely additive; no other card moved). `just check-card-printing` passes for both.

Also considered and deliberately skipped as needing real feature work: Elenda, Saint of Dusk ("hexproof from instants" has no enforcement path — hexproof-from is color-only today) and Vizier of the Menagerie (no "spend mana as any color for creature spells" static).

## Test plan
- [x] `just build` green (includes CardLintTest + snapshot net)
- [x] `just check-card-printing` for both cards
- [x] Snapshot diff reviewed — only the two new card trees added

🤖 Generated with [Claude Code](https://claude.com/claude-code)