### PR TITLE
Add a database storage panel to the admin dashboard

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -244,6 +244,7 @@ Per-user endpoints take `Authorization: Bearer …`; admin endpoints take either
 | GET | `/api/stats/admin/cards` · `/cards/win-rates?minDecks` | most-played + per-card win rate |
 | GET | `/api/stats/admin/tournaments?limit` | recorded tournaments |
 | GET | `/api/stats/admin/geo` | IP → coarse location, aggregated by location (raw IPs never returned) |
+| GET | `/api/stats/admin/database` | storage: `{ databaseName, databaseSizeBytes, tables: [{ tableName, rows, tableBytes, indexBytes, totalBytes }] }`. Row counts are exact `count(*)`s (one scan per table) — fetch on demand, don't poll |
 
 ### Admin — players (`/api/admin/users`, either admin credential)
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
@@ -117,6 +117,16 @@ class AdminStatsController(
             .body(entries)
     }
 
+    /**
+     * Storage overview of the accounts database: total size plus per-table row counts and on-disk
+     * footprint. Row counts are exact, so this does a scan per table — fetch it on demand, don't poll.
+     */
+    @GetMapping("/database")
+    fun database(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) { ResponseEntity.ok(statsQuery.databaseStats()) }
+
     @GetMapping("/geo")
     fun geo(
         @RequestHeader("X-Admin-Password", required = false) password: String?,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -115,6 +115,28 @@ data class GlobalOverview(
 /** One day's game count for the games-per-day chart. */
 data class DailyCount(val day: String, val count: Long)
 
+/** One table's row count and on-disk footprint, for the admin dashboard's database panel. */
+data class DatabaseTableStat(
+    val tableName: String,
+    /** Exact `count(*)`. */
+    val rows: Long,
+    /** Heap + TOAST + free-space/visibility maps, excluding indexes (`pg_table_size`). */
+    val tableBytes: Long,
+    /** Every index on the table (`pg_indexes_size`). */
+    val indexBytes: Long,
+    /** [tableBytes] + [indexBytes] (`pg_total_relation_size`) — what the table really costs. */
+    val totalBytes: Long,
+)
+
+/** Storage overview of the accounts database: whole-database size plus a row per table. */
+data class DatabaseStats(
+    val databaseName: String,
+    /** `pg_database_size` — includes catalogs, so it exceeds the sum of [tables]. */
+    val databaseSizeBytes: Long,
+    /** Tables in the app schema, largest total footprint first. */
+    val tables: List<DatabaseTableStat>,
+)
+
 /** One IP and how many games connected from it (admin-only; resolved to a location elsewhere). */
 data class IpCount(val ip: String, val count: Long)
 
@@ -254,6 +276,10 @@ class StatsQueryService(
     private val printingRegistry: PrintingRegistry,
     private val geoIp: GeoIpService,
 ) {
+    private companion object {
+        /** Table names safe to splice into `count(*)` SQL — see [databaseStats]. */
+        val SAFE_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
+    }
 
     // ---- Per-user ----------------------------------------------------------------------------
 
@@ -879,6 +905,48 @@ class StatsQueryService(
         ) ?: 0
         val totalTournaments = jdbc.queryForObject("SELECT count(*) FROM tournaments", Long::class.java) ?: 0
         return GlobalOverview(totalGames, totalPlayers, totalAccounts, totalTournaments, games24h, games7d)
+    }
+
+    /**
+     * Storage overview of the accounts database: total database size plus every table in the current
+     * schema (largest first) with its exact row count and heap/index footprint. Postgres-specific —
+     * sizes come from `pg_total_relation_size` and friends.
+     *
+     * Row counts are exact `count(*)`s rather than `pg_class.reltuples` estimates: the estimate is
+     * `-1` for a table that has never been analyzed and drifts between autovacuum runs, which reads
+     * as a bug on a dashboard. That means one sequential scan per table, so this is admin-only and
+     * not something to poll.
+     */
+    fun databaseStats(): DatabaseStats {
+        val databaseName = jdbc.queryForObject("SELECT current_database()", String::class.java) ?: "?"
+        val databaseSize = jdbc.queryForObject(
+            "SELECT pg_database_size(current_database())",
+            Long::class.java,
+        ) ?: 0
+        // Sizes first (one catalog query), then a count per table.
+        data class Sizes(val name: String, val tableBytes: Long, val indexBytes: Long, val totalBytes: Long)
+        val sizes = jdbc.query(
+            """
+            SELECT c.relname AS name,
+                   pg_table_size(c.oid) AS table_bytes,
+                   pg_indexes_size(c.oid) AS index_bytes,
+                   pg_total_relation_size(c.oid) AS total_bytes
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind = 'r' AND n.nspname = current_schema()
+            ORDER BY pg_total_relation_size(c.oid) DESC, c.relname
+            """.trimIndent(),
+        ) { rs, _ ->
+            Sizes(rs.getString("name"), rs.getLong("table_bytes"), rs.getLong("index_bytes"), rs.getLong("total_bytes"))
+        }
+        val tables = sizes
+            // Catalog-sourced names, but the count below interpolates them — refuse anything unquotable.
+            .filter { SAFE_IDENTIFIER.matches(it.name) }
+            .map { s ->
+                val rows = jdbc.queryForObject("SELECT count(*) FROM \"${s.name}\"", Long::class.java) ?: 0
+                DatabaseTableStat(s.name, rows, s.tableBytes, s.indexBytes, s.totalBytes)
+            }
+        return DatabaseStats(databaseName, databaseSize, tables)
     }
 
     /** Games per calendar day (UTC) over the last [days] days, oldest first. */

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/persistence/FlywayMigrationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/persistence/FlywayMigrationTest.kt
@@ -1,9 +1,18 @@
 package com.wingedsheep.gameserver.persistence
 
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.registry.PrintingRegistry
+import com.wingedsheep.gameserver.stats.DeckProfiler
+import com.wingedsheep.gameserver.stats.GeoIpService
+import com.wingedsheep.gameserver.stats.StatsQueryService
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.flywaydb.core.Flyway
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.DriverManagerDataSource
 import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
@@ -281,6 +290,54 @@ class FlywayMigrationTest : FunSpec({
                     st.executeQuery("SELECT count(*) FROM friendships").use { rs -> rs.next(); rs.getInt(1) shouldBe 0 }
                 }
             }
+        } finally {
+            postgres.stop()
+        }
+    }
+
+    test("databaseStats reports per-table row counts and sizes").config(enabled = dockerAvailable) {
+        val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:16-alpine"))
+        postgres.start()
+        try {
+            migrateAll(postgres)
+
+            DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+                conn.createStatement().use { st ->
+                    st.execute("INSERT INTO users(id, email, display_name) VALUES ('$alice', 'a@test.com', 'Alice')")
+                    st.execute("INSERT INTO match_results(id, game_id) VALUES (10, 'g1'), (11, 'g2')")
+                    st.execute("INSERT INTO match_participants(match_id, user_id, player_name, won) VALUES (10, '$alice', 'Alice', true)")
+                }
+            }
+
+            val dataSource = DriverManagerDataSource(postgres.jdbcUrl, postgres.username, postgres.password)
+            val stats = StatsQueryService(
+                jdbc = JdbcTemplate(dataSource),
+                deckProfiler = DeckProfiler(CardRegistry()),
+                cardRegistry = CardRegistry(),
+                printingRegistry = PrintingRegistry(),
+                geoIp = GeoIpService(),
+            ).databaseStats()
+
+            stats.databaseName shouldBe postgres.databaseName
+            stats.databaseSizeBytes shouldBeGreaterThan 0L
+
+            val byName = stats.tables.associateBy { it.tableName }
+            // Exact counts, including an empty table (which must report 0, not an estimate).
+            byName["users"]?.rows shouldBe 1L
+            byName["match_results"]?.rows shouldBe 2L
+            byName["match_participants"]?.rows shouldBe 1L
+            byName["decks"]?.rows shouldBe 0L
+            // Flyway's own bookkeeping table is a table too — it shows up like any other.
+            byName.keys shouldContain "flyway_schema_history"
+
+            // A populated, indexed table has a real footprint, and total = data + indexes.
+            val users = byName.getValue("users")
+            users.tableBytes shouldBeGreaterThan 0L
+            users.indexBytes shouldBeGreaterThan 0L
+            users.totalBytes shouldBe users.tableBytes + users.indexBytes
+
+            // Largest total footprint first.
+            stats.tables.map { it.totalBytes } shouldBe stats.tables.map { it.totalBytes }.sortedDescending()
         } finally {
             postgres.stop()
         }

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -20,6 +20,25 @@ export interface DailyCount {
   readonly count: number
 }
 
