### PR TITLE
Add Nine-Lives Familiar and Maze's End (FDN)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -202,7 +202,7 @@ excluded.
 > (`PayCost.OwnManaCost` / `PayCost.Choice`; `AdditionalCost`'s Behold / Blight / Forage / ChooseEntity
 > / per-target life / variable exile; `AbilityCost`'s `Free`, `Tap`/`Untap`, the X-variable costs
 > (`PayXLife`, `ExileXFromGraveyard`, `TapXPermanents`), the self-referential `SacrificeSelf` /
-> `ExileSelf` / `ExileGrantingPermanent`, counter-removal, `Loyalty`, `Composite`, and named mechanics
+> `ExileSelf` / `ReturnSelfToHand` / `ExileGrantingPermanent`, counter-removal, `Loyalty`, `Composite`, and named mechanics
 > `Forage` / `Blight` / `Craft`). The `Costs.*` facades below are unchanged — they construct the right
 > `…Atom(CostAtom.X(…))` for you, so card authoring is identical. A *new* payable thing is one
 > `CostAtom` variant + one engine payment branch, available in every context.
@@ -239,6 +239,15 @@ excluded.
   since left their hand (matches the Scryfall ruling: "If you do not have the card still in your
   hand, you can't pay the cost").
 - `Costs.ExileSelf` — exile this permanent (or graveyard card, for graveyard-activated abilities).
+- `Costs.ReturnSelfToHand` — return this permanent to its owner's hand (Maze's End: "{3}, {T},
+  Return this land to its owner's hand: …"). The bounce-to-hand sibling of `Costs.SacrificeSelf` /
+  `Costs.ExileSelf`: deterministic, so there is no player selection and no `additionalCostInfo` is
+  surfaced to the client — the engine pays it during activation, before the ability goes on the
+  stack (CR 601.2h), and the ability still resolves with its source gone. Contrast
+  `Costs.ReturnToHand(filter, count)`, the choose-a-permanent-you-control bounce cost, which
+  deliberately excludes the source. Like the other self-removing costs it snapshots the source's
+  counters first, so the resolving effect can still read them via
+  `DynamicAmounts.lastKnownSourceCounters(...)`.
 - `Costs.ExileFromGraveyard(count, filter)` — exile N matching cards from your graveyard.
 - `Costs.ExileXFromGraveyard(filter)` — exile X cards from your graveyard (X = the ability's
   chosen X value).
@@ -864,6 +873,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   keep it out of `StateProjector.KEYWORD_COUNTER_MAP` since it grants no keyword. Recent examples:
   `Counters.LANDMARK` (Treasure Map — three flip it into Treasure Cove), `Counters.DREAD` (Grasping Shadows —
   three flip it into Shadows' Lair), `Counters.BORE` (Brass's Tunnel-Grinder — three flip it into Tecutlan),
+  `Counters.REVIVAL` (Nine-Lives Familiar — a "lives left" counter: it enters with eight if you cast it and its
+  dies trigger reads the last-known count to come back with one fewer),
   `Counters.NET`, `Counters.FIRE`, `Counters.CONQUEROR`, `Counters.POINT` (Contested Game Ball — its
   `{2}, {T}` ability adds one per activation and, when five or more are present, sacrifices the artifact and
   creates a Treasure), `Counters.WISH` (Wishclaw Talisman — see below).
@@ -6109,23 +6120,38 @@ Numbers computed at resolution time.
 ### Counters
 
 - `CountersOnSource(type)` — counters of `type` on the source permanent.
-- `LastKnownCountersOnSource(type)` — counters when source last existed (for dies-triggers).
+- `LastKnownSourceCounters(type)` — counters the source had as it last existed on the battlefield (dies/leaves
+  triggers, and self-exile/self-sacrifice costs) — see "Last-known source counters" below.
 - `CountersOnTarget(target, type)` — counters on a target permanent.
 - `CountersOnContext(path, type)` — counters stored in an `EffectContext` path.
 
-### Last-known source counters (self-exile / self-sacrifice cost)
+### Last-known source counters (self-exile / self-sacrifice cost, dies/leaves triggers)
 
-- `LastKnownSourceCounters(CounterTypeFilter)` — the number of matching counters the *source* had the moment its
-  self-exile / self-sacrifice cost wiped them (CR 112.7a / 122.2). When an activated ability's cost exiles or
-  sacrifices its own source, the counters are gone by resolution, so `ActivateAbilityHandler` snapshots them into the
-  resolution context at cost-payment time and this node reads them back. `CounterTypeFilter.Any` sums all counter
-  types; otherwise it reads the named/typed counter. Facade: `DynamicAmounts.lastKnownSourceCounters(filter)`.
-  Example — Lost Isle Calling: "{4}{U}{U}, Exile this enchantment: Draw a card for each verse counter on this
-  enchantment. If it had seven or more verse counters on it, take an extra turn." Both the draw amount
-  (`DrawCards(lastKnownSourceCounters(Named(Counters.VERSE)))`) and the seven-or-more gate
-  (`Compare(lastKnownSourceCounters(Named(Counters.VERSE)), GTE, Fixed(7))`) read this node. Contrast
-  `EntityProperty(Source, CounterCount(filter))`, which reads counters on the still-present source (zero after a
-  self-exile cost).
+- `LastKnownSourceCounters(CounterTypeFilter)` — the number of matching counters the *source* had as it last existed
+  on the battlefield (CR 112.7a / 608.2h). Counters cease to exist on a zone change (CR 122.2), so the value comes
+  from whichever snapshot the resolution context carries — the two never both apply to one resolution:
+  - the **cost-payment** snapshot, taken by `ActivateAbilityHandler` when an activated ability's cost exiles or
+    sacrifices its own source. Lost Isle Calling: "{4}{U}{U}, Exile this enchantment: Draw a card for each verse
+    counter on this enchantment. If it had seven or more verse counters on it, take an extra turn." Both the draw
+    amount (`DrawCards(lastKnownSourceCounters(Named(Counters.VERSE)))`) and the seven-or-more gate
+    (`Compare(lastKnownSourceCounters(Named(Counters.VERSE)), GTE, Fixed(7))`) read this node.
+  - the **leaves-the-battlefield** snapshot carried on a dies/leaves trigger (`TriggerContext.lastKnownCounters`),
+    available both to the intervening-`if` (`triggerCondition`) and to the resolving effect. Nine-Lives Familiar:
+    "When this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival
+    counter on it at the beginning of the next end step."
+
+  `CounterTypeFilter.Any` sums all counter types; otherwise it reads the named/typed counter — naming the kind is
+  what stops an unrelated +1/+1 counter from satisfying "if it had a revival counter on it". This is the
+  parameterized sibling of `ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT` (fixed to +1/+1) and
+  `LAST_KNOWN_TOTAL_COUNTER_COUNT` (sums every kind). Facade: `DynamicAmounts.lastKnownSourceCounters(filter)`.
+  Contrast `EntityProperty(Source, CounterCount(filter))`, which reads counters on the still-present source (zero
+  once it has left the battlefield).
+
+  **Scheduling it into a delayed trigger:** a value read from the dies-trigger context is gone by the time a
+  `CreateDelayedTriggerEffect` fires, so `CreateDelayedTriggerExecutor` snapshots the `amount` of a nested
+  `AddDynamicCountersEffect` into a `Fixed` literal at scheduling time (the same treatment `AddManaEffect` gets).
+  That is how Nine-Lives Familiar's "with one fewer revival counter" —
+  `Subtract(lastKnownSourceCounters(Named(Counters.REVIVAL)), Fixed(1))` — survives to the end step.
 
 - **Last-known source P/T (self-exile / self-sacrifice cost)** — the P/T analogue of
   `LastKnownSourceCounters`, applied automatically to `EntityProperty(EntityReference.Source, Power|Toughness)`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -343,7 +343,7 @@ object Counters {
      * Revival counter (FDN — Nine-Lives Familiar). Passive "lives left" counter with no inherent
      * rule of its own — the Familiar enters with eight if you cast it, and its dies trigger reads
      * the last-known count (via
-     * `DynamicAmounts.lastKnownCountersOnSelf(CounterTypeFilter.Named(Counters.REVIVAL))`) to
+     * `DynamicAmounts.lastKnownSourceCounters(CounterTypeFilter.Named(Counters.REVIVAL))`) to
      * return itself with one fewer. NOT a keyword counter, so it is intentionally absent from
      * `StateProjector.KEYWORD_COUNTER_MAP`.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -74,7 +74,8 @@ enum class CounterType {
     BAIT,
     BORE,
     POINT,
-    WISH;
+    WISH,
+    REVIVAL;
 
     companion object {
         /**
@@ -337,6 +338,16 @@ object Counters {
      * `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val WISH = "wish"
+
+    /**
+     * Revival counter (FDN — Nine-Lives Familiar). Passive "lives left" counter with no inherent
+     * rule of its own — the Familiar enters with eight if you cast it, and its dies trigger reads
+     * the last-known count (via
+     * `DynamicAmounts.lastKnownCountersOnSelf(CounterTypeFilter.Named(Counters.REVIVAL))`) to
+     * return itself with one fewer. NOT a keyword counter, so it is intentionally absent from
+     * `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val REVIVAL = "revival"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -172,6 +172,13 @@ object Costs {
     val ExileSelf: AbilityCost = AbilityCost.ExileSelf
 
     /**
+     * Return this permanent to its owner's hand (for abilities that bounce themselves as cost —
+     * Maze's End). No player selection: the source is the only thing that moves. Contrast
+     * [ReturnToHand], the choose-a-permanent-you-control bounce cost, which excludes the source.
+     */
+    val ReturnSelfToHand: AbilityCost = AbilityCost.ReturnSelfToHand
+
+    /**
      * Exile the permanent that granted this activated ability (e.g., the equipment
      * granting the ability to its equipped creature, like The Dominion Bracelet).
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -331,10 +331,12 @@ object DynamicAmounts {
         DynamicAmount.ContextProperty(ContextPropertyKey.ADDITIONAL_COST_EXILED_COUNT)
 
     /**
-     * The number of [filter] counters the source had the moment its self-exile / self-sacrifice
-     * cost wiped them — "for each verse counter on this" / "if it had seven or more counters on it"
-     * read as last-known information (CR 112.7a). See
-     * [DynamicAmount.LastKnownSourceCounters] (Lost Isle Calling).
+     * The number of [filter] counters the source had as it last existed on the battlefield
+     * (CR 112.7a / 608.2h) — either wiped by its own self-exile / self-sacrifice cost ("for each
+     * verse counter on this" / "if it had seven or more counters on it", Lost Isle Calling) or
+     * captured when it left the battlefield, for a dies/leaves trigger ("if it had a revival
+     * counter on it", Nine-Lives Familiar). See [DynamicAmount.LastKnownSourceCounters]; use
+     * [countersOnSelf] for a permanent that is still on the battlefield.
      */
     fun lastKnownSourceCounters(
         filter: com.wingedsheep.sdk.scripting.events.CounterTypeFilter

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -284,6 +284,21 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
+     * Return self to its owner's hand — "Return this land to its owner's hand" as part of an
+     * activation cost (Maze's End). The bounce-to-hand sibling of [SacrificeSelf] / [ExileSelf]:
+     * the source itself is the only thing that moves, so there is no player selection, and the
+     * cost is paid (and therefore uninterruptible, CR 601.2h) before the ability goes on the stack.
+     *
+     * Distinct from `CostAtom.ReturnToHand`, which is the *choose-a-permanent-you-control* bounce
+     * cost and deliberately excludes the source.
+     */
+    @SerialName("CostReturnSelfToHand")
+    @Serializable
+    data object ReturnSelfToHand : AbilityCost {
+        override val description: String = "Return this permanent to its owner's hand"
+    }
+
+    /**
      * Exile the permanent that granted this activated ability to the source.
      * Used by cards like The Dominion Bracelet whose static ability grants an
      * activated ability to the equipped creature with "exile [the equipment]"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -392,16 +392,25 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
-     * The number of counters matching [counterType] that the *source* of the current ability had
-     * the moment its self-exile / self-sacrifice cost was paid (CR 112.7a / 608.2h last-known
-     * information). When an activated ability's cost exiles or sacrifices its own source, the
-     * source's counters are gone by the time the effect resolves (CR 122.2 removes counters on a
-     * zone change), so the count is snapshotted into the resolution context at cost-payment time.
+     * The number of counters matching [counterType] the *source* of the current ability had as it
+     * last existed on the battlefield (CR 112.7a / 608.2h last-known information). Counters cease
+     * to exist on a zone change (CR 122.2), so the count comes from whichever snapshot the
+     * resolution context carries:
      *
-     * Example — Lost Isle Calling: "{4}{U}{U}, Exile this enchantment: Draw a card for each verse
-     * counter on this enchantment. If it had seven or more verse counters on it, take an extra turn
-     * after this one." Both the draw amount and the seven-or-more test read
-     * `LastKnownSourceCounters(CounterTypeFilter.Named(Counters.VERSE))`.
+     *  - the **cost-payment** snapshot, when an activated ability's cost exiles or sacrifices its
+     *    own source — Lost Isle Calling: "{4}{U}{U}, Exile this enchantment: Draw a card for each
+     *    verse counter on this enchantment. If it had seven or more verse counters on it, take an
+     *    extra turn after this one." Both the draw amount and the seven-or-more test read
+     *    `LastKnownSourceCounters(CounterTypeFilter.Named(Counters.VERSE))`.
+     *  - the **leaves-the-battlefield trigger** snapshot, for a dies/leaves ability reading the
+     *    counters its source had as it died — Nine-Lives Familiar: "When this creature dies, if it
+     *    had a revival counter on it, return it … with one fewer revival counter on it."
+     *
+     * The parameterized sibling of [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] (fixed to
+     * +1/+1) and [ContextPropertyKey.LAST_KNOWN_TOTAL_COUNTER_COUNT] (sums every kind): naming one
+     * kind means an unrelated +1/+1 counter can't satisfy "if it had a revival counter on it".
+     * Evaluates to `0` when neither snapshot is present; a permanent still on the battlefield
+     * should be read with [com.wingedsheep.sdk.dsl.DynamicAmounts.countersOnSelf] instead.
      */
     @SerialName("LastKnownSourceCounters")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/MazesEnd.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/MazesEnd.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dgm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val gate = GameObjectFilter.Land.withSubtype(Subtype.GATE.value)
+
+/**
+ * Maze's End
+ * Land
+ * This land enters tapped.
+ * {T}: Add {C}.
+ * {3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it
+ * onto the battlefield, then shuffle. If you control ten or more Gates with different names,
+ * you win the game.
+ *
+ * Modeling notes:
+ *  - Returning Maze's End to hand is part of the **cost** (`Costs.ReturnSelfToHand`), not the
+ *    effect — per the 2013-04-15 ruling players can't respond between announcement and payment,
+ *    and the ability resolves even though its source has left the battlefield.
+ *  - The win check happens *as the ability resolves*, after the search, and happens even if no
+ *    Gate was found (the search is "search for a Gate card", which may fail or be declined). It's
+ *    modeled as a `ConditionalEffect` sequenced after the search rather than a separate trigger,
+ *    so it is checked once, at resolution, and never at other times.
+ *  - "ten or more Gates with different names" counts each name once, hence
+ *    `distinctNames()` — controlling several Guildgates of the same name adds nothing.
+ *  - Maze's End itself is a plain Land, not a Gate, so it never counts toward its own total.
+ */
+val MazesEnd = card("Maze's End") {
+    manaCost = ""
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {C}.\n{3}, {T}, Return this land to its " +
+        "owner's hand: Search your library for a Gate card, put it onto the battlefield, then " +
+        "shuffle. If you control ten or more Gates with different names, you win the game."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.ReturnSelfToHand)
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = gate,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+                shuffleAfter = true
+            ),
+            ConditionalEffect(
+                condition = Conditions.CompareAmounts(
+                    DynamicAmounts.battlefield(Player.You, gate).distinctNames(),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(10)
+                ),
+                effect = Effects.WinGame()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "152"
+        artist = "Cliff Childs"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg?1783940010"
+        ruling("2013-04-15", "Returning Maze's End to its owner's hand is part of the cost to activate its last ability. Once that ability is announced, players can't respond to it until after you've paid its activation cost and returned Maze's End to hand.")
+        ruling("2013-04-15", "When the last ability of Maze's End resolves, you'll search for a Gate and put it onto the battlefield before checking to see if you win the game. This check will happen even if you don't put a Gate onto the battlefield this way. This check will happen only as the ability resolves, not at other times.")
+        ruling("2013-04-15", "Putting a Gate onto the battlefield with Maze's End doesn't count as the one land you can play during your turn. If it's your turn, you can play Maze's End or a different land card from your hand after its ability has resolved.")
+        ruling("2013-04-15", "Controlling multiple Gates with the same name has no effect on your ability to win the game with Maze's End. The excess Gates are simply ignored.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MazesEndReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MazesEndReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maze's End reprint in Foundations. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Dragon's Maze
+ * (`definitions/dgm/cards/MazesEnd.kt`); this file contributes only presentation data.
+ */
+val MazesEndReprint = Printing(
+    oracleId = "49479778-c4c0-43ba-a7b7-45f00d067462",
+    name = "Maze's End",
+    setCode = "FDN",
+    collectorNumber = "727",
+    scryfallId = "ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea9a4d1a-79dd-4b15-8e3b-f111f16d6bfc.jpg?1783908887",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NineLivesFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NineLivesFamiliar.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val revivalCounters = CounterTypeFilter.Named(Counters.REVIVAL)
+
+/**
+ * Nine-Lives Familiar
+ * {1}{B}{B}
+ * Creature — Cat
+ * 1/1
+ * This creature enters with eight revival counters on it if you cast it.
+ * When this creature dies, if it had a revival counter on it, return it to the battlefield with
+ * one fewer revival counter on it at the beginning of the next end step.
+ *
+ * Modeling notes:
+ *  - "Enters with … if you cast it" is a replacement effect (CR 614.1c), not an ETB trigger, so a
+ *    reanimated or "put onto the battlefield" Familiar simply enters with no counters and never
+ *    comes back. [Conditions.WasCast] is the same gate the Sunderflock family uses.
+ *  - The dies trigger's intervening "if" reads the *last-known* revival count (CR 603.10a) — the
+ *    counters ceased to exist the moment it left the battlefield (CR 122.2). Naming the counter
+ *    kind matters: an unrelated +1/+1 counter must not keep the loop alive.
+ *  - The return is a delayed trigger at the next end step, on *any* player's turn (the oracle says
+ *    "the next end step", not "your next end step"), so it uses the default timing with no
+ *    `fireOnPlayer` gate. The count is snapshotted when the delayed trigger is scheduled, because
+ *    the last-known-counter context belongs to the dies trigger and is gone by the time it fires.
+ *  - `fromZone = Zone.GRAVEYARD` makes the return a no-op if something else moved the card out of
+ *    the graveyard in the meantime.
+ */
+val NineLivesFamiliar = card("Nine-Lives Familiar") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 1
+    oracleText = "This creature enters with eight revival counters on it if you cast it.\n" +
+        "When this creature dies, if it had a revival counter on it, return it to the battlefield " +
+        "with one fewer revival counter on it at the beginning of the next end step."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = revivalCounters,
+            count = 8,
+            selfOnly = true,
+            condition = Conditions.WasCast
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerCondition = Compare(
+            DynamicAmounts.lastKnownSourceCounters(revivalCounters),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(1)
+        )
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END,
+            effect = Effects.Composite(
+                Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
+                Effects.AddDynamicCounters(
+                    counterType = Counters.REVIVAL,
+                    amount = DynamicAmount.Subtract(
+                        DynamicAmounts.lastKnownSourceCounters(revivalCounters),
+                        DynamicAmount.Fixed(1)
+                    ),
+                    target = EffectTarget.Self
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        artist = "Bram Sels"
+        flavorText = "Her master gathered the bones to resurrect her, only to find her purring on the altar."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg?1783909109"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DGM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DGM.json
@@ -1,3 +1,134 @@
+// Maze's End
+{
+    "name": "Maze's End",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {C}.\n{3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle. If you control ten or more Gates with different names, you win the game.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        "CostReturnSelfToHand"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "land Gate"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "land Gate",
+                                        "aggregation": "DISTINCT_NAMES"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 10
+                                    }
+                                }
+                            },
+                            "then": "WinGame"
+                        }
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "MYTHIC",
+        "artist": "Cliff Childs",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/401f7042-24fd-42a0-ae7c-e6b7de1aa446.jpg?1783940010",
+        "rulings": [
+            {
+                "date": "2013-04-15",
+                "text": "Returning Maze's End to its owner's hand is part of the cost to activate its last ability. Once that ability is announced, players can't respond to it until after you've paid its activation cost and returned Maze's End to hand."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "When the last ability of Maze's End resolves, you'll search for a Gate and put it onto the battlefield before checking to see if you win the game. This check will happen even if you don't put a Gate onto the battlefield this way. This check will happen only as the ability resolves, not at other times."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "Putting a Gate onto the battlefield with Maze's End doesn't count as the one land you can play during your turn. If it's your turn, you can play Maze's End or a different land card from your hand after its ability has resolved."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "Controlling multiple Gates with the same name has no effect on your ability to win the game with Maze's End. The excess Gates are simply ignored."
+            }
+        ]
+    }
+}
+
 // Unflinching Courage
 {
     "name": "Unflinching Courage",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -5483,6 +5483,101 @@
     ]
 }
 
+// Nine-Lives Familiar
+{
+    "name": "Nine-Lives Familiar",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": "Self",
+                                "destination": "Battlefield",
+                                "fromZone": "Graveyard"
+                            },
+                            {
+                                "type": "AddDynamicCounters",
+                                "counterType": "revival",
+                                "amount": {
+                                    "type": "Subtract",
+                                    "left": {
+                                        "type": "LastKnownSourceCounters",
+                                        "counterType": {
+                                            "type": "Named",
+                                            "name": "revival"
+                                        }
+                                    },
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "LastKnownSourceCounters",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "revival"
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "revival"
+                },
+                "count": 8,
+                "selfOnly": true,
+                "condition": "WasCast"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "Bram Sels",
+        "flavorText": "Her master gathered the bones to resurrect her, only to find her purring on the altar.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/988c23f6-59fe-49f9-a9ce-9881dccb7033.jpg?1783909109"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Niv-Mizzet, Visionary
 {
     "name": "Niv-Mizzet, Visionary",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1622,6 +1622,10 @@ class TriggerMatcher(
                 triggerCounterCount = trigger.triggerContext.counterCount,
                 triggerTotalCounterCount = trigger.triggerContext.totalCounterCount,
                 triggerMinusOneMinusOneCounterCount = trigger.triggerContext.minusOneMinusOneCounterCount,
+                // Per-kind last-known counters, so an intervening "if" can name the counter it
+                // cares about ("if it had a revival counter on it" — Nine-Lives Familiar) instead
+                // of settling for the +1/+1-only or sum-of-all-kinds scalars above.
+                triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,
                 triggerLastKnownSubtypes = trigger.triggerContext.lastKnownSubtypes,
                 triggerLastKnownPower = trigger.triggerContext.lastKnownPower,
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -124,6 +124,10 @@ class CostHandler {
                 // Source must exist (can be on battlefield or in graveyard for graveyard abilities)
                 state.getEntity(sourceId) != null
             }
+            is AbilityCost.ReturnSelfToHand -> {
+                // Source must be on the battlefield to be bounced from it (Maze's End).
+                state.getZone(ZoneKey(controllerId, Zone.BATTLEFIELD)).contains(sourceId)
+            }
             is AbilityCost.ExileGrantingPermanent -> {
                 // Granter is resolved from the static-grant lookup at activation time.
                 // If the ability is enumerable, the granter is on the battlefield; if it has
@@ -345,6 +349,19 @@ class CostHandler {
                 // Delegate zone movement to ZoneTransitionService for full cleanup
                 val transitionResult = ZoneTransitionService.moveToZone(
                     state, sourceId, Zone.EXILE
+                )
+
+                CostPaymentResult.success(transitionResult.state, manaPool, transitionResult.events)
+            }
+            is AbilityCost.ReturnSelfToHand -> {
+                // Return the source permanent to its owner's hand (Maze's End). Paid as part of
+                // the activation cost, so it happens before the ability is on the stack — the
+                // ability still resolves even though its source has left the battlefield.
+                state.getEntity(sourceId)
+                    ?: return CostPaymentResult.failure("Source permanent not found")
+
+                val transitionResult = ZoneTransitionService.moveToZone(
+                    state, sourceId, Zone.HAND
                 )
 
                 CostPaymentResult.success(transitionResult.state, manaPool, transitionResult.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -117,11 +117,16 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.XValue -> context.xValue ?: 0
 
-            // Counters the source had the moment its self-exile / self-sacrifice cost wiped them
-            // (CR 112.7a). Snapshotted into the resolution context at cost-payment time so the
-            // resolving effect reads the pre-cost count rather than zero (Lost Isle Calling).
+            // Counters the source had as it last existed on the battlefield (CR 112.7a / 608.2h).
+            // Two snapshots feed this, and they never both apply to one resolution: the cost-payment
+            // one, taken when a self-exile / self-sacrifice cost wiped the counters (Lost Isle
+            // Calling), and the leaves-the-battlefield one carried on a dies/leaves trigger
+            // (Nine-Lives Familiar's "if it had a revival counter on it"). Prefer the cost snapshot
+            // and fall back to the trigger's, so either path reads the pre-departure count rather
+            // than zero.
             is DynamicAmount.LastKnownSourceCounters -> {
                 val snapshot = context.lastKnownSourceCounters
+                    .ifEmpty { context.triggerLastKnownCounters ?: emptyMap() }
                 when (val filter = amount.counterType) {
                     is CounterTypeFilter.Any -> snapshot.values.sum()
                     else -> snapshot[counterTypeToString(resolveCounterType(filter))] ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1904,12 +1904,12 @@ class ActivateAbilityHandler(
     }
 
     /**
-     * Whether [cost] removes the source from its current zone — a self-exile or self-sacrifice.
-     * Used to decide whether to snapshot the source's counters before payment so the resolving
-     * effect can read the pre-cost count (DynamicAmount.LastKnownSourceCounters).
+     * Whether [cost] removes the source from its current zone — a self-exile, self-sacrifice, or
+     * self-bounce. Used to decide whether to snapshot the source's counters before payment so the
+     * resolving effect can read the pre-cost count (DynamicAmount.LastKnownSourceCounters).
      */
     private fun costExilesOrSacrificesSelf(cost: AbilityCost): Boolean = when (cost) {
-        is AbilityCost.ExileSelf, is AbilityCost.SacrificeSelf -> true
+        is AbilityCost.ExileSelf, is AbilityCost.SacrificeSelf, is AbilityCost.ReturnSelfToHand -> true
         is AbilityCost.Composite -> cost.costs.any { costExilesOrSacrificesSelf(it) }
         else -> false
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimes
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
@@ -233,6 +234,17 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             is AddCountersEffect -> {
                 val resolvedId = context.resolveTarget(effect.target)
                 if (resolvedId != null) effect.copy(target = EffectTarget.SpecificEntity(resolvedId)) else effect
+            }
+            // Same as AddCountersEffect, plus: the count is context-derived, and the context that
+            // can answer it is gone by the time the trigger fires. Nine-Lives Familiar schedules
+            // "return it with one fewer revival counter" from its *dies* trigger — the last-known
+            // counter snapshot lives on that trigger's context only — so snapshot the amount NOW.
+            is AddDynamicCountersEffect -> {
+                val resolvedId = context.resolveTarget(effect.target)
+                effect.copy(
+                    target = if (resolvedId != null) EffectTarget.SpecificEntity(resolvedId) else effect.target,
+                    amount = snapshotAmount(effect.amount, context, state)
+                )
             }
             // "At the beginning of the next end step, create a token that's a copy of that
             // <permanent>" — the copied permanent (e.g. a just-sacrificed artifact, bound here as

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazesEndScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MazesEndScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dgm.cards.MazesEnd
+import com.wingedsheep.mtg.sets.definitions.rtr.cards.AzoriusGuildgate
+import com.wingedsheep.mtg.sets.definitions.gtc.cards.BorosGuildgate
+import com.wingedsheep.mtg.sets.definitions.gtc.cards.DimirGuildgate
+import com.wingedsheep.mtg.sets.definitions.rtr.cards.GolgariGuildgate
+import com.wingedsheep.mtg.sets.definitions.gtc.cards.GruulGuildgate
+import com.wingedsheep.mtg.sets.definitions.rtr.cards.IzzetGuildgate
+import com.wingedsheep.mtg.sets.definitions.gtc.cards.OrzhovGuildgate
+import com.wingedsheep.mtg.sets.definitions.rtr.cards.RakdosGuildgate
+import com.wingedsheep.mtg.sets.definitions.rtr.cards.SelesnyaGuildgate
+import com.wingedsheep.mtg.sets.definitions.gtc.cards.SimicGuildgate
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Maze's End (DGM #152, reprinted in FDN #727) — Land.
+ *
+ * "This land enters tapped.
+ *  {T}: Add {C}.
+ *  {3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it
+ *  onto the battlefield, then shuffle. If you control ten or more Gates with different names,
+ *  you win the game."
+ *
+ * Covers the self-bounce activation cost (`Costs.ReturnSelfToHand`), the Gate tutor, and the
+ * distinct-name win check evaluated at resolution *after* the search.
+ */
+class MazesEndScenarioTest : FunSpec({
+
+    val guildgates = listOf(
+        AzoriusGuildgate, BorosGuildgate, DimirGuildgate, GolgariGuildgate, GruulGuildgate,
+        IzzetGuildgate, OrzhovGuildgate, RakdosGuildgate, SelesnyaGuildgate, SimicGuildgate
+    )
+
+    /** The tutor ability — the second activated ability (the first is the {T}: Add {C} mana ability). */
+    val tutorAbilityId = MazesEnd.activatedAbilities[1].id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MazesEnd)
+        driver.registerCards(guildgates)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Put [count] differently-named Guildgates onto [player]'s battlefield, then seed the library
+     * with the next distinct one so the tutor has something to find. Returns the library card's id.
+     */
+    fun setUpGates(driver: GameTestDriver, player: EntityId, count: Int): EntityId {
+        guildgates.take(count).forEach { driver.putLandOnBattlefield(player, it.name) }
+        return driver.putCardOnTopOfLibrary(player, guildgates[count].name)
+    }
+
+    fun activateTutor(driver: GameTestDriver, player: EntityId, mazesEnd: EntityId) {
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = mazesEnd, abilityId = tutorAbilityId)
+        ).isSuccess shouldBe true
+    }
+
+    test("returning Maze's End to hand is part of the cost — it is in hand before the ability resolves") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        setUpGates(driver, player, 2)
+        val mazesEnd = driver.putLandOnBattlefield(player, "Maze's End")
+
+        activateTutor(driver, player, mazesEnd)
+
+        // Cost paid on activation, before anyone gets priority: the land has already left.
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(mazesEnd) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(mazesEnd) shouldBe false
+    }
+
+    test("tutors a Gate onto the battlefield") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val libraryGate = setUpGates(driver, player, 2)
+        val mazesEnd = driver.putLandOnBattlefield(player, "Maze's End")
+
+        activateTutor(driver, player, mazesEnd)
+        driver.bothPass()
+        driver.submitCardSelection(player, listOf(libraryGate))
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(libraryGate) shouldBe true
+        driver.state.gameOver shouldBe false
+    }
+
+    test("nine differently-named Gates after the search is not enough to win") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val libraryGate = setUpGates(driver, player, 8) // 8 + the tutored one = 9
+        val mazesEnd = driver.putLandOnBattlefield(player, "Maze's End")
+
+        activateTutor(driver, player, mazesEnd)
+        driver.bothPass()
+        driver.submitCardSelection(player, listOf(libraryGate))
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(libraryGate) shouldBe true
+        driver.state.gameOver shouldBe false
+    }
+
+    test("tutoring the tenth differently-named Gate wins the game") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val libraryGate = setUpGates(driver, player, 9) // 9 + the tutored one = 10
+        val mazesEnd = driver.putLandOnBattlefield(player, "Maze's End")
+
+        activateTutor(driver, player, mazesEnd)
+        driver.bothPass()
+        driver.submitCardSelection(player, listOf(libraryGate))
+
+        driver.assertGameOver(expectedWinner = player)
+    }
+
+    test("duplicate Gate names don't count twice") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        // Nine Gates on the battlefield, but two of them share a name → eight distinct names.
+        guildgates.take(8).forEach { driver.putLandOnBattlefield(player, it.name) }
+        driver.putLandOnBattlefield(player, guildgates[0].name)
+        val libraryGate = driver.putCardOnTopOfLibrary(player, guildgates[8].name)
+        val mazesEnd = driver.putLandOnBattlefield(player, "Maze's End")
+
+        activateTutor(driver, player, mazesEnd)
+        driver.bothPass()
+        driver.submitCardSelection(player, listOf(libraryGate))
+
+        // Nine distinct names — no win.
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(libraryGate) shouldBe true
+        driver.state.gameOver shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NineLivesFamiliarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NineLivesFamiliarScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.NineLivesFamiliar
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nine-Lives Familiar (FDN #66) — {1}{B}{B} 1/1 Creature — Cat.
+ *
+ * "This creature enters with eight revival counters on it if you cast it.
+ *  When this creature dies, if it had a revival counter on it, return it to the battlefield with
+ *  one fewer revival counter on it at the beginning of the next end step."
+ *
+ * Covers the cast-gated enters-with-counters replacement, the last-known-counter intervening "if"
+ * on the dies trigger, and the delayed end-step return with the decremented count.
+ */
+class NineLivesFamiliarScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(NineLivesFamiliar)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun revivalCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.counters?.get(CounterType.REVIVAL) ?: 0
+
+    /** Cast the Familiar from hand and resolve it. Returns its entity id. */
+    fun castFamiliar(driver: GameTestDriver, player: EntityId): EntityId {
+        val cat = driver.putCardInHand(player, "Nine-Lives Familiar")
+        driver.giveMana(player, Color.BLACK, 3)
+        driver.castSpell(player, cat).isSuccess shouldBe true
+        driver.bothPass()
+        return cat
+    }
+
+    /** Bolt [victim] and let the death (and its dies trigger) resolve fully. */
+    fun bolt(driver: GameTestDriver, player: EntityId, victim: EntityId) {
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // Bolt resolves; the creature dies and its trigger goes on the stack
+        driver.bothPass() // the dies trigger resolves, scheduling the delayed return
+    }
+
+    test("cast Familiar enters with eight revival counters") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val cat = castFamiliar(driver, player)
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(cat) shouldBe true
+        revivalCounters(driver, cat) shouldBe 8
+    }
+
+    test("a Familiar put onto the battlefield without being cast enters with no counters") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val cat = driver.putCreatureOnBattlefield(player, "Nine-Lives Familiar")
+
+        revivalCounters(driver, cat) shouldBe 0
+    }
+
+    test("dies trigger returns it at the next end step with one fewer revival counter") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val cat = castFamiliar(driver, player)
+        bolt(driver, player, cat)
+
+        // It is dead and stays dead until the end step — the return is delayed, not immediate.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(cat) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(cat) shouldBe false
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // the delayed trigger resolves
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(cat) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(cat) shouldBe false
+        revivalCounters(driver, cat) shouldBe 7
+    }
+
+    test("a Familiar that entered without revival counters stays in the graveyard") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val cat = driver.putCreatureOnBattlefield(player, "Nine-Lives Familiar")
+        bolt(driver, player, cat)
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        // The intervening "if" was false, so nothing was ever scheduled.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(cat) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(cat) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NineLivesFamiliarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NineLivesFamiliarScenarioTest.kt
@@ -94,6 +94,28 @@ class NineLivesFamiliarScenarioTest : FunSpec({
         revivalCounters(driver, cat) shouldBe 7
     }
 
+    test("dying during the end step defers the return to the next turn's end step") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val cat = castFamiliar(driver, player)
+        driver.passPriorityUntil(Step.END)
+        bolt(driver, player, cat)
+
+        // The current end step's beginning has already passed, so nothing comes back now.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(cat) shouldBe true
+
+        // Leave this turn, then reach the *next* end step (the opponent's — the oracle says "the
+        // next end step", not "your next end step").
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(cat) shouldBe true
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(cat) shouldBe true
+        revivalCounters(driver, cat) shouldBe 7
+    }
+
     test("a Familiar that entered without revival counters stays in the graveyard") {
         val driver = newDriver()
         val player = driver.player1

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -128,4 +128,5 @@ export const counterManaClass: Record<string, string> = {
   BAIT: 'counter-fungus',
   POINT: 'counter-charge',
   WISH: 'counter-charge',
+  REVIVAL: 'counter-charge',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -688,6 +688,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.BORE,
   CounterType.POINT,
   CounterType.WISH,
+  CounterType.REVIVAL,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1900,6 +1900,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   BAIT: { bg: 'rgba(18, 48, 62, 0.95)', border: 'rgba(96, 186, 214, 0.65)', color: '#9ed4e8', glow: 'rgba(96, 186, 214, 0.5)' },
   POINT: { bg: 'rgba(20, 55, 35, 0.95)', border: 'rgba(110, 210, 150, 0.7)', color: '#9ce0b8', glow: 'rgba(110, 210, 150, 0.55)' },
   WISH: { bg: 'rgba(35, 22, 48, 0.95)', border: 'rgba(170, 130, 210, 0.7)', color: '#c8a8e0', glow: 'rgba(170, 130, 210, 0.55)' },
+  REVIVAL: { bg: 'rgba(22, 34, 30, 0.95)', border: 'rgba(120, 205, 165, 0.7)', color: '#9ee0c0', glow: 'rgba(120, 205, 165, 0.55)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -408,6 +408,7 @@ export enum CounterType {
   BORE = 'BORE',
   POINT = 'POINT',
   WISH = 'WISH',
+  REVIVAL = 'REVIVAL',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -472,6 +473,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.BORE]: 'Bore',
   [CounterType.POINT]: 'Point',
   [CounterType.WISH]: 'Wish',
+  [CounterType.REVIVAL]: 'Revival',
 }
 
 /**


### PR DESCRIPTION
Two Foundations cards. Both needed a small, general SDK/engine addition rather than pure authoring — see the note at the bottom on why the batch is two cards and not five.

## Nine-Lives Familiar (FDN #66)

> This creature enters with eight revival counters on it if you cast it.
> When this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.

- **New `revival` counter** — a passive counter with no inherent rule, wired through `CounterType` / `Counters` and the client's data-driven passive-counter badge path (`PASSIVE_COUNTER_TYPES`, palette, icon, display name).
- **`DynamicAmount.LastKnownSourceCounters` broadened.** It already meant "counters the source had the moment its self-exile/self-sacrifice cost wiped them". It now means "counters the source had as it last existed on the battlefield" (CR 112.7a / 608.2h) and falls back to the leaves-the-battlefield snapshot that a dies/leaves trigger already carries. Naming the kind is what stops a stray +1/+1 counter from satisfying "if it had a revival counter on it".
- **Bug fix:** `TriggerMatcher.filterByTriggerCondition` was building its `EffectContext` without `triggerLastKnownCounters`, so any per-kind last-known read inside an intervening-`if` evaluated to 0. Now passed through.
- **`CreateDelayedTriggerExecutor`** snapshots a nested `AddDynamicCountersEffect`'s amount into a `Fixed` literal at scheduling time — the same treatment `AddManaEffect` already had. Without it, "with one fewer revival counter" would read 0 at the end step, because the last-known-counter context belongs to the dies trigger.

Entry counters are gated on `Conditions.WasCast`, so a reanimated Familiar enters bare and never loops. The delayed return is not player-gated (the oracle says "the next end step", not "your next end step"), and `fromZone = GRAVEYARD` makes it a no-op if the card left the graveyard first.

## Maze's End (canonical in Dragon's Maze; FDN #727 is a `Printing` row)

> {3}, {T}, Return this land to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle. If you control ten or more Gates with different names, you win the game.

- **New `Costs.ReturnSelfToHand` / `AbilityCost.ReturnSelfToHand`** — the bounce-to-hand sibling of `SacrificeSelf` / `ExileSelf`. Deterministic, so no `additionalCostInfo` is surfaced and the client shows no extra prompt (matching how `ExileSelf` already behaves); paid during activation per CR 601.2h, so the ability resolves with its source gone. Distinct from `CostAtom.ReturnToHand`, the choose-a-permanent bounce cost, which deliberately excludes the source. It also counts as a self-removing cost for the last-known-counters snapshot.
- The win check is a `ConditionalEffect` sequenced after the tutor, gated on `distinctNames()` over Gates you control — matching the ruling that it is checked once, as the ability resolves, even if no Gate was found.

## Testing

`just test` green; `web-client` typechecks. New scenario tests:

- `NineLivesFamiliarScenarioTest` — cast entry (8 counters) vs. put-onto-battlefield (0), the delayed end-step return at 7, and a counter-less Familiar staying dead.
- `MazesEndScenarioTest` — the land is in hand before the ability resolves, the tutor works, and the win boundary at 9 vs 10 distinct names, including duplicate names not counting twice.

`CardDefinitionSnapshotTest` goldens re-blessed: DGM and FDN, additions only. `just check-card-printing` clean for both cards. SDK reference updated for both additions.

## Why two cards

FDN's 16 unimplemented cards are the residue, and every one needs an engine capability that doesn't exist yet. These two needed the smallest, most reusable ones. The rest are genuinely `/add-feature` work and were left alone:

- **Wilt-Leaf Liege / Loxodon Smiter** — "if a spell or ability an opponent controls causes you to discard this card" needs discard-*cause* tracking threaded through `ZoneTransitionService.discardCards`; nothing today distinguishes an opponent's discard effect from a cleanup discard or your own looting.
- **Carnelian Orb of Dragonkind, Pyromancer's Goggles** — "if that mana is spent on …" mana riders.
- **Vizier of the Menagerie, Tinybones** — "spend mana as though it were mana of any type".
- **Elenda, Saint of Dusk** — hexproof-from is color-only today; this needs hexproof-from-a-card-type.
- **Curator of Destinies** — a face-down pile the opponent chooses blind; `ChoosePileEffect` has no hidden-pile visibility.
- **Steel Hellkite** — per-source "was dealt combat damage by *this* creature this turn" (only the legendary-creature variant is tracked).
- **Abyssal Harvester** — "put into a graveyard this turn" tracking plus a typed token copy.
- **Chandra / Kaito / Liliana / Kellan** — planeswalkers, large surface each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
