### PR TITLE
Add an in-game deck tracker

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -153,6 +153,35 @@ wholeGame, autoAnswer }`. A triggered/activated ability on the stack carries its
 in its `ClientCard`, so the stack-item context menu can target it. When a yield auto-answers a
 may-question, the server emits an `abilityAutoAnswered` log event (shown only to the controller).
 
+### B3. Deck Tracker (`deck` on the client state)
+
+The state update carries the viewer's own decklist as `deck` — one entry per distinct card,
+`{ cardName, copies, remaining, cmc, cardTypes, colors, imageUri }`. It drives the in-game deck
+panel behind the Deck pile (also `D`), which renders it through the same `DeckCardBody` component
+as the recorded-deck viewer — hence the field names matching `GameDeckCard`.
+
+The server builds it in `ClientStateTransformer` from live *ownership* rather than a stored
+decklist, which is what keeps it honest: a permanent an opponent stole is still in its owner's deck
+(CR 108.3), a token copy of one never is, and a permanent copying something else counts as the card
+it was printed as. The sideboard is excluded as outside the game (CR 400.11a); the command zone is
+included so a commander doesn't flicker in and out as it's cast and returns.
+
+Two masking rules matter:
+
+- **`deck` describes only `viewingPlayerId`, and is empty for spectators.** No player, spectator or
+  replay viewer ever receives another player's decklist.
+- **`remaining` is "copies you can't currently see", not "copies in your library."** Those are the
+  same number in an ordinary game, but a card of yours hidden elsewhere — exiled face down, or a
+  face-down permanent an opponent controls — stays counted as `remaining`. Publishing an exact
+  library count would let the panel be read backwards to learn *which* card got exiled face down.
+
+Aggregate counts only: library *order* is never exposed here. (The Library-order tab in the same
+panel is the pre-existing view, and shows card backs for everything not revealed to the viewer.)
+
+`StateDelta.deck` is sent only when a count actually moved (a draw, a mill, a tutor), so the
+many updates that just shuffle the battlefield around don't re-send the list. Absent from a delta
+means unchanged — the client carries the previous value forward.
+
 ### C. Connection Liveness (Client <-> Server)
 
 `{"type": "ping"}` (client) is always answered with `{"type": "pong"}` (server), regardless of

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -175,6 +175,25 @@ App
     └── DeathEffect
 ```
 
+## In-game deck tracker
+
+Clicking your own Deck pile (or pressing `D`) opens `board/DeckBrowser.tsx`, a two-tab overlay:
+
+- **Deck list** — your decklist with a `remaining/copies` count per card, fully-drawn rows dimmed,
+  next-draw odds, and the deckbuilder's mana curve and colour pips. It renders
+  `ClientGameState.deck` through `components/deck/GameDeckView.tsx`'s `DeckCardBody`, the same
+  component the profile and admin deck viewers use — a `DeckViewCard` is just a recorded
+  `GameDeckCard` plus an optional `remaining`, and supplying it is what switches rows into tracker
+  mode.
+- **Library order** — the pre-existing library view (top to bottom, card backs for anything not
+  revealed to you).
+
+Everything shown comes from the server: `deck` is populated only for `viewingPlayerId` and is empty
+for spectators, so an opponent's Deck pile has no deck-list tab at all and the client never has to
+decide what to hide. See `data-contracts.md` §B3 for the payload and its two masking rules — in
+particular that `remaining` means "copies you haven't seen", which is not always the same as
+"copies in your library".
+
 ## Battlefield card grouping (token quantity aggregation)
 
 Identical permanents on one player's board collapse into a single visual **stack**
@@ -310,9 +329,10 @@ are gated on `players.length > 2`).
   (hand `CardRow`, `CommandZone`, `Battlefield`, `ZonePile`, and everything inside
   `GameCard`) that is full-screen or positioned in viewport coordinates must go through
   `createPortal(..., document.body)`.** Current portals: the
-  graveyard/exile/library/plotted/paradigm browsers (`ZonePiles.tsx` — titles carry the
+  graveyard/exile/plotted/paradigm browsers (`ZonePiles.tsx` — titles carry the
   owner's name, "Carol's Graveyard", since "Opponent's" is ambiguous at a multiplayer
-  table), the attachments browser (`Battlefield.tsx`), the copy-of hover preview and the
+  table) and the deck browser (`DeckBrowser.tsx`), the attachments browser
+  (`Battlefield.tsx`), the copy-of hover preview and the
   active-effect badge tooltip (`GameCard.tsx` / `CardOverlays.tsx`). Overlays rendered
   from `GameBoard` itself (stack, action menu, decision modals, yield menu) sit outside
   the strip and don't need it.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -96,7 +96,47 @@ data class ClientGameState(
      * per-player: only the viewer's own yields are ever included. Drives the "Active yields" panel
      * (revoke / clear-all) and lets the client suppress re-prompting cues. Empty for spectators.
      */