+/** One table's row count and on-disk footprint in the accounts database. */
+export interface DatabaseTableStat {
+  readonly tableName: string
+  readonly rows: number
+  /** Heap + TOAST, excluding indexes. */
+  readonly tableBytes: number
+  readonly indexBytes: number
+  /** tableBytes + indexBytes. */
+  readonly totalBytes: number
+}
+
+/** Storage overview of the accounts database. */
+export interface DatabaseStats {
+  readonly databaseName: string
+  /** Whole-database size — includes catalogs, so it exceeds the sum of the tables. */
+  readonly databaseSizeBytes: number
+  readonly tables: DatabaseTableStat[]
+}
+
 export interface GeoBucket {
   readonly country: string | null
   readonly countryCode: string | null
@@ -111,6 +130,8 @@ export const fetchTopCards = (auth: AdminAuth, limit = 50) =>
   getAdminStats<CardStat[]>(auth, `/cards?limit=${limit}`)
 export const fetchCardWinRates = (auth: AdminAuth, minDecks = 10, limit = 50) =>
   getAdminStats<CardWinRate[]>(auth, `/cards/win-rates?minDecks=${minDecks}&limit=${limit}`)
+/** Per-table row counts + sizes. Exact counts server-side, so fetch on demand rather than polling. */
+export const fetchDatabaseStats = (auth: AdminAuth) => getAdminStats<DatabaseStats>(auth, '/database')
 export const fetchTournaments = (auth: AdminAuth, limit = 50) =>
   getAdminStats<TournamentSummary[]>(auth, `/tournaments?limit=${limit}`)
 

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -24,11 +24,13 @@ import {
   type CardStat,
   type CardWinRate,
   type DailyCount,
+  type DatabaseStats,
   type GeoBucket,
   type GlobalOverview,
   type TournamentSummary,
   fetchCardWinRates,
   fetchColorDistribution,
+  fetchDatabaseStats,
   fetchGamesPerDay,
   fetchGeo,
   fetchModeDistribution,
@@ -41,7 +43,7 @@ import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
 import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
 import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
-import { colorLabel, gameModeLabel, mergeModeBuckets } from './statFormat'
+import { colorLabel, formatBytes, formatCount, gameModeLabel, mergeModeBuckets } from './statFormat'
 import { GeoMap } from './GeoMap'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
 
@@ -58,6 +60,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
   const [tournaments, setTournaments] = useState<TournamentSummary[]>([])
   const [tournamentSets, setTournamentSets] = useState<StatBucket[]>([])
   const [geo, setGeo] = useState<GeoBucket[]>([])
+  const [database, setDatabase] = useState<DatabaseStats | null>(null)
   const [showAllCards, setShowAllCards] = useState(false)
   const [showAllWinRates, setShowAllWinRates] = useState(false)
   const [openTournament, setOpenTournament] = useState<number | null>(null)
@@ -88,6 +91,8 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         setTournamentSets(ts)
         // Geo can be slow (external lookups) — load it separately so the rest renders first.
         fetchGeo(auth).then((g) => !cancelled && setGeo(g)).catch(() => {})
+        // Same for the database panel: exact row counts mean a scan per table.
+        fetchDatabaseStats(auth).then((d) => !cancelled && setDatabase(d)).catch(() => {})
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load dashboard')
       }
@@ -196,10 +201,51 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         )}
       </Panel>
 
