### PR TITLE
Eliminated spectator: put the survivors on opposite sides of the table

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -262,7 +262,13 @@ are gated on `players.length > 2`).
   remaining boards split the freed width, and a collapsed seat's full board moves to
   the off-screen group so its anchors bundle back to the rail chip. Collapse state is
   overview-only — the focused camera and the combat split ignore it — and persists
-  across overview toggles until the game resets.
+  across overview toggles until the game resets. In a 3+ player game the overview is
+  **two rows**, not one strip: `GameBoard` partitions the living seats into a top row (the
+  opponent strip) and a bottom row (grid rows 4-5) around an *anchor* seat — a team game
+  splits by team (your team at the bottom), a free-for-all balances evenly with the anchor
+  at the bottom and the odd seat on top. The bottom row renders as a second strip of cells
+  (`bottomHalf` — lands toward the bottom edge, per-board collapse) whenever it holds more
+  than the anchor; a lone anchor keeps the classic single bottom board.
 - **Combat defender-focus split** (`useCombatDefenderFocus`): when the server's confirmed
   combat is between two *other* players, the attacker's and defenders' boards share the
   strip so the fight renders as real arrows between real boards instead of a bundled
@@ -271,15 +277,18 @@ are gated on `players.length > 2`).
   whole combat so boards don't shift mid-fight.
 - **Eliminated spectator** (`boardView.eliminatedSpectating`): a personal
   `PlayerEliminatedMessage` marks the defeat overlay `GameOverState.eliminated`, which
-  adds a "Keep Watching" button. It dismisses the overlay, forces the table overview, and
-  collapses the dead bottom half (grid rows 4-5 → 0, hand/pass/undo/concede hidden) with
-  a "spectating" banner + Leave Game button; the freed height flows to the opponent
-  strip. The banner also carries a **bottom-board picker**
-  (`boardView.eliminatedBottomSeatId`): choosing a living player anchors their board in
-  the empty bottom half the way spectating renders a bottom seat — read-only board +
-  face-down hand, their life on the right center-HUD orb (which takes over their
-  anchors from the rail chip), and their cell leaves the opponent strip. Clicking the
-  active seat again clears it; the choice self-heals to "collapsed" if that player dies.
+  adds a "Keep Watching" button. It dismisses the overlay, turns on the table overview,
+  and hides all action UI (hand/pass/undo/concede) behind a "spectating" banner + Leave
+  Game button. An eliminated player is just an observer without a board of their own
+  (`viewerIsObserver` = spectating ‖ eliminated), so they get the same two-row overview a
+  spectator gets: the survivors face each other across the table, with a survivor's board
+  holding their now-vacant bottom half — read-only board + face-down hand, that seat's
+  life on the right center-HUD orb (which takes over their anchors from the rail chip),
+  and their cell out of the opponent strip. `useEliminatedBottomSeatId` resolves which
+  survivor that is: the banner's **bottom-seat picker**
+  (`boardView.eliminatedBottomSeatId`), else a living teammate (team game), else the next
+  living seat in turn order — so it self-heals when that seat dies. Only when no survivor
+  is left do grid rows 4-5 collapse to 0 and the freed height flow to the opponent strip.
 - **Seat identity**: `styles/seatColors.ts` (Okabe-Ito, by seat index = turn-order index in
   `gameState.players`) colors rail chips, combat arrows and chevrons, stack item borders
   (caster), and log entry names.

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useRef, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
-import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId } from '@/store/selectors'
+import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId } from '@/store/selectors'
 import { useMultiplayerView, useCombatDefenderFocus } from '@/hooks/useMultiplayerView'
 import { OpponentRail, railReservedWidth } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
@@ -102,45 +102,59 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const collapsedSeats = useGameStore((state) => state.collapsedSeats)
   const toggleSeatCollapsed = useGameStore((state) => state.toggleSeatCollapsed)
   const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
-  const eliminatedBottomSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
+  const eliminatedBottomSeatId = useEliminatedBottomSeatId()
   const setEliminatedBottomSeat = useGameStore((state) => state.setEliminatedBottomSeat)
   const returnToMenu = useGameStore((state) => state.returnToMenu)
   const viewingPlayer = useViewingPlayer()
   // Eliminated-spectator layout: the local player is out of a multiplayer game and chose
