### PR TITLE
Add three Foundations cards: Wishclaw Talisman, Demonic Pact, Quilled Greatwurm

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -866,7 +866,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   three flip it into Shadows' Lair), `Counters.BORE` (Brass's Tunnel-Grinder — three flip it into Tecutlan),
   `Counters.NET`, `Counters.FIRE`, `Counters.CONQUEROR`, `Counters.POINT` (Contested Game Ball — its
   `{2}, {T}` ability adds one per activation and, when five or more are present, sacrifices the artifact and
-  creates a Treasure).
+  creates a Treasure), `Counters.WISH` (Wishclaw Talisman — see below).
 - `DistributeCountersFromSelf(type?, count?)` — split source's counters among creatures you control.
 - `DistributeCountersAmongTargets(total, type?, minPerTarget?)` — divvy N counters among chosen targets.
 - `DistributeCountersAmongFiltered(total, type?, filter, minPerTarget?)` — distribute N **new** counters among permanents matching `filter`, chosen at resolution (not the spell's targets); `minPerTarget = 0` models "among any number of". Unlike `DistributeCountersFromSelf` nothing is removed from a source. Crashing Wave: `DistributeCountersAmongFiltered(3, Counters.STUN, Filters.Creature.tapped().opponentControls())` — "distribute three stun counters among any number of tapped creatures your opponents control."
@@ -7170,6 +7170,11 @@ substitution.
   DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.withChosenSubtype()))`; a
   `GrantDynamicStatsEffect` sized by `DynamicAmounts.countersOnSelf(...)` reads the count back) — a pure
   passive resource counter with no inherent rule.
+  `wish` (`Counters.WISH`): ELD — Wishclaw Talisman (enters with three via an `EntersWithCounters(
+  CounterTypeFilter.Named(Counters.WISH), count = 3, selfOnly = true)` replacement; each activation of its
+  tutor ability spends one via `Costs.RemoveCounterFromSelf(Counters.WISH, 1)`). A pure "uses left" counter
+  with no inherent rule — when it hits zero the activation cost is simply unpayable, which is exactly the
+  printed ruling that the Talisman then sits inert on the battlefield.
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -73,7 +73,8 @@ enum class CounterType {
     FELLOWSHIP,
     BAIT,
     BORE,
-    POINT;
+    POINT,
+    WISH;
 
     companion object {
         /**
@@ -327,6 +328,15 @@ object Counters {
      * `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val POINT = "point"
