### PR TITLE
Use the set's standard-art basic lands in sealed/draft deck building

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -63,9 +63,8 @@ class SealedDeckGenerator(
         val pool = boosterGenerator.generateSealedPool(setCode, boosterCount = 8)
         val deck = buildSealedDeck(pool, setCode)
 
-        // Distribute basic lands across art variants for visual variety
-        val variants = boosterGenerator.getAllBasicLandVariants(setCode)
-        return BoosterGenerator.distributeBasicLandVariants(deck, variants)
+        // Pin the basics to the set's standard art, exactly as a human's submitted deck is.
+        return BoosterGenerator.withBasicLandArt(deck, boosterGenerator.getBasicLands(setCode))
     }
 
     /**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -24,6 +24,11 @@ section; do not let SDK additions land without a corresponding doc update.
   their color; `"Wastes"` is the colorless basic — type line `Basic Land` with no subtype, intrinsic `{T}: Add {C}`.
   Supports `collectorNumber`, `artist`, `flavorText`, `imageUri`, `rarity`, and `inBooster` (set `false` to keep an
   art variant defined but exclude it from the draft/sealed deck-building basic pool).
+  A set declares one `basicLand(...)` per art variant. Limited deck building hands out exactly **one** printing per
+  land type — the set's *standard* art, i.e. its lowest-numbered `inBooster` variant (`BasicLandArt.standardFirst`),
+  since paper numbers the plain booster arts inside the main set numbering and appends full-art / extended /
+  borderless treatments above the set's card count. So `collectorNumber` is what decides which art a drafted deck
+  is played with: give a special treatment a number below the regular art and limited will use the treatment.
 
 **Card builder properties**
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -112,9 +112,9 @@ class FreeForAllHandler(
 
         for (playerState in playerStates) {
             val identity = playerState.identity
-            val baseDeck = BoosterGenerator.distributeBasicLandVariants(
+            val baseDeck = BoosterGenerator.withBasicLandArt(
                 lobby.getSubmittedDeck(identity.playerId) ?: return false,
-                lobby.allBasicLandVariants
+                lobby.basicLands
             )
             val deckWithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(identity.playerName, baseDeck)
             val commander = if (isCommanderShape) playerState.commander else null

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -517,8 +517,8 @@ class LobbyHandler(
         sealedSession.players.forEach { (playerId, playerState) ->
             val baseDeck = playerState.submittedDeck
                 ?: throw IllegalStateException("Player $playerId has no submitted deck")
-            val deckWithVariants = BoosterGenerator.distributeBasicLandVariants(baseDeck, sealedSession.allBasicLandVariants)
-            val deck = EasterEggDeckInjector.maybeInjectEasterEggs(playerState.session.playerName, deckWithVariants)
+            val deckWithLandArt = BoosterGenerator.withBasicLandArt(baseDeck, sealedSession.basicLands)
+            val deck = EasterEggDeckInjector.maybeInjectEasterEggs(playerState.session.playerName, deckWithLandArt)
             gameSession.addPlayer(playerState.session, deck, sideboard = playerState.submittedSideboard)
 
             // Store player info for persistence

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -425,13 +425,13 @@ class TournamentMatchHandler(
         val player1State = lobby.players[match.player1Id] ?: return false
         val player2State = lobby.players[match.player2Id ?: return false] ?: return false
 
-        val baseDeck1 = BoosterGenerator.distributeBasicLandVariants(
+        val baseDeck1 = BoosterGenerator.withBasicLandArt(
             lobby.getSubmittedDeck(match.player1Id) ?: return false,
-            lobby.allBasicLandVariants
+            lobby.basicLands
         )
-        val baseDeck2 = BoosterGenerator.distributeBasicLandVariants(
+        val baseDeck2 = BoosterGenerator.withBasicLandArt(
             lobby.getSubmittedDeck(match.player2Id) ?: return false,
-            lobby.allBasicLandVariants
+            lobby.basicLands
         )
         val deck1WithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(
             player1State.identity.playerName, baseDeck1

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -469,14 +469,12 @@ class TournamentLobby(
     var completedAt: Long? = null
         private set
 
-    /** Basic lands available for deck building (one variant per type, for client display) */
+    /**
+     * Basic lands available for deck building: the set's standard art, one printing per type. Shown
+     * to the player while building and stamped onto the submitted deck, so both agree.
+     */
     val basicLands: Map<String, CardDefinition> by lazy {
         if (setCodes.isEmpty()) emptyMap() else boosterGenerator.getBasicLands(setCodes)
-    }
-
-    /** All basic land art variants grouped by land name (for distributing across variants in decks) */
-    val allBasicLandVariants: Map<String, List<CardDefinition>> by lazy {
-        if (setCodes.isEmpty()) emptyMap() else boosterGenerator.getAllBasicLandVariants(setCodes)
     }
 
     /** Players who are ready for the next round */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