-    val activeYields: List<ClientYield> = emptyList()
+    val activeYields: List<ClientYield> = emptyList(),
+
+    /**
+     * The viewing player's own decklist — one entry per distinct card they own, with how many
+     * copies they still haven't seen. Drives the in-game deck tracker. Strictly private: empty for
+     * spectators and never populated for anyone but [viewingPlayerId], so a player can review their
+     * own 60 without learning anything about an opponent's. Library *order* is never exposed —
+     * entries are aggregated counts, not positions. See [ClientDeckCard].
+     */
+    val deck: List<ClientDeckCard> = emptyList()
+)
+
+/**
+ * One distinct card in the viewing player's deck, aggregated across every zone.
+ *
+ * Field names mirror the recorded-deck DTO the profile/admin deck viewer already uses
+ * (`GameDeckCard`), so the client renders both through the same component.
+ *
+ * @property copies Total copies of this card the player owns that are in the game — the printed
+ *   count in their deck. Cards in the sideboard are excluded (CR 400.11a puts them outside the game);
+ *   a card wished in from the sideboard therefore *adds* to the deck when it enters.
+ * @property remaining Copies whose current location the viewer cannot identify — i.e. still in
+ *   their library, or hidden from them elsewhere (a card of theirs exiled face down, or a
+ *   face-down permanent an opponent controls). Lumping "hidden elsewhere" in with "in library"
+ *   is deliberate: reporting an exact library count would leak *which* card an opponent exiled
+ *   face down. In an ordinary game nothing is hidden outside the library, so `remaining` is
+ *   exactly "cards of this name left to draw".
+ */
+@Serializable
+data class ClientDeckCard(
+    val cardName: String,
+    val copies: Int,
+    val remaining: Int,
+    /** Mana value, for the curve histogram. */
+    val cmc: Int,
+    /** Card type enum names, e.g. `["CREATURE"]` — the client buckets rows by these. */
+    val cardTypes: List<String>,
+    /** The card's own colours as enum names; empty for colourless. */
+    val colors: List<String>,
+    /** Art URL for the hover preview; null falls back to a client-side name lookup. */
+    val imageUri: String? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -293,6 +293,9 @@ class ClientStateTransformer(
         // Persistent yields are private to each player: only ever surface the viewer's own.
         val activeYields = if (isSpectator) emptyList() else buildClientYields(state.yieldsFor(viewingPlayerId))
 
+        // The deck tracker is the viewer's own decklist — never a spectator's or an opponent's.
+        val deck = if (isSpectator) emptyList() else buildDeckList(state, viewingPlayerId)
+
         return ClientGameState(
             viewingPlayerId = viewingPlayerId,
             cards = cards,
@@ -310,8 +313,97 @@ class ClientStateTransformer(
             youAreHijacking = youAreHijacking,
             youAreHijackedBy = youAreHijackedBy,
             hotseat = hotseat,
-            activeYields = activeYields
+            activeYields = activeYields,
+            deck = deck
         )
+    }
+
+    /**
+     * Build [viewingPlayerId]'s own decklist: every non-token card they *own*, wherever it now is,
+     * grouped by printed card.
+     *
+     * Deriving the list from live ownership rather than a stored decklist keeps it honest for free —
+     * a stolen creature is still in its owner's deck (ownership never changes, CR 108.3), a token
+     * copy of one never is, and a permanent copying something else counts as the card it was printed
+     * as (that's what [CopyOfComponent] remembers).
+     *
+     * Zones: the sideboard is excluded as outside the game (CR 400.11a); the command zone is included
+     * so a commander stays one stable row instead of appearing and vanishing as it's cast and
+     * returns. The stack lives outside [GameState.zones], so it is walked separately.
+     */
+    private fun buildDeckList(state: GameState, viewingPlayerId: EntityId): List<ClientDeckCard> {
+        class Tally {
+            var copies = 0
+            var remaining = 0
+            /** Art from a real (non-copy) printing of this card in the game, if we saw one. */
+            var printingImageUri: String? = null
+        }
+
+        val tallies = HashMap<String, Tally>()
+
+        fun record(entityId: EntityId, zoneType: Zone) {
+            val container = state.getEntity(entityId) ?: return
+            if (container.has<TokenComponent>()) return
+            val cardComponent = container.get<CardComponent>() ?: return
+            val ownerId = cardComponent.ownerId ?: container.get<OwnerComponent>()?.playerId
+            if (ownerId != viewingPlayerId) return
+
+            // A copy effect overwrites CardComponent with the copied card; CopyOfComponent holds
+            // what this card is actually printed as, which is what belongs in the decklist.
+            val copyOf = container.get<CopyOfComponent>()
+            val definitionId = copyOf?.originalCardDefinitionId ?: cardComponent.cardDefinitionId
+
+            val tally = tallies.getOrPut(definitionId) { Tally() }
+            tally.copies++
+            if (!ownerKnowsIdentity(state, entityId, zoneType, viewingPlayerId)) tally.remaining++
+            if (copyOf == null && tally.printingImageUri == null) {
+                tally.printingImageUri = cardComponent.imageUri
+            }
+        }
+
+        for ((zoneKey, entityIds) in state.zones) {
+            if (zoneKey.zoneType == Zone.SIDEBOARD) continue
+            for (entityId in entityIds) record(entityId, zoneKey.zoneType)
+        }
+        for (entityId in state.stack) record(entityId, Zone.STACK)
+
+        return tallies.mapNotNull { (definitionId, tally) ->
+            val definition = cardRegistry.getCard(definitionId) ?: return@mapNotNull null
+            ClientDeckCard(
+                cardName = definition.name,
+                copies = tally.copies,
+                remaining = tally.remaining,
+                cmc = definition.cmc,
+                cardTypes = definition.typeLine.cardTypes.map { it.name },
+                colors = definition.colors.map { it.name },
+                imageUri = tally.printingImageUri ?: definition.metadata.imageUri
+            )
+        }.sortedWith(compareBy({ it.cmc }, { it.cardName }))
+    }
+
+    /**
+     * Whether the owner of [entityId] can currently tell *which* of their cards this one is.
+     *
+     * False for anything in their library (that's the whole point — you know what's in your deck,
+     * not where), and for a card of theirs that is face down somewhere they can't look: exiled face
+     * down, or a face-down permanent an opponent controls. Mirrors the face-down masking in
+     * [transformCard] so the tracker never claims knowledge the client wasn't sent.
+     */
+    private fun ownerKnowsIdentity(
+        state: GameState,
+        entityId: EntityId,
+        zoneType: Zone,
+        viewingPlayerId: EntityId
+    ): Boolean {
+        if (zoneType == Zone.LIBRARY) return false
+        val container = state.getEntity(entityId) ?: return false
+        val isInFaceDownZone =
+            zoneType == Zone.BATTLEFIELD || zoneType == Zone.STACK || zoneType == Zone.EXILE
+        if (!isInFaceDownZone || !container.has<FaceDownComponent>()) return true
+        val controllerId = container.get<ControllerComponent>()?.playerId
+        return controllerId == viewingPlayerId ||
+            isCardRevealedTo(state, entityId, viewingPlayerId) ||
+            (zoneType == Zone.BATTLEFIELD && hasLookAtFaceDownCreatures(state, viewingPlayerId))
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/StateDelta.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/StateDelta.kt
@@ -53,4 +53,11 @@ data class StateDelta(
 
     /** Hotseat indicator. Always present in the delta; overwrites the client field. */
     val hotseat: Boolean? = null,
+
+    /**
+     * The viewer's decklist, sent only when it changed. Its *composition* is fixed for a whole
+     * game, so in practice this fires when a card's `remaining` count moves — a draw, a mill, a
+     * tutor — and not on the many updates that only shuffle the battlefield around.
+     */
+    val deck: List<ClientDeckCard>? = null,
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/StateDiffCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/StateDiffCalculator.kt
@@ -74,6 +74,9 @@ object StateDiffCalculator {
             null
         }
 
+        // --- Deck diff (whole list; changes only when a card's remaining count moves) ---
+        val deckDelta = if (current.deck != previous.deck) current.deck else null
+
         return StateDelta(
             addedCards = addedCards.ifEmpty { null },
             removedCardIds = removedCardIds.ifEmpty { null },
@@ -93,6 +96,7 @@ object StateDiffCalculator {
             youAreHijacking = current.youAreHijacking,
             youAreHijackedBy = current.youAreHijackedBy,
             hotseat = current.hotseat,
+            deck = deckDelta,
         )
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
@@ -1,0 +1,232 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.view.ClientDeckCard
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.engine.view.StateDiffCalculator
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The in-game deck tracker: `ClientGameState.deck`, one row per distinct card the viewing player
+ * *owns*, with a `remaining` count of copies whose location they can't identify.
+ *
+ * The list is derived from live ownership rather than a stored decklist, which is what makes the
+ * awkward cases fall out for free — ownership never changes (CR 108.3), so a stolen permanent is
+ * still in its owner's deck; tokens were never cards in anyone's deck; and the sideboard is outside
+ * the game (CR 400.11a) until something wishes a card in.
+ *
+ * The privacy contract is the other half of the feature: the list only ever describes the viewer,
+ * it is empty for spectators, and it reports "copies you haven't seen" rather than "copies in your
+ * library" precisely so it can't be read backwards to learn which card an opponent exiled face
+ * down. Library *order* is never exposed at all — these are aggregate counts.
+ */
+class DeckListClientViewTest : ScenarioTestBase() {
+
+    private val transformer = ClientStateTransformer(cardRegistry)
+    private val p1 = EntityId.of("player-1")
+    private val p2 = EntityId.of("player-2")
+
+    private fun deckOf(state: GameState, viewer: EntityId = p1): List<ClientDeckCard> =
+        transformer.transform(state, viewer).deck
+
+    private fun row(state: GameState, name: String, viewer: EntityId = p1): ClientDeckCard? =
+        deckOf(state, viewer).firstOrNull { it.cardName == name }
+
+    init {
+        test("the deck lists every card you own, counting only unseen copies as remaining") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInHand(1, "Lightning Bolt")
+                .withCardInGraveyard(1, "Lightning Bolt")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .build()
+
+            val bolt = row(game.state, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.copies shouldBe 4
+            bolt.remaining shouldBe 2 // only the two still in the library are unaccounted for
+
+            val bears = row(game.state, "Grizzly Bears")
+            bears.shouldNotBeNull()
+            bears.copies shouldBe 1
+            bears.remaining shouldBe 0 // it's on the battlefield; you can see it
+        }
+
+        test("rows carry the display metadata the tracker renders — curve, colours, type buckets") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .build()
+
+            val bolt = row(game.state, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.cmc shouldBe 1
+            bolt.cardTypes shouldContainExactly listOf("INSTANT")
+            bolt.colors shouldContainExactly listOf("RED")
+        }
+
+        test("the deck is ordered by mana value then name, so the panel needn't re-sort") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Divination")      // {2}{U}
+                .withCardInLibrary(1, "Lightning Bolt")  // {R}
+                .withCardInLibrary(1, "Pacifism")        // {1}{W}
+                .build()
+
+            deckOf(game.state).map { it.cardName } shouldContainExactly
+                listOf("Lightning Bolt", "Pacifism", "Divination")
+        }
+
+        test("a card an opponent owns is never in your deck, whoever controls it") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+
+            row(game.state, "Grizzly Bears", viewer = p1).shouldBeNull()
+            row(game.state, "Grizzly Bears", viewer = p2).shouldNotBeNull()
+        }
+
+        test("a permanent an opponent stole is still in its owner's deck (CR 108.3)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .build()
+
+            val bears = game.state.getBattlefield().single()
+            val stolen = game.state.updateEntity(bears) { it.with(ControllerComponent(p2)) }
+
+            // Owned by p1, controlled by p2: p1's deck still has it, p2's still doesn't.
+            val p1Row = row(stolen, "Grizzly Bears", viewer = p1)
+            p1Row.shouldNotBeNull()
+            p1Row.copies shouldBe 1
+            p1Row.remaining shouldBe 0 // face up on the battlefield — its owner can see it
+            row(stolen, "Grizzly Bears", viewer = p2).shouldBeNull()
+        }
+
+        test("tokens are not cards and never enter the decklist") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears", isToken = true)
+                .build()
+
+            deckOf(game.state).shouldContainExactly(emptyList())
+        }
+
+        test("the sideboard is outside the game and isn't counted (CR 400.11a)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInSideboard(1, "Lightning Bolt")
+                .build()
+
+            val bolt = row(game.state, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.copies shouldBe 1
+            bolt.remaining shouldBe 1
+        }
+
+        test("the command zone counts, so a commander stays one stable row as it's cast and returns") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInCommandZone(1, "Grizzly Bears")
+                .build()
+
+            val commander = row(game.state, "Grizzly Bears")
+            commander.shouldNotBeNull()
+            commander.copies shouldBe 1
+            commander.remaining shouldBe 0 // the command zone is public
+        }
+
+        test("your own card exiled face down stays 'unseen' rather than being revealed as exiled") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInExile(1, "Lightning Bolt")
+                .build()
+
+            val exiled = game.state.getZone(p1, Zone.EXILE).single()
+            // An opponent's effect exiled it face down: they control the exile, you can't look.
+            val hidden = game.state.updateEntity(exiled) {
+                it.with(FaceDownComponent).with(ControllerComponent(p2))
+            }
+
+            val bolt = row(hidden, "Lightning Bolt")
+            bolt.shouldNotBeNull()
+            bolt.copies shouldBe 2
+            // Both are "unseen" — reporting 1 would tell you a Bolt is the card that got exiled.
+            bolt.remaining shouldBe 2
+        }
+
+        test("a face-down card you control yourself is one you can identify") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .build()
+
+            val bears = game.state.getBattlefield().single()
+            val faceDown = game.state.updateEntity(bears) { it.with(FaceDownComponent) }
+
+            val row = row(faceDown, "Grizzly Bears")
+            row.shouldNotBeNull()
+            row.remaining shouldBe 0
+        }
+
+        test("spectators are told nothing about anyone's deck") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .build()
+
+            transformer.transform(game.state, p1, isSpectator = true).deck
+                .shouldContainExactly(emptyList())
+        }
+
+        test("each player's view describes only their own deck") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(2, "Divination")
+                .build()
+
+            deckOf(game.state, viewer = p1).map { it.cardName } shouldContainExactly listOf("Lightning Bolt")
+            deckOf(game.state, viewer = p2).map { it.cardName } shouldContainExactly listOf("Divination")
+        }
+
+        test("the delta only carries the deck when a count actually moved") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .build()
+
+            val before = transformer.transform(game.state, p1)
+
+            // An unrelated change must not drag the whole decklist along with it.
+            val laterTurn = game.state.copy(turnNumber = game.state.turnNumber + 1)
+            StateDiffCalculator.computeDelta(before, transformer.transform(laterTurn, p1))
+                .deck.shouldBeNull()
+
+            // Drawing one moves a copy from unseen to seen, so the tracker has to be resent.
+            val boltId = game.state.getLibrary(p1).first()
+            val drawn = game.state.moveToZone(
+                boltId,
+                com.wingedsheep.engine.state.ZoneKey(p1, Zone.LIBRARY),
+                com.wingedsheep.engine.state.ZoneKey(p1, Zone.HAND),
+            )
+            val delta = StateDiffCalculator.computeDelta(before, transformer.transform(drawn, p1))
+            delta.deck.shouldNotBeNull()
+            delta.deck!!.single().remaining shouldBe 1
+        }
+    }
+}

