### PR TITLE
Use the deckbuilder's full-art deck gallery in the lobby deck pickers

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -297,8 +297,9 @@ accept/unfriend.
   deck picker's Paste-tab save.
 - **Unified deck library (`useUnifiedDecks`):** merges account decks (fetched in full via `?full`) with
   browser-only decks, each tagged `online`. Feeds (a) the deckbuilder's saved-deck **browser** overlay,
-  which shows an **Online / Browser** badge per deck and routes load/rename/delete to the right store,
-  and (b) the lobby deck picker's "My Decks" tab, so signed-in users can pick their cloud decks to play.
+  which routes load/rename/delete to the right store, and (b) the lobby deck picker's "My Decks" tab,
+  so signed-in users can pick their cloud decks to play. Both render the same full-art gallery tile
+  (`components/deck/DeckTile`), whose **Cloud / Local** badge is where a deck's storage shows up.
 - **Display name:** editable on the profile page (`PUT /api/auth/me`); the email stays the identity.
 - Profile page at `/profile` shows the win/loss summary plus colors played (a Recharts bar chart),
   sets, game modes, head-to-head, most-played cards, tournament finishes, and a recent-games list — all

--- a/web-client/src/components/deck/DeckTile.module.css
+++ b/web-client/src/components/deck/DeckTile.module.css
@@ -1,0 +1,269 @@
+/* Full-art deck tile: the deck's hero-card art fills the whole card, with a bottom
+ * scrim carrying the name, format, colours and count — like a game's deck gallery.
+ * Shared by the deckbuilder's saved-decks browser and the lobby deck pickers. */
+.tile {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #14141c;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.tile:hover {
+  border-color: var(--accent-primary, #6aa3ff);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
+}
+
+.tileSelected {
+  border-color: var(--accent-primary, #6aa3ff);
+  box-shadow: 0 0 0 1px rgba(106, 163, 255, 0.55) inset, 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
+/* The clickable surface — fills the tile and carries the art + overlay. A plain button
+ * reset so the whole card reads as one big "pick this deck" target. */
+.surface {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.surface:disabled {
+  cursor: default;
+}
+
+.art {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center 28%;
+  background-repeat: no-repeat;
+  transition: transform 0.3s ease;
+}
+
+.tile:hover .art {
+  transform: scale(1.05);
+}
+
+.scrim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    to top,
+    rgba(8, 8, 12, 0.94) 0%,
+    rgba(8, 8, 12, 0.82) 24%,
+    rgba(8, 8, 12, 0.34) 52%,
+    rgba(8, 8, 12, 0.04) 78%
+  );
+}
+
+.info {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px 11px;
+}
+
+.name {
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.15;
+  letter-spacing: 0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9), 0 0 16px rgba(0, 0, 0, 0.5);
+}
+
+/* Optional flavour line (example decks' description). Clamped to two lines so a long
+ * description can never push the name or meta row out of the scrim. */
+.description {
+  font-size: 0.72rem;
+  line-height: 1.25;
+  color: rgba(255, 255, 255, 0.72);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: -2px;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.format {
+  flex: 0 0 auto;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.pips {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.8));
+}
+
+.count {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Storage badge — top-left. Cloud = synced to the account; monitor = browser-only. */
+.storage {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 3px 8px 3px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(3px);
+  pointer-events: auto;
+}
+
+.storage svg {
+  display: block;
+}
+
+.storageCloud {
+  color: #74e2a4;
+  background: rgba(16, 54, 38, 0.6);
+  border-color: rgba(116, 226, 164, 0.42);
+}
+
+.storageLocal {
+  color: #cfd5e1;
+}
+
+/* Top-right cluster: the status ribbon and the hover-revealed action buttons share one row,
+ * so a selected tile never has its buttons stacked on top of its ribbon. */
+.corner {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.tile:hover .actions,
+.tile:focus-within .actions {
+  opacity: 1;
+}
+
+.actionButton {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.actionButton:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.actionButtonDanger {
+  composes: actionButton;
+}
+
+.actionButtonDanger:hover {
+  color: #ff8888;
+  background: rgba(255, 100, 100, 0.22);
+}
+
+/* Status ribbon ("Editing" / "Selected") — sits in the top-right cluster next to the
+ * action buttons. */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: #eaf1ff;
+  background: rgba(106, 163, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-weight: 700;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  white-space: nowrap;
+}
+
+.badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
+  animation: badgePulse 1.6s ease-in-out infinite;
+}
+
+@keyframes badgePulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/web-client/src/components/deck/DeckTile.tsx
+++ b/web-client/src/components/deck/DeckTile.tsx
@@ -1,0 +1,331 @@
+/**
+ * Shared full-art deck tile — the deck-gallery visual used everywhere a user picks a deck:
+ * the deckbuilder's saved-decks browser, the Quick Game lobby picker, and the tournament
+ * Premade Decks picker. One place to restyle a deck tile.
+ *
+ * Each tile paints the art of the deck's rarest non-land card ({@link rarestCard}) as a wide
+ * Scryfall art crop, with a bottom scrim carrying the deck name (tinted by the hero card's
+ * rarity), a format chip, colour pips and the card count. Decks with no catalogued non-land
+ * card fall back to a colour-identity gradient.
+ *
+ * Everything a caller varies rides on props: the corner ribbon (`badge`), the storage
+ * provenance badge (`storage`), and the hover-revealed corner buttons (`actions`, built with
+ * {@link DeckTileActionButton}).
+ */
+import { useMemo, type ReactNode } from 'react'
+import { ManaSymbol } from '@/components/ui/ManaSymbols'
+import { rarityColor } from '@/components/draft/RarityBadge'
+import { COLOR_DOT } from '@/components/ui/DeckSummary'
+import { labelForFormat } from '@/utils/deckLegality'
+import { getCdnArtCropUrl, getScryfallArtCropUrl } from '@/utils/cardImages'
+import styles from './DeckTile.module.css'
+
+/**
+ * The card shape a tile needs. Structurally satisfied by both the deckbuilder's
+ * `cardFilter.CardSummary` and the trimmed catalog shape the lobby pickers fetch.
+ */
+export interface DeckTileCard {
+  name: string
+  cmc: number
+  colors: string[]
+  cardTypes: string[]
+  basicLand: boolean
+  rarity: string
+  imageUri?: string | null
+}
+
+export interface DeckTileProps {
+  /** Deck name, shown in the scrim and tinted by the hero card's rarity. */
+  name: string
+  /** Total cards (commander included) shown bottom-right. */
+  total: number
+  /** Deck colours in {@link deckColors} order, rendered as mana pips. */
+  colors: string[]
+  /** Hero card whose art fills the tile. Null = colour-identity gradient. */
+  hero: DeckTileCard | null
+  /** Format chip. Null/undefined hides the chip. */
+  format?: string | null | undefined
+  /** Tooltip for the format chip (e.g. "Saved as Commander" vs "Legal in Commander"). */
+  formatTitle?: string | undefined
+  /** Optional flavour line under the name — used for example decks' descriptions. */
+  description?: string | undefined
+  /** Draws the accent ring: this tile is the current selection. */
+  selected?: boolean
+  /** Corner ribbon text ("Editing" / "Selected"). Fades on hover so `actions` can take over. */
+  badge?: string | null | undefined
+  /** Storage provenance. Omit for decks that have none (server-supplied examples). */
+  storage?: 'cloud' | 'local' | undefined
+  /** Tooltip on the tile's click surface. */
+  title?: string | undefined
+  disabled?: boolean
+  onClick: () => void
+  /** Hover-revealed corner buttons. Build them with {@link DeckTileActionButton}. */
+  actions?: ReactNode
+}
+
+export function DeckTile({
+  name,
+  total,
+  colors,
+  hero,
+  format = null,
+  formatTitle,
+  description,
+  selected = false,
+  badge,
+  storage,
+  title,
+  disabled = false,
+  onClick,
+  actions,
+}: DeckTileProps) {
+  // Hero art = the deck's rarest card as a wide Scryfall art crop. Derive it straight
+  // from the card's CDN image URL (no rate-limited api.scryfall.com lookup) when we have
+  // one, falling back to the by-name API lookup otherwise.
+  const artUrl = useMemo(
+    () => (hero ? (getCdnArtCropUrl(hero.imageUri) ?? getScryfallArtCropUrl(hero.name)) : null),
+    [hero],
+  )
+  const gradient = useMemo(() => deckBannerGradient(colors), [colors])
+
+  return (
+    <div className={`${styles.tile} ${selected ? styles.tileSelected : ''}`}>
+      <button
+        type="button"
+        className={styles.surface}
+        onClick={onClick}
+        disabled={disabled}
+        {...(title ? { title } : {})}
+      >
+        <span
+          className={styles.art}
+          // The URL is quoted inside url() because card names can contain apostrophes
+          // ("Barrin's Spite"), which encodeURIComponent leaves literal — an unquoted
+          // url() with a bare ' is invalid CSS and the browser silently drops the art.
+          style={artUrl ? { backgroundImage: `url("${artUrl}")` } : { background: gradient }}
+          aria-hidden="true"
+        />
+        <span className={styles.scrim} aria-hidden="true" />
+        <span className={styles.info}>
+          <span className={styles.name} style={{ color: deckNameColor(hero?.rarity) }}>
+            {name}
+          </span>
+          {description && <span className={styles.description}>{description}</span>}
+          <span className={styles.metaRow}>
+            {format && (
+              <span
+                className={styles.format}
+                style={{ color: formatAccent(format), borderColor: `${formatAccent(format)}66` }}
+                {...(formatTitle ? { title: formatTitle } : {})}
+              >
+                {labelForFormat(format)}
+              </span>
+            )}
+            <span className={styles.pips}>
+              {colors.length > 0 ? (
+                colors.map((c) => <ManaSymbol key={c} symbol={COLOR_PIP_SYMBOL[c] ?? 'C'} size={15} />)
+              ) : (
+                <ManaSymbol symbol="C" size={15} />
+              )}
+            </span>
+            <span className={styles.count}>{total} cards</span>
+          </span>
+        </span>
+      </button>
+
+      {storage && (
+        <span
+          className={`${styles.storage} ${storage === 'cloud' ? styles.storageCloud : styles.storageLocal}`}
+          title={
+            storage === 'cloud'
+              ? 'Saved to your account — synced to the cloud and available on any device'
+              : 'Saved only in this browser — not backed up to your account'
+          }
+        >
+          {storage === 'cloud' ? <CloudIcon /> : <MonitorIcon />}
+          {storage === 'cloud' ? 'Cloud' : 'Local'}
+        </span>
+      )}
+
+      {(badge || actions) && (
+        <div className={styles.corner}>
+          {badge && <span className={styles.badge}>{badge}</span>}
+          {actions && <div className={styles.actions}>{actions}</div>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * A hover-revealed corner button for a tile's `actions` slot. Stops propagation so clicking
+ * it never also fires the tile's own "pick this deck" click.
+ */
+export function DeckTileActionButton({
+  onClick,
+  title,
+  ariaLabel,
+  danger = false,
+  children,
+}: {
+  onClick: () => void
+  title: string
+  ariaLabel: string
+  danger?: boolean
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      className={danger ? styles.actionButtonDanger : styles.actionButton}
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+      title={title}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  )
+}
+
+/** Mana-pip symbol per colour key, matching the deckbuilder's colour token order. */
+const COLOR_PIP_SYMBOL: Record<string, string> = {
+  WHITE: 'W',
+  BLUE: 'U',
+  BLACK: 'B',
+  RED: 'R',
+  GREEN: 'G',
+}
+
+// Rarity ranking for choosing a deck's "hero" card — the splashiest spell whose art
+// represents the deck in the gallery. Higher wins.
+const RARITY_RANK: Record<string, number> = { MYTHIC: 3, RARE: 2, UNCOMMON: 1, COMMON: 0 }
+
+/**
+ * The deck's rarest non-land card, used as the gallery tile's hero art. Lands (even rare
+ * duals) and basics are skipped — they make for dull, repetitive tiles across a collection.
+ * Ties break toward the commander (the deck's identity), then the highest mana value (the
+ * marquee bomb), then name for stable ordering. Returns null only for an empty / all-land /
+ * uncatalogued deck, in which case the tile falls back to a colour-identity gradient.
+ */
+export function rarestCard<T extends DeckTileCard>(
+  cards: Record<string, number>,
+  catalog: Record<string, T>,
+  commander: string | null,
+): T | null {
+  let best: T | null = null
+  let bestRank = -1
+  let bestIsCommander = false
+  for (const [rawName, n] of Object.entries(cards)) {
+    if (n <= 0) continue
+    const name = rawName.split('#')[0] ?? rawName
+    const c = catalog[name]
+    if (!c || c.basicLand) continue
+    if (c.cardTypes.some((t) => t.toUpperCase() === 'LAND')) continue
+    const rank = RARITY_RANK[(c.rarity ?? 'COMMON').toUpperCase()] ?? 0
+    const isCommander = commander != null && name === commander
+    if (best === null || rank > bestRank) {
+      best = c
+      bestRank = rank
+      bestIsCommander = isCommander
+      continue
+    }
+    if (rank === bestRank && !bestIsCommander) {
+      if (isCommander || c.cmc > best.cmc || (c.cmc === best.cmc && c.name < best.name)) {
+        best = c
+        bestIsCommander = isCommander
+      }
+    }
+  }
+  return best
+}
+
+/** The deck's colours, most-represented first — drives the tile's pips and gradient. */
+export function deckColors(
+  cards: Record<string, number>,
+  catalog: Record<string, DeckTileCard>,
+): string[] {
+  const counts: Record<string, number> = {}
+  for (const [name, n] of Object.entries(cards)) {
+    if (n <= 0) continue
+    const c = catalog[name.split('#')[0] ?? name]
+    if (!c) continue
+    for (const col of c.colors) counts[col] = (counts[col] ?? 0) + n
+  }
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([color]) => color)
+}
+
+/** Colour-identity gradient used when a deck has no catalogued non-land card to show art for. */
+function deckBannerGradient(colors: string[]): string {
+  if (colors.length === 0) {
+    return 'linear-gradient(135deg, rgba(120,120,140,0.5), rgba(60,60,80,0.6))'
+  }
+  if (colors.length === 1) {
+    const c = COLOR_DOT[colors[0]!] ?? '#888'
+    return `linear-gradient(135deg, ${c}aa, ${c}55)`
+  }
+  const stops = colors.map((c, i) => {
+    const hex = COLOR_DOT[c] ?? '#888'
+    return `${hex} ${Math.round((i / (colors.length - 1)) * 100)}%`
+  })
+  return `linear-gradient(135deg, ${stops.join(', ')})`
+}
+
+// Deck-name tint by hero rarity — reuses the draft rarity palette so colours read
+// consistently across the app, but lifts COMMON off near-black so names stay legible
+// over the dark art scrim.
+function deckNameColor(rarity: string | undefined): string {
+  if (!rarity || rarity.toUpperCase() === 'COMMON') return '#eef1f6'
+  return rarityColor(rarity)
+}
+
+// Per-format accent for the format chip. Keyed by upper-case format name; anything
+// unmapped falls back to a neutral slate so new formats still render cleanly.
+const FORMAT_ACCENT: Record<string, string> = {
+  STANDARD: '#6aa3ff',
+  PIONEER: '#c47dff',
+  MODERN: '#8a7bff',
+  LEGACY: '#7bd0ff',
+  VINTAGE: '#ff9d57',
+  PAUPER: '#9aa6b8',
+  COMMANDER: '#e0b15a',
+  BRAWL: '#e0b15a',
+  STANDARD_BRAWL: '#e0b15a',
+  HISTORIC: '#ff8aa8',
+  CUSTOM_DECKS: '#7be0a8',
+}
+
+function formatAccent(format: string): string {
+  return FORMAT_ACCENT[format.toUpperCase()] ?? '#9aa6b8'
+}
+
+function CloudIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4 7.5 7.5 0 0 0 5.35 8.04 5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z" />
+    </svg>
+  )
+}
+
+function MonitorIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
+  )
+}

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -314,36 +314,6 @@
   display: inline-block;
 }
 
-.savedIconButton {
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  width: 26px;
-  height: 26px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-sm);
-  font-size: 0.9rem;
-  line-height: 1;
-  padding: 0;
-}
-
-.savedIconButton:hover {
-  color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.savedIconButtonDanger {
-  composes: savedIconButton;
-}
-
-.savedIconButtonDanger:hover {
-  color: #ff8888;
-  background: rgba(255, 100, 100, 0.14);
-}
-
 /* ------------- Saved-decks browser overlay ------------- */
 .browserBackdrop {
   position: fixed;
@@ -429,241 +399,21 @@
   flex: 0 0 auto;
 }
 
-.browserGrid {
+/* The scroll box, not the grid itself: a grid that *is* the scroll container has a definite
+ * block size, and its `auto` rows then get squashed to fit — the tiles' `aspect-ratio` height
+ * overflows its row and every tile's caption lands on the row below (visible once the deck
+ * count overflows the dialog). Keeping the grid content-sized avoids that. */
+.browserScroll {
   flex: 1;
   overflow-y: auto;
   padding: var(--space-4);
+}
+
+.browserGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: var(--space-3);
   align-content: start;
-}
-
-/* Full-art deck tile: the deck's hero-card art fills the whole card, with a bottom
- * scrim carrying the name, format, colours and count — like a game's deck gallery. */
-.deckCard {
-  position: relative;
-  aspect-ratio: 4 / 3;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  background: #14141c;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
-}
-
-.deckCard:hover {
-  border-color: var(--accent-primary, #6aa3ff);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
-}
-
-.deckCardActive {
-  border-color: var(--accent-primary, #6aa3ff);
-  box-shadow: 0 0 0 1px rgba(106, 163, 255, 0.55) inset, 0 6px 18px rgba(0, 0, 0, 0.45);
-}
-
-/* The clickable surface — fills the tile and carries the art + overlay. A plain button
- * reset so the whole card reads as one big "load this deck" target. */
-.deckCardLoad {
-  position: absolute;
-  inset: 0;
-  display: block;
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  border: none;
-  background: none;
-  text-align: left;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-
-.deckCardArt {
-  position: absolute;
-  inset: 0;
-  background-size: cover;
-  background-position: center 28%;
-  background-repeat: no-repeat;
-  transition: transform 0.3s ease;
-}
-
-.deckCard:hover .deckCardArt {
-  transform: scale(1.05);
-}
-
-.deckCardScrim {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(
-    to top,
-    rgba(8, 8, 12, 0.94) 0%,
-    rgba(8, 8, 12, 0.82) 24%,
-    rgba(8, 8, 12, 0.34) 52%,
-    rgba(8, 8, 12, 0.04) 78%
-  );
-}
-
-.deckCardInfo {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px 11px;
-}
-
-.deckCardName {
-  font-weight: 700;
-  font-size: 1rem;
-  line-height: 1.15;
-  letter-spacing: 0.01em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9), 0 0 16px rgba(0, 0, 0, 0.5);
-}
-
-.deckCardMetaRow {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  min-width: 0;
-}
-
-.deckCardFormat {
-  flex: 0 0 auto;
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 2px 7px;
-  border-radius: 4px;
-  border: 1px solid currentColor;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(2px);
-}
-
-.deckCardPips {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.8));
-}
-
-.deckCardCount {
-  margin-left: auto;
-  flex: 0 0 auto;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85);
-  font-variant-numeric: tabular-nums;
-}
-
-/* Storage badge — top-left. Cloud = synced to the account; monitor = browser-only. */
-.deckCardStorage {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  z-index: 3;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  padding: 3px 8px 3px 6px;
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  backdrop-filter: blur(3px);
-  pointer-events: auto;
-}
-
-.deckCardStorage svg {
-  display: block;
-}
-
-.deckCardStorageOnline {
-  color: #74e2a4;
-  background: rgba(16, 54, 38, 0.6);
-  border-color: rgba(116, 226, 164, 0.42);
-}
-
-.deckCardStorageLocal {
-  color: #cfd5e1;
-}
-
-.deckCardActions {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  z-index: 4;
-  display: flex;
-  gap: 2px;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.deckCard:hover .deckCardActions,
-.deckCard:focus-within .deckCardActions {
-  opacity: 1;
-}
-
-.deckCardActions .savedIconButton,
-.deckCardActions .savedIconButtonDanger {
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(2px);
-  color: #fff;
-}
-
-/* Active "Editing" ribbon — top-right, fades out on hover so the action buttons
- * (same corner) take over cleanly. */
-.deckCardActiveBadge {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 3;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.09em;
-  color: #eaf1ff;
-  background: rgba(106, 163, 255, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  border-radius: 999px;
-  padding: 2px 9px;
-  font-weight: 700;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(4px);
-  transition: opacity 0.12s ease;
-}
-
-.deckCard:hover .deckCardActiveBadge {
-  opacity: 0;
-}
-
-.deckCardActiveBadge::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #ffffff;
-  box-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
-  animation: deckCardActiveBadgePulse 1.6s ease-in-out infinite;
-}
-
-@keyframes deckCardActiveBadgePulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
 }
 
 .linkButton {

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -25,8 +25,13 @@ import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
-import { getCardImageUrl, getCdnArtCropUrl, getScryfallArtCropUrl, splitImageRotateDeg } from '@/utils/cardImages'
-import { rarityColor } from '@/components/draft/RarityBadge'
+import { getCardImageUrl, splitImageRotateDeg } from '@/utils/cardImages'
+import {
+  DeckTile,
+  DeckTileActionButton,
+  deckColors,
+  rarestCard,
+} from '@/components/deck/DeckTile'
 import {
   parseQuery,
   toggleToken,
@@ -1329,6 +1334,7 @@ export function DeckbuilderPage() {
       {examplesOpen && (
         <ExampleDecksModal
           examples={examples}
+          catalog={catalogIndex}
           onCancel={() => setExamplesOpen(false)}
           onLoad={handleLoadExample}
         />
@@ -1669,10 +1675,12 @@ function DeckCentricFooter({
 
 function ExampleDecksModal({
   examples,
+  catalog,
   onCancel,
   onLoad,
 }: {
   examples: ExampleDeck[]
+  catalog: Record<string, CardSummary>
   onCancel: () => void
   onLoad: (ex: ExampleDeck) => void
 }) {
@@ -1692,25 +1700,23 @@ function ExampleDecksModal({
         {examples.length === 0 ? (
           <p className={styles.importHint}>No examples available.</p>
         ) : (
-          <div className={styles.browserGrid}>
-            {examples.map((ex) => {
-              const total = Object.values(ex.cards).reduce((a, b) => a + b, 0)
-              return (
-                <button
+          <div className={styles.browserScroll}>
+            <div className={styles.browserGrid}>
+              {examples.map((ex) => (
+                <DeckTile
                   key={ex.id}
-                  className={styles.deckCard}
+                  name={ex.name}
+                  description={ex.description}
+                  total={Object.values(ex.cards).reduce((a, b) => a + b, 0)}
+                  colors={deckColors(ex.cards, catalog)}
+                  hero={rarestCard(ex.cards, catalog, ex.commander ?? null)}
+                  format={ex.format ?? null}
+                  formatTitle={ex.format ? `Built for ${labelForFormat(ex.format)}` : undefined}
+                  title={`Load ${ex.name} into the builder`}
                   onClick={() => onLoad(ex)}
-                  type="button"
-                >
-                  <div className={styles.deckCardBody}>
-                    <span className={styles.deckCardName}>{ex.name}</span>
-                    <span className={styles.deckCardMeta}>
-                      {total} card{total === 1 ? '' : 's'} · {ex.description}
-                    </span>
-                  </div>
-                </button>
-              )
-            })}
+                />
+              ))}
+            </div>
           </div>
         )}
         <div className={styles.importActions}>
@@ -2417,132 +2423,41 @@ function SavedDecksBrowser({
           </div>
         </div>
 
-        <div className={styles.browserGrid}>
-          {filtered.length === 0 ? (
-            <div className={styles.savedEmpty}>
-              {decks.length === 0
-                ? 'No saved decks yet. Build one and click Save.'
-                : 'No decks match the current filters.'}
-            </div>
-          ) : (
-            filtered.map(({ deck, total, colors, legalFormats, hero }) => (
-              <DeckCard
-                key={deck.id}
-                deck={deck}
-                total={total}
-                colors={colors}
-                legalFormats={legalFormats}
-                isActive={deck.id === activeDeckId}
-                hero={hero}
-                onLoad={onLoad}
-                onRename={onRename}
-                onDelete={onDelete}
-              />
-            ))
-          )}
+        <div className={styles.browserScroll}>
+          <div className={styles.browserGrid}>
+            {filtered.length === 0 ? (
+              <div className={styles.savedEmpty}>
+                {decks.length === 0
+                  ? 'No saved decks yet. Build one and click Save.'
+                  : 'No decks match the current filters.'}
+              </div>
+            ) : (
+              filtered.map(({ deck, total, colors, legalFormats, hero }) => (
+                <DeckCard
+                  key={deck.id}
+                  deck={deck}
+                  total={total}
+                  colors={colors}
+                  legalFormats={legalFormats}
+                  isActive={deck.id === activeDeckId}
+                  hero={hero}
+                  onLoad={onLoad}
+                  onRename={onRename}
+                  onDelete={onDelete}
+                />
+              ))
+            )}
+          </div>
         </div>
       </div>
     </>
   )
 }
 
-// Rarity ranking for choosing a deck's "hero" card — the splashiest spell whose art
-// represents the deck in the gallery. Higher wins.
-const RARITY_RANK: Record<string, number> = { MYTHIC: 3, RARE: 2, UNCOMMON: 1, COMMON: 0 }
-
 /**
- * The deck's rarest non-land card, used as the gallery tile's hero art. Lands (even rare
- * duals) and basics are skipped — they make for dull, repetitive tiles across a collection.
- * Ties break toward the commander (the deck's identity), then the highest mana value (the
- * marquee bomb), then name for stable ordering. Returns null only for an empty / all-land /
- * uncatalogued deck, in which case the tile falls back to a colour-identity gradient.
+ * Deckbuilder adapter over the shared {@link DeckTile}: click loads the deck into the editor,
+ * hover exposes rename/delete, and the active deck gets the "Editing" ribbon.
  */
-function rarestCard(
-  cards: Record<string, number>,
-  catalog: Record<string, CardSummary>,
-  commander: string | null,
-): CardSummary | null {
-  let best: CardSummary | null = null
-  let bestRank = -1
-  let bestIsCommander = false
-  for (const [rawName, n] of Object.entries(cards)) {
-    if (n <= 0) continue
-    const name = rawName.split('#')[0] ?? rawName
-    const c = catalog[name]
-    if (!c || c.basicLand) continue
-    if (c.cardTypes.some((t) => t.toUpperCase() === 'LAND')) continue
-    const rank = RARITY_RANK[(c.rarity ?? 'COMMON').toUpperCase()] ?? 0
-    const isCommander = commander != null && name === commander
-    if (best === null || rank > bestRank) {
-      best = c
-      bestRank = rank
-      bestIsCommander = isCommander
-      continue
-    }
-    if (rank === bestRank && !bestIsCommander) {
-      if (isCommander || c.cmc > best.cmc || (c.cmc === best.cmc && c.name < best.name)) {
-        best = c
-        bestIsCommander = isCommander
-      }
-    }
-  }
-  return best
-}
-
-// Deck-name tint by hero rarity — reuses the draft rarity palette so colours read
-// consistently across the app, but lifts COMMON off near-black so names stay legible
-// over the dark art scrim.
-function deckNameColor(rarity: string | undefined): string {
-  if (!rarity || rarity.toUpperCase() === 'COMMON') return '#eef1f6'
-  return rarityColor(rarity)
-}
-
-// Per-format accent for the single saved-format chip. Keyed by upper-case format name;
-// anything unmapped falls back to a neutral slate so new formats still render cleanly.
-const FORMAT_ACCENT: Record<string, string> = {
-  STANDARD: '#6aa3ff',
-  PIONEER: '#c47dff',
-  MODERN: '#8a7bff',
-  LEGACY: '#7bd0ff',
-  VINTAGE: '#ff9d57',
-  PAUPER: '#9aa6b8',
-  COMMANDER: '#e0b15a',
-  BRAWL: '#e0b15a',
-  STANDARD_BRAWL: '#e0b15a',
-  HISTORIC: '#ff8aa8',
-  CUSTOM_DECKS: '#7be0a8',
-}
-function formatAccent(format: string): string {
-  return FORMAT_ACCENT[format.toUpperCase()] ?? '#9aa6b8'
-}
-
-function CloudIcon({ size = 12 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4 7.5 7.5 0 0 0 5.35 8.04 5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z" />
-    </svg>
-  )
-}
-
-function MonitorIcon({ size = 12 }: { size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="2" y="3" width="20" height="14" rx="2" />
-      <path d="M8 21h8M12 17v4" />
-    </svg>
-  )
-}
-
 function DeckCard({
   deck,
   total,
@@ -2564,126 +2479,48 @@ function DeckCard({
   onRename: (d: UnifiedDeck) => void
   onDelete: (d: UnifiedDeck) => void
 }) {
-  // Hero art = the deck's rarest card as a wide Scryfall art crop. Derive it straight
-  // from the card's CDN image URL (no rate-limited api.scryfall.com lookup) when we have
-  // one, falling back to the by-name API lookup otherwise. Falls back to a colour-identity
-  // gradient when the deck has no catalogued non-land card yet.
-  const artUrl = useMemo(
-    () => (hero ? (getCdnArtCropUrl(hero.imageUri) ?? getScryfallArtCropUrl(hero.name)) : null),
-    [hero]
-  )
-  const gradient = useMemo(() => deckBannerGradient(colors), [colors])
-  const nameColor = deckNameColor(hero?.rarity)
   // One chip only: the format the deck was saved as, else the first format it's legal in.
   const shownFormat = deck.format ?? legalFormats[0] ?? null
-
   return (
-    <div className={`${styles.deckCard} ${isActive ? styles.deckCardActive : ''}`}>
-      <button
-        type="button"
-        className={styles.deckCardLoad}
-        onClick={() => onLoad(deck)}
-        title={`Load ${deck.name}`}
-      >
-        <span
-          className={styles.deckCardArt}
-          // The URL is quoted inside url() because card names can contain apostrophes
-          // ("Barrin's Spite"), which encodeURIComponent leaves literal — an unquoted
-          // url() with a bare ' is invalid CSS and the browser silently drops the art.
-          style={artUrl ? { backgroundImage: `url("${artUrl}")` } : { background: gradient }}
-          aria-hidden="true"
-        />
-        <span className={styles.deckCardScrim} aria-hidden="true" />
-        <span className={styles.deckCardInfo}>
-          <span className={styles.deckCardName} style={{ color: nameColor }}>
-            {deck.name}
-          </span>
-          <span className={styles.deckCardMetaRow}>
-            {shownFormat && (
-              <span
-                className={styles.deckCardFormat}
-                style={{
-                  color: formatAccent(shownFormat),
-                  borderColor: `${formatAccent(shownFormat)}66`,
-                }}
-                title={
-                  deck.format
-                    ? `Saved as ${labelForFormat(shownFormat)}`
-                    : `Legal in ${labelForFormat(shownFormat)}`
-                }
-              >
-                {labelForFormat(shownFormat)}
-              </span>
-            )}
-            <span className={styles.deckCardPips}>
-              {colors.length > 0 ? (
-                colors.map((c) => {
-                  const tok = COLOR_TOKENS.find((t) => t.key === c)
-                  return <ManaSymbol key={c} symbol={tok ? tok.label : 'C'} size={15} />
-                })
-              ) : (
-                <ManaSymbol symbol="C" size={15} />
-              )}
-            </span>
-            <span className={styles.deckCardCount}>{total} cards</span>
-          </span>
-        </span>
-      </button>
-
-      {/* Storage status — cloud (synced to your account) vs. local (this browser only). */}
-      <span
-        className={`${styles.deckCardStorage} ${
-          deck.online ? styles.deckCardStorageOnline : styles.deckCardStorageLocal
-        }`}
-        title={
-          deck.online
-            ? 'Saved to your account — synced to the cloud and available on any device'
-            : 'Saved only in this browser — not backed up to your account'
-        }
-      >
-        {deck.online ? <CloudIcon /> : <MonitorIcon />}
-        {deck.online ? 'Cloud' : 'Local'}
-      </span>
-
-      <div className={styles.deckCardActions}>
-        <button
-          className={styles.savedIconButton}
-          onClick={() => onRename(deck)}
-          type="button"
-          title="Rename"
-          aria-label={`Rename ${deck.name}`}
-        >
-          ✎
-        </button>
-        <button
-          className={styles.savedIconButtonDanger}
-          onClick={() => onDelete(deck)}
-          type="button"
-          title="Delete"
-          aria-label={`Delete ${deck.name}`}
-        >
-          ✕
-        </button>
-      </div>
-
-      {isActive && <span className={styles.deckCardActiveBadge}>Editing</span>}
-    </div>
+    <DeckTile
+      name={deck.name}
+      total={total}
+      colors={colors}
+      hero={hero}
+      format={shownFormat}
+      formatTitle={
+        shownFormat
+          ? deck.format
+            ? `Saved as ${labelForFormat(shownFormat)}`
+            : `Legal in ${labelForFormat(shownFormat)}`
+          : undefined
+      }
+      selected={isActive}
+      badge={isActive ? 'Editing' : undefined}
+      storage={deck.online ? 'cloud' : 'local'}
+      title={`Load ${deck.name}`}
+      onClick={() => onLoad(deck)}
+      actions={
+        <>
+          <DeckTileActionButton
+            onClick={() => onRename(deck)}
+            title="Rename"
+            ariaLabel={`Rename ${deck.name}`}
+          >
+            ✎
+          </DeckTileActionButton>
+          <DeckTileActionButton
+            onClick={() => onDelete(deck)}
+            title="Delete"
+            ariaLabel={`Delete ${deck.name}`}
+            danger
+          >
+            ✕
+          </DeckTileActionButton>
+        </>
+      }
+    />
   )
-}
-
-function deckBannerGradient(colors: string[]): string {
-  if (colors.length === 0) {
-    return 'linear-gradient(135deg, rgba(120,120,140,0.5), rgba(60,60,80,0.6))'
-  }
-  if (colors.length === 1) {
-    const c = COLOR_DOT[colors[0]!] ?? '#888'
-    return `linear-gradient(135deg, ${c}aa, ${c}55)`
-  }
-  const stops = colors.map((c, i) => {
-    const hex = COLOR_DOT[c] ?? '#888'
-    return `${hex} ${Math.round((i / (colors.length - 1)) * 100)}%`
-  })
-  return `linear-gradient(135deg, ${stops.join(', ')})`
 }
 
 function colorBucketKey(colors: string[]): number {
@@ -2697,22 +2534,6 @@ function colorBucketKey(colors: string[]): number {
     case 'GREEN': return 4
     default: return 5
   }
-}
-
-function deckColors(
-  cards: Record<string, number>,
-  catalog: Record<string, CardSummary>
-): string[] {
-  const counts: Record<string, number> = {}
-  for (const [name, n] of Object.entries(cards)) {
-    if (n <= 0) continue
-    const c = catalog[name.split('#')[0] ?? name]
-    if (!c) continue
-    for (const col of c.colors) counts[col] = (counts[col] ?? 0) + n
-  }
-  return Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .map(([color]) => color)
 }
 
 function SearchBar({

--- a/web-client/src/components/ui/DeckPicker.module.css
+++ b/web-client/src/components/ui/DeckPicker.module.css
@@ -51,137 +51,25 @@
   gap: var(--space-2);
 }
 
-.savedList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 240px;
+/* Deck gallery — the shared full-art <DeckTile/> grid used by the "My Decks" and
+ * "Examples" tabs. Two columns at the picker's 540px cap.
+ *
+ * The scroll cap lives on the wrapper, never on the grid itself: a grid that *is* the
+ * scroll container has a definite block size, and its `auto` rows then get squashed to
+ * fit it — the tiles' `aspect-ratio` height overflows its row and every tile's caption
+ * lands on the row below. Keeping the grid content-sized avoids that. */
+.deckGridScroll {
+  max-height: 360px;
   overflow-y: auto;
+  /* Room for the tiles' hover lift + shadow, which the scroll container would clip. */
+  padding: 3px 2px;
 }
 
-.savedItem {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-2) var(--space-3);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-}
-
-.savedItem:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.savedItemSelected {
-  border-color: var(--accent-primary, #6aa3ff);
-  background: rgba(106, 163, 255, 0.12);
-}
-
-.savedItemMeta {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.savedItemName {
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.savedItemCount {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.savedItemFormats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 3px;
-  margin-top: 2px;
-}
-
-.savedItemFormatBadge {
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: rgba(108, 192, 74, 0.14);
-  color: #8ed171;
-  border: 1px solid rgba(108, 192, 74, 0.3);
-  border-radius: 999px;
-  padding: 1px 6px;
-  font-weight: 600;
-}
-
-/* Variant for the format the deck was *saved* against (vs. the green pills
- * showing formats it's currently *legal* in). Accent-blue to read as
- * "intent" rather than "validation status". */
-.savedItemFormatBadgeSaved {
-  composes: savedItemFormatBadge;
-  background: rgba(106, 163, 255, 0.16);
-  color: #b9d4ff;
-  border-color: rgba(106, 163, 255, 0.45);
-}
-
-.savedItemActions {
-  display: flex;
-  gap: var(--space-1);
-}
-
-.linkButton {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-size: 0.75rem;
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-}
-
-.linkButton:hover {
-  color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.dangerButton {
-  composes: linkButton;
-  color: #ff8888;
-}
-
-.exampleGrid {
+.deckGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: var(--space-2);
-}
-
-.exampleCard {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: var(--radius-sm);
-  padding: var(--space-2);
-  cursor: pointer;
-  text-align: left;
-  color: var(--text-primary);
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.exampleCard:hover {
-  border-color: var(--accent-primary, #6aa3ff);
-}
-
-.exampleName {
-  font-weight: 600;
-}
-
-.exampleDesc {
-  font-size: 0.75rem;
-  color: var(--text-muted);
+  align-content: start;
 }
 
 .textarea {

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -1,9 +1,9 @@
 /**
- * DeckPicker — tabbed deck selector for the quick-game flow.
+ * DeckPicker — tabbed deck selector for the quick-game and tournament lobby flows.
  *
  * Tabs:
- *   - My decks: localStorage-backed library (load / delete)
- *   - Examples: server-supplied starter lists
+ *   - My decks: the unified deck library (cloud + browser), as a full-art deck gallery
+ *   - Examples: server-supplied starter lists, same gallery tiles
  *   - Paste:    free-form deck list parser ("4 Lightning Bolt" / "Lightning Bolt x4")
  *   - Random:   defer to the server (empty deck list → random sealed pool)
  *
@@ -37,7 +37,14 @@ import {
   computeDeckStats,
   type DeckValidationResult,
 } from './DeckSummary'
+import {
+  DeckTile,
+  DeckTileActionButton,
+  deckColors,
+  rarestCard,
+} from '@/components/deck/DeckTile'
 import { parseArenaDeckList } from '../deckbuilder/parseArenaDeck'
+import type { CardSummary } from '../deckbuilder/cardFilter'
 import { SetIcon } from './SetIcon'
 import { SetPickerModal } from './SetPickerModal'
 import styles from './DeckPicker.module.css'
@@ -82,21 +89,6 @@ export interface DeckPickerProps {
    * Null/undefined = no restriction.
    */
   format?: string | null
-}
-
-interface CardSummary {
-  name: string
-  manaCost: string
-  cmc: number
-  colors: string[]
-  cardTypes: string[]
-  supertypes: string[]
-  subtypes: string[]
-  basicLand: boolean
-  rarity: string
-  setCode: string | null
-  collectorNumber: string | null
-  legalFormats?: string[]
 }
 
 interface ExampleDeck {
@@ -418,10 +410,12 @@ export function DeckPicker({
         {tab === 'saved' && (
           <SavedDecksPanel
             decks={visibleDecks}
+            catalog={cards}
             legalityMap={legalityMap}
             format={format}
             hiddenCount={decks.length - visibleDecks.length}
             selectedId={selectedSavedId}
+            disabled={disabled}
             onSelect={setSelectedSavedId}
             onDelete={(d) => {
               void removeDeck(d)
@@ -439,20 +433,13 @@ export function DeckPicker({
         )}
 
         {tab === 'examples' && (
-          <div className={styles.exampleGrid}>
-            {visibleExamples.map((ex) => (
-              <button key={ex.id} className={styles.exampleCard} onClick={() => handleLoadExample(ex)} disabled={disabled}>
-                <span className={styles.exampleName}>{ex.name}</span>
-                <span className={styles.exampleDesc}>{ex.description}</span>
-                <span className={styles.savedItemCount}>{Object.values(ex.cards).reduce((a, b) => a + b, 0)} cards</span>
-              </button>
-            ))}
-            {visibleExamples.length === 0 && (
-              <p className={styles.helperText}>
-                {examples.length === 0 ? 'Loading examples…' : 'No examples for this format.'}
-              </p>
-            )}
-          </div>
+          <ExampleDecksPanel
+            examples={visibleExamples}
+            catalog={cards}
+            loading={examples.length === 0}
+            disabled={disabled}
+            onLoad={handleLoadExample}
+          />
         )}
 
         {tab === 'paste' && (
@@ -564,18 +551,42 @@ function TabButton({
   )
 }
 
+/**
+ * "My Decks" gallery. Same full-art {@link DeckTile} the deckbuilder's saved-deck browser
+ * uses, so a deck looks identical wherever it's picked; clicking a tile selects it as the
+ * deck to play, and hover exposes Edit (opens it in the Paste tab) / Delete.
+ */
 function SavedDecksPanel({
-  decks, legalityMap, format, hiddenCount, selectedId, onSelect, onDelete, onEdit,
+  decks, catalog, legalityMap, format, hiddenCount, selectedId, disabled, onSelect, onDelete, onEdit,
 }: {
   decks: UnifiedDeck[]
+  catalog: Record<string, CardSummary>
   legalityMap: Record<string, string[]>
   format: string | null
   hiddenCount: number
   selectedId: string | null
+  disabled: boolean
   onSelect: (id: string) => void
   onDelete: (d: UnifiedDeck) => void
   onEdit: (d: UnifiedDeck) => void
 }) {
+  // Tile metadata per deck. The commander is folded back into the card map (saved decks keep
+  // it out of `cards` per `SavedDeck.commander`) so the count and pips match what actually
+  // gets played, and so a commander can win the hero-art tie-break.
+  const tiles = useMemo(
+    () =>
+      decks.map((d) => {
+        const fullCards = mergeCommanderIntoCards(d.cards, d.commander ?? null)
+        return {
+          deck: d,
+          total: Object.values(fullCards).reduce((a, b) => a + b, 0),
+          colors: deckColors(fullCards, catalog),
+          hero: rarestCard(fullCards, catalog, d.commander ?? null),
+        }
+      }),
+    [decks, catalog],
+  )
+
   if (decks.length === 0) {
     if (format && hiddenCount > 0) {
       return (
@@ -595,66 +606,110 @@ function SavedDecksPanel({
           hiding {hiddenCount} that {hiddenCount === 1 ? 'is not' : 'are not'} legal.
         </p>
       )}
-      <ul className={styles.savedList}>
-        {decks.map((d) => {
-          const fullCards = mergeCommanderIntoCards(d.cards, d.commander ?? null)
-          const total = Object.values(fullCards).reduce((a, b) => a + b, 0)
-          const legalIn = legalityMap[d.id] ?? []
-          return (
-            <li
-              key={d.id}
-              className={`${styles.savedItem} ${selectedId === d.id ? styles.savedItemSelected : ''}`}
-              onClick={() => onSelect(d.id)}
-            >
-              <div className={styles.savedItemMeta}>
-                <span className={styles.savedItemName}>
-                  {d.name}
-                  <span
-                    className={styles.savedItemFormatBadge}
-                    style={{
-                      marginLeft: 6,
-                      color: d.online ? '#9be8bd' : '#b8b8c4',
-                      borderColor: d.online ? 'rgba(62,207,122,0.35)' : undefined,
-                    }}
-                    title={d.online ? 'Backed up to your account' : 'Saved only in this browser'}
-                  >
-                    {d.online ? 'Online' : 'Browser'}
-                  </span>
-                </span>
-                <span className={styles.savedItemCount}>{total} cards</span>
-                {(d.format || legalIn.length > 0) && (
-                  <span className={styles.savedItemFormats}>
-                    {d.format && (
-                      <span
-                        className={styles.savedItemFormatBadgeSaved}
-                        title={`Saved as ${labelForFormat(d.format)}`}
-                      >
-                        {labelForFormat(d.format)}
-                      </span>
-                    )}
-                    {legalIn
-                      .filter((f) => f !== d.format)
-                      .map((f) => (
-                        <span
-                          key={f}
-                          className={styles.savedItemFormatBadge}
-                          title={`Legal in ${labelForFormat(f)}`}
-                        >
-                          {labelForFormat(f)}
-                        </span>
-                      ))}
-                  </span>
-                )}
-              </div>
-              <div className={styles.savedItemActions}>
-                <button className={styles.linkButton} onClick={(e) => { e.stopPropagation(); onEdit(d) }} type="button">Edit</button>
-                <button className={styles.dangerButton} onClick={(e) => { e.stopPropagation(); onDelete(d) }} type="button">Delete</button>
-              </div>
-            </li>
-          )
-        })}
-      </ul>
+      <div className={styles.deckGridScroll}>
+        <div className={styles.deckGrid}>
+          {tiles.map(({ deck, total, colors, hero }) => {
+            // One chip only: the format the deck was saved as, else the first format it's legal in.
+            const shownFormat = deck.format ?? legalityMap[deck.id]?.[0] ?? null
+            return (
+              <DeckTile
+                key={deck.id}
+                name={deck.name}
+                total={total}
+                colors={colors}
+                hero={hero}
+                format={shownFormat}
+                formatTitle={
+                  shownFormat
+                    ? deck.format
+                      ? `Saved as ${labelForFormat(shownFormat)}`
+                      : `Legal in ${labelForFormat(shownFormat)}`
+                    : undefined
+                }
+                selected={deck.id === selectedId}
+                badge={deck.id === selectedId ? 'Selected' : undefined}
+                storage={deck.online ? 'cloud' : 'local'}
+                title={`Play with ${deck.name}`}
+                disabled={disabled}
+                onClick={() => onSelect(deck.id)}
+                actions={
+                  <>
+                    <DeckTileActionButton
+                      onClick={() => onEdit(deck)}
+                      title="Edit in the Paste tab"
+                      ariaLabel={`Edit ${deck.name}`}
+                    >
+                      ✎
+                    </DeckTileActionButton>
+                    <DeckTileActionButton
+                      onClick={() => onDelete(deck)}
+                      title="Delete"
+                      ariaLabel={`Delete ${deck.name}`}
+                      danger
+                    >
+                      ✕
+                    </DeckTileActionButton>
+                  </>
+                }
+              />
+            )
+          })}
+        </div>
+      </div>
     </>
   )
 }
 
+/**
+ * Server-supplied starter decks, shown as the same art tiles as "My Decks" so both halves of
+ * the picker read as one gallery. Clicking a tile loads the list into the Paste tab (where the
+ * user can tweak and save it) — matching the pre-gallery behaviour.
+ */
+function ExampleDecksPanel({
+  examples, catalog, loading, disabled, onLoad,
+}: {
+  examples: ExampleDeck[]
+  catalog: Record<string, CardSummary>
+  loading: boolean
+  disabled: boolean
+  onLoad: (ex: ExampleDeck) => void
+}) {
+  const tiles = useMemo(
+    () =>
+      examples.map((ex) => ({
+        example: ex,
+        total: Object.values(ex.cards).reduce((a, b) => a + b, 0),
+        colors: deckColors(ex.cards, catalog),
+        hero: rarestCard(ex.cards, catalog, ex.commander ?? null),
+      })),
+    [examples, catalog],
+  )
+  if (tiles.length === 0) {
+    return (
+      <p className={styles.helperText}>
+        {loading ? 'Loading examples…' : 'No examples for this format.'}
+      </p>
+    )
+  }
+  return (
+    <div className={styles.deckGridScroll}>
+      <div className={styles.deckGrid}>
+        {tiles.map(({ example, total, colors, hero }) => (
+          <DeckTile
+            key={example.id}
+            name={example.name}
+            description={example.description}
+            total={total}
+            colors={colors}
+            hero={hero}
+            format={example.format ?? null}
+            formatTitle={example.format ? `Built for ${labelForFormat(example.format)}` : undefined}
+            title={`Load ${example.name} into the Paste tab`}
+            disabled={disabled}
+            onClick={() => onLoad(example)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Brings the deckbuilder's full-art deck gallery to the **Quick Game** lobby and the **tournament Premade Decks** lobby. Both went through `DeckPicker`, whose "My Decks" tab was a plain text list while the deckbuilder had the tile gallery — now they render the same tile, so a deck looks identical wherever it gets picked.

### What changed

- **New shared `components/deck/DeckTile`** (+ CSS module): hero art from the deck's rarest non-land card, rarity-tinted name, format chip, colour pips, card count, plus an optional Cloud/Local storage badge, status ribbon and hover action buttons. `rarestCard` / `deckColors` moved here with it.
- **DeckPicker** — "My Decks" and "Examples" are tile galleries. Clicking a tile selects that deck (accent ring + "Selected" ribbon); hover still exposes **Edit** (loads the list into the Paste tab) and **Delete**. Format filtering, the "hiding N not legal" note, validation and the summary panel are unchanged.
- **Deckbuilder** — its saved-deck browser now renders the shared tile (same look as before), and the "Load an example deck" modal renders tiles too: it had been borrowing the gallery's class names (`.deckCard`, `.deckCardName`) for plain text cards.

### Two layout fixes that fell out of the extraction

- A grid that is *itself* the scroll container has a definite block size, so its `auto` rows get squashed to fit and each tile's `aspect-ratio` height overflows its row — every caption lands on the tile below. The scroll cap now lives on a wrapper. This was visibly broken in the deckbuilder browser too once the deck count overflowed the dialog (rows collapsed to 74px for 223px tiles at 30 decks).
- The status ribbon and the hover action buttons shared the top-right corner and stacked on a selected tile; they now sit side by side in one cluster.

### Screenshots

Quick Game — My Decks (deck selected, another tile hovered):

![Quick Game My Decks](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/quickgame-mydecks.png)

Quick Game — Examples (descriptions ride along under the name):

![Quick Game Examples](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/quickgame-examples.png)

In lobby context:

![Quick Game lobby](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/quickgame-lobby.png)

Tournament — Premade Decks lobby:

![Tournament Premade Decks](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/tournament-premade.png)

Deckbuilder — saved decks (24 decks, overflowing grid, no caption overlap):

![Deckbuilder gallery](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/deckbuilder-gallery.png)

Deckbuilder — example-decks modal now uses the shared tile:

![Deckbuilder examples](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-gallery-selector-screenshots/deckbuilder-examples.png)

*(The `deck-gallery-selector-screenshots` branch is a throwaway image host — safe to delete after merge.)*

### Verification

`npm run typecheck` + `npm run build` pass. Driven manually against the running stack: Quick Game vs AI, tournament Premade lobby (incl. the Modern-restricted filter), deckbuilder saved-deck browser at 12/24/30 decks, and the example-decks modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