+      <Panel
+        title="Database"
+        subtitle={
+          database
+            ? `${database.databaseName} — ${formatBytes(database.databaseSizeBytes)} total (including catalogs)`
+            : 'Row counts and on-disk size per table'
+        }
+      >
+        <DatabaseTables stats={database} />
+      </Panel>
+
       {openTournament != null && (
         <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
       )}
     </AdminScreen>
+  )
+}
+
+/**
+ * Per-table row counts and storage, largest first, with a totals row. Sizes are what the tables
+ * themselves occupy; the whole-database figure in the panel subtitle is larger (it counts catalogs).
+ */
+function DatabaseTables({ stats }: { stats: DatabaseStats | null }) {
+  if (!stats) return <p style={cellStyle.muted}>Measuring tables…</p>
+  if (stats.tables.length === 0) return <p style={cellStyle.muted}>No tables found.</p>
+  const sum = (pick: (t: DatabaseStats['tables'][number]) => number) => stats.tables.reduce((a, t) => a + pick(t), 0)
+  return (
+    <Table head={['Table', 'Rows', 'Data', 'Indexes', 'Total']}>
+      {stats.tables.map((t) => (
+        <tr key={t.tableName}>
+          <td style={cellStyle.td}>{t.tableName}</td>
+          <td style={cellStyle.tdNum}>{formatCount(t.rows)}</td>
+          <td style={cellStyle.tdNum}>{formatBytes(t.tableBytes)}</td>
+          <td style={cellStyle.tdNum}>{formatBytes(t.indexBytes)}</td>
+          <td style={cellStyle.tdNum}>{formatBytes(t.totalBytes)}</td>
+        </tr>
+      ))}
+      <tr>
+        <td style={styles.totalCell}>{stats.tables.length} tables</td>
+        <td style={styles.totalCellNum}>{formatCount(sum((t) => t.rows))}</td>
+        <td style={styles.totalCellNum}>{formatBytes(sum((t) => t.tableBytes))}</td>
+        <td style={styles.totalCellNum}>{formatBytes(sum((t) => t.indexBytes))}</td>
+        <td style={styles.totalCellNum}>{formatBytes(sum((t) => t.totalBytes))}</td>
+      </tr>
+    </Table>
   )
 }
 