-  // "Keep watching" — their dead bottom half collapses and all action UI hides.
+  // "Keep watching" — their own board is gone and all action UI hides, so they watch the
+  // surviving seats spread across the table like any other spectator.
   const isEliminatedSpectator =
     isMulti && !spectatorMode && eliminatedSpectating && (viewingPlayer?.hasLost ?? false)
-  // Eliminated spectator's chosen bottom seat: a living player whose board fills the
-  // (otherwise collapsed) bottom half, the way spectating anchors a bottom seat. Their
-  // board leaves the opponent strip while anchored here. Self-heals if the seat dies.
+  // The viewer has no board of their own in this game: a spectator/replay stream, or a player
+  // who was eliminated and kept watching. Nothing in the bottom half is theirs — it belongs to
+  // a survivor — so no cell there is interactive and their own hand never renders.
+  const viewerIsObserver = spectatorMode || isEliminatedSpectator
+  // Eliminated spectator's bottom seat: the living player whose board takes over the bottom
+  // half of the table (see `useEliminatedBottomSeatId` for the pick/default). Their board
+  // leaves the opponent strip while it sits down here.
   const eliminatedBottomSeat = useMemo(() => {
     if (!isEliminatedSpectator || !eliminatedBottomSeatId) return null
-    const p = gameState?.players.find((pp) => pp.playerId === eliminatedBottomSeatId)
-    return p && !p.hasLost ? p : null
+    return gameState?.players.find((pp) => pp.playerId === eliminatedBottomSeatId) ?? null
   }, [isEliminatedSpectator, eliminatedBottomSeatId, gameState])
+  // Opponents still in the game — the seats an eliminated spectator can watch from.
+  const survivors = useMemo(() => opponents.filter((o) => !o.hasLost), [opponents])
   // In a Two-Headed Giant game the orb/edge tints follow the *team* hue (both teammates share
   // it); otherwise they keep the per-seat hue. The team map is empty in every non-team game.
   const teamMap = useGameStore(selectTeamMap)
   const viewerTeam = useViewerTeamIndex()
   const isTeamGame = viewerTeam != null && Object.keys(teamMap).length > 0
-  // The seat anchoring the bottom row: you when playing, the spectator's chosen/first seat otherwise.
-  const anchorId = useGameStore(selectViewingPlayerId)
+  // The seat anchoring the bottom row: you when playing, the spectator's chosen/first seat, or —
+  // for an eliminated spectator, whose own board left the game with them — the survivor sitting
+  // on their side of the table.
+  const viewingSeatId = useGameStore(selectViewingPlayerId)
+  const anchorId = eliminatedBottomSeat?.playerId ?? viewingSeatId
   // "Show the whole table" — the unified overview: two rows of boards. A team game splits by team
   // (your team on the bottom row, the enemy team on top); a free-for-all balances the seats evenly
   // with the anchor on the bottom (e.g. 6 players → 3 top / 3 bottom rather than 5 crammed on top).
-  // The classic single-opponent sliding camera is what you get when this is off. Not for the
-  // eliminated-spectator layout, which has its own bottom handling.
-  const twoRowActive = isMulti && overviewModeOn && !isEliminatedSpectator
+  // The classic single-opponent sliding camera is what you get when this is off. An eliminated
+  // spectator gets the same two rows — the survivors face each other across the table instead of
+  // all crowding the top half.
+  const twoRowActive = isMulti && overviewModeOn
   const twoRow = useMemo(() => {
     const empty = { top: [] as EntityId[], bottom: [] as EntityId[] }
     if (!twoRowActive || !gameState) return empty
-    const living = gameState.players.filter(
-      (p) => !p.hasLost && p.playerId !== eliminatedBottomSeat?.playerId,
-    )
+    const living = gameState.players.filter((p) => !p.hasLost)
     if (isTeamGame && viewerTeam != null) {
+      // The anchor joins the bottom row even when it isn't on the viewer's team — an eliminated
+      // spectator whose whole team is gone still watches from behind a survivor's board.
+      const bottom = living.filter(
+        (p) => teamMap[p.playerId] === viewerTeam || p.playerId === anchorId,
+      )
+      const bottomIds = new Set(bottom.map((p) => p.playerId))
       return {
-        top: living.filter((p) => teamMap[p.playerId] !== viewerTeam).map((p) => p.playerId),
-        bottom: living.filter((p) => teamMap[p.playerId] === viewerTeam).map((p) => p.playerId),
+        bottom: bottom.map((p) => p.playerId),
+        top: living.filter((p) => !bottomIds.has(p.playerId)).map((p) => p.playerId),
       }
     }
     // Free-for-all: anchor first on the bottom, the rest split evenly — the top row takes the odd
@@ -154,7 +168,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       bottom: anchorFirst.slice(0, bottomCount).map((p) => p.playerId),
       top: anchorFirst.slice(bottomCount).map((p) => p.playerId),
     }
-  }, [twoRowActive, gameState, eliminatedBottomSeat, isTeamGame, viewerTeam, teamMap, anchorId])
+  }, [twoRowActive, gameState, isTeamGame, viewerTeam, teamMap, anchorId])
   const bottomRowIds = twoRow.bottom
   const topRowIds = twoRow.top
   // Camera pool = opponents not pulled down to the bottom row (so no board renders in both halves).
