### PR TITLE
Fix duplicate spectator after a spectator rejoins or refreshes

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -278,12 +278,7 @@ class ConnectionHandler(
                     // Re-sync the spectator-count badge for the reconnecting player.
                     // Spectator joins/leaves only push to currently-connected players, so a
                     // mid-game reconnect would otherwise see count = 0 until the next change.
-                    val currentSpectators = gameSession.getSpectators()
-                    sender.send(session, ServerMessage.SpectatorCountChanged(
-                        gameSessionId = gameSession.sessionId,
-                        count = currentSpectators.size,
-                        spectatorNames = currentSpectators.map { it.playerName }
-                    ))
+                    sender.send(session, gameSession.spectatorCountMessage())
 
                     if (gameSession.isStarted) {
                         when {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbySharedContext.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbySharedContext.kt
@@ -112,12 +112,7 @@ class LobbySharedContext(
      * Spectators themselves do not receive this message.
      */
     fun broadcastSpectatorCount(gameSession: GameSession) {
-        val spectators = gameSession.getSpectators()
-        val message = ServerMessage.SpectatorCountChanged(
-            gameSessionId = gameSession.sessionId,
-            count = spectators.size,
-            spectatorNames = spectators.map { it.playerName }
-        )
+        val message = gameSession.spectatorCountMessage()
         gameSession.getPlayers().forEach { player ->
             val ws = player.webSocketSession
             if (ws.isOpen) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
 private val logger = LoggerFactory.getLogger(GameSession::class.java)
@@ -137,7 +138,13 @@ class GameSession(
     private val sideboards = mutableMapOf<EntityId, List<String>>()
     /** Per-player commander card name for commander-shape formats. Null = no commander. */
     private val commanderCardNames = mutableMapOf<EntityId, String>()
-    private val spectators = mutableSetOf<PlayerSession>()
+    /**
+     * Active spectators, keyed by player id. Keyed by *identity* rather than held as a set of
+     * sessions because a reconnect (refresh, or leaving and coming back) arrives on a brand-new
+     * [PlayerSession]: a set would then hold both the dead and the live socket and the same person
+     * would show up twice in the players' "N watching" list.
+     */
+    private val spectators = ConcurrentHashMap<EntityId, PlayerSession>()
 
     /**
      * Format the engine should run this game under. Set by the lobby / quick-game / tournament
@@ -350,23 +357,49 @@ class GameSession(
     // =========================================================================
 
     /**
-     * Add a spectator to this game session.
+     * Add a spectator to this game session, replacing any earlier session that same spectator
+     * was watching on (see [spectators]).
      */
     fun addSpectator(spectator: PlayerSession) {
-        spectators.add(spectator)
+        spectators[spectator.playerId] = spectator
     }
 
     /**
-     * Remove a spectator from this game session.
+     * Remove a spectator from this game session. Only drops the entry while it still points at
+     * [spectator]'s socket, so a late cleanup for a socket the spectator has already replaced by
+     * reconnecting can't evict their live session.
      */
     fun removeSpectator(spectator: PlayerSession) {
-        spectators.remove(spectator)
+        spectators.remove(spectator.playerId, spectator)
     }
 
     /**
-     * Get all spectators.
+     * Get all spectators with a live socket. Closed sockets are filtered out rather than counted:
+     * a spectator who closed their tab is not watching, even before [pruneDisconnectedSpectators]
+     * gets around to dropping them.
      */
-    fun getSpectators(): Set<PlayerSession> = spectators.toSet()
+    fun getSpectators(): Set<PlayerSession> =
+        spectators.values.filterTo(mutableSetOf()) { it.isConnected }
+
+    /**
+     * Drop spectators whose socket has closed, returning true when anything was removed so the
+     * caller can refresh the players' spectator badge. Closing a tab produces no StopSpectating
+     * message, so without this sweep those entries would live as long as the game session.
+     */
+    fun pruneDisconnectedSpectators(): Boolean =
+        spectators.values.removeAll { !it.isConnected }
+
+    /**
+     * The spectator badge shown to the seated players: how many people are watching, and who.
+     */
+    fun spectatorCountMessage(): ServerMessage.SpectatorCountChanged {
+        val current = getSpectators()
+        return ServerMessage.SpectatorCountChanged(
+            gameSessionId = sessionId,
+            count = current.size,
+            spectatorNames = current.map { it.playerName }
+        )
+    }
 
     /**
      * Player names in seat order, for spectator display.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/ZombieSessionSweeper.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/ZombieSessionSweeper.kt
@@ -30,7 +30,21 @@ class ZombieSessionSweeper(
         sweepFinishedGames()
         sweepEmptyLobbies()
         sweepDisconnectedIdentities()
+        sweepDisconnectedSpectators()
         sweepStaleTrackingEntries()
+    }
+
+    /**
+     * Drop spectators whose socket has closed. Leaving a game by closing the tab sends no
+     * StopSpectating, so the entry would otherwise sit in the session for the rest of the game;
+     * re-push the badge to the players whenever a game actually lost one.
+     */
+    private fun sweepDisconnectedSpectators() {
+        for (game in gameRepository.findAll()) {
+            if (game.pruneDisconnectedSpectators()) {
+                lobbySharedContext.broadcastSpectatorCount(game)
+            }
+        }
     }
 
     private fun sweepFinishedGames() {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionSpectatorTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionSpectatorTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.gameserver.session
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.model.EntityId
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * The spectator set is keyed by identity, not by socket: a spectator who refreshes (or leaves and
+ * comes back) reconnects on a brand-new [PlayerSession], and must still be listed exactly once in
+ * the "N watching" badge the seated players see.
+ */
+class GameSessionSpectatorTest : FunSpec({
+
+    fun ws(id: String, open: Boolean = true): WebSocketSession = mockk(relaxed = true) {
+        every { this@mockk.id } returns id
+        every { isOpen } returns open
+    }
+
+    fun session() = GameSession(cardRegistry = CardRegistry())
+
+    val watcherId = EntityId.of("watcher")
+
+    test("a spectator reconnecting on a new socket is listed once, on the live socket") {
+        val session = session()
+        val old = PlayerSession(ws("ws-old", open = false), watcherId, "Watcher")
+        val new = PlayerSession(ws("ws-new"), watcherId, "Watcher")
+
+        session.addSpectator(old)
+        session.addSpectator(new)
+
+        session.getSpectators().map { it.sessionId } shouldContainExactly listOf("ws-new")
+        session.spectatorCountMessage().count shouldBe 1
+        session.spectatorCountMessage().spectatorNames shouldContainExactly listOf("Watcher")
+    }
+
+    test("cleanup for a socket the spectator already replaced doesn't evict their live session") {
+        val session = session()
+        val old = PlayerSession(ws("ws-old", open = false), watcherId, "Watcher")
+        val new = PlayerSession(ws("ws-new"), watcherId, "Watcher")
+
+        session.addSpectator(old)
+        session.addSpectator(new)
+        session.removeSpectator(old)
+
+        session.getSpectators().map { it.sessionId } shouldContainExactly listOf("ws-new")
+    }
+
+    test("stopping spectating on the current socket removes the spectator") {
+        val session = session()
+        val watcher = PlayerSession(ws("ws-1"), watcherId, "Watcher")
+
+        session.addSpectator(watcher)
+        session.removeSpectator(watcher)
+
+        session.getSpectators().shouldBeEmpty()
+        session.spectatorCountMessage().count shouldBe 0
+    }
+
+    test("a spectator whose socket closed is not counted, and is pruned") {
+        val session = session()
+        session.addSpectator(PlayerSession(ws("ws-gone", open = false), watcherId, "Watcher"))
+        session.addSpectator(PlayerSession(ws("ws-live"), EntityId.of("other"), "Other"))
+
+        session.getSpectators().map { it.playerName } shouldContainExactly listOf("Other")
+
+        session.pruneDisconnectedSpectators().shouldBeTrue()
+        session.pruneDisconnectedSpectators().shouldBeFalse()
+        session.getSpectators().map { it.playerName } shouldContainExactly listOf("Other")
+    }
+
+    test("distinct spectators are all listed") {
+        val session = session()
+        session.addSpectator(PlayerSession(ws("ws-1"), EntityId.of("a"), "Ann"))
+        session.addSpectator(PlayerSession(ws("ws-2"), EntityId.of("b"), "Bob"))
+
+        session.spectatorCountMessage().count shouldBe 2
+        session.spectatorCountMessage().spectatorNames.sorted() shouldContainExactly listOf("Ann", "Bob")
+    }
+})


### PR DESCRIPTION
## Problem

A spectator who left and came back — or just refreshed — was listed **twice** in the players' "N watching" badge, with the count inflated to match.

`GameSession` held its spectators as a `Set<PlayerSession>`, and `PlayerSession` is a data class over the `WebSocketSession`. A reconnect always arrives on a brand-new socket, so `restoreSpectating`'s `addSpectator` couldn't recognise the returning spectator and appended a second entry — one live socket, one dead one. Nothing on the disconnect path removes a spectator from the game session, so the stale entry stuck around for the rest of the game.

## Fix

- **`spectators` is keyed by player id** (`ConcurrentHashMap<EntityId, PlayerSession>`) — a rejoin replaces the spectator's earlier session instead of stacking on top of it.
- **`getSpectators()` filters closed sockets**, so a spectator who closed their tab isn't counted, and a rejoin under a fresh identity (anonymous live-game viewer with a new token) can't double-count either.
- **`removeSpectator` only drops the entry while it still points at that socket** (`map.remove(key, value)`), so a late cleanup for a socket the spectator already replaced can't evict their live session.
- **`ZombieSessionSweeper` prunes closed-socket spectators** once a minute and re-pushes the badge to the seated players when a game actually lost one — closing a tab sends no `StopSpectating`, so nothing else would ever clear it.
- The `SpectatorCountChanged` payload is now built in one place (`GameSession.spectatorCountMessage()`) instead of being assembled at each of its call sites.

## Testing

New `GameSessionSpectatorTest` (5 cases): rejoin-on-a-new-socket lists the spectator once on the live socket; cleanup for a replaced socket doesn't evict the live session; normal stop-spectating still removes; closed sockets are uncounted and pruned (idempotently); distinct spectators are all listed.

`just test-server` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)