@@ -239,4 +285,6 @@ const styles: Record<string, React.CSSProperties> = {
   twoCol: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 18 },
   toggle: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 12, padding: 0 },
   clickableRow: { cursor: 'pointer' },
+  totalCell: { textAlign: 'left', color: adminTheme.text, fontWeight: 600, padding: '8px 10px', borderTop: `1px solid ${adminTheme.border}` },
+  totalCellNum: { textAlign: 'right', color: adminTheme.text, fontWeight: 600, padding: '8px 10px', borderTop: `1px solid ${adminTheme.border}` },
 }

--- a/web-client/src/components/admin/statFormat.ts
+++ b/web-client/src/components/admin/statFormat.ts
@@ -109,3 +109,19 @@ export function mergeModeBuckets(
   }
   return [...acc.entries()].map(([label, count]) => ({ label, count })).sort((a, b) => b.count - a.count)
 }
+
+/** Byte count as a compact binary-unit size: 0 → "0 B", 1536 → "1.5 KiB", 5e6 → "4.8 MiB". */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+  const exp = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)))
+  const value = bytes / 1024 ** exp
+  // Whole bytes read oddly as "512.0 B"; above that one decimal is enough precision.
+  const digits = exp === 0 ? 0 : value < 10 ? 1 : value < 100 ? 1 : 0
+  return `${value.toFixed(digits)} ${units[exp]}`
+}
+
+/** Thousands-separated integer, so six-figure row counts stay readable. */
+export function formatCount(n: number): string {
+  return n.toLocaleString('en-US')
+}


### PR DESCRIPTION
Admin → Stats gains a **Database** panel: per-table row counts and on-disk footprint, largest first, with a totals row. The whole-database size sits in the panel subtitle.

![Database panel](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-database-stats-screenshots/database-panel.png)

<details>
<summary>In context, below the geo panel</summary>

![In context](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-database-stats-screenshots/database-panel-in-context.png)

</details>

*(Both hosted on the throwaway `admin-database-stats-screenshots` branch, not in the diff — delete it whenever.)*

## What's in it

| File | Change |
|------|--------|
| `stats/StatsQueryService.kt` | `databaseStats()` + `DatabaseStats` / `DatabaseTableStat`. Sizes from `pg_table_size` / `pg_indexes_size` / `pg_total_relation_size` over `pg_class`, plus `pg_database_size` |
| `controller/AdminStatsController.kt` | `GET /api/stats/admin/database`, behind the existing `AdminAuthService` guard |
| `api/adminStats.ts` | `fetchDatabaseStats` + types |
| `admin/AdminDashboard.tsx` | `DatabaseTables` panel — Table / Rows / Data / Indexes / Total |
| `admin/statFormat.ts` | `formatBytes` (binary units) + `formatCount` |
| `docs/accounts-and-persistence.md` | endpoint row |

## Two decisions worth reviewing

**Exact `count(*)`, not `pg_class.reltuples`.** The estimate is `-1` for a table that has never been analyzed and drifts between autovacuum runs — which reads as a bug on a dashboard. The cost is one sequential scan per table, so the panel loads separately from the rest of the screen (the same treatment the geo panel gets) and the docs say not to poll it. If `game_replays` ever grows enough for this to drag, switching to estimates is a one-line change.

**Table names are spliced into the count SQL.** They come from the catalog rather than user input, but they're still filtered through an identifier regex before interpolation.

## Verification

- New `FlywayMigrationTest` case against a real Postgres 16 via Testcontainers: exact counts including an empty table (must report `0`, not an estimate), `total == data + indexes`, descending order by footprint, and `flyway_schema_history` present. Full class passes.
- End-to-end against a live server + Postgres with seeded rows — counts matched the seed exactly (`users` 2, `match_results` 3, `match_participants` 4, `match_participant_cards` 5); totals row read `13 tables · 23 · 144 KiB · 424 KiB · 568 KiB`. Unauthenticated request → `401`, with the admin password → `200`.
- `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)