@@ -191,20 +205,21 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
   const responsive = useResponsive(effectiveTopOffset, zoneRowCounts)
 
-  // Spectators (replay + live) default to the all-boards table overview: one seat anchored
-  // at the bottom, every other board across the top — the natural "watch the whole table"
-  // layout, rather than a one-board camera that hides most of the game. One-shot on entry so
-  // a spectator who then focuses a single board (rail-chip click / key 0) isn't yanked back.
-  // Desktop only — GameBoard degrades overview to the single-board camera on phones anyway.
-  const didDefaultSpectatorOverview = useRef(false)
+  // Anyone watching without a board of their own — a spectator/replay viewer, or a player who
+  // was eliminated and kept watching — defaults to the all-boards table overview: the survivors
+  // spread across both halves of the table, rather than a one-board camera that hides most of the
+  // game. One-shot on entry so an observer who then focuses a single board (rail-chip click /
+  // key 0) isn't yanked back. Desktop only — GameBoard degrades overview to the single-board
+  // camera on phones anyway.
+  const didDefaultObserverOverview = useRef(false)
   useEffect(() => {
-    if (didDefaultSpectatorOverview.current) return
-    if (spectatorMode && isMulti && !responsive.isMobile) {
-      didDefaultSpectatorOverview.current = true
+    if (didDefaultObserverOverview.current) return
+    if (viewerIsObserver && isMulti && !responsive.isMobile) {
+      didDefaultObserverOverview.current = true
       const store = useGameStore.getState()
       if (!store.overviewMode) store.toggleOverviewMode()
     }
-  }, [spectatorMode, isMulti, responsive.isMobile])
+  }, [viewerIsObserver, isMulti, responsive.isMobile])
 
   // Grid row 1: keeps the battlefield clear of the fixed/absolute opponent hand.
   const oppHandReservation =
@@ -303,13 +318,6 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     collapsedStripIds.length > 0
       ? `calc((100% - ${collapsedStripIds.length * COLLAPSED_TAB_WIDTH}px) / ${Math.max(1, expandedStripIds.length)})`
       : `${100 / Math.max(1, expandedStripIds.length)}%`
-  // The rail chips also cover the eliminated spectator's bottom-anchored board, whose
-  // anchors live on the bottom life orb while it is on screen.
-  const anchorVisibleBoardIds = useMemo<readonly EntityId[]>(
-    () => (eliminatedBottomSeat ? [...expandedStripIds, eliminatedBottomSeat.playerId] : expandedStripIds),
-    [expandedStripIds, eliminatedBottomSeat],
-  )
-
   // Mindslaver-style hijack indicators (Phase 2C). Spectators don't get the UX promotions.
   const youAreHijacking = !spectatorMode ? (gameState?.youAreHijacking ?? null) : null
   const youAreHijackedBy = !spectatorMode ? (gameState?.youAreHijackedBy ?? null) : null
@@ -380,24 +388,39 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   // games; 4+ player free-for-alls). A lone anchor keeps the classic single bottom board.
   const bottomStripActive = twoRowActive && bottomRowOrdered.length > 1
   // Any bottom board may collapse to a tab — except your own interactive board when *playing*