+
+    /**
+     * Wish counter (ELD — Wishclaw Talisman). Passive "uses left" counter with no inherent rule of
+     * its own — the Talisman enters with three and each activation of its tutor ability removes one
+     * as part of the cost, so the counters bound how many times it can be used before it is stuck on
+     * the battlefield. NOT a keyword counter, so it is intentionally absent from
+     * `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val WISH = "wish"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WishclawTalisman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WishclawTalisman.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wishclaw Talisman
+ * {1}{B}
+ * Artifact
+ * This artifact enters with three wish counters on it.
+ * {1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it into
+ *   your hand, then shuffle. An opponent gains control of this artifact. Activate only during your turn.
+ *
+ * Modelling notes:
+ * - "Enters with three wish counters" is a replacement effect (CR 614.1c), not an ETB trigger, so it
+ *   is an [EntersWithCounters] with `selfOnly = true`.
+ * - The wish counters *are* the use limit: once they run out the Talisman just sits on the
+ *   battlefield with an unactivatable ability (Scryfall ruling), which falls out of the cost being
+ *   unpayable — no extra gate needed.
+ * - "An opponent gains control" is not targeted; the controller picks while the ability resolves
+ *   (Scryfall ruling), so [Effects.ChooseOpponent] records the pick on the source and
+ *   [GiveControlToTargetPlayerEffect] reads it back through [Player.ChosenOpponent]. In a two-player
+ *   game the pick is forced, so no extra decision is surfaced.
+ */
+val WishclawTalisman = card("Wishclaw Talisman") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with three wish counters on it.\n" +
+        "{1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it " +
+        "into your hand, then shuffle. An opponent gains control of this artifact. Activate only " +
+        "during your turn."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.WISH),
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.WISH, 1)
+        )
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                destination = SearchDestination.HAND
+            ),
+            Effects.ChooseOpponent("Choose an opponent to gain control of Wishclaw Talisman"),
+            GiveControlToTargetPlayerEffect(
+                permanent = EffectTarget.Self,
+                newController = EffectTarget.PlayerRef(Player.ChosenOpponent)
+            )
+        )
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "110"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg?1783932629"
+        ruling(
+            "2019-10-04",
+            "Once Wishclaw Talisman runs out of wish counters, it remains on the battlefield. " +
+                "You can't activate its last ability at all."
+        )
+        ruling(
+            "2019-10-04",
+            "You choose which opponent gains control of Wishclaw Talisman while its ability is " +
+                "resolving. If that player later leaves the game, you regain control of Wishclaw Talisman."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DemonicPactReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DemonicPactReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demonic Pact reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in ORI's `cards/`
+ * package (the card's earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DemonicPactReprint = Printing(
+    oracleId = "19a2f0a0-9e68-4982-a5f5-b77d805befd7",
+    name = "Demonic Pact",
+    setCode = "FDN",
+    collectorNumber = "602",
+    scryfallId = "5b0b7242-df91-48cf-bf4e-b68306c9965f",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b0b7242-df91-48cf-bf4e-b68306c9965f.jpg?1783908933",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/QuilledGreatwurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/QuilledGreatwurm.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Quilled Greatwurm
+ * {4}{G}{G}
+ * Creature — Wurm
+ * 7/7
+ * Trample
+ * Whenever a creature you control deals combat damage during your turn, put that many +1/+1
+ *   counters on it. (It must survive to get the counters.)
+ * You may cast this card from your graveyard by removing six counters from among creatures you
+ *   control in addition to paying its other costs.
+ *
+ * Modelling notes:
+ * - The counters trigger is battlefield-wide (`TriggerBinding.ANY` over
+ *   `GameObjectFilter.Creature.youControl()`), not self-bound, and covers combat damage dealt to
+ *   *anything* — player, planeswalker, battle or blocking creature (`RecipientFilter.Any`).
+ * - "during your turn" is a fire-time gate, so it is a `triggerCondition` rather than a condition on
+ *   the effect: a creature that deals combat damage on an opponent's turn never triggers at all.
+ * - "put that many" reads the damage off the trigger payload
+ *   (`ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`) and "on it" is the damage source
+ *   (`EffectTarget.TriggeringEntity`). The reminder text "(It must survive to get the counters.)" is
+ *   just the normal resolution rule — a dead creature isn't there to receive counters.
+ * - The graveyard clause is an intrinsic self-permission with a bundled additional cost:
+ *   [MayCastSelfFromZones] keeps normal timing and the printed {4}{G}{G} mana cost, and the six
+ *   counters may be of any type spread across any creatures you control.
+ */
+val QuilledGreatwurm = card("Quilled Greatwurm") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 7
+    toughness = 7
+    oracleText = "Trample\n" +
+        "Whenever a creature you control deals combat damage during your turn, put that many +1/+1 " +
+        "counters on it. (It must survive to get the counters.)\n" +
+        "You may cast this card from your graveyard by removing six counters from among creatures " +
+        "you control in addition to paying its other costs."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.Any,
+            sourceFilter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            target = EffectTarget.TriggeringEntity,
+        )
+    }
+
+    staticAbility {
+        ability = MayCastSelfFromZones(
+            zones = listOf(Zone.GRAVEYARD),
+            additionalCost = Costs.additional.RemoveCounters(
+                count = 6,
+                counterType = null,
+                filter = GameObjectFilter.Creature
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "111"
+        artist = "Michal Ivan"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg?1783909095"
+        ruling(
+            "2024-11-08",
+            "You must follow all normal timing rules when casting Quilled Greatwurm from your " +
+                "graveyard with the permission granted by its last ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WishclawTalismanReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WishclawTalismanReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wishclaw Talisman reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in ELD's `cards/`
+ * package (the card's earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val WishclawTalismanReprint = Printing(
+    oracleId = "81c70ae7-3c18-4c9b-8505-e4db9e0e6518",
+    name = "Wishclaw Talisman",
+    setCode = "FDN",
+    collectorNumber = "617",
+    scryfallId = "69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/69d0f5bd-ccea-49b2-bd79-ad5e4d850cf5.jpg?1783908926",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DemonicPact.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DemonicPact.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Demonic Pact
+ * {2}{B}{B}
+ * Enchantment
+ * At the beginning of your upkeep, choose one that hasn't been chosen —
+ * • This enchantment deals 4 damage to any target and you gain 4 life.
+ * • Target opponent discards two cards.
+ * • Draw two cards.
+ * • You lose the game.
+ *
+ * Modelling notes:
+ * - "Choose one that hasn't been chosen" is [ModalEffect.chooseOneNotYetChosen]: the mode memory is
+ *   keyed to this specific permanent (CR 700.4 object identity), which matches the rulings — a
+ *   second copy of Demonic Pact starts fresh, and a new controller inherits the modes already
+ *   chosen rather than resetting them.
+ * - The mode is picked as the triggered ability goes on the stack, and a chosen mode counts as
+ *   chosen even if the ability later fizzles or is countered — both fall out of the shared modal
+ *   machinery, which commits the pick at trigger-put-on-stack time.
+ * - Once the first three modes are gone the fourth is the only legal pick, so the pact collects
+ *   (the printed trap). If even that has been chosen the ability leaves the stack doing nothing.
+ */
+val DemonicPact = card("Demonic Pact") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, choose one that hasn't been chosen —\n" +
+        "• This enchantment deals 4 damage to any target and you gain 4 life.\n" +
+        "• Target opponent discards two cards.\n" +
+        "• Draw two cards.\n" +
+        "• You lose the game."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = ModalEffect.chooseOneNotYetChosen(
+            // • This enchantment deals 4 damage to any target and you gain 4 life.
+            Mode.withTarget(
+                Effects.Composite(
+                    Effects.DealDamage(4, EffectTarget.ContextTarget(0), damageSource = EffectTarget.Self),
+                    Effects.GainLife(4)
+                ),
+                Targets.Any,
+                "This enchantment deals 4 damage to any target and you gain 4 life"
+            ),
+            // • Target opponent discards two cards.
+            Mode.withTarget(
+                Effects.Discard(2, EffectTarget.ContextTarget(0)),
+                Targets.Opponent,
+                "Target opponent discards two cards"
+            ),
+            // • Draw two cards.
+            Mode.noTarget(
+                Effects.DrawCards(2),
+                "Draw two cards"
+            ),
+            // • You lose the game.
+            Mode.noTarget(
+                Effects.LoseGame(),
+                "You lose the game"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "92"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg?1783938343"
+        ruling(
+            "2015-06-22",
+            "You choose the mode as the triggered ability goes on the stack. You can choose a mode " +
+                "that requires targets only if there are legal targets available."
+        )
+        ruling(
+            "2015-06-22",
+            "If the ability doesn't resolve (either for having its target become illegal or because " +
+                "a spell or ability counters it), the mode chosen for that instance of the ability " +
+                "still counts as being chosen."
+        )
+        ruling(
+            "2015-06-22",
+            "The phrase \"that hasn't been chosen\" refers only to that specific Demonic Pact. If you " +
+                "control one and cast another one, you can choose any mode for the second one the " +
+                "first time its ability triggers."
+        )
+        ruling(
+            "2015-06-22",
+            "It doesn't matter who has chosen any particular mode. For example, say you control " +
+                "Demonic Pact and have chosen the first two modes. If an opponent gains control of " +
+                "Demonic Pact, that player can choose only the third or fourth mode."
+        )
+        ruling(
+            "2015-06-22",
+            "In some very unusual situations, you may not be able to choose a mode, either because " +
+                "all modes have previously been chosen or the only remaining modes require targets " +
+                "and there are no legal targets available. In this case, the ability is simply " +
+                "removed from the stack with no effect."
+        )
+        ruling(
+            "2015-06-22",
+            "Yes, if the fourth mode is the only one remaining, you must choose it. You read the " +
+                "whole contract, right?"
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -663,3 +663,124 @@
         "GREEN"
     ]
 }
+
+// Wishclaw Talisman
+{
+    "name": "Wishclaw Talisman",
+    "manaCost": "{1}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with three wish counters on it.\n{1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it into your hand, then shuffle. An opponent gains control of this artifact. Activate only during your turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "wish",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    }
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        },
+                        {
+                            "type": "ChooseOpponentForSource",
+                            "prompt": "Choose an opponent to gain control of Wishclaw Talisman"
+                        },
+                        {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": "Self",
+                            "newController": {
+                                "type": "PlayerRef",
+                                "player": "ChosenOpponent"
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "wish"
+                },
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07c17b01-ee5d-491a-8403-b3f819b778c4.jpg?1783932629",
+        "rulings": [
+            {
+                "date": "2019-10-04",
+                "text": "Once Wishclaw Talisman runs out of wish counters, it remains on the battlefield. You can't activate its last ability at all."
+            },
+            {
+                "date": "2019-10-04",
+                "text": "You choose which opponent gains control of Wishclaw Talisman while its ability is resolving. If that player later leaves the game, you regain control of Wishclaw Talisman."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -5913,6 +5913,78 @@
     "colorIdentityOverride": []
 }
 
+// Quilled Greatwurm
+{
+    "name": "Quilled Greatwurm",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Trample\nWhenever a creature you control deals combat damage during your turn, put that many +1/+1 counters on it. (It must survive to get the counters.)\nYou may cast this card from your graveyard by removing six counters from among creatures you control in addition to paying its other costs.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "sourceFilter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": "TriggeringEntity"
+                },
+                "triggerCondition": "IsYourTurn"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "MayCastSelfFromZones",
+                "zones": [
+                    "Graveyard"
+                ],
+                "additionalCost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 6
+                        },
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "MYTHIC",
+        "artist": "Michal Ivan",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31b60531-3d33-4e66-923a-29008716b15c.jpg?1783909095",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "You must follow all normal timing rules when casting Quilled Greatwurm from your graveyard with the permission granted by its last ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Raise the Past
 {
     "name": "Raise the Past",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -50,6 +50,162 @@
     ]
 }
 
+// Demonic Pact
+{
+    "name": "Demonic Pact",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, choose one that hasn't been chosen —\n• This enchantment deals 4 damage to any target and you gain 4 life.\n• Target opponent discards two cards.\n• Draw two cards.\n• You lose the game.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 4
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "damageSource": "Self"
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 4
+                                        }
+                                    }
+                                ]
+                            },
+                            "targetRequirements": [
+                                "AnyTarget"
+                            ],
+                            "description": "This enchantment deals 4 damage to any target and you gain 4 life"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            }
+                                        },
+                                        "chooser": "TargetPlayer",
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 2 cards to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            "targetRequirements": [
+                                "TargetOpponent"
+                            ],
+                            "description": "Target opponent discards two cards"
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "description": "Draw two cards"
+                        },
+                        {
+                            "effect": "LoseGame",
+                            "description": "You lose the game"
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "MYTHIC",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82c04014-91f9-4197-b4b4-f62c4739a5c2.jpg?1783938343",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "You choose the mode as the triggered ability goes on the stack. You can choose a mode that requires targets only if there are legal targets available."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "If the ability doesn't resolve (either for having its target become illegal or because a spell or ability counters it), the mode chosen for that instance of the ability still counts as being chosen."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "The phrase \"that hasn't been chosen\" refers only to that specific Demonic Pact. If you control one and cast another one, you can choose any mode for the second one the first time its ability triggers."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "It doesn't matter who has chosen any particular mode. For example, say you control Demonic Pact and have chosen the first two modes. If an opponent gains control of Demonic Pact, that player can choose only the third or fourth mode."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "In some very unusual situations, you may not be able to choose a mode, either because all modes have previously been chosen or the only remaining modes require targets and there are no legal targets available. In this case, the ability is simply removed from the stack with no effect."
+            },
+            {
+                "date": "2015-06-22",
+                "text": "Yes, if the fourth mode is the only one remaining, you must choose it. You read the whole contract, right?"
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dwynen's Elite
 {
     "name": "Dwynen's Elite",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
@@ -38,7 +38,10 @@ class GiveControlToTargetPlayerExecutor : EffectExecutor<GiveControlToTargetPlay
         val cardComponent = targetContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Target is not a card")
 
-        val newControllerId = context.resolvePlayerTarget(effect.newController)
+        // State-aware overload: the new controller may be a relational / stored player reference
+        // (Player.ChosenOpponent for Wishclaw Talisman's "an opponent gains control of this
+        // artifact", Player.ControllerOf, …), none of which the stateless resolver can see.
+        val newControllerId = context.resolvePlayerTarget(effect.newController, state)
             ?: return EffectResult.error(state, "No valid player target for control change")
 
         // Use projected controller so floating-effect-based control changes are respected

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicPactScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicPactScenarioTest.kt
@@ -1,0 +1,206 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Demonic Pact (ORI #92, canonical printing) — {2}{B}{B} Enchantment.
+ *
+ * "At the beginning of your upkeep, choose one that hasn't been chosen —
+ *  • This enchantment deals 4 damage to any target and you gain 4 life.
+ *  • Target opponent discards two cards.
+ *  • Draw two cards.
+ *  • You lose the game."
+ *
+ * Proven here:
+ *  - the upkeep trigger offers all four modes the first time, and the damage/lifegain mode resolves;
+ *  - a chosen mode is never offered again ("that hasn't been chosen" — memory keyed to the permanent);
+ *  - the trigger fires only on the controller's upkeep, not an opponent's;
+ *  - after the three "good" modes are spent, only "You lose the game" remains — and taking it ends
+ *    the game (the printed trap).
+ */
+class DemonicPactScenarioTest : ScenarioTestBase() {
+
+    private val damageMode = "This enchantment deals 4 damage to any target and you gain 4 life"
+    private val discardMode = "Target opponent discards two cards"
+    private val drawMode = "Draw two cards"
+    private val loseMode = "You lose the game"
+
+    /** Resolve the stack until the modal ChooseOptionDecision appears. */
+    private fun TestGame.resolveToModeChoice(): ChooseOptionDecision {
+        resolveStack()
+        val decision = getPendingDecision()
+        decision.shouldNotBeNull()
+        return decision as ChooseOptionDecision
+    }
+
+    private fun TestGame.chooseMode(decision: ChooseOptionDecision, description: String) {
+        val index = decision.options.indexOf(description)
+        check(index >= 0) { "Mode '$description' not offered; options=${decision.options}" }
+        submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    /**
+     * Resolve the stack, answering any card-selection prompt the chosen mode produces (the discard
+     * mode makes the *opponent* pick two cards). Stops on any other decision so the caller can
+     * handle it explicitly.
+     */
+    private fun TestGame.resolveAnsweringCardSelections(maxIterations: Int = 20) {
+        var guard = 0
+        while (guard++ < maxIterations) {
+            val decision = getPendingDecision()
+            if (decision is SelectCardsDecision) {
+                selectCards(decision.options.take(maxOf(decision.minSelections, 1)))
+                continue
+            }
+            if (decision != null) return
+            if (state.stack.isEmpty()) return
+            resolveStack()
+        }
+    }
+
+    /** Advance from the current point to the controller's next upkeep. */
+    private fun TestGame.toNextOwnUpkeep() {
+        passUntilPhase(Phase.ENDING, Step.END)
+        passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // opponent's upkeep
+        resolveStack()
+        passUntilPhase(Phase.ENDING, Step.END)
+        passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // controller's upkeep again
+    }
+
+    init {
+        test("first upkeep offers all four modes; the damage mode burns and gains life") {
+            var builder = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Demonic Pact")
+                .withLifeTotal(1, 20)
+                .withLifeTotal(2, 20)
+                .withActivePlayer(1)
+                .inPhase(Phase.BEGINNING, Step.UNTAP)
+            repeat(12) { builder = builder.withCardInLibrary(1, "Swamp") }
+            repeat(12) { builder = builder.withCardInLibrary(2, "Swamp") }
+            val game = builder.build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+            val choice = game.resolveToModeChoice()
+            withClue("All four modes are available the first time") {
+                choice.options.size shouldBe 4
+                choice.options shouldContain damageMode
+                choice.options shouldContain loseMode
+            }
+            game.chooseMode(choice, damageMode)
+
+            // The damage mode needs "any target" — point it at the opponent.
+            game.selectTargets(listOf(game.player2Id)).error shouldBe null
+            game.resolveStack()
+
+            withClue("4 damage to the opponent") { game.getLifeTotal(2) shouldBe 16 }
+            withClue("You gain 4 life") { game.getLifeTotal(1) shouldBe 24 }
+        }
+
+        test("a chosen mode is never offered again, and only the controller's upkeep triggers") {
+            var builder = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Demonic Pact")
+                .withLifeTotal(1, 20)
+                .withLifeTotal(2, 20)
+                .withActivePlayer(1)
+                .inPhase(Phase.BEGINNING, Step.UNTAP)
+            repeat(20) { builder = builder.withCardInLibrary(1, "Swamp") }
+            repeat(20) { builder = builder.withCardInLibrary(2, "Swamp") }
+            val game = builder.build()
+
+            // Upkeep 1 — take "Draw two cards".
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            val first = game.resolveToModeChoice()
+            first.options.size shouldBe 4
+            val handBefore = game.handSize(1)
+            game.chooseMode(first, drawMode)
+            game.resolveStack()
+            withClue("The draw mode drew two cards") {
+                game.handSize(1) shouldBe handBefore + 2
+            }
+
+            // Through the opponent's turn: no trigger there ("your upkeep").
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.resolveStack()
+            withClue("No modal choice pending on the opponent's upkeep") {
+                (game.getPendingDecision() as? ChooseOptionDecision) shouldBe null
+            }
+
+            // Upkeep 2 (controller's) — the draw mode is gone.
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            val second = game.resolveToModeChoice()
+            withClue("The already-chosen draw mode is no longer offered") {
+                second.options.size shouldBe 3
+                second.options shouldNotContain drawMode
+                second.options shouldContain discardMode
+            }
+        }
+
+        test("once the three good modes are spent, the pact collects") {
+            var builder = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Demonic Pact")
+                .withCardsInHand(2, "Swamp", 4)
+                .withLifeTotal(1, 20)
+                .withLifeTotal(2, 20)
+                .withActivePlayer(1)
+                .inPhase(Phase.BEGINNING, Step.UNTAP)
+            repeat(30) { builder = builder.withCardInLibrary(1, "Swamp") }
+            repeat(30) { builder = builder.withCardInLibrary(2, "Swamp") }
+            val game = builder.build()
+
+            // Upkeep 1 — draw two.
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.chooseMode(game.resolveToModeChoice(), drawMode)
+            game.resolveStack()
+
+            // Upkeep 2 — target opponent discards two. With a single opponent the target is forced,
+            // so resolution runs straight into the opponent's discard selection.
+            game.toNextOwnUpkeep()
+            val second = game.resolveToModeChoice()
+            val opponentHandBefore = game.handSize(2)
+            game.chooseMode(second, discardMode)
+            game.resolveAnsweringCardSelections()
+            withClue("The opponent discarded two cards") {
+                game.handSize(2) shouldBe opponentHandBefore - 2
+            }
+
+            // Upkeep 3 — 4 damage / gain 4.
+            game.toNextOwnUpkeep()
+            val third = game.resolveToModeChoice()
+            third.options.size shouldBe 2
+            game.chooseMode(third, damageMode)
+            game.selectTargets(listOf(game.player2Id)).error shouldBe null
+            game.resolveAnsweringCardSelections()
+
+            // Upkeep 4 — the contract's last clause is the only pick left.
+            game.toNextOwnUpkeep()
+            val fourth = game.resolveToModeChoice()
+            withClue("Only 'You lose the game' remains") {
+                fourth.options.size shouldBe 1
+                fourth.options shouldContain loseMode
+            }
+            game.chooseMode(fourth, loseMode)
+            game.resolveStack()
+
+            withClue("Choosing the last clause loses the game — the opponent wins") {
+                game.state.gameOver shouldBe true
+                game.state.winnerId shouldBe game.player2Id
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuilledGreatwurmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuilledGreatwurmScenarioTest.kt
@@ -1,0 +1,212 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.DistributedCounterRemoval
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Quilled Greatwurm (FDN #111) — {4}{G}{G} 7/7 Creature — Wurm.
+ *
+ * "Trample
+ *  Whenever a creature you control deals combat damage during your turn, put that many +1/+1
+ *  counters on it. (It must survive to get the counters.)
+ *  You may cast this card from your graveyard by removing six counters from among creatures you
+ *  control in addition to paying its other costs."
+ *
+ * Proven here:
+ *  - the counters trigger is battlefield-wide, not self-only: another creature you control that
+ *    connects gets counters equal to the damage it dealt;
+ *  - it does not fire on an opponent's turn (the "during your turn" gate);
+ *  - the graveyard-cast permission works once six counters are available to remove, and the counters
+ *    are actually spent;
+ *  - without six counters among your creatures, the graveyard cast isn't affordable.
+ */
+class QuilledGreatwurmScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.givePlusOneCounters(id: EntityId, count: Int) {
+        replaceState(
+            state.updateEntity(id) { c ->
+                c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to count)))
+            }
+        )
+    }
+
+    /**
+     * Attack unblocked with [attackers], push combat damage through, and resolve every resulting
+     * trigger — including the trigger-ordering prompt two simultaneous counter triggers produce.
+     */
+    fun GameTestDriver.swingUnblocked(player: EntityId, opponent: EntityId, attackers: List<EntityId>) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(player, attackers, opponent)
+        passPriorityUntil(Step.DECLARE_BLOCKERS)
+        passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (pendingDecision is CombatResolutionDecision) confirmCombatDamage()
+        var guard = 0
+        while (guard++ < 30) {
+            val decision = pendingDecision
+            when {
+                decision is CombatResolutionDecision -> confirmCombatDamage()
+                decision is OrderObjectsDecision ->
+                    submitOrderedResponse(decision.playerId, decision.objects)
+                decision != null -> autoResolveDecision()
+                state.stack.isNotEmpty() -> bothPass()
+                else -> return
+            }
+        }
+    }
+
+    fun canCastFromGraveyard(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        return enumerator.enumerate(driver.state, player, EnumerationMode.FULL).any {
+            it.sourceZone == "GRAVEYARD" && it.affordable && (it.action as? CastSpell)?.cardId == cardId
+        }
+    }
+
+    test("has trample") {
+        val d = newDriver()
+        val wurm = d.putCreatureOnBattlefield(d.player1, "Quilled Greatwurm")
+        d.state.projectedState.hasKeyword(wurm, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("a creature you control that deals combat damage on your turn gets that many +1/+1 counters") {
+        val d = newDriver()
+        val you = d.player1
+        val opponent = d.player2
+
+        val wurm = d.putCreatureOnBattlefield(you, "Quilled Greatwurm")
+        d.removeSummoningSickness(wurm)
+        // A second, unrelated creature you control — the trigger is battlefield-wide.
+        val bears = d.putCreatureOnBattlefield(you, "Grizzly Bears") // 2/2
+        d.removeSummoningSickness(bears)
+
+        d.swingUnblocked(you, opponent, listOf(wurm, bears))
+
+        withClue("The Wurm's 7 combat damage becomes seven +1/+1 counters on itself") {
+            d.plusOneCounters(wurm) shouldBe 7
+        }
+        withClue("Grizzly Bears' 2 combat damage becomes two +1/+1 counters on the Bears") {
+            d.plusOneCounters(bears) shouldBe 2
+        }
+        withClue("The opponent still took the printed damage (7 + 2)") {
+            d.getLifeTotal(opponent) shouldBe 11
+        }
+    }
+
+    test("does not trigger on an opponent's turn") {
+        val d = newDriver()
+        val you = d.player1
+        val opponent = d.player2
+
+        val wurm = d.putCreatureOnBattlefield(you, "Quilled Greatwurm")
+        val theirBears = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        d.removeSummoningSickness(theirBears)
+
+        // Hand the turn over, then let the opponent attack you.
+        d.passPriorityUntil(Step.UPKEEP)
+        withClue("It should now be the opponent's turn") {
+            (d.activePlayer == opponent) shouldBe true
+        }
+        d.swingUnblocked(opponent, you, listOf(theirBears))
+
+        withClue("The Wurm's trigger only watches YOUR creatures, and only on your turn") {
+            d.plusOneCounters(wurm) shouldBe 0
+            d.plusOneCounters(theirBears) shouldBe 0
+        }
+    }
+
+    test("castable from the graveyard by removing six counters from among your creatures") {
+        val d = newDriver()
+        val you = d.player1
+
+        val wurm = d.putCardInGraveyard(you, "Quilled Greatwurm")
+        val bears = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val elf = d.putCreatureOnBattlefield(you, "Elvish Warrior")
+        d.givePlusOneCounters(bears, 4)
+        d.givePlusOneCounters(elf, 2)
+        d.giveMana(you, Color.GREEN, 6)
+
+        withClue("Six counters across two creatures is enough") {
+            canCastFromGraveyard(d, you, wurm) shouldBe true
+        }
+
+        val result = d.submit(
+            CastSpell(
+                playerId = you,
+                cardId = wurm,
+                targets = emptyList(),
+                paymentStrategy = PaymentStrategy.FromPool,
+                additionalCostPayment = AdditionalCostPayment(
+                    distributedCounterRemovals = listOf(
+                        DistributedCounterRemoval(bears, "+1/+1", 4),
+                        DistributedCounterRemoval(elf, "+1/+1", 2)
+                    )
+                )
+            )
+        )
+        withClue("Casting from the graveyard should succeed") { result.isSuccess shouldBe true }
+        d.bothPass()
+
+        withClue("The Wurm resolved onto the battlefield") {
+            (d.findPermanent(you, "Quilled Greatwurm") != null) shouldBe true
+        }
+        withClue("All six counters were actually removed") {
+            d.plusOneCounters(bears) shouldBe 0
+            d.plusOneCounters(elf) shouldBe 0
+        }
+    }
+
+    test("not castable from the graveyard without six counters to remove") {
+        val d = newDriver()
+        val you = d.player1
+
+        val wurm = d.putCardInGraveyard(you, "Quilled Greatwurm")
+        val bears = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.givePlusOneCounters(bears, 5)
+        d.giveMana(you, Color.GREEN, 6)
+
+        withClue("Five counters is one short") {
+            canCastFromGraveyard(d, you, wurm) shouldBe false
+        }
+        d.submitExpectFailure(
+            CastSpell(
+                playerId = you,
+                cardId = wurm,
+                targets = emptyList(),
+                paymentStrategy = PaymentStrategy.FromPool,
+                additionalCostPayment = AdditionalCostPayment(
+                    distributedCounterRemovals = listOf(
+                        DistributedCounterRemoval(bears, "+1/+1", 5)
+                    )
+                )
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WishclawTalismanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WishclawTalismanScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eld.cards.WishclawTalisman
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wishclaw Talisman (ELD #110, canonical printing) — {1}{B} Artifact.
+ *
+ * "This artifact enters with three wish counters on it.
+ *  {1}, {T}, Remove a wish counter from this artifact: Search your library for a card, put it into
+ *  your hand, then shuffle. An opponent gains control of this artifact. Activate only during your
+ *  turn."
+ *
+ * Proven here:
+ *  - the enters-with-three-wish-counters replacement (CR 614.1c) fires when it resolves from a cast;
+ *  - activating tutors a card to hand, spends one wish counter, and hands the artifact to the
+ *    opponent (the "an opponent gains control" clause, chosen on resolution — forced in a two-player
+ *    game);
+ *  - the ability is unactivatable on an opponent's turn (`ActivationRestriction.OnlyDuringYourTurn`);
+ *  - with no wish counters left the ability can't be activated at all, matching the printed ruling
+ *    that the Talisman simply sits there once the counters run out.
+ */
+class WishclawTalismanScenarioTest : FunSpec({
+
+    val abilityId = WishclawTalisman.activatedAbilities.first().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Drain the stack, stopping at decisions or errors. */
+    fun GameTestDriver.drainStack(maxIterations: Int = 20) {
+        var guard = 0
+        while (state.stack.isNotEmpty() && !isPaused && guard++ < maxIterations) {
+            bothPass()
+        }
+    }
+
+    fun GameTestDriver.wishCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.WISH) ?: 0
+
+    fun GameTestDriver.setWishCounters(id: EntityId, count: Int) {
+        replaceState(
+            state.updateEntity(id) { c ->
+                c.with(CountersComponent(mapOf(CounterType.WISH to count)))
+            }
+        )
+    }
+
+    test("enters with three wish counters when cast") {
+        val d = newDriver()
+        val you = d.player1
+
+        val talisman = d.putCardInHand(you, "Wishclaw Talisman")
+        d.giveMana(you, Color.BLACK, 2)
+        d.castSpell(you, talisman)
+        d.bothPass()
+
+        val onBattlefield = d.findPermanent(you, "Wishclaw Talisman")
+        withClue("Wishclaw Talisman should resolve onto the battlefield") {
+            (onBattlefield != null) shouldBe true
+        }
+        withClue("It enters with three wish counters") {
+            d.wishCounters(onBattlefield!!) shouldBe 3
+        }
+    }
+
+    test("activating tutors a card to hand, spends a wish counter, and gives the artifact to the opponent") {
+        val d = newDriver()
+        val you = d.player1
+        val opponent = d.player2
+
+        val talisman = d.putPermanentOnBattlefield(you, "Wishclaw Talisman")
+        d.setWishCounters(talisman, 3)
+        d.giveColorlessMana(you, 1)
+
+        val handBefore = d.getHandSize(you)
+
+        val result = d.submit(
+            ActivateAbility(playerId = you, sourceId = talisman, abilityId = abilityId)
+        )
+        withClue("Activating the tutor ability during your own turn should succeed") {
+            result.isSuccess shouldBe true
+        }
+
+        // Resolve until the library-search selection pauses.
+        d.drainStack()
+        withClue("The library search should present a SelectCardsDecision") {
+            (d.pendingDecision is SelectCardsDecision) shouldBe true
+        }
+        val decision = d.pendingDecision as SelectCardsDecision
+        withClue("The search should offer the whole library (no filter)") {
+            decision.options.isEmpty() shouldBe false
+        }
+        val fetched = decision.options.first()
+        d.submitCardSelection(you, listOf(fetched))
+        d.drainStack()
+
+        withClue("The searched card should be in your hand") {
+            d.state.getZone(ZoneKey(you, Zone.HAND)).contains(fetched) shouldBe true
+        }
+        withClue("Your hand grew by exactly the tutored card") {
+            d.getHandSize(you) shouldBe handBefore + 1
+        }
+        withClue("Paying the cost removed one wish counter (3 -> 2)") {
+            d.wishCounters(talisman) shouldBe 2
+        }
+        withClue("Tapping was part of the cost") {
+            d.isTapped(talisman) shouldBe true
+        }
+        withClue("The opponent now controls the Talisman") {
+            d.state.projectedState.getController(talisman) shouldBe opponent
+        }
+    }
+
+    test("cannot be activated during an opponent's turn") {
+        val d = newDriver()
+        val you = d.player1
+
+        val talisman = d.putPermanentOnBattlefield(you, "Wishclaw Talisman")
+        d.setWishCounters(talisman, 3)
+
+        // Advance into the opponent's turn.
+        d.passPriorityUntil(Step.UPKEEP)
+        withClue("The opponent should now be the active player") {
+            (d.activePlayer != you) shouldBe true
+        }
+        d.giveColorlessMana(you, 1)
+
+        val activatable = d.legalActions(you).any {
+            (it.action as? ActivateAbility)?.let { a -> a.sourceId == talisman && a.abilityId == abilityId } == true
+        }
+        withClue("OnlyDuringYourTurn should keep the ability out of the legal actions") {
+            activatable shouldBe false
+        }
+        d.submitExpectFailure(
+            ActivateAbility(playerId = you, sourceId = talisman, abilityId = abilityId)
+        )
+    }
+
+    test("cannot be activated once the wish counters run out") {
+        val d = newDriver()
+        val you = d.player1
+
+        val talisman = d.putPermanentOnBattlefield(you, "Wishclaw Talisman")
+        d.setWishCounters(talisman, 0)
+        d.giveColorlessMana(you, 1)
+
+        val activatable = d.legalActions(you).any {
+            val a = it.action as? ActivateAbility
+            a != null && a.sourceId == talisman && a.abilityId == abilityId && it.affordable
+        }
+        withClue("With zero wish counters the removal cost is unpayable") {
+            activatable shouldBe false
+        }
+        d.submitExpectFailure(
+            ActivateAbility(playerId = you, sourceId = talisman, abilityId = abilityId)
+        )
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -127,4 +127,5 @@ export const counterManaClass: Record<string, string> = {
   FELLOWSHIP: 'counter-devotion',
   BAIT: 'counter-fungus',
   POINT: 'counter-charge',
+  WISH: 'counter-charge',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -687,6 +687,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.BAIT,
   CounterType.BORE,
   CounterType.POINT,
+  CounterType.WISH,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1899,6 +1899,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   FELLOWSHIP: { bg: 'rgba(58, 44, 20, 0.95)', border: 'rgba(214, 178, 96, 0.65)', color: '#e8d3a0', glow: 'rgba(214, 178, 96, 0.5)' },
   BAIT: { bg: 'rgba(18, 48, 62, 0.95)', border: 'rgba(96, 186, 214, 0.65)', color: '#9ed4e8', glow: 'rgba(96, 186, 214, 0.5)' },
   POINT: { bg: 'rgba(20, 55, 35, 0.95)', border: 'rgba(110, 210, 150, 0.7)', color: '#9ce0b8', glow: 'rgba(110, 210, 150, 0.55)' },
+  WISH: { bg: 'rgba(35, 22, 48, 0.95)', border: 'rgba(170, 130, 210, 0.7)', color: '#c8a8e0', glow: 'rgba(170, 130, 210, 0.55)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -407,6 +407,7 @@ export enum CounterType {
   BAIT = 'BAIT',
   BORE = 'BORE',
   POINT = 'POINT',
+  WISH = 'WISH',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -470,6 +471,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.BAIT]: 'Bait',
   [CounterType.BORE]: 'Bore',
   [CounterType.POINT]: 'Point',
+  [CounterType.WISH]: 'Wish',
 }
 
 /**


### PR DESCRIPTION
Implements three of the remaining unimplemented Foundations cards. Each is placed
in its **earliest real printing** with an FDN `Printing` row where needed
(`just check-card-printing` clean for all three).

| Card | Canonical set | FDN row |
|---|---|---|
| Wishclaw Talisman | ELD #110 | #617 |
| Demonic Pact | ORI #92 | #602 |
| Quilled Greatwurm | FDN #111 (original) | — |

## Wishclaw Talisman
`{1}{B}` Artifact — enters with three wish counters; `{1}, {T}`, remove a wish
counter: tutor a card to hand, then an opponent gains control of it. Activate only
during your turn.

- Adds the passive **`wish` counter type** across all five layers (SDK enum +
  `Counters` constant, client enum / display name / mana-font class / passive-counter
  badge palette). No inherent rule, so it stays out of
  `StateProjector.KEYWORD_COUNTER_MAP`.
- "An opponent gains control" is *not* targeted — the controller picks while the
  ability resolves (Scryfall ruling) — so it composes `Effects.ChooseOpponent` with
  `GiveControlToTargetPlayerEffect(newController = Player.ChosenOpponent)`.
- **Engine fix:** `GiveControlToTargetPlayerExecutor` resolved the new controller via
  the *stateless* `resolvePlayerTarget` overload, which cannot see stored/relational
  player references (`Player.ChosenOpponent`, `Player.ControllerOf`, …) and silently
  errored out. Switched to the state-aware overload — strictly more capable; the
  existing `ContextTarget(0)` users (Custody Battle, Harmless Offering, Witch Engine,
  Risky Move) are unaffected.
- Running out of counters simply makes the cost unpayable, which is exactly the
  printed ruling that the Talisman then sits inert on the battlefield.

## Demonic Pact
`{2}{B}{B}` Enchantment — "At the beginning of your upkeep, choose one that hasn't
been chosen —" over the four modes. Pure authoring on
`ModalEffect.chooseOneNotYetChosen`, whose mode memory is keyed to the permanent
(CR 700.4 object identity) — matching the rulings that a second copy starts fresh and
a new controller inherits the spent modes.

## Quilled Greatwurm
`{4}{G}{G}` 7/7 Wurm, trample. Pure authoring on existing primitives:
- Battlefield-wide counters trigger:
  `Triggers.dealsDamage(Combat, RecipientFilter.Any, Creature.youControl(), ANY)` with
  `triggerCondition = Conditions.IsYourTurn` (a fire-time gate, so nothing triggers at
  all on an opponent's turn), `TRIGGER_DAMAGE_AMOUNT` for "that many" and
  `EffectTarget.TriggeringEntity` for "on it".
- Graveyard clause: `MayCastSelfFromZones(GRAVEYARD, additionalCost =
  Costs.additional.RemoveCounters(6))` — normal timing and the printed mana cost still
  apply, and the six counters may be any type spread across any of your creatures.

## Verification
- 3 new scenario tests, 12 cases, all passing — enters-with-counters, the tutor +
  control handover, both activation restrictions, mode exhaustion across four turns,
  the losing clause ending the game, the battlefield-wide counters trigger (and its
  your-turn gate), and the graveyard cast both with and without enough counters.
- `just test` green across every module; `npm run typecheck` green.
- `CardDefinitionSnapshotTest` re-blessed: ELD/ORI/FDN goldens show **only** the three
  new card trees added, no unrelated card moved.
- `docs/card-sdk-language-reference.md` updated for the new counter type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)