@@ -62,14 +62,12 @@ class SealedSession(
     var state: SealedSessionState = SealedSessionState.WAITING_FOR_PLAYERS
         private set
 
-    /** Basic lands available for deck building (one variant per type, for client display) */
+    /**
+     * Basic lands available for deck building: the set's standard art, one printing per type. Shown
+     * to the player while building and stamped onto the submitted deck, so both agree.
+     */
     val basicLands: Map<String, CardDefinition> by lazy {
         boosterGenerator.getBasicLands(setCodes)
-    }
-
-    /** All basic land art variants grouped by land name (for distributing across variants in decks) */
-    val allBasicLandVariants: Map<String, List<CardDefinition>> by lazy {
-        boosterGenerator.getAllBasicLandVariants(setCodes)
     }
 
     val isFull: Boolean get() = players.size >= 2

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/BasicLandArt.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/BasicLandArt.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.sdk.model
+
+/**
+ * Ordering over the art variants a set prints of one basic land type.
+ *
+ * Paper numbers the regular booster arts inside the main set numbering and appends special
+ * treatments — full-art, extended, borderless — above the set's card count: Bloomburrow's Plains
+ * are 262-265 regular and 369-370 full-art, Lord of the Rings' are 262-263 regular and 272-273
+ * full-art map, Final Fantasy's are 294-296 regular and 572 borderless. Ascending collector number
+ * therefore puts a set's **standard** art first, which is the single printing limited deck building
+ * hands out (`BoosterGenerator.getBasicLands`).
+ *
+ * Variants with an absent or non-numeric collector number sort last: they hold no position in the
+ * set's numbering, so they can't claim to be its standard art.
+ */
+object BasicLandArt {
+
+    /**
+     * Standard art first, then the set's remaining treatments in printed order. Total and
+     * deterministic — [com.wingedsheep.sdk.model.MtgSet.basicLands] is ordered by it so every
+     * consumer sees the same variant sequence across runs, not whatever order reflection yielded.
+     */
+    val standardFirst: Comparator<CardDefinition> = compareBy(
+        { it.metadata.collectorNumber?.toIntOrNull() ?: Int.MAX_VALUE },
+        { it.metadata.collectorNumber ?: "" },
+    )
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -41,9 +41,10 @@ data class ScryfallMetadata(
     /**
      * Whether this printing is part of the set's draft/sealed product. Mirrors Scryfall's
      * `booster` field — false for Special Guests, The List, promos, and other non-draft slots.
-     * Drives [com.wingedsheep.engine.limited.BoosterGenerator]: gates both the booster pool and
-     * the basic-land variants offered during draft/sealed deck building (so a basic art variant
-     * marked `false` is still defined, just not selectable in limited).
+     * Drives [com.wingedsheep.engine.limited.BoosterGenerator]: gates both the booster pool and the
+     * basic-land variants a set can offer during draft/sealed deck building (so a basic art variant
+     * marked `false` is still defined, just never the printing limited hands out — of the remaining
+     * variants, the standard art wins; see [BasicLandArt]).
      */
     val inBooster: Boolean = true
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/discovery/CardDiscovery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/discovery/CardDiscovery.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.discovery
 
+import com.wingedsheep.sdk.model.BasicLandArt
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
@@ -137,7 +138,12 @@ object CardDiscovery {
             }
         return ScannedPackage(
             cards = cards.sortedBy { it.name },
-            basicLands = basicLands.sortedBy { it.name },
+            // Name alone is not a total order for basics — every art variant of a type shares one
+            // name, so a stable sort by name would leave the within-type order at the mercy of
+            // whatever order reflection happened to yield this run. Break the tie on collector
+            // number so `basicLands` is deterministic and each type leads with its standard art
+            // (see [BasicLandArt]); limited deck building takes that first variant.
+            basicLands = basicLands.sortedWith(compareBy<CardDefinition> { it.name }.then(BasicLandArt.standardFirst)),
             // Sort by name first so `printings.toString()` reads naturally; the
             // (setCode, collectorNumber) tiebreakers are only relevant if a future
             // discovery picks up >1 reprint of the same card from the same package.

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/BasicLandArtOrderTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/BasicLandArtOrderTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the art order of every set's basic lands: each land type leads with the set's **standard**
+ * art, then its remaining treatments in printed order.
+ *
+ * This matters because limited deck building takes exactly one printing per type
+ * (`BoosterGenerator.getBasicLands`) and it must be the plain booster art, not a full-art or
+ * borderless treatment. `MtgSet.basicLands` is discovered reflectively, so before
+ * [com.wingedsheep.sdk.model.BasicLandArt] ordering was applied the within-type order was whatever
+ * the JVM happened to yield — meaning a drafted deck could come out full-art on one run and regular
+ * on the next.
+ */
+class BasicLandArtOrderTest : FunSpec({
+
+    test("every set orders each basic land type standard-art first") {
+        val setsWithBasics = MtgSetCatalog.all.filter { it.basicLands.isNotEmpty() }
+        setsWithBasics.shouldNotBeEmpty()
+
+        assertSoftly {
+            for (set in setsWithBasics) {
+                for ((landName, variants) in set.basicLands.groupBy { it.name }) {
+                    val numbers = variants.map { it.metadata.collectorNumber }
+                    withClue("${set.code} $landName art order (collector numbers $numbers)") {
+                        // Ascending collector number is what puts the main-set booster art ahead of
+                        // the treatments numbered above the set's card count.
+                        numbers shouldBe numbers.sortedBy { it?.toIntOrNull() ?: Int.MAX_VALUE }
+                    }
+                }
+            }
+        }
+    }
+
+    test("sets that print both regular and special art lead with the regular art") {
+        // Each pair is (set code, land name) -> the collector number of the plain booster art, with
+        // the treatment it must beat noted. Read off each set's basic-land file header.
+        val expected = mapOf(
+            ("BLB" to "Plains") to "262", // vs full-art 369-370
+            ("LTR" to "Forest") to "270", // vs full-art Middle-earth map 280-281
+            ("FIN" to "Island") to "297", // vs borderless 573
+            ("EOE" to "Swamp") to "264", // vs extended art 369
+            ("TDM" to "Mountain") to "275", // vs the non-booster Dragon's Eye full-art 290
+            ("OTJ" to "Plains") to "272", // its one booster art, vs non-booster 277-278
+            ("DSK" to "Forest") to "276",
+            ("FDN" to "Plains") to "272",
+            ("SOS" to "Plains") to "267",
+            ("POR" to "Plains") to "196",
+        )
+
+        assertSoftly {
+            for ((key, standardNumber) in expected) {
+                val (setCode, landName) = key
+                val set = MtgSetCatalog.all.single { it.code == setCode }
+                withClue("$setCode $landName") {
+                    // Mirrors BoosterGenerator.getBasicLands: in-booster variants only, first wins.
+                    set.basicLands
+                        .filter { it.name == landName && it.metadata.inBooster }
+                        .first().metadata.collectorNumber shouldBe standardNumber
+                }
+            }
+        }
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.limited
 
 import com.wingedsheep.sdk.limited.BoosterStrategy
 import com.wingedsheep.sdk.limited.StandardBooster
+import com.wingedsheep.sdk.model.BasicLandArt
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Printing
 import kotlin.random.Random
@@ -86,8 +87,6 @@ class BoosterGenerator(
 
     companion object {
 
-        private val BASIC_LAND_NAMES = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
-
         /**
          * Re-skin each generated card with one of its alternate-frame printings (showcase /
          * borderless) with probability [chance], leaving the card's oracle identity untouched.
@@ -117,66 +116,58 @@ class BoosterGenerator(
         }
 
         /**
-         * Distribute basic lands in a deck list across art variants for a nice mix.
+         * Pin every basic land in a deck list to the printing it was built with.
          *
-         * Replaces plain land names (e.g., "Plains" → 8) with variant identifiers
-         * (e.g., "Plains#331" → 2, "Plains#332" → 2, "Plains#333" → 2, "Plains#334" → 2).
+         * Replaces plain land names (e.g., "Plains" → 8) with the printing identifier of the
+         * matching entry in [basics] (e.g., "Plains#BLB-262" → 8). [basics] is the very map the
+         * player's deck builder was handed by [getBasicLands], so the art previewed while building
+         * is the art the deck is played with — one standard-art printing per type, not a mix.
          *
-         * The variant identifiers are `Name#SetCode-CollectorNumber` strings that resolve
-         * via [com.wingedsheep.engine.registry.CardRegistry]'s secondary index — predating
-         * the multi-printing system. This works correctly under multi-printing because the
-         * resolved [CardDefinition.metadata.imageUri] is stamped onto each entity's
-         * [com.wingedsheep.engine.state.components.identity.CardComponent.imageUri] at
-         * game-init, which then beats the canonical metadata via the precedence flip in
-         * `ClientStateTransformer`. The rich `cardEntries` channel (Phase 4 of the
-         * multi-printing plan) is not used here — switching is part of the Phase 6.5
-         * cleanup that retires the `Name#SET-CN` secondary index. See
-         * `backlog/multi-printing-system.md`.
+         * Without this the name would resolve to whichever printing the card registry considers
+         * canonical for "Plains" (some other set entirely), so the stamp is what keeps a limited
+         * deck's basics inside the set that was drafted.
          *
-         * @param deckList The original deck list with basic land names
-         * @param variants Map of land name to all art variants from the set
-         * @return Modified deck list with basic lands distributed across variants
+         * Names absent from [basics] pass through untouched — that covers every spell, and a basic
+         * land type the set doesn't print. Keying off [basics] rather than a hardcoded name list is
+         * also what lets a colorless-basic set (Final Fantasy's Wastes) get its art stamped.
+         *
+         * Counts are merged rather than replaced, so a deck list that already names the printing it
+         * gets stamped with (premade lists may carry `Name#SET-CN` entries) keeps all its copies.
+         *
+         * The identifiers are `Name#SetCode-CollectorNumber` strings that resolve via
+         * [com.wingedsheep.engine.registry.CardRegistry]'s secondary index — predating the
+         * multi-printing system. This works correctly under multi-printing because the resolved
+         * [CardDefinition.metadata.imageUri] is stamped onto each entity's
+         * [com.wingedsheep.engine.state.components.identity.CardComponent.imageUri] at game-init,
+         * which then beats the canonical metadata via the precedence flip in
+         * `ClientStateTransformer`. The rich `cardEntries` channel (Phase 4 of the multi-printing
+         * plan) is not used here — switching is part of the Phase 6.5 cleanup that retires the
+         * `Name#SET-CN` secondary index. See `backlog/multi-printing-system.md`.
+         *
+         * @param deckList The submitted deck list, keyed by card name
+         * @param basics Land name to the printing that deck building offered, from [getBasicLands]
+         * @return The deck list with basic land names replaced by printing identifiers
          */
-        fun distributeBasicLandVariants(
+        fun withBasicLandArt(
             deckList: Map<String, Int>,
-            variants: Map<String, List<CardDefinition>>
+            basics: Map<String, CardDefinition>,
         ): Map<String, Int> {
             val result = mutableMapOf<String, Int>()
-
             for ((cardName, count) in deckList) {
-                if (cardName !in BASIC_LAND_NAMES || count <= 0) {
-                    result[cardName] = count
-                    continue
-                }
-
-                val landVariants = variants[cardName]
-                if (landVariants.isNullOrEmpty()) {
-                    result[cardName] = count
-                    continue
-                }
-
-                // Distribute evenly across variants with round-robin assignment
-                val variantCount = landVariants.size
-                val basePerVariant = count / variantCount
-                val remainder = count % variantCount
-
-                for ((i, variant) in landVariants.withIndex()) {
-                    val variantCopies = basePerVariant + if (i < remainder) 1 else 0
-                    if (variantCopies > 0) {
-                        val collectorNumber = variant.metadata.collectorNumber
-                        val identifier = if (collectorNumber != null && variant.setCode != null) {
-                            "$cardName#${variant.setCode}-$collectorNumber"
-                        } else if (collectorNumber != null) {
-                            "$cardName#$collectorNumber"
-                        } else {
-                            cardName
-                        }
-                        result[identifier] = (result[identifier] ?: 0) + variantCopies
-                    }
-                }
+                val identifier = basics[cardName]?.let { printingIdentifier(cardName, it) } ?: cardName
+                result.merge(identifier, count, Int::plus)
             }
-
             return result
+        }
+
+        /**
+         * The `Name#SetCode-CollectorNumber` identifier for [land], degrading to `Name#Number` and
+         * then to the bare name as the printing loses the coordinates to address it by.
+         */
+        private fun printingIdentifier(cardName: String, land: CardDefinition): String {
+            val collectorNumber = land.metadata.collectorNumber ?: return cardName
+            val setCode = land.setCode ?: return "$cardName#$collectorNumber"
+            return "$cardName#$setCode-$collectorNumber"
         }
     }
 
@@ -382,64 +373,43 @@ class BoosterGenerator(
     }
 
     /**
-     * Get basic lands available for deck building from a set.
+     * The basic lands a set offers for limited deck building: one printing per land type.
+     *
+     * A set prints several arts of each basic, but a limited deck gets exactly one of them — the
+     * set's **standard** art, i.e. the lowest-numbered variant that's actually in the draft/sealed
+     * product (see [BasicLandArt]). Special treatments (full-art, extended, borderless) stay
+     * defined for collection and display; they're simply not what a drafted deck is played with.
+     * The chosen printing is both what the deck builder previews and — via [withBasicLandArt] —
+     * what every copy in the submitted deck resolves to.
      *
      * @param setCode The set code
-     * @return Map of land name to CardDefinition (one variant per type)
+     * @return Map of land name to the set's standard printing of it
      */
     fun getBasicLands(setCode: String): Map<String, CardDefinition> {
         val setConfig = availableSets[setCode]
             ?: throw IllegalArgumentException("Unknown set code: $setCode")
 
-        // Return one variant of each basic land type (only those in the draft/sealed product)
         return setConfig.basicLands
             .filter { it.metadata.inBooster }
             .groupBy { it.name }
-            .mapValues { (_, variants) -> variants.first() }
+            .mapValues { (_, variants) -> variants.minWith(BasicLandArt.standardFirst) }
     }
 
     /**
-     * Get basic lands available for deck building from multiple sets.
-     * Uses the basic lands from the first set that has them.
+     * [getBasicLands] for a multi-set pool: the basics come from the first set that prints any, so
+     * a mixed pool still hands out one coherent set of lands rather than a blend.
      *
      * @param setCodes The set codes
-     * @return Map of land name to CardDefinition (one variant per type)
+     * @return Map of land name to the standard printing of it, empty if no set prints basics
      */
     fun getBasicLands(setCodes: List<String>): Map<String, CardDefinition> {
         if (setCodes.isEmpty()) {
             throw IllegalArgumentException("At least one set code is required")
         }
-        // Use basic lands from the first set
-        return getBasicLands(setCodes.first())
-    }
-
-    /**
-     * Get all basic land variants for deck building from a set.
-     *
-     * @param setCode The set code
-     * @return Map of land name to list of all art variants
-     */
-    fun getAllBasicLandVariants(setCode: String): Map<String, List<CardDefinition>> {
-        val setConfig = availableSets[setCode]
-            ?: throw IllegalArgumentException("Unknown set code: $setCode")
-
-        return setConfig.basicLands
-            .filter { it.metadata.inBooster }
-            .groupBy { it.name }
-    }
-
-    /**
-     * Get all basic land variants for deck building from multiple sets.
-     * Uses the basic lands from the first set that has them.
-     *
-     * @param setCodes The set codes
-     * @return Map of land name to list of all art variants
-     */
-    fun getAllBasicLandVariants(setCodes: List<String>): Map<String, List<CardDefinition>> {
-        if (setCodes.isEmpty()) {
-            throw IllegalArgumentException("At least one set code is required")
-        }
-        return getAllBasicLandVariants(setCodes.first())
+        return setCodes.asSequence()
+            .map { getBasicLands(it) }
+            .firstOrNull { it.isNotEmpty() }
+            ?: emptyMap()
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBasicLandArtTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBasicLandArtTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.dsl.basicLand
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins limited basic-land art: a sealed/draft deck gets exactly one printing of each basic — the
+ * set's standard art — and it is the same printing the deck builder previewed.
+ *
+ * Previously the deck builder showed one variant while [BoosterGenerator] round-robined the deck's
+ * copies across *all* of the set's variants, so a player who built with regular art ended up
+ * holding full-art / borderless lands in game with no way to choose.
+ */
+class BoosterGeneratorBasicLandArtTest : DescribeSpec({
+
+    fun land(type: String, cn: String, set: String = "BLB", draftable: Boolean = true): CardDefinition =
+        basicLand(type) {
+            collectorNumber = cn
+            imageUri = "$set-$cn.jpg"
+            inBooster = draftable
+        }.copy(setCode = set)
+
+    /** Regular booster arts 262-263, full-art treatments 369-370, mirroring Bloomburrow. */
+    val regular262 = land("Plains", "262")
+    val regular263 = land("Plains", "263")
+    val fullArt369 = land("Plains", "369")
+    val fullArt370 = land("Plains", "370")
+
+    fun generatorFor(basics: List<CardDefinition>, setCode: String = "BLB") = BoosterGenerator(
+        mapOf(
+            setCode to BoosterGenerator.SetConfig(
+                setCode = setCode,
+                setName = "Test Set",
+                cards = emptyList(),
+                basicLands = basics,
+            ),
+        ),
+    )
+
+    describe("getBasicLands") {
+
+        it("offers the standard art — the lowest-numbered variant — not a special treatment") {
+            val basics = generatorFor(listOf(regular262, regular263, fullArt369, fullArt370)).getBasicLands("BLB")
+            basics.keys shouldContainExactlyInAnyOrder setOf("Plains")
+            basics["Plains"]!!.metadata.collectorNumber shouldBe "262"
+        }
+
+        it("picks the standard art regardless of the order the set lists its variants in") {
+            // The set's basicLands come from reflective discovery, so the incoming order is not a
+            // contract — the choice must come from the collector number itself.
+            val shuffled = listOf(fullArt370, regular263, fullArt369, regular262)
+            generatorFor(shuffled).getBasicLands("BLB")["Plains"]!!
+                .metadata.collectorNumber shouldBe "262"
+        }
+
+        it("ignores variants excluded from the draft/sealed product even when they number lowest") {
+            val basics = generatorFor(
+                listOf(land("Plains", "100", draftable = false), regular262),
+            ).getBasicLands("BLB")
+            basics["Plains"]!!.metadata.collectorNumber shouldBe "262"
+        }
+
+        it("offers one printing per land type") {
+            val basics = generatorFor(
+                listOf(regular262, fullArt369, land("Forest", "280"), land("Forest", "375")),
+            ).getBasicLands("BLB")
+            basics.keys shouldContainExactlyInAnyOrder setOf("Plains", "Forest")
+            basics["Forest"]!!.metadata.collectorNumber shouldBe "280"
+        }
+
+        it("falls through a multi-set pool to the first set that prints basics") {
+            // A pool led by a set with no basics of its own must still hand out lands.
+            val generator = BoosterGenerator(
+                mapOf(
+                    "DMU" to BoosterGenerator.SetConfig("DMU", "Dominaria United", emptyList(), emptyList()),
+                    "POR" to BoosterGenerator.SetConfig("POR", "Portal", emptyList(), listOf(land("Plains", "196", "POR"))),
+                ),
+            )
+            generator.getBasicLands(listOf("DMU", "POR"))["Plains"]!!
+                .metadata.collectorNumber shouldBe "196"
+        }
+
+        it("returns no basics when no set in the pool prints any") {
+            val generator = BoosterGenerator(
+                mapOf("DMU" to BoosterGenerator.SetConfig("DMU", "Dominaria United", emptyList(), emptyList())),
+            )
+            generator.getBasicLands(listOf("DMU")) shouldBe emptyMap()
+        }
+    }
+
+    describe("withBasicLandArt") {
+
+        val basics = mapOf("Plains" to regular262, "Forest" to land("Forest", "280"))
+
+        it("stamps every copy of a basic with the one printing deck building offered") {
+            BoosterGenerator.withBasicLandArt(mapOf("Plains" to 8, "Forest" to 9), basics)
+                .shouldContainExactly(mapOf("Plains#BLB-262" to 8, "Forest#BLB-280" to 9))
+        }
+
+        it("leaves spells untouched") {
+            BoosterGenerator.withBasicLandArt(mapOf("Llanowar Elves" to 2, "Plains" to 1), basics)
+                .shouldContainExactly(mapOf("Llanowar Elves" to 2, "Plains#BLB-262" to 1))
+        }
+
+        it("passes a basic through unchanged when the set prints none of that type") {
+            // A pool whose set has no basics at all can't stamp art onto the deck's lands.
+            BoosterGenerator.withBasicLandArt(mapOf("Plains" to 8), emptyMap())
+                .shouldContainExactly(mapOf("Plains" to 8))
+            BoosterGenerator.withBasicLandArt(mapOf("Island" to 8), basics)
+                .shouldContainExactly(mapOf("Island" to 8))
+        }
+
+        it("stamps a colorless basic too — the land names come from the set, not a fixed list") {
+            // Final Fantasy prints Wastes; the old hardcoded five-name gate silently skipped it.
+            val wastes = mapOf("Wastes" to land("Wastes", "309", "FIN"))
+            BoosterGenerator.withBasicLandArt(mapOf("Wastes" to 4), wastes)
+                .shouldContainExactly(mapOf("Wastes#FIN-309" to 4))
+        }
+
+        it("degrades to the bare name when the printing has no collector number to address") {
+            val unnumbered = mapOf("Plains" to basicLand("Plains") { imageUri = "x.jpg" }.copy(setCode = "BLB"))
+            BoosterGenerator.withBasicLandArt(mapOf("Plains" to 8), unnumbered)
+                .shouldContainExactly(mapOf("Plains" to 8))
+        }
+
+        it("keeps every copy when the deck already names the printing it gets stamped with") {
+            // Premade tournament lists may carry Name#SET-CN entries; merging (not replacing) keeps
+            // the 4 plain Plains from being swallowed by the 4 already-stamped ones.
+            BoosterGenerator.withBasicLandArt(mapOf("Plains" to 4, "Plains#BLB-262" to 4), basics)
+                .shouldContainExactly(mapOf("Plains#BLB-262" to 8))
+        }
+
+        it("is a no-op on an empty deck list") {
+            BoosterGenerator.withBasicLandArt(emptyMap(), basics) shouldBe emptyMap()
+        }
+    }
+})


### PR DESCRIPTION
## The problem

In sealed and draft tournaments you couldn't pick the selected set's plain basic lands — you got whatever art the engine felt like. A deck built while previewing regular Plains was played with a mix of full-art / borderless ones.

Two independent causes:

1. **`CardDiscovery` ordered basics by card name**, which is the identical string for every art variant of a type (`"Plains"`). `sortedBy` is stable, so the within-type order was whatever the JVM's reflection scan yielded — the single variant `getBasicLands` previewed to the deck builder was effectively arbitrary, and could be the full-art one.
2. **`distributeBasicLandVariants` round-robined the deck's copies across *all* of the set's variants** anyway, so even a correct preview didn't match what you played.

## The fix

Limited deck building now hands out exactly one printing per land type: the set's **standard** art, defined as its lowest-numbered `inBooster` variant. Paper numbers the plain booster arts inside the main set numbering and appends special treatments above the set's card count, so collector number is what distinguishes them — verified against all 25 sets that define basics:

| Set | Standard | Special treatment it now beats |
|---|---|---|
| BLB | Plains 262 | full-art 369-370 |
| LTR | Forest 270 | full-art Middle-earth map 280-281 |
| FIN | Island 297 | borderless 573 |
| EOE | Swamp 264 | extended art 369 |
| TDM | Mountain 275 | Dragon's Eye full-art 290 |

The rule lives in one place, `BasicLandArt.standardFirst`, used by both the discovery ordering and `BoosterGenerator.getBasicLands`.

`distributeBasicLandVariants` is replaced by **`withBasicLandArt`**, which stamps the submitted deck using the very map the deck builder was handed. Preview art and played art now come from the same object, so they can't drift.

## Incidental fixes on the same path

- Keying the stamp off the offered-basics map retires a hardcoded `setOf("Plains", "Island", "Swamp", "Mountain", "Forest")`, which silently skipped **Final Fantasy's Wastes**.
- `getBasicLands(setCodes)` now does what its KDoc always claimed and falls through to the first set that actually prints basics — a pool led by a basics-less set previously offered **no lands at all**.
- Counts are merged rather than replaced when stamping, so a premade list that already names the printing keeps all its copies.

## Compatibility

Special-art variants stay defined for collection/display, and every printing stays registered in the card registry — replays that recorded a full-art `Name#SET-CN` identifier still resolve. No client change: the server already sends the chosen printing's `imageUri`/`setCode`/`collectorNumber`, which is now deterministic and standard.

## Tests

- `BasicLandArtOrderTest` (mtg-sets) — corpus-wide: every set orders each land type standard-art first, plus pinned regular-vs-special expectations for 10 sets.
- `BoosterGeneratorBasicLandArtTest` (rules-engine, 13 cases) — standard art chosen regardless of input order, `inBooster = false` respected even when numbered lowest, stamping/passthrough/Wastes/merge/no-collector-number edge cases, multi-set fall-through.

`:rules-engine:test --tests "*BoosterGenerator*"`, `:mtg-sets:test --tests "*BasicLandArtOrderTest"`, `:ai:test --tests "*SealedDeckGeneratorTest"` — 36 tests, 0 failures. `:game-server:compileTestKotlin` and `:ai:compileTestKotlin` green.

> Note: the full `just test` sweep didn't run — a `:game-server:bootRun` dev server holds the machine-global Gradle lock indefinitely, and building outside it OOMs the 4 GB Kotlin daemon under the current load. Verification was scoped to the affected modules plus their test-source compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)