-  // (there's no collapse control on it, and folding the board you act from makes no sense). A
-  // spectator's anchor seat is just another board, so it stays collapsible.
+  // (there's no collapse control on it, and folding the board you act from makes no sense). An
+  // observer's anchor seat is just another board, so it stays collapsible.
   const bottomCollapsedIds = useMemo(
     () =>
       bottomRowOrdered
         .filter(
           (p) =>
             collapsedSeats.includes(p.playerId) &&
-            !(!spectatorMode && p.playerId === anchorId),
+            !(!viewerIsObserver && p.playerId === anchorId),
         )
         .map((p) => p.playerId),
-    [bottomRowOrdered, collapsedSeats, anchorId, spectatorMode],
+    [bottomRowOrdered, collapsedSeats, anchorId, viewerIsObserver],
   )
   const bottomExpandedCount = Math.max(1, bottomRowOrdered.length - bottomCollapsedIds.length)
   const bottomCellBasis =
     bottomCollapsedIds.length > 0
       ? `calc((100% - ${bottomCollapsedIds.length * COLLAPSED_TAB_WIDTH}px) / ${bottomExpandedCount})`
       : `${100 / bottomExpandedCount}%`
+  // Exactly one element per player carries that player's card/life anchors. A rail chip hands
+  // them over whenever the seat's own board is on screen: an expanded cell in the top strip, an
+  // expanded cell in the bottom row, or the eliminated spectator's bottom board.
+  const anchorVisibleBoardIds = useMemo<readonly EntityId[]>(() => {
+    const ids = [...expandedStripIds]
+    if (eliminatedBottomSeat) ids.push(eliminatedBottomSeat.playerId)
+    if (bottomStripActive) {
+      for (const p of bottomRowOrdered) {
+        if (!bottomCollapsedIds.includes(p.playerId) && !ids.includes(p.playerId)) {
+          ids.push(p.playerId)
+        }
+      }
+    }
+    return ids
+  }, [expandedStripIds, eliminatedBottomSeat, bottomStripActive, bottomRowOrdered, bottomCollapsedIds])
 
   if (!gameState || (!spectatorMode && (!playerId || !viewingPlayer))) {
     return null
@@ -652,10 +675,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       // Hand reservation rows (1 and 5) keep the battlefield rows from sliding
       // under the position:fixed hand overlays. Both 1fr rows then receive
       // identical heights → symmetric card sizes for player and opponent.
-      // Eliminated spectator: the dead bottom half (rows 4-5) collapses — the freed
-      // space flows to the opponent strip (row 2, the only remaining 1fr) — unless a
-      // living player's board is anchored there, which restores the spectator-shaped
-      // rows (small face-down hand at the bottom).
+      // Eliminated spectator: a survivor's board takes over their dead bottom half, so the
+      // rows stay spectator-shaped (small face-down hand at the bottom). Only when no living
+      // seat is left to sit there (the game is effectively over) do rows 4-5 collapse and the
+      // freed space flow to the opponent strip (row 2, then the only remaining 1fr).
       gridTemplateRows: isEliminatedSpectator
         ? eliminatedBottomSeat
           ? `${oppHandReservation}px minmax(0, 1fr) auto minmax(0, 1fr) ${
@@ -704,9 +727,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           </button>
           {/* Spectating banner — top center, in the chrome row between the Fullscreen
               and Leave Game buttons (the bottom of the screen belongs to the step strip
-              or the anchored bottom board). It also carries the bottom-board picker:
-              put a living player's board in the empty bottom half (click the active
-              seat again to clear it). */}
+              or the bottom board). It also carries the bottom-seat picker: which survivor
+              sits on your (now vacant) side of the table. Only shown while there's more
+              than one survivor to choose between. */}
           <div
             role="status"
             style={{
@@ -731,19 +754,19 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           >
             <span aria-hidden>💀</span>
             You've been eliminated — spectating
+            {survivors.length > 1 && (
+              <>
             <span aria-hidden style={{ width: 1, height: 14, background: '#3a3a44' }} />
-            <span style={{ color: '#7c8aa8', fontWeight: 600 }}>Board below:</span>
-            {opponents.filter((o) => !o.hasLost).map((o) => {
+            <span style={{ color: '#7c8aa8', fontWeight: 600 }}>Bottom seat:</span>
+            {survivors.map((o) => {
               const idx = gameState.players.findIndex((p) => p.playerId === o.playerId)
               const seat = identitySeatColor(teamMap, o.playerId, idx)
               const active = eliminatedBottomSeat?.playerId === o.playerId
               return (
                 <button
                   key={o.playerId}
-                  onClick={() => setEliminatedBottomSeat(active ? null : o.playerId)}
-                  title={active
-                    ? `Stop showing ${o.name}'s board at the bottom`
-                    : `Show ${o.name}'s board in the bottom half`}
+                  onClick={() => setEliminatedBottomSeat(o.playerId)}
+                  title={`Watch from behind ${o.name}'s board (bottom half of the table)`}
                   style={{
                     display: 'inline-flex',
                     alignItems: 'center',
@@ -771,6 +794,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 </button>
               )
             })}