--- a/web-client/src/components/deck/GameDeckView.tsx
+++ b/web-client/src/components/deck/GameDeckView.tsx
@@ -1,11 +1,15 @@
 /**
- * Shared, polished renderer for a recorded/saved deck — the single deck UI reused by the player's
- * recent-games deck modal and the admin player view. It takes the registry-enriched card lines the
- * server sends ({@link GameDeckCard}: copies + cmc + types + colours) and renders them the way the
+ * Shared, polished renderer for a deck — the single deck UI reused by the player's recent-games
+ * deck modal, the admin player view, and the in-game deck tracker. It takes registry-enriched card
+ * lines ({@link GameDeckCard}: copies + cmc + types + colours) and renders them the way the
  * deckbuilder does: cards grouped by type with running counts, a stacked-by-colour mana curve and
  * colour pips (both from the deckbuilder's {@link DeckSummary} helpers), and a cursor-following card
- * image on hover ({@link HoverCardPreview}). Nothing here is admin- or profile-specific, so both
- * surfaces — and any future deck viewer — share exactly one look.
+ * image on hover ({@link HoverCardPreview}). Nothing here is admin- or profile-specific, so every
+ * surface shares exactly one look.
+ *
+ * Live games pass {@link DeckViewCard}s carrying a `remaining` count, which switches rows into
+ * tracker mode: `remaining/copies` instead of a bare copy count, fully-drawn rows dimmed, and — when
+ * `drawPoolSize` is given — the chance the next card drawn is that one.
  */
 import { useState } from 'react'
 import type React from 'react'
@@ -33,20 +37,27 @@ const TYPE_LABEL: Record<string, string> = {
   OTHER: 'Other',
 }
 
+/**
+ * A deck line, optionally annotated with how many copies are still unaccounted for. `remaining` is
+ * absent for a recorded deck (nothing to track) and present for a live game.
+ */
+export type DeckViewCard = GameDeckCard & { readonly remaining?: number }
+
 interface TypeGroup {
   key: string
   label: string
-  cards: GameDeckCard[]
+  cards: DeckViewCard[]
   count: number
+  remaining: number
 }
 
-function primaryType(card: GameDeckCard): string {
+function primaryType(card: DeckViewCard): string {
   for (const t of TYPE_ORDER) if (card.cardTypes.includes(t)) return t
   return 'OTHER'
 }
 
-function groupByType(cards: GameDeckCard[]): TypeGroup[] {
-  const buckets = new Map<string, GameDeckCard[]>()
+function groupByType(cards: readonly DeckViewCard[]): TypeGroup[] {
+  const buckets = new Map<string, DeckViewCard[]>()
   for (const card of cards) {
     const key = primaryType(card)
     const list = buckets.get(key)
@@ -66,6 +77,7 @@ function groupByType(cards: GameDeckCard[]): TypeGroup[] {
         label: TYPE_LABEL[k] ?? k,
         cards: groupCards,
         count: groupCards.reduce((sum, c) => sum + c.copies, 0),
+        remaining: groupCards.reduce((sum, c) => sum + (c.remaining ?? c.copies), 0),
       }
     })
 }
@@ -74,12 +86,28 @@ type HoverState = { name: string; imageUri: string | null; pos: { x: number; y: 
 
 /**
  * The body of a single deck: colour pips, mana curve, and the cards grouped by type. Used standalone
- * for a saved deck and inside {@link SeatDeckColumn} for a game seat. Manages its own hover preview.
+ * for a saved deck, inside {@link SeatDeckColumn} for a game seat, and by the in-game deck tracker.
+ * Manages its own hover preview.
+ *
+ * The curve and colour pips always describe the *whole* deck — that's the decklist you built, and
+ * it shouldn't reshape itself as you draw. Only the per-card rows track what's left.
+ *
+ * @param drawPoolSize Library size, when known. Turns on the per-row "chance your next draw is this
+ *   card" column. Omit for a recorded deck.
+ * @param emptyLabel What to show when there are no cards at all.
  */
-export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
+export function DeckCardBody({
+  cards,
+  drawPoolSize,
+  emptyLabel = 'Deck not recorded.',
+}: {
+  cards: readonly DeckViewCard[]
+  drawPoolSize?: number
+  emptyLabel?: string
+}) {
   const [hover, setHover] = useState<HoverState>(null)
 
-  if (cards.length === 0) return <p style={styles.muted}>Deck not recorded.</p>
+  if (cards.length === 0) return <p style={styles.muted}>{emptyLabel}</p>
 
   // Reuse the deckbuilder's stats helper — GameDeckCard satisfies DeckStatsCard structurally.
   const deckRecord: Record<string, number> = {}
@@ -90,6 +118,7 @@ export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
   }
   const stats = computeDeckStats(deckRecord, cardMeta)
   const groups = groupByType(cards)
+  const tracking = cards.some((c) => c.remaining !== undefined)
 
   return (
     <div style={styles.body}>
@@ -114,21 +143,36 @@ export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
         {groups.map((g) => (
           <div key={g.key}>
             <div style={styles.groupTitle}>
-              {g.label} <span style={styles.groupCount}>{g.count}</span>
+              {g.label}{' '}
+              <span style={styles.groupCount}>{tracking ? `${g.remaining}/${g.count}` : g.count}</span>
             </div>
             <ul style={styles.cardList}>
-              {g.cards.map((c) => (
-                <li
-                  key={c.cardName}
-                  style={styles.cardRow}
-                  onMouseEnter={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
-                  onMouseMove={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
-                  onMouseLeave={() => setHover(null)}
-                >
-                  <span style={styles.copies}>{c.copies}</span>
-                  <span style={styles.cardName}>{c.cardName}</span>
-                </li>
-              ))}
+              {g.cards.map((c) => {
+                const remaining = c.remaining ?? c.copies
+                const drawn = tracking && remaining === 0
+                // Chance the very next card drawn is this one. Capped at 100% because a copy
+                // hidden outside the library (a face-down exile) still counts as "remaining".
+                const odds =
+                  drawPoolSize && drawPoolSize > 0 && remaining > 0
+                    ? Math.min(100, Math.round((remaining / drawPoolSize) * 100))
+                    : null
+                return (
+                  <li
+                    key={c.cardName}
+                    style={drawn ? { ...styles.cardRow, ...styles.cardRowDrawn } : styles.cardRow}
+                    onMouseEnter={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
+                    onMouseMove={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
+                    onMouseLeave={() => setHover(null)}
+                  >
+                    <span style={tracking ? { ...styles.copies, ...styles.copiesTracking } : styles.copies}>
+                      {tracking ? remaining : c.copies}
+                      {tracking && <span style={styles.ofCopies}>/{c.copies}</span>}
+                    </span>
+                    <span style={styles.cardName}>{c.cardName}</span>
+                    {odds !== null && <span style={styles.odds}>{odds}%</span>}
+                  </li>
+                )
+              })}
             </ul>
           </div>
         ))}
@@ -237,6 +281,10 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 6,
     cursor: 'default',
   },
+  cardRowDrawn: { opacity: 0.35 },
   copies: { color: '#8b9bff', fontVariantNumeric: 'tabular-nums', minWidth: 18, textAlign: 'right', fontWeight: 600 },
-  cardName: { color: '#d6d9e6' },
+  copiesTracking: { minWidth: 34 },
+  ofCopies: { color: '#5a6180', fontWeight: 500 },
+  cardName: { color: '#d6d9e6', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  odds: { color: '#6b7394', fontSize: 11, fontVariantNumeric: 'tabular-nums', flexShrink: 0 },
 }

--- a/web-client/src/components/game/board/DeckBrowser.tsx
+++ b/web-client/src/components/game/board/DeckBrowser.tsx
@@ -1,0 +1,312 @@
+/**
+ * Full-screen overlay behind a Deck pile, with two views.
+ *
+ * - **Deck list** — what you're playing and what's left of it: every distinct card with a
+ *   `remaining/copies` count, fully-drawn rows dimmed, next-draw odds, plus the deckbuilder's mana
+ *   curve and colour pips. This is the in-game equivalent of a companion-app deck tracker, and it's
+ *   built entirely from aggregated counts, so it never reveals library *order*.
+ * - **Library order** — the actual library, top to bottom. Cards revealed to the viewer (Scry,
+ *   Surveil, look-at-top-N) show face up in position; everything else is a card back.
+ *
+ * The server only ever sends `deck` for the viewing player (never for spectators, never describing
+ * an opponent), so an opponent's Deck pile falls through to the Library-order view alone with no
+ * tab strip. That masking is the server's call — this component just renders what it was given.
+ */
+import { useEffect, useState } from 'react'
+import type React from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import { selectGameState } from '@/store/selectors.ts'
+import type { ClientDeckCard, EntityId } from '@/types'
+import { CARD_BACK_IMAGE_URL, getCardImageUrl } from '@/utils/cardImages.ts'
+import { DeckCardBody, type DeckViewCard } from '@/components/deck/GameDeckView'
+import { useResponsiveContext, handleImageError } from './shared'
+import { styles } from './styles'
+
+type Tab = 'deck' | 'order'
+
+export function DeckBrowser({
+  ownerLabel,
+  entityIds,
+  deck,
+  onClose,
+}: {
+  /** Title prefix, e.g. "Your" / "Alice's". */
+  ownerLabel: string
+  /** Library contents in order, top first. Opaque ids for cards not revealed to the viewer. */
+  entityIds: readonly EntityId[]
+  /** The viewer's own decklist. Empty when this isn't their pile — hides the deck-list tab. */
+  deck: readonly ClientDeckCard[]
+  onClose: () => void
+}) {
+  const responsive = useResponsiveContext()
+  const [minimized, setMinimized] = useState(false)
+  // Default to the deck list when there is one: "what am I playing" is the common question, and
+  // library order is only ever interesting right after a scry or surveil.
+  const [tab, setTab] = useState<Tab>(deck.length > 0 ? 'deck' : 'order')
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (minimized) setMinimized(false)
+        else onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose, minimized])
+
+  if (minimized) {
+    return (
+      <button onClick={() => setMinimized(false)} style={restoreButtonStyle(responsive.isMobile, responsive.fontSize.normal)}>
+        ↑ Return to Deck
+      </button>
+    )
+  }
+
+  const showTabs = deck.length > 0
+
+  return (
+    <div style={styles.libraryOverlay} onClick={onClose}>
+      <div style={styles.libraryBrowserContent} onClick={(e) => e.stopPropagation()}>
+        <div style={styles.libraryBrowserHeader}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <h2 style={styles.libraryBrowserTitle}>{ownerLabel} Deck</h2>
+            {showTabs && (
+              <div style={tabStrip}>
+                <TabButton active={tab === 'deck'} onClick={() => setTab('deck')}>
+                  Deck list
+                </TabButton>
+                <TabButton active={tab === 'order'} onClick={() => setTab('order')}>
+                  Library order ({entityIds.length})
+                </TabButton>
+              </div>
+            )}
+          </div>
+          <button style={styles.libraryCloseButton} onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        {tab === 'deck' ? (
+          <DeckListTab deck={deck} librarySize={entityIds.length} />
+        ) : (
+          <LibraryOrderTab entityIds={entityIds} />
+        )}
+
+        <div style={{ display: 'flex', gap: 16 }}>
+          <button onClick={() => setMinimized(true)} style={footerButton(responsive.isMobile, responsive.fontSize.normal, true)}>
+            View Battlefield
+          </button>
+          <button onClick={onClose} style={footerButton(responsive.isMobile, responsive.fontSize.normal, false)}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The deck-tracker view. `remaining` counts copies the player can't currently see — normally
+ * "still in the library", but a copy hidden from them elsewhere (their card exiled face down)
+ * stays counted here too, which is what keeps the panel from leaking what an opponent exiled.
+ * The summary line says "unseen" rather than "in library" for exactly that reason.
+ */
+function DeckListTab({ deck, librarySize }: { deck: readonly ClientDeckCard[]; librarySize: number }) {
+  const total = deck.reduce((sum, c) => sum + c.copies, 0)
+  const remaining = deck.reduce((sum, c) => sum + c.remaining, 0)
+  const cards: readonly DeckViewCard[] = deck.map((c) => ({
+    cardName: c.cardName,
+    copies: c.copies,
+    remaining: c.remaining,
+    cmc: c.cmc,
+    cardTypes: c.cardTypes,
+    colors: c.colors,
+    imageUri: c.imageUri,
+  }))
+
+  return (
+    <div style={deckTabBody}>
+      <div style={summaryLine}>
+        <strong style={{ color: '#bfdbfe' }}>{remaining}</strong> of {total} cards unseen
+        <span style={{ color: '#475569' }}> · </span>
+        {librarySize} in library
+      </div>
+      <DeckCardBody cards={cards} drawPoolSize={librarySize} emptyLabel="No deck recorded for this game." />
+    </div>
+  )
+}
+
+/**
+ * The library top-to-bottom. Order matches the real library; a shuffle on the server clears every
+ * reveal, so a freshly shuffled library shows entirely face-down.
+ */
+function LibraryOrderTab({ entityIds }: { entityIds: readonly EntityId[] }) {
+  const hoverCard = useGameStore((state) => state.hoverCard)
+  const cardsMap = useGameStore((state) => selectGameState(state)?.cards)
+  const responsive = useResponsiveContext()
+
+  const cardWidth = responsive.isMobile ? 120 : 160
+  const cardHeight = Math.round(cardWidth * 1.4)
+  const revealedCount = entityIds.reduce((acc, id) => acc + (cardsMap?.[id] ? 1 : 0), 0)
+
+  return (
+    <>
+      <span style={{ color: '#64748b', fontSize: 11, letterSpacing: 0.5 }}>
+        Reading order: top → bottom, left to right
+        {revealedCount > 0 ? ` · ${revealedCount} known` : ''}
+      </span>
+      <div style={styles.libraryCardGrid}>
+        {entityIds.map((id, index) => {
+          const card = cardsMap?.[id]
+          const isTop = index === 0
+          const isBottom = index === entityIds.length - 1 && entityIds.length > 1
+          const accent = isTop ? '#fde68a' : isBottom ? '#fb923c' : null
+          return (
+            <div
+              key={id}
+              style={{
+                width: cardWidth,
+                height: cardHeight,
+                borderRadius: 6,
+                overflow: 'hidden',
+                flexShrink: 0,
+                position: 'relative',
+                boxShadow: accent ? `0 0 0 2px ${accent}, 0 0 14px ${accent}66` : 'none',
+              }}
+              onMouseEnter={(e) => {
+                if (card) hoverCard(card.id, { x: e.clientX, y: e.clientY })
+              }}
+              onMouseLeave={() => hoverCard(null)}
+            >
+              {card ? (
+                <img
+                  src={getCardImageUrl(card.name, card.imageUri, 'normal')}
+                  alt={card.name}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                  onError={(e) => handleImageError(e, card.name, 'normal')}
+                />
+              ) : (
+                <img
+                  src={CARD_BACK_IMAGE_URL}
+                  alt="Card back"
+                  style={{ width: '100%', height: '100%', objectFit: 'cover', opacity: 0.85 }}
+                />
+              )}
+              {/* Position badge — shown on every card */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  left: 4,
+                  fontSize: 10,
+                  color: '#bfdbfe',
+                  backgroundColor: 'rgba(0,0,0,0.65)',
+                  padding: '2px 6px',
+                  borderRadius: 3,
+                  pointerEvents: 'none',
+                }}
+              >
+                #{index + 1}
+              </div>
+              {/* Anchor banner across the bottom of the first/last card so orientation
+                  is unambiguous regardless of how the grid wraps */}
+              {accent && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    backgroundColor: accent,
+                    color: '#1c1917',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    letterSpacing: 1,
+                    textAlign: 'center',
+                    padding: '4px 0',
+                    textTransform: 'uppercase',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  {isTop ? 'Top · Next draw' : 'Bottom'}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </>
+  )
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: '4px 12px',
+        fontSize: 12,
+        fontWeight: 600,
+        borderRadius: 6,
+        cursor: 'pointer',
+        border: `1px solid ${active ? '#3b82f6' : '#1e293b'}`,
+        backgroundColor: active ? '#1e3a8a' : 'transparent',
+        color: active ? '#dbeafe' : '#64748b',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+const tabStrip: React.CSSProperties = { display: 'flex', gap: 6 }
+
+// Unlike the library-order grid — which is a wall of card art and needs no surface of its own —
+// the deck list is text, so it gets a panel to sit on or it's unreadable over the battlefield.
+const deckTabBody: React.CSSProperties = {
+  overflowY: 'auto',
+  minWidth: 420,
+  maxWidth: 560,
+  backgroundColor: '#12121c',
+  border: '1px solid #2a2a3e',
+  borderRadius: 12,
+  padding: '14px 18px',
+}
+
+const summaryLine: React.CSSProperties = {
+  color: '#94a3b8',
+  fontSize: 12,
+  fontVariantNumeric: 'tabular-nums',
+  marginBottom: 4,
+}
+
+const restoreButtonStyle = (isMobile: boolean, fontSize: number | string): React.CSSProperties => ({
+  position: 'fixed',
+  bottom: 70,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  padding: isMobile ? '10px 16px' : '12px 24px',
+  fontSize,
+  backgroundColor: '#1e3a8a',
+  color: 'white',
+  border: 'none',
+  borderRadius: 8,
+  cursor: 'pointer',
+  fontWeight: 600,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+  zIndex: 100,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+})
+
+const footerButton = (isMobile: boolean, fontSize: number | string, primary: boolean): React.CSSProperties => ({
+  padding: isMobile ? '10px 20px' : '12px 28px',
+  fontSize,
+  backgroundColor: primary ? '#1e3a8a' : '#333',
+  color: primary ? 'white' : '#aaa',
+  border: primary ? 'none' : '1px solid #555',
+  borderRadius: 8,
+  cursor: 'pointer',
+})

--- a/web-client/src/components/game/board/ZonePiles.tsx
+++ b/web-client/src/components/game/board/ZonePiles.tsx
@@ -3,11 +3,15 @@ import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useZoneCards, useStackCards, useZone, selectGameState } from '@/store/selectors.ts'
 import { graveyard, exile, library } from '@/types'
-import type { ClientCard, ClientPlayer, EntityId } from '@/types'
+import type { ClientCard, ClientDeckCard, ClientPlayer } from '@/types'
 import { CARD_BACK_IMAGE_URL } from '@/utils/cardImages.ts'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { useResponsiveContext, handleImageError } from './shared'
+import { DeckBrowser } from './DeckBrowser'
 import { styles } from './styles'
+
+/** Stable empty array so the `ownDeck` selector doesn't hand Zustand a new reference each render. */
+const EMPTY_DECK: readonly ClientDeckCard[] = []
 
 const CARD_RATIO = 1.4
 const LABEL_HEIGHT = 14
@@ -39,6 +43,13 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
   const topParadigmCard = paradigmCards[paradigmCards.length - 1]
   const libraryZone = useZone(library(player.playerId))
   const libraryEntityIds = libraryZone?.cardIds ?? []
+  // The server sends `deck` only for the viewing player, so this is empty on every other seat's
+  // pile — which is exactly what suppresses the deck-list tab there.
+  const ownDeck = useGameStore((state) => {
+    const gameState = selectGameState(state)
+    if (!gameState || gameState.viewingPlayerId !== player.playerId) return EMPTY_DECK
+    return gameState.deck ?? EMPTY_DECK
+  })
   const hoverCard = useGameStore((state) => state.hoverCard)
   const responsive = useResponsiveContext()
   const [browsingGraveyard, setBrowsingGraveyard] = useState(false)
@@ -130,14 +141,35 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
     ? { alignSelf: 'flex-start' as const }
     : { alignSelf: 'flex-end' as const, marginBottom: responsive.sectionGap * 2 }
 
+  // The deck list is worth opening even on an empty library (you can still read what you played).
+  const isOwnDeck = ownDeck.length > 0
+  const canBrowseDeck = player.librarySize > 0 || isOwnDeck
+
+  // `D` opens your own deck — the shortcut lives here rather than in a global handler because
+  // exactly one ZonePile on the table is the viewer's, and `ownDeck` is how we know which.
+  useEffect(() => {
+    if (!isOwnDeck) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'd' && e.key !== 'D') return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const active = document.activeElement
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return
+      if (active instanceof HTMLElement && active.isContentEditable) return
+      setBrowsingLibrary((open) => !open)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isOwnDeck])
+
   return (
     <div ref={containerRef} style={{ ...styles.zonePile, gap: responsive.cardGap, minWidth: effectivePileWidth + 10, ...verticalOffset }}>
       {/* Library/Deck */}
       <div style={styles.zoneStack}>
         <div
           data-zone={isOpponent ? 'opponent-library' : 'player-library'}
-          style={{ ...styles.deckPile, ...pileStyle, cursor: player.librarySize > 0 ? 'pointer' : 'default' }}
-          onClick={() => { if (player.librarySize > 0) setBrowsingLibrary(true) }}
+          title={canBrowseDeck ? (isOwnDeck ? 'Your deck list and library (D)' : 'Library') : undefined}
+          style={{ ...styles.deckPile, ...pileStyle, cursor: canBrowseDeck ? 'pointer' : 'default' }}
+          onClick={() => { if (canBrowseDeck) setBrowsingLibrary(true) }}
         >
           {player.librarySize > 0 ? (
             <img
@@ -333,9 +365,10 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
         document.body,
       )}
       {browsingLibrary && createPortal(
-        <LibraryBrowser
-          ownerLabel={ownerLabel('Library')}
+        <DeckBrowser
+          ownerLabel={isOpponent ? `${player.name}'s` : 'Your'}
           entityIds={libraryEntityIds}
+          deck={ownDeck}
           onClose={() => setBrowsingLibrary(false)}
         />,
         document.body,
@@ -843,204 +876,6 @@ function ParadigmBrowser({
               fontSize: responsive.fontSize.normal,
               backgroundColor: '#15756d',
               color: '#e6fffb',
-              border: 'none',
-              borderRadius: 8,
-              cursor: 'pointer',
-            }}
-          >
-            View Battlefield
-          </button>
-          <button
-            onClick={onClose}
-            style={{
-              padding: responsive.isMobile ? '10px 20px' : '12px 28px',
-              fontSize: responsive.fontSize.normal,
-              backgroundColor: '#333',
-              color: '#aaa',
-              border: '1px solid #555',
-              borderRadius: 8,
-              cursor: 'pointer',
-            }}
-          >
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/**
- * Full-screen overlay for browsing a library.
- *
- * Cards that have been revealed to the viewer (Scry, Surveil, look-at-top-N, etc.)
- * appear face-up in their library positions. All other slots render as card backs.
- * The order matches the actual library order — top of deck first. A shuffle on the
- * server clears all reveals, so a freshly shuffled library shows entirely face-down.
- */
-function LibraryBrowser({
-  ownerLabel,
-  entityIds,
-  onClose,
-}: {
-  ownerLabel: string
-  entityIds: readonly EntityId[]
-  onClose: () => void
-}) {
-  const hoverCard = useGameStore((state) => state.hoverCard)
-  const cardsMap = useGameStore((state) => selectGameState(state)?.cards)
-  const responsive = useResponsiveContext()
-  const [minimized, setMinimized] = useState(false)
-
-  const cardWidth = responsive.isMobile ? 120 : 160
-  const cardHeight = Math.round(cardWidth * 1.4)
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (minimized) {
-          setMinimized(false)
-        } else {
-          onClose()
-        }
-      }
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [onClose, minimized])
-
-  if (minimized) {
-    return (
-      <button
-        onClick={() => setMinimized(false)}
-        style={{
-          position: 'fixed',
-          bottom: 70,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          padding: responsive.isMobile ? '10px 16px' : '12px 24px',
-          fontSize: responsive.fontSize.normal,
-          backgroundColor: '#1e3a8a',
-          color: 'white',
-          border: 'none',
-          borderRadius: 8,
-          cursor: 'pointer',
-          fontWeight: 600,
-          boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
-          zIndex: 100,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-        }}
-      >
-        ↑ Return to Library
-      </button>
-    )
-  }
-
-  const revealedCount = entityIds.reduce((acc, id) => acc + (cardsMap?.[id] ? 1 : 0), 0)
-
-  return (
-    <div style={styles.libraryOverlay} onClick={onClose}>
-      <div style={styles.libraryBrowserContent} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.libraryBrowserHeader}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <h2 style={styles.libraryBrowserTitle}>
-              {ownerLabel} ({entityIds.length}
-              {revealedCount > 0 ? ` · ${revealedCount} known` : ''})
-            </h2>
-            <span style={{ color: '#64748b', fontSize: 11, letterSpacing: 0.5 }}>
-              Reading order: top → bottom, left to right
-            </span>
-          </div>
-          <button style={styles.libraryCloseButton} onClick={onClose}>✕</button>
-        </div>
-        <div style={styles.libraryCardGrid}>
-          {entityIds.map((id, index) => {
-            const card = cardsMap?.[id]
-            const isTop = index === 0
-            const isBottom = index === entityIds.length - 1 && entityIds.length > 1
-            const accent = isTop ? '#fde68a' : isBottom ? '#fb923c' : null
-            return (
-              <div
-                key={id}
-                style={{
-                  width: cardWidth,
-                  height: cardHeight,
-                  borderRadius: 6,
-                  overflow: 'hidden',
-                  flexShrink: 0,
-                  position: 'relative',
-                  boxShadow: accent ? `0 0 0 2px ${accent}, 0 0 14px ${accent}66` : 'none',
-                }}
-                onMouseEnter={(e) => { if (card) hoverCard(card.id, { x: e.clientX, y: e.clientY }) }}
-                onMouseLeave={() => hoverCard(null)}
-              >
-                {card ? (
-                  <img
-                    src={getCardImageUrl(card.name, card.imageUri, 'normal')}
-                    alt={card.name}
-                    style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-                    onError={(e) => handleImageError(e, card.name, 'normal')}
-                  />
-                ) : (
-                  <img
-                    src={CARD_BACK_IMAGE_URL}
-                    alt="Card back"
-                    style={{ width: '100%', height: '100%', objectFit: 'cover', opacity: 0.85 }}
-                  />
-                )}
-                {/* Position badge — shown on every card */}
-                <div
-                  style={{
-                    position: 'absolute',
-                    top: 4,
-                    left: 4,
-                    fontSize: 10,
-                    color: '#bfdbfe',
-                    backgroundColor: 'rgba(0,0,0,0.65)',
-                    padding: '2px 6px',
-                    borderRadius: 3,
-                    pointerEvents: 'none',
-                  }}
-                >
-                  #{index + 1}
-                </div>
-                {/* Anchor banner across the bottom of the first/last card so orientation
-                    is unambiguous regardless of how the grid wraps */}
-                {accent && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      backgroundColor: accent,
-                      color: '#1c1917',
-                      fontSize: 11,
-                      fontWeight: 700,
-                      letterSpacing: 1,
-                      textAlign: 'center',
-                      padding: '4px 0',
-                      textTransform: 'uppercase',
-                      pointerEvents: 'none',
-                    }}
-                  >
-                    {isTop ? 'Top · Next draw' : 'Bottom'}
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
-        <div style={{ display: 'flex', gap: 16, marginTop: 16 }}>
-          <button
-            onClick={() => setMinimized(true)}
-            style={{
-              padding: responsive.isMobile ? '10px 20px' : '12px 28px',
-              fontSize: responsive.fontSize.normal,
-              backgroundColor: '#1e3a8a',
-              color: 'white',
               border: 'none',
               borderRadius: 8,
               cursor: 'pointer',

--- a/web-client/src/network/deltaApplicator.test.ts
+++ b/web-client/src/network/deltaApplicator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { applyStateDelta } from './deltaApplicator'
+import type { ClientDeckCard, ClientGameState, StateDelta } from '@/types'
+import { entityId } from '@/types'
+
+/**
+ * `applyStateDelta` rebuilds the whole state object rather than patching it, so any field the
+ * server omits from a delta has to be carried forward explicitly — forgetting one silently blanks
+ * that part of the UI on the very next update. These cover the two "sent only when changed" fields
+ * (`deck`, `activeYields`), which are exactly the ones a rebuild is prone to dropping.
+ */
+
+const bolt: ClientDeckCard = {
+  cardName: 'Lightning Bolt',
+  copies: 4,
+  remaining: 3,
+  cmc: 1,
+  cardTypes: ['INSTANT'],
+  colors: ['RED'],
+  imageUri: null,
+}
+
+function baseState(over: Partial<ClientGameState> = {}): ClientGameState {
+  return {
+    viewingPlayerId: entityId('player-1'),
+    cards: {},
+    zones: [],
+    players: [],
+    currentPhase: 'MAIN_1' as ClientGameState['currentPhase'],
+    currentStep: 'MAIN' as ClientGameState['currentStep'],
+    activePlayerId: entityId('player-1'),
+    priorityPlayerId: entityId('player-1'),
+    turnNumber: 1,
+    isGameOver: false,
+    winnerId: null,
+    combat: null,
+    ...over,
+  }
+}
+
+const emptyDelta: StateDelta = { players: [] }
+
+describe('applyStateDelta', () => {
+  it('keeps the deck tracker when the delta omits it (nothing was drawn)', () => {
+    const next = applyStateDelta(baseState({ deck: [bolt] }), emptyDelta)
+    expect(next.deck).toEqual([bolt])
+  })
+
+  it('replaces the deck tracker when the delta carries a new one', () => {
+    const drawn = { ...bolt, remaining: 2 }
+    const next = applyStateDelta(baseState({ deck: [bolt] }), { ...emptyDelta, deck: [drawn] })
+    expect(next.deck).toEqual([drawn])
+  })
+
+  it('keeps active yields, which the server never puts in a delta', () => {
+    const yields = [{ cardDefinitionId: 'Soul Warden#ALA-25', abilityId: 'ability_42', displayName: 'Soul Warden' }]
+    const next = applyStateDelta(baseState({ activeYields: yields }), emptyDelta)
+    expect(next.activeYields).toEqual(yields)
+  })
+})

--- a/web-client/src/network/deltaApplicator.ts
+++ b/web-client/src/network/deltaApplicator.ts
@@ -95,5 +95,9 @@ export function applyStateDelta(
     youAreHijacking: delta.youAreHijacking ?? null,
     youAreHijackedBy: delta.youAreHijackedBy ?? null,
     hotseat: delta.hotseat ?? false,
+    // Carried forward: the server omits these from a delta when unchanged, and rebuilding the
+    // state object without them would silently blank the yields panel / deck tracker.
+    activeYields: current.activeYields ?? [],
+    deck: delta.deck ?? current.deck ?? [],
   }
 }

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -77,6 +77,37 @@ export interface ClientGameState {
    * Masked per-player: only your own yields appear. Drives the Active Yields panel.
    */
   readonly activeYields?: readonly ClientYield[]
+
+  /**
+   * The viewing player's own decklist — one row per distinct card, with how many copies they
+   * still haven't seen. Drives the in-game deck tracker. Always empty for spectators, and never
+   * describes anyone but the viewer, so opening it reveals nothing about an opponent's deck.
+   */
+  readonly deck?: readonly ClientDeckCard[]
+}
+
+/**
+ * One distinct card in the viewing player's deck. Structurally a superset of the recorded-deck
+ * `GameDeckCard` the profile/admin deck viewer uses, so both render through `DeckCardBody`.
+ */
+export interface ClientDeckCard {
+  readonly cardName: string
+  /** Total copies in the deck (all zones; the sideboard is not counted). */
+  readonly copies: number
+  /**
+   * Copies whose location the viewer can't identify — still in the library, or hidden from them
+   * elsewhere (e.g. a card of theirs exiled face down). In an ordinary game this is exactly
+   * "copies left to draw"; the fuzzier definition is what stops it leaking face-down exiles.
+   */
+  readonly remaining: number
+  /** Mana value, for the curve histogram. */
+  readonly cmc: number
+  /** Card type enum names, e.g. `["CREATURE"]`. */
+  readonly cardTypes: string[]
+  /** The card's own colours as enum names; empty for colourless. */
+  readonly colors: string[]
+  /** Art URL for the hover preview; null falls back to a name lookup. */
+  readonly imageUri: string | null
 }
 
 /** The stable (cardDefinitionId, abilityId) key an ability is yielded against. */

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -62,6 +62,7 @@ export type {
   ClientBlocker,
   ClientChosenTarget,
   ClientPerModeTargetGroup,
+  ClientDeckCard,
 } from './gameState'
 export {
   totalMana,

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -2,7 +2,7 @@ import { ErrorCode, GameOverReason } from './enums'
 import { EntityId } from './entities'
 import { GameAction } from './actions'
 import { ClientEvent } from './events'
-import { ClientGameState, ClientCard, ClientZone, ClientPlayer, ClientCombatState, ClientCommanderDamage } from './gameState'
+import { ClientGameState, ClientCard, ClientZone, ClientPlayer, ClientCombatState, ClientCommanderDamage, ClientDeckCard } from './gameState'
 
 // ============================================================================
 // Server Messages (received from server)
@@ -250,6 +250,8 @@ export interface StateDelta {
   readonly youAreHijackedBy?: EntityId | null
   /** Hotseat indicator — always overwritten on apply */
   readonly hotseat?: boolean | null
+  /** The viewer's decklist, present only when a `remaining` count moved (draw, mill, tutor). */
+  readonly deck?: readonly ClientDeckCard[] | null
 }
 
 /**


### PR DESCRIPTION
Adds the companion-app thing you can't do in this client today: **see what's in your deck, and what's left of it, without leaving the game.**

Clicking your own Deck pile (or pressing `D`) now opens a two-tab overlay. The **Deck list** tab is the new part — your decklist with a `remaining/copies` count per card, dimmed rows for what you've already drawn, next-draw odds, and the deckbuilder's mana curve and colour pips. The **Library order** tab is the view that used to live behind that pile, unchanged.

![Deck list](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-tracker-screenshots/decklist.png)

## How the list is built

The server builds it in `ClientStateTransformer` from live **ownership** rather than a stored decklist, which is what makes the awkward cases fall out for free:

- a permanent an opponent stole is still in its owner's deck (CR 108.3),
- a token copy of one never is,
- a permanent copying something else counts as the card it was *printed* as (`CopyOfComponent`),
- the sideboard is excluded as outside the game (CR 400.11a), so a wished-in card *adds* to the deck when it enters,
- the command zone is included, so a commander stays one stable row instead of vanishing every time it's cast.

## Privacy

This is the half worth reviewing closely. Two rules:

**`deck` is populated only for `viewingPlayerId`, and is empty for spectators.** No player, spectator or replay viewer ever receives another player's decklist — so an opponent's Deck pile simply has no deck-list tab, and the client never has to decide what to hide:

![Opponent's pile — library order only](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-tracker-screenshots/opponent.png)

**`remaining` means "copies you can't currently see", not "copies in your library."** Those are the same number in an ordinary game, but a card of yours hidden elsewhere — exiled face down, or a face-down permanent an opponent controls — stays counted as remaining. Reporting an exact library count would let the panel be read backwards to learn *which* card an opponent just exiled face down. Library *order* is never exposed here at all; these are aggregate counts.

## Reuse & cost

The panel renders through `GameDeckView`'s `DeckCardBody` — the same component the profile and admin deck viewers already use. A `DeckViewCard` is just a recorded `GameDeckCard` plus an optional `remaining`, and supplying it is what switches rows into tracker mode; the recorded-deck surfaces pass no `remaining` and render exactly as before.

`StateDelta.deck` is sent only when a count actually moved (a draw, a mill, a tutor), so the many updates that just shuffle the battlefield around don't re-send the list.

While wiring that up I also fixed **`activeYields` being silently dropped** by `applyStateDelta` — it rebuilds the whole state object, so any field the server omits from a delta has to be carried forward explicitly. The yields panel would blank out on the first delta after it was populated. That's the same trap the new `deck` field would have fallen into, and there's now a test covering both.

## Tests

- `DeckListClientViewTest` (13 cases) — ownership vs. control, tokens, sideboard, command zone, face-down exile, spectator masking, per-viewer isolation, and that the delta omits the deck unless a count moved.
- `deltaApplicator.test.ts` — `deck` and `activeYields` survive a delta that omits them.
- Full `:rules-engine` + `:game-server` suites and the client suite (17 files / 183 tests) pass; `npm run typecheck` and `npm run build` clean.

## Notes for the reviewer

- Extracting `LibraryBrowser` out of the 1000-line `ZonePiles.tsx` into `board/DeckBrowser.tsx` is most of the client diff; the library-order rendering itself is moved verbatim.
- Replays run through the spectator path, so they show no deck tracker. That's the safe default rather than a deliberate feature decision — worth revisiting if you want to review your own deck in a replay.
- The screenshot branch `deck-tracker-screenshots` is throwaway; delete it whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)