+              </>
+            )}
           </div>
         </>
       )}
@@ -1072,11 +1097,13 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
       {/* Player area (grid row 4) — player-hand reservation lives in row 5,
           so no padding here. Equal-height with row 2 → symmetric cards.
-          Collapsed (row is 0px) for an eliminated spectator — their permanents
-          left the game with them. */}
-      {/* Eliminated spectator with a chosen bottom seat: that living player's board fills
-          the bottom half, rendered read-only the way spectating renders a bottom seat. */}
-      {isEliminatedSpectator && eliminatedBottomSeat && (
+          Collapsed (row is 0px) for an eliminated spectator with nobody left to watch —
+          their own permanents left the game with them. */}
+      {/* Eliminated spectator whose bottom half holds a single survivor's board (a 3-player
+          game after one death, or a focused camera): that board fills the bottom half,
+          rendered read-only the way spectating renders a bottom seat. When the bottom row
+          holds several seats the strip below takes over. */}
+      {isEliminatedSpectator && eliminatedBottomSeat && !bottomStripActive && (
         <div style={styles.playerArea}>
           <div style={styles.playerRowWithZones}>
             <CommandZone player={eliminatedBottomSeat} />
@@ -1087,7 +1114,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           </div>
         </div>
       )}
-      {isEliminatedSpectator && eliminatedBottomSeat && (
+      {isEliminatedSpectator && eliminatedBottomSeat && !bottomStripActive && (
         <div
           data-zone="hand"
           style={{
@@ -1104,10 +1131,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
       {/* Show-table bottom row: the viewer's team (team game) or the balanced bottom half (FFA)
           shares the bottom as a multi-board strip (rows 4-5), mirroring the top row. Your own
-          board (when playing) keeps its interactive battlefield + fixed hand; the others render as
-          overview cells (lands toward the bottom edge) with per-board collapse. Otherwise the
-          classic single bottom board. */}
-      {!isEliminatedSpectator && (bottomStripActive ? (
+          board (when playing) keeps its interactive battlefield + fixed hand; every other seat —
+          including every seat for an observer — renders as an overview cell (lands toward the
+          bottom edge) with per-board collapse. Otherwise the classic single bottom board. */}
+      {bottomStripActive ? (
         <div
           data-team-strip="bottom"
           style={{
@@ -1122,7 +1149,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           }}
         >
           {bottomRowOrdered.map((p) => {
-            const isAnchorSelf = !spectatorMode && p.playerId === anchorId
+            // Only a *playing* viewer has an interactive board down here; an observer's anchor
+            // seat (spectator stream, eliminated player) is somebody else's board.
+            const isAnchorSelf = !viewerIsObserver && p.playerId === anchorId
             if (bottomCollapsedIds.includes(p.playerId)) {
               return (
                 <CollapsedBoardTab key={`${p.playerId}-collapsed`} player={p} onExpand={() => toggleSeatCollapsed(p.playerId)} />
@@ -1167,7 +1196,9 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 bottomHalf
                 plateCarriesAnchors={p.playerId !== bottomHudPlayer?.playerId}
                 onToggleCollapse={() => toggleSeatCollapsed(p.playerId)}
-                spectatorMode={spectatorMode}
+                // `bottomHalf` orients the board as a bottom-side board, which would also make
+                // it interactive — so an observer's bottom cells must render read-only.
+                spectatorMode={viewerIsObserver}
                 isHijacking={hijackControlledOpponentId === p.playerId}
                 hijackedSurfaceStyle={hijackedSurfaceStyle}
                 isAlly={isTeamGame && !spectatorMode}
@@ -1176,7 +1207,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             )
           })}
         </div>
-      ) : (
+      ) : isEliminatedSpectator ? null : (
         <div style={styles.playerArea}>
           <div style={styles.playerRowWithZones}>
             {/* Player command zone (left side) — Commander format only; renders nothing otherwise. */}
@@ -1195,7 +1226,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
             {effectiveViewingPlayer && <ZonePile player={effectiveViewingPlayer} />}
           </div>
         </div>
-      ))}
+      )}
 
       {/* Spectator mode: floating player name label for bottom player */}
       {spectatorMode && effectiveViewingPlayer && !bottomStripActive && (

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -986,7 +986,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 life={effectiveOpponent.life}
                 playerId={effectiveOpponent.playerId}
                 playerName={effectiveOpponent.name}
-                spectatorMode={spectatorMode}
+                // An eliminated spectator has no opponents left to speak of — their orbs read
+                // spectator-shaped (no "OPPONENT" role tag, no targeting click), like the
+                // bottom-seat orb already does.
+                spectatorMode={viewerIsObserver}
                 poisonCounters={effectiveOpponent.poisonCounters}
                 commanderDamage={effectiveOpponent.commanderDamage ?? []}
                 handSize={effectiveOpponent.handSize}

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -239,25 +239,46 @@ export function useOpponents(): readonly ClientPlayer[] {
 }
 
 /**
+ * The living seat that holds the bottom half of the table for an eliminated spectator.
+ * A dead player has no board of their own to sit there, so the bottom side of the table
+ * belongs to a survivor: their explicit pick from the spectating banner, or — by default —
+ * a living teammate (team game) else the next living seat in turn order. Self-heals when
+ * that seat dies. Null outside the eliminated-spectator layout, or when nobody is left.
+ */
+export function useEliminatedBottomSeatId(): EntityId | null {
+  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const pickedSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
+  const opponents = useOpponents()
+  const teamMap = useGameStore(selectTeamMap)
+  const viewerTeam = useViewerTeamIndex()
+  return useMemo(() => {
+    if (!eliminatedSpectating) return null
+    const living = opponents.filter((p) => !p.hasLost)
+    const picked = living.find((p) => p.playerId === pickedSeatId)
+    if (picked) return picked.playerId
+    const ally = viewerTeam != null ? living.find((p) => teamMap[p.playerId] === viewerTeam) : undefined
+    return (ally ?? living[0])?.playerId ?? null
+  }, [eliminatedSpectating, pickedSeatId, opponents, teamMap, viewerTeam])
+}
+
+/**
  * The opponent whose board occupies the viewed slot. Resolves the boardView
  * selection with fallbacks: an eliminated or unknown selection falls back to the
  * first opponent still in the game (or the first opponent, if all have lost).
- * The eliminated spectator's chosen bottom seat never occupies the viewed slot —
- * its board is already fully visible at the bottom of the screen.
+ * The eliminated spectator's bottom seat never occupies the viewed slot — its board
+ * is already fully visible on the bottom half of the screen.
  */
 export function useViewedOpponent(): ClientPlayer | null {
   const opponents = useOpponents()
   const viewedOpponentId = useGameStore((state) => state.viewedOpponentId)
-  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
-  const eliminatedBottomSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
+  const bottomSeatId = useEliminatedBottomSeatId()
   return useMemo(() => {
-    const bottomSeatId = eliminatedSpectating ? eliminatedBottomSeatId : null
     const candidates = bottomSeatId ? opponents.filter((p) => p.playerId !== bottomSeatId) : opponents
     if (candidates.length === 0) return null
     const selected = candidates.find((p) => p.playerId === viewedOpponentId)
     if (selected && !selected.hasLost) return selected
     return candidates.find((p) => !p.hasLost) ?? candidates[0] ?? null
-  }, [opponents, viewedOpponentId, eliminatedSpectating, eliminatedBottomSeatId])
+  }, [opponents, viewedOpponentId, bottomSeatId])
 }
 
 /**


### PR DESCRIPTION
## Problem

Die in a 3-player pod and pick "Keep Watching", and both survivors end up crammed
side-by-side across the *top* half of the screen while your dead bottom half stays empty —
unless you notice the banner's picker and manually anchor one of them below. You'd expect
the two remaining players to sit across the table from each other.

The unified two-row "show table" overview (PR #1378) already does exactly that for
spectators, but it explicitly excluded the eliminated-spectator layout
(`twoRowActive = isMulti && overviewModeOn && !isEliminatedSpectator`), which had its own
"collapse rows 4-5 to 0" handling.

## Change

An eliminated player is just an observer without a board of their own, so they now get the
same two-row overview a spectator gets — the overview is on as soon as you're out of the
game, and the survivors partition into a top and a bottom row with a survivor's board
holding your now-vacant side of the table.

- **`useEliminatedBottomSeatId`** (selectors) resolves the bottom seat once for both
  `useViewedOpponent` and `GameBoard`: the banner pick, else a living teammate (team game),
  else the next living seat in turn order — self-healing when that seat dies. Previously the
  bottom half was empty until you picked a seat by hand.
- **`viewerIsObserver`** (`spectatorMode || isEliminatedSpectator`) now drives the rules that
  were keyed on `spectatorMode` alone: no interactive anchor cell in the bottom row, bottom
  cells render read-only (`bottomHalf` makes them bottom-*side* boards, which would otherwise
  be interactive — `Battlefield.interactive = !spectatorMode && !isOpponent`), the anchor seat
  stays collapsible, and the viewed life orb drops its "OPPONENT" role tag like the bottom orb
  already did. The observer overview one-shot covers both kinds of observer.
- **Team split keeps the anchor on the bottom row** even when it isn't a teammate, so an
  eliminated player whose whole team is gone can't get the same board rendered in both halves.
- **`anchorVisibleBoardIds` now covers expanded bottom-row cells.** Their name plates carry the
  seat's card/life anchors, so the rail chip has to drop them — duplicate anchors make
  `querySelector` pick whichever comes first in the DOM. (Pre-existing gap in the bottom strip;
  this change makes it reachable for eliminated players too.)
- Banner picker is now a plain **"Bottom seat:"** selector (no clear-to-empty, hidden while
  only one survivor is left), and rows 4-5 only collapse when no survivor is left to sit there.

`docs/web-client-architecture.md`: documented the two-row overview (it wasn't) and rewrote the
eliminated-spectator bullet.

## Screenshots

3-player pod, you're out — before (both survivors on top, empty bottom half, bottom orb still
"VINCENT · YOU") vs after (Boris top, Ada bottom, facing each other):

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/eliminated-spectator-two-row-screenshots/before-eliminated.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/eliminated-spectator-two-row-screenshots/after-eliminated.png) |

4-player pod, you're out — 2 survivors on top (plates + collapse), 1 below; and after clicking
"Cleo" in the bottom-seat picker (rows repartition, no board rendered twice):

| 3 survivors | bottom seat switched to Cleo |
|---|---|
| ![4p](https://raw.githubusercontent.com/wingedsheep/argentum-engine/eliminated-spectator-two-row-screenshots/after-4p-eliminated.png) | ![4p switched](https://raw.githubusercontent.com/wingedsheep/argentum-engine/eliminated-spectator-two-row-screenshots/after-4p-eliminated-switched.png) |

(Screenshot branch `eliminated-spectator-two-row-screenshots` is throwaway.)

## Verification

`npm run typecheck` clean. Captured against the real stack (game server + vite) driving a
3- and a 4-seat hotseat scenario: hotseat connections never receive `PlayerEliminatedMessage`,
so the elimination itself was applied the way the server would send it — `hasLost` on our seat
in the store's `gameState`, then `enterEliminatedSpectate()` — with everything downstream
(layout, partitioning, orbs, picker) rendering real game data.

Not exercised live: the bottom row as a *multi-board strip* for an eliminated player, which
needs 4+ survivors (5+ seat pod) and the scenario builder caps at 4 seats. That path is the
same code the shipped spectator team-split uses; only `isAnchorSelf` / `spectatorMode` /
`anchorVisibleBoardIds` changed there, and it typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
