### PR TITLE
Promise a permanent's gift as you cast it, not after it enters

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1697,7 +1697,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   single opponent, so 2-player games see no extra decision. The source may be a spell on the stack
   (the choice lives on the spell entity for its resolution) or a permanent (recorded durably).
   `Patterns.Mechanic.giftSpell` prefixes its gift mode with this automatically — gift recipients
-  address `Player.ChosenOpponent`. The *as-enters* analogue is `EntersWithChoice(ChoiceType.OPPONENT)`,
+  address `Player.ChosenOpponent`. (Permanent gift cards don't need it: `gift(kind)` records the
+  promised opponent in the same slot as part of the cast — see § 11 "Gift".) The *as-enters* analogue
+  is `EntersWithChoice(ChoiceType.OPPONENT)`,
   which writes the same slot (Jihad, The Rack).
 - `GrantHexproofFromChosenColorEffect(target)` — hexproof from chosen color.
 - `GrantProtectionFromChosenColorEffect(target)` — protection from chosen color. Must run inside `ChooseColorThen`; wrap in `ForEachInGroup` for the group case (Akroma's Blessing: "Creatures you control gain protection from the chosen color").
@@ -4852,7 +4854,7 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > mechanics — `mayBeginGameOnBattlefield()`, `flurry { }`, `mobilize(…)`, `firebending(n)`, `sneak(cost)`, `decayed()`,
 > `vividEtb { }` / `vividCostReduction()`, `convergeEntersWithCounters(counterType?)`,
 > `impending(time, cost)`, `renew(cost) { }`, `enduring()`,
-> `craft(filter, cost)`, `station()`, `jobSelect()` — are `CardBuilder` **extension functions** in
+> `craft(filter, cost)`, `station()`, `jobSelect()`, `gift(kind)` — are `CardBuilder` **extension functions** in
 > `mtg-sdk/.../dsl/mechanics/` (one file per mechanic), not methods on the core `CardBuilder`. They
 > stay in package `com.wingedsheep.sdk.dsl`, so the call syntax is unchanged, but a card file that
 > uses one needs the matching import (e.g. `import com.wingedsheep.sdk.dsl.station`). Evergreen /
@@ -4883,6 +4885,30 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > SourceReturnedAsEnchantment)` so, while the marker is present, the permanent is an enchantment with no other
 > card types or subtypes. Author the printed dies-clause + reminder text into `oracleText`. The
 > `Keyword.ENDURING` display keyword carries no combat behavior.
+
+> **Gift** (CR 702.174, Bloomburrow). "Gift a \[something\]" is two abilities: an **additional cost**
+> — "as an additional cost to cast this spell, you may choose an opponent" — and, on a permanent, the
+> triggered ability "when this permanent enters, if its gift cost was paid, \[effect\]" whose effect the
+> \[something\] defines (CR 702.174d–i: a card → they draw, a Food/Treasure → they create that token, a
+> tapped Fish → tapped 1/1 blue Fish, an Octopus → 8/8 blue Octopus, an extra turn → they take one).
+>
+> *Permanents:* `card { gift(GiftKind.CARD) }` (import `com.wingedsheep.sdk.dsl.gift`) adds
+> `KeywordAbility.Gift(kind)` **and** the derived enters-ability (`giftEnterTrigger(kind)` — an
+> intervening-if trigger on `Conditions.GiftWasPromised`, closing with `Effects.GiftGiven()` so
+> "whenever you give a gift" fires per CR 702.174c). Because the promise is a *cast* choice, the
+> legal-action enumerator clones each normal cast into a `CastWithGift` variant per opponent
+> (`CastSpell.giftRecipient`), the cast handler records it on the stack object, and the resolving
+> permanent carries `ChoiceSlot.GIFT_PROMISED` + `ChoiceSlot.OPPONENT` durably — so the card's own
+> printed enters-abilities gate on `Conditions.GiftWasPromised` / `Conditions.Not(...)` instead of asking
+> the player anything at resolution. **Never model the promise as a resolution-time choice**: the gift is
+> promised as the spell is cast, so a mode picker on the enters-trigger asks after the permanent has
+> already entered.
+>
+> *Instants and sorceries* have no permanent to trigger off — their gift-paid branch is part of the
+> spell's own effect, so they keep `Patterns.Mechanic.giftSpell(noGiftMode, giftMode)`: a two-mode
+> `ModalEffect` (`countsAsModalSpell = false`) whose mode is chosen **at cast time** by the engine's
+> cast-time mode picker, which is what makes the choice legal there (Long River's Pull, Crumb and Get It).
+> The gift mode is prefixed with `Effects.ChooseOpponent(...)` and addresses `Player.ChosenOpponent`.
 
 > **Converge** (ability word, CR 207.2c — flavor only, no keyword, like Opus/Vivid). Scales an effect
 > by the number of distinct colors of mana spent to cast the spell. Three shapes:
@@ -5589,6 +5615,12 @@ answer it and would silently return `false`.
   extra +1/+1 counter", `WasCastFromZone(Zone.LIBRARY)`).
 - `WasKicked` — cast with kicker / multikicker / offspring (i.e. an `OptionalAdditionalCost` with `branchesEffect = true` whose extra cost was paid). FlashKicker payments are intentionally invisible to this condition.
 - `SneakCostWasPaid` — the source was cast for its `Sneak` cost (CR 702.190 — mana + returning an unblocked attacker). Reads the durable `ChoiceSlot.SNEAK` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. Backs riders like Leonardo, Leader in Blue and The Last Ronin's Technique.
+- `GiftWasPromised` — the spell's **gift** additional cost was paid, i.e. "if the gift was promised"
+  (CR 702.174a/b, Bloomburrow). A facade over `CastChoiceMade(ChoiceSlot.GIFT_PROMISED)` — the flag the
+  engine stamps (together with the promised opponent in `ChoiceSlot.OPPONENT`) on a permanent whose
+  gift was promised while casting. Gate a permanent's printed enters-abilities with it (Scrapshooter's
+  destroy, Starforged Sword's attach) and with `Conditions.Not(GiftWasPromised)` for the "if the gift
+  wasn't promised" riders (Kitnap's stun counters). See `gift(kind)` in § 11.
 - `WaterbendWasPaid` — the spell's optional spell-level **waterbend** additional cost (`waterbendCost(..., optional = true)`, Avatar: The Last Airbender) was paid. Reads the durable `ChoiceSlot.WATERBEND_PAID` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. The waterbend analogue of `BlightWasPaid`; backs "if this spell's additional cost was paid" on Ruinous Waterbending and Spirit Water Revival.
 - `NoManaSpentToCast` — "it wasn't cast or no mana was spent to cast it": the standard free-cast
   payoff clause (**Freestrider Commando**, **Satoru, the Infiltrator**). True when the *total* mana

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4907,7 +4907,12 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > printed enters-abilities gate on `Conditions.GiftWasPromised` / `Conditions.Not(...)` instead of asking
 > the player anything at resolution. **Never model the promise as a resolution-time choice**: the gift is
 > promised as the spell is cast, so a mode picker on the enters-trigger asks after the permanent has
-> already entered.
+> already entered. CR 702.174m is the rule that makes this mandatory rather than merely tidy — "if part
+> of a spell's ability has its effect only if its gift was promised, and that part of the ability includes
+> any targets, the spell's controller chooses those targets only if the gift was promised" — so a
+> promise-carrying mode that also collects targets picks them before the promise exists.
+> The promise rides *every* cost path, since it's an additional cost (CR 601.2b, 601.2f–h): the
+> enumerator clones alternative-cost and free casts too, not just the plain one.
 >
 > *Instants and sorceries* have no permanent to trigger off — their gift-paid branch is part of the
 > spell's own effect, so they keep `Patterns.Mechanic.giftSpell(noGiftMode, giftMode)`: a two-mode

--- a/e2e-scenarios/helpers/scenarioApi.ts
+++ b/e2e-scenarios/helpers/scenarioApi.ts
@@ -1,4 +1,7 @@
-const BASE_URL = 'http://localhost:8080/api/dev/scenarios'
+// Override when the game server under test isn't on the default port — e.g. a worktree running its
+// own server next to an already-running main checkout. The `E2E_BASE_URL` sibling in
+// playwright.config.ts does the same for the web client.
+const BASE_URL = `${process.env.E2E_SERVER_URL ?? 'http://localhost:8080'}/api/dev/scenarios`
 
 export interface BattlefieldCardConfig {
   name: string

--- a/e2e-scenarios/tests/general/gift-promised-at-cast-time.spec.ts
+++ b/e2e-scenarios/tests/general/gift-promised-at-cast-time.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+
+/**
+ * E2E browser tests for the gift mechanic's timing (Bloomburrow, CR 702.174a).
+ *
+ * The gift is promised **as you cast** — so the choice has to be a cast option in the action menu,
+ * never a question after the card has been played. Kitnap (a gift permanent) used to ask at
+ * resolution, once the Aura had already entered the battlefield.
+ */
+test.describe('Gift promised at cast time', () => {
+  test('Kitnap offers the gift as a cast option and asks nothing afterwards', async ({ createGame }) => {
+    const { player1, player2 } = await createGame({
+      player1Name: 'Caster',
+      player2Name: 'Opponent',
+      player1: {
+        hand: ['Kitnap'],
+        battlefield: [{ name: 'Island' }, { name: 'Island' }, { name: 'Island' }, { name: 'Island' }],
+        library: ['Island'],
+      },
+      player2: {
+        battlefield: [{ name: 'Grizzly Bears' }],
+        library: ['Forest', 'Forest'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+    })
+
+    const p1 = player1.gamePage
+    const p2 = player2.gamePage
+
+    // The action menu must present both casts: with and without the promise.
+    await p1.clickCard('Kitnap')
+    await expect(p1.page.locator('button').filter({ hasText: 'Cast Kitnap (Gift a card)' })).toBeVisible()
+    await p1.screenshot('Cast options include the gift promise')
+
+    await p1.selectAction('Cast Kitnap (Gift a card)')
+    await p1.selectTarget('Grizzly Bears')
+    await p1.confirmTargets()
+    await p2.resolveStack('Kitnap')
+
+    // Once the Aura is on the battlefield the promise is already locked in: the gift arrives as a
+    // triggered ability (CR 702.174b), and the player is asked nothing at all.
+    await p1.expectOnBattlefield('Kitnap')
+    await expect(p1.page.getByText('Kitnap trigger')).toBeVisible()
+    await expect(p1.page.locator('button').filter({ hasText: /gift/i })).toHaveCount(0)
+    await p1.screenshot('Aura entered, gift already promised, nothing asked')
+  })
+
+  test("Long River's Pull picks its gift among the cast options too", async ({ createGame }) => {
+    const { player1, player2 } = await createGame({
+      player1Name: 'Caster',
+      player2Name: 'Opponent',
+      player1: {
+        hand: ["Long River's Pull"],
+        battlefield: [{ name: 'Island' }, { name: 'Island' }],
+      },
+      player2: {
+        hand: ['Grizzly Bears'],
+        battlefield: [{ name: 'Forest' }, { name: 'Forest' }],
+        library: ['Forest'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 2,
+    })
+
+    const p1 = player1.gamePage
+    const p2 = player2.gamePage
+
+    await p2.clickCard('Grizzly Bears')
+    await p2.selectAction('Cast Grizzly Bears')
+
+    // An instant with gift folds the promise into its cast-time mode choice (both modes shown).
+    await p1.clickCard("Long River's Pull")
+    await expect(
+      p1.page.locator('button').filter({ hasText: 'Counter target creature spell' })
+    ).toBeVisible()
+    await expect(
+      p1.page.locator('button').filter({ hasText: 'Gift a card — counter target spell' })
+    ).toBeVisible()
+    await p1.screenshot('Both gift modes offered while casting')
+
+    await p1.selectAction('Gift a card — counter target spell')
+    await p1.selectTarget('Grizzly Bears')
+    await p1.confirmTargets()
+    await p2.resolveStack("Long River's Pull")
+
+    await p1.expectNotOnBattlefield('Grizzly Bears')
+    await p2.expectHandSize(1) // the promised card
+  })
+})

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
@@ -82,6 +82,8 @@ class AutoPassManager(
             "CastWithHarmonize",
             "CastWithWarp",
             "CastWithKicker",
+            // Gift (CR 702.174a) — the "promise a gift" twin of a normal cast.
+            "CastWithGift",
             "CastWithConspire",
             "CastWithoutPayingManaCost",
             "CastFaceDown",

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -806,6 +806,21 @@ object Conditions {
         WaterbendWasPaidCondition
 
     /**
+     * If this spell's **gift** additional cost was paid — "if the gift was promised"
+     * (CR 702.174a/b, Bloomburrow). The promise is elected as the spell is cast and stamped
+     * durably on the resulting permanent, so a gift permanent's enters-the-battlefield abilities
+     * branch on it: `Conditions.GiftWasPromised` for the gift itself and the riders that need it,
+     * `Conditions.Not(Conditions.GiftWasPromised)` for "if the gift wasn't promised" (Kitnap's
+     * stun counters).
+     *
+     * A facade over the durable choice-slot read — gift needs no condition type of its own.
+     * Pairs with [com.wingedsheep.sdk.scripting.KeywordAbility.Gift] and the `gift(kind)` DSL
+     * helper.
+     */
+    val GiftWasPromised: ConditionInterface =
+        CastChoiceMadeCondition(com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED)
+
+    /**
      * If a value was locked in for [slot] when the source was cast / as it entered
      * ("a color was chosen", "this spell was kicked"). Reads the durable cast-choices bag.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -816,6 +816,12 @@ object Conditions {
      * A facade over the durable choice-slot read — gift needs no condition type of its own.
      * Pairs with [com.wingedsheep.sdk.scripting.KeywordAbility.Gift] and the `gift(kind)` DSL
      * helper.
+     *
+     * **Permanents only.** Unlike `SneakCostWasPaid` / `WaterbendWasPaid` this has no resolution-time
+     * fallback for a spell's own effect: the flag is written as the permanent enters, so a read from
+     * a still-on-the-stack instant or sorcery is always false. Instants and sorceries branch on the
+     * promise through `Patterns.Mechanic.giftSpell`'s mode instead (CR 702.174b gives them
+     * "if this spell's gift cost was paid, [effect]" rather than an enters trigger).
      */
     val GiftWasPromised: ConditionInterface =
         CastChoiceMadeCondition(com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDsl.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.GiftKind
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The gift itself: what the promised opponent receives (CR 702.174d–i).
+ *
+ * Always addressed to [Player.ChosenOpponent] — the opponent locked into
+ * [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT] when the gift cost was paid.
+ */
+fun giftEffect(kind: GiftKind): Effect {
+    val recipient = EffectTarget.PlayerRef(Player.ChosenOpponent)
+    return when (kind) {
+        GiftKind.CARD -> Effects.DrawCards(1, recipient)
+        GiftKind.FOOD -> Effects.CreateFood(1, recipient)
+        GiftKind.TREASURE -> Effects.CreateTreasure(1, controller = recipient)
+        GiftKind.TAPPED_FISH -> Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Fish"),
+            controller = recipient,
+            tapped = true,
+            imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
+        )
+        GiftKind.OCTOPUS -> Effects.CreateToken(
+            power = 8,
+            toughness = 8,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Octopus"),
+            controller = recipient
+        )
+        GiftKind.EXTRA_TURN -> Effects.TakeExtraTurn(recipient)
+    }
+}
+
+/**
+ * The triggered ability that *is* gift on a permanent (CR 702.174b): "When this permanent enters,
+ * if its gift cost was paid, [effect]."
+ *
+ * An intervening-if trigger gated on [Conditions.GiftWasPromised], so a permanent cast without
+ * promising the gift never puts the ability on the stack at all. Resolving it is what makes the
+ * controller "give a gift" (CR 702.174c), hence the closing [Effects.GiftGiven] marker that fires
+ * "whenever you give a gift" triggers.
+ */
+fun giftEnterTrigger(kind: GiftKind): TriggeredAbility =
+    TriggeredAbility.create(
+        trigger = Triggers.EntersBattlefield.event,
+        binding = Triggers.EntersBattlefield.binding,
+        triggerCondition = Conditions.GiftWasPromised,
+        effect = giftEffect(kind).then(Effects.GiftGiven()),
+        descriptionOverride =
+            "When this permanent enters, if the gift was promised, ${kind.effectText}."
+    )
+
+/**
+ * Add Gift a [kind] (CR 702.174, Bloomburrow) to a **permanent** card — the keyword ability plus
+ * the derived enters-the-battlefield gift ability.
+ *
+ * The promise is an additional cost elected as the spell is cast (CR 702.174a): the legal-action
+ * enumerator offers a "promise a gift" cast variant per opponent, the cast handler records the
+ * chosen opponent, and the resolving permanent carries
+ * [com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED] + `OPPONENT` for the rest of its life.
+ * The card's other enters-the-battlefield abilities read that fact through
+ * [Conditions.GiftWasPromised] (Scrapshooter's destroy, Starforged Sword's attach) or its negation
+ * (Kitnap's stun counters) — never a resolution-time choice, which would ask the player *after*
+ * the permanent had already entered.
+ *
+ * Instants and sorceries have no permanent to trigger off, so their gift branch is folded into the
+ * spell's own effect via [MechanicPatterns.giftSpell] instead.
+ */
+fun CardBuilder.gift(kind: GiftKind) {
+    keywordAbilityList.add(KeywordAbility.Gift(kind))
+    triggeredAbilities.add(giftEnterTrigger(kind))
+}
+
+/**
+ * This card's gift keyword, or null when it has none — the single check the engine's cast
+ * enumerator, cast handler and stack view use to decide whether "promise a gift" applies.
+ */
+fun CardDefinition.giftKeyword(): KeywordAbility.Gift? =
+    keywordAbilities.filterIsInstance<KeywordAbility.Gift>().firstOrNull()

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDsl.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.dsl
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.GiftKind
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -45,19 +46,22 @@ fun giftEffect(kind: GiftKind): Effect {
  * The triggered ability that *is* gift on a permanent (CR 702.174b): "When this permanent enters,
  * if its gift cost was paid, [effect]."
  *
- * An intervening-if trigger gated on [Conditions.GiftWasPromised], so a permanent cast without
- * promising the gift never puts the ability on the stack at all. Resolving it is what makes the
- * controller "give a gift" (CR 702.174c), hence the closing [Effects.GiftGiven] marker that fires
- * "whenever you give a gift" triggers.
+ * An intervening-if trigger gated on [Conditions.GiftWasPromised] (CR 603.4), so a permanent cast
+ * without promising the gift never puts the ability on the stack at all. Resolving it is what makes
+ * the controller "give a gift" (CR 702.174c), hence the closing [Effects.GiftGiven] marker that
+ * fires "whenever you give a gift" triggers.
+ *
+ * [subject] names the permanent the way the printed card does ("this Aura", "this Equipment") for
+ * the rules text only; it defaults to the rule's own generic wording.
  */
-fun giftEnterTrigger(kind: GiftKind): TriggeredAbility =
+fun giftEnterTrigger(kind: GiftKind, subject: String = "this permanent"): TriggeredAbility =
     TriggeredAbility.create(
         trigger = Triggers.EntersBattlefield.event,
         binding = Triggers.EntersBattlefield.binding,
         triggerCondition = Conditions.GiftWasPromised,
         effect = giftEffect(kind).then(Effects.GiftGiven()),
         descriptionOverride =
-            "When this permanent enters, if the gift was promised, ${kind.effectText}."
+            "When $subject enters, if the gift was promised, ${kind.effectText}."
     )
 
 /**
@@ -74,11 +78,31 @@ fun giftEnterTrigger(kind: GiftKind): TriggeredAbility =
  * the permanent had already entered.
  *
  * Instants and sorceries have no permanent to trigger off, so their gift branch is folded into the
- * spell's own effect via [MechanicPatterns.giftSpell] instead.
+ * spell's own effect via [MechanicPatterns.giftSpell] instead — `CardValidator` rejects this keyword
+ * on a non-permanent for exactly that reason.
+ *
+ * Call this *after* `typeLine`: the derived ability names the permanent the way the printed card
+ * does ("When this Aura enters, …"), read off the type line. Out of order it falls back to the
+ * rule's own generic "this permanent" — the wording gets less specific, never wrong.
  */
 fun CardBuilder.gift(kind: GiftKind) {
     keywordAbilityList.add(KeywordAbility.Gift(kind))
-    triggeredAbilities.add(giftEnterTrigger(kind))
+    triggeredAbilities.add(giftEnterTrigger(kind, giftSubjectFor(typeLine)))
+}
+
+/** How the printed card refers to itself in its gift ability, given its type line. */
+private fun giftSubjectFor(typeLineString: String): String {
+    val typeLine = runCatching { TypeLine.parse(typeLineString) }.getOrNull()
+        ?: return "this permanent"
+    return when {
+        typeLine.isAura -> "this Aura"
+        typeLine.isEquipment -> "this Equipment"
+        typeLine.isCreature -> "this creature"
+        typeLine.isEnchantment -> "this enchantment"
+        typeLine.isArtifact -> "this artifact"
+        typeLine.isLand -> "this land"
+        else -> "this permanent"
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
@@ -68,6 +68,16 @@ enum class ChoiceSlot {
     WATERBEND_PAID,
 
     /**
+     * Whether the spell's **gift** additional cost was paid when cast (CR 702.174a, Bloomburrow —
+     * "as an additional cost to cast this spell, you may choose an opponent"). A present value
+     * means the gift was promised; the promised opponent rides along in [OPPONENT]. Read back
+     * through [com.wingedsheep.sdk.dsl.Conditions.GiftWasPromised] (and its negation for the
+     * "if the gift wasn't promised" riders). Pairs with
+     * [com.wingedsheep.sdk.scripting.KeywordAbility.Gift].
+     */
+    GIFT_PROMISED,
+
+    /**
      * An opponent chosen as the object entered, stored as a [ChoiceValue.EntityChoice]
      * carrying the player entity id (e.g. Jihad "as this enchantment enters, choose
      * a color and an opponent"). Read back through the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GiftKind.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/GiftKind.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.sdk.scripting
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The `[something]` in "Gift a [something]" (CR 702.174d–i) — what the opponent chosen as the
+ * gift cost receives.
+ *
+ * The rules enumerate the whole list, and each entry maps to exactly one effect, so a gift card
+ * only names its kind: [com.wingedsheep.sdk.dsl.giftEffect] derives the effect and
+ * [com.wingedsheep.sdk.dsl.giftEnterTrigger] derives the permanent's gift triggered ability
+ * (CR 702.174b) from it.
+ *
+ * Pairs with [KeywordAbility.Gift] and the `gift(kind)` DSL helper on
+ * [com.wingedsheep.sdk.dsl.CardBuilder].
+ */
+@Serializable
+enum class GiftKind(
+    /** Reminder-text noun phrase — renders as "Gift <label>", e.g. "Gift a tapped Fish". */
+    val label: String,
+    /** What the chosen player gets, phrased for the derived ability's rules text. */
+    val effectText: String
+) {
+    /** CR 702.174e — "The chosen player draws a card." */
+    CARD("a card", "the chosen player draws a card"),
+
+    /** CR 702.174d — "The chosen player creates a Food token." */
+    FOOD("a Food", "the chosen player creates a Food token"),
+
+    /** CR 702.174f — "The chosen player creates a tapped 1/1 blue Fish creature token." */
+    TAPPED_FISH("a tapped Fish", "the chosen player creates a tapped 1/1 blue Fish creature token"),
+
+    /** CR 702.174h — "The chosen player creates a Treasure token." */
+    TREASURE("a Treasure", "the chosen player creates a Treasure token"),
+
+    /** CR 702.174i — "The chosen player creates an 8/8 blue Octopus creature token." */
+    OCTOPUS("an Octopus", "the chosen player creates an 8/8 blue Octopus creature token"),
+
+    /** CR 702.174g — "The chosen player takes an extra turn after this one." */
+    EXTRA_TURN("an extra turn", "the chosen player takes an extra turn after this one"),
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -586,6 +586,31 @@ sealed interface KeywordAbility {
     }
 
     // =========================================================================
+    // Gift
+    // =========================================================================
+
+    /**
+     * Gift a [kind] (CR 702.174, Bloomburrow).
+     *
+     * Two abilities in one keyword (CR 702.174a): the additional cost "as an additional cost to
+     * cast this spell, you may choose an opponent" — elected **as the spell is cast**, carried on
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED] + [ChoiceSlot.OPPONENT] and readable
+     * via [com.wingedsheep.sdk.dsl.Conditions.GiftWasPromised] — and, on a permanent, the triggered
+     * ability "when this permanent enters, if its gift cost was paid, [effect]" (CR 702.174b),
+     * whose effect [kind] defines.
+     *
+     * Attach via the `gift(kind)` DSL helper on [com.wingedsheep.sdk.dsl.CardBuilder], which adds
+     * this keyword *and* the derived enters-the-battlefield ability. Instants and sorceries fold
+     * their gift-paid branch into the spell's own effect instead — see
+     * [com.wingedsheep.sdk.dsl.MechanicPatterns.giftSpell].
+     */
+    @SerialName("Gift")
+    @Serializable
+    data class Gift(val kind: GiftKind) : KeywordAbility {
+        override val description: String = "Gift ${kind.label}"
+    }
+
+    // =========================================================================
     // Sneak
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -362,6 +362,13 @@ object CardLinter {
             is JsonObject -> {
                 val type = element.typeName()
                 slotDeclarers[type]?.let { slots.declared.add(it) }
+                // Gift (CR 702.174a): the cast-time promise declares both the "was it promised"
+                // flag and the promised opponent, read back by Conditions.GiftWasPromised and
+                // Player.ChosenOpponent respectively.
+                if (type == "Gift") {
+                    slots.declared.add("GIFT_PROMISED")
+                    slots.declared.add("OPPONENT")
+                }
                 if (type == "EntersWithChoice") {
                     val choiceType = (element["choiceType"] as? JsonPrimitive)?.contentOrNull
                     choiceTypeToSlot[choiceType]?.let { slots.declared.add(it) }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -296,21 +296,24 @@ object CardLinter {
     // Choice slots
     // =========================================================================================
 
-    /** Node types that declare a slot just by being present. */
-    private val slotDeclarers: Map<String, String> = mapOf(
-        "Kicker" to "KICKED",
-        "Sneak" to "SNEAK",
-        "Ninjutsu" to "SNEAK",
-        "BlightVariable" to "BLIGHT_AMOUNT",
-        "BlightOrPay" to "BLIGHT_AMOUNT",
+    /** Node types that declare one or more slots just by being present. */
+    private val slotDeclarers: Map<String, List<String>> = mapOf(
+        "Kicker" to listOf("KICKED"),
+        "Sneak" to listOf("SNEAK"),
+        "Ninjutsu" to listOf("SNEAK"),
+        "BlightVariable" to listOf("BLIGHT_AMOUNT"),
+        "BlightOrPay" to listOf("BLIGHT_AMOUNT"),
         // Resolution-time color choices: ChooseColorThen sets EffectContext.chosenColor for its
         // wrapped effect; ChooseColorForTarget stamps a ChosenColorComponent on the permanent.
         // Both are what HasChosenColor / GrantChosenColor-style readers consume.
-        "ChooseColorThen" to "COLOR",
-        "ChooseColorForTarget" to "COLOR",
+        "ChooseColorThen" to listOf("COLOR"),
+        "ChooseColorForTarget" to listOf("COLOR"),
         // Resolution-time opponent choice: writes ChoiceSlot.OPPONENT on the source entity,
         // read back by Player.ChosenOpponent (gift recipient).
-        "ChooseOpponentForSource" to "OPPONENT",
+        "ChooseOpponentForSource" to listOf("OPPONENT"),
+        // Gift (CR 702.174a): the cast-time promise declares both the "was it promised" flag and
+        // the promised opponent, read back by Conditions.GiftWasPromised and Player.ChosenOpponent.
+        "Gift" to listOf("GIFT_PROMISED", "OPPONENT"),
     )
 
     /** [com.wingedsheep.sdk.scripting.ReplacementEffect] `EntersWithChoice.choiceType` → slot. */
@@ -361,14 +364,7 @@ object CardLinter {
         when (element) {
             is JsonObject -> {
                 val type = element.typeName()
-                slotDeclarers[type]?.let { slots.declared.add(it) }
-                // Gift (CR 702.174a): the cast-time promise declares both the "was it promised"
-                // flag and the promised opponent, read back by Conditions.GiftWasPromised and
-                // Player.ChosenOpponent respectively.
-                if (type == "Gift") {
-                    slots.declared.add("GIFT_PROMISED")
-                    slots.declared.add("OPPONENT")
-                }
+                slotDeclarers[type]?.let { slots.declared.addAll(it) }
                 if (type == "EntersWithChoice") {
                     val choiceType = (element["choiceType"] as? JsonPrimitive)?.contentOrNull
                     choiceTypeToSlot[choiceType]?.let { slots.declared.add(it) }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardValidator.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.serialization
 
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import kotlinx.serialization.json.JsonArray
@@ -29,6 +30,7 @@ object CardValidator {
         validateAuraConsistency(card, errors)
         validateEquipmentConsistency(card, errors)
         validatePlaneswalkerLoyalty(card, errors)
+        validateGiftKeyword(card, errors)
         validateSuccessCriteria(card, errors)
         errors.addAll(CardLinter.lint(card))
 
@@ -135,6 +137,28 @@ object CardValidator {
             )
         }
     }
+
+    /**
+     * `KeywordAbility.Gift` only works on a permanent. On a permanent, gift's second ability is a
+     * triggered ability that functions on the battlefield (CR 702.174b), which is what the
+     * `gift(kind)` DSL derives and what stamps `ChoiceSlot.GIFT_PROMISED` durably. An instant or
+     * sorcery instead has "if this spell's gift cost was paid, [effect]" as part of its own
+     * resolution — there is no permanent to trigger off and nothing to stamp, so the keyword would
+     * offer a `CastWithGift` action whose promise is silently dropped and whose
+     * `Conditions.GiftWasPromised` reads false. Those cards use `Patterns.Mechanic.giftSpell`.
+     */
+    private fun validateGiftKeyword(card: CardDefinition, errors: MutableList<CardValidationError>) {
+        val hasGift = card.keywordAbilities.any { it is KeywordAbility.Gift }
+        if (hasGift && !card.typeLine.isPermanent) {
+            errors.add(
+                CardValidationError.GiftKeywordOnNonPermanent(
+                    cardName = card.name,
+                    message = "'${card.name}' is not a permanent, so KeywordAbility.Gift can never " +
+                        "trigger (CR 702.174b). Use Patterns.Mechanic.giftSpell for instants and sorceries."
+                )
+            )
+        }
+    }
 }
 
 /**
@@ -227,6 +251,12 @@ sealed interface CardValidationError {
 
     /** A choice-slot read (`CastChoiceMade`, `HasChosenColor`, …) with no declaring ability. */
     data class UndeclaredChoiceSlotRead(
+        override val cardName: String,
+        override val message: String
+    ) : CardValidationError
+
+    /** `KeywordAbility.Gift` on an instant or sorcery, where it can never trigger (CR 702.174b). */
+    data class GiftKeywordOnNonPermanent(
         override val cardName: String,
         override val message: String
     ) : CardValidationError

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDslTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/mechanics/GiftDslTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.GiftKind
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.CastChoiceMade
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GiftGivenEffect
+import com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.serialization.CardValidationError
+import com.wingedsheep.sdk.serialization.CardValidator
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unit coverage for the gift DSL surface (CR 702.174).
+ *
+ * The rules enumerate the whole `[something]` list (CR 702.174d–i) but only two kinds have a card
+ * today, so the four unused mappings are pinned here rather than left to the first card that needs
+ * one. Also covers the derived enters-ability's shape (CR 702.174b) and the permanent-only guard.
+ */
+class GiftDslTest : DescribeSpec({
+
+    /** The derived gift ability's rules text. */
+    fun CardDefinition.giftAbilityText(): String =
+        script.triggeredAbilities.single().descriptionOverride ?: ""
+
+
+    /** The recipient every gift effect must address: the opponent locked in as the cost was paid. */
+    val recipient = EffectTarget.PlayerRef(Player.ChosenOpponent)
+
+    describe("giftEffect maps each GiftKind to its CR-defined effect") {
+
+        it("CARD — the chosen player draws a card (CR 702.174e)") {
+            val draw = giftEffect(GiftKind.CARD).shouldBeInstanceOf<DrawCardsEffect>()
+            draw.target shouldBe recipient
+        }
+
+        it("FOOD — the chosen player creates a Food token (CR 702.174d)") {
+            val food = giftEffect(GiftKind.FOOD).shouldBeInstanceOf<CreatePredefinedTokenEffect>()
+            food.tokenType shouldBe "Food"
+            food.controller shouldBe recipient
+        }
+
+        it("TREASURE — the chosen player creates a Treasure token (CR 702.174h)") {
+            val treasure = giftEffect(GiftKind.TREASURE).shouldBeInstanceOf<CreatePredefinedTokenEffect>()
+            treasure.tokenType shouldBe "Treasure"
+            treasure.controller shouldBe recipient
+        }
+
+        it("TAPPED_FISH — a tapped 1/1 blue Fish for the chosen player (CR 702.174f)") {
+            val fish = giftEffect(GiftKind.TAPPED_FISH).shouldBeInstanceOf<CreateTokenEffect>()
+            fish.power shouldBe 1
+            fish.toughness shouldBe 1
+            fish.colors shouldBe setOf(Color.BLUE)
+            fish.creatureTypes shouldBe setOf("Fish")
+            fish.tapped shouldBe true
+            fish.controller shouldBe recipient
+        }
+
+        it("OCTOPUS — an 8/8 blue Octopus for the chosen player (CR 702.174i)") {
+            val octopus = giftEffect(GiftKind.OCTOPUS).shouldBeInstanceOf<CreateTokenEffect>()
+            octopus.power shouldBe 8
+            octopus.toughness shouldBe 8
+            octopus.colors shouldBe setOf(Color.BLUE)
+            octopus.creatureTypes shouldBe setOf("Octopus")
+            octopus.tapped shouldBe false
+            octopus.controller shouldBe recipient
+        }
+
+        it("EXTRA_TURN — the chosen player takes an extra turn (CR 702.174g)") {
+            val extraTurn = giftEffect(GiftKind.EXTRA_TURN).shouldBeInstanceOf<TakeExtraTurnEffect>()
+            extraTurn.target shouldBe recipient
+        }
+
+        it("covers every kind the rules list, so a new one can't ship unmapped") {
+            GiftKind.entries.forEach { kind -> giftEffect(kind).shouldBeInstanceOf<Effect>() }
+        }
+    }
+
+    describe("gift(kind) on a permanent") {
+
+        val equipment = card("Test Gift Equipment") {
+            typeLine = "Artifact — Equipment"
+            gift(GiftKind.TAPPED_FISH)
+        }
+
+        it("adds the keyword and exactly one derived enters ability (CR 702.174a–b)") {
+            equipment.keywordAbilities shouldHaveSize 1
+            equipment.keywordAbilities.single() shouldBe KeywordAbility.Gift(GiftKind.TAPPED_FISH)
+            equipment.script.triggeredAbilities shouldHaveSize 1
+        }
+
+        it("gates the enters ability on the promise as an intervening if (CR 603.4)") {
+            val condition = equipment.script.triggeredAbilities.single().triggerCondition
+                .shouldBeInstanceOf<CastChoiceMade>()
+            condition.slot shouldBe ChoiceSlot.GIFT_PROMISED
+        }
+
+        it("closes with the GiftGiven marker so \"whenever you give a gift\" fires (CR 702.174c)") {
+            val composite = equipment.script.triggeredAbilities.single().effect
+                .shouldBeInstanceOf<CompositeEffect>()
+            composite.effects.last().shouldBeInstanceOf<GiftGivenEffect>()
+        }
+
+        it("names the permanent the way the printed card does") {
+            equipment.giftAbilityText() shouldContain "When this Equipment enters"
+
+            val aura = card("Test Gift Aura") {
+                typeLine = "Enchantment — Aura"
+                gift(GiftKind.CARD)
+            }
+            aura.giftAbilityText() shouldContain "When this Aura enters"
+        }
+
+        it("falls back to the rule's own wording when the type line isn't set yet") {
+            val unordered = card("Test Gift Unordered") {
+                gift(GiftKind.CARD)
+                typeLine = "Creature — Raccoon"
+                power = 1
+                toughness = 1
+            }
+            unordered.giftAbilityText() shouldContain "When this permanent enters"
+        }
+    }
+
+    describe("the keyword is permanent-only") {
+
+        it("is rejected on an instant, which has no enters trigger to fire (CR 702.174b)") {
+            val instant = card("Test Gift Instant") {
+                typeLine = "Instant"
+                gift(GiftKind.CARD)
+            }
+            val errors = CardValidator.validate(instant)
+                .filterIsInstance<CardValidationError.GiftKeywordOnNonPermanent>()
+            errors shouldHaveSize 1
+            errors.single().message shouldContain "giftSpell"
+        }
+
+        it("accepts a permanent") {
+            CardValidator.validate(
+                card("Test Gift Enchantment") {
+                    typeLine = "Enchantment"
+                    gift(GiftKind.FOOD)
+                }
+            ).filterIsInstance<CardValidationError.GiftKeywordOnNonPermanent>() shouldHaveSize 0
+        }
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
@@ -1,15 +1,15 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.gift
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
-import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
-import com.wingedsheep.sdk.scripting.effects.Mode
-import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.GiftKind
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -25,9 +25,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * put three stun counters on it.
  * You control enchanted creature.
  *
- * Gift is modeled as a modal choice on the ETB trigger.
- * Mode 1 (no gift): tap enchanted + 3 stun counters.
- * Mode 2 (gift): opponent draws + tap enchanted (no stun counters).
+ * The gift is promised as you cast (CR 702.174a) — `gift(...)` adds both the additional cost and
+ * the "when this permanent enters, if the gift was promised, the chosen player draws a card"
+ * ability. The printed enters ability below reads the same promise back through
+ * [Conditions.GiftWasPromised] for its "if the gift wasn't promised" rider.
  */
 val Kitnap = card("Kitnap") {
     manaCost = "{2}{U}{U}"
@@ -37,23 +38,17 @@ val Kitnap = card("Kitnap") {
 
     auraTarget = Targets.Creature
 
+    gift(GiftKind.CARD)
+
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Patterns.Mechanic.giftSpell(
-            // Mode 1: No gift — tap enchanted creature + 3 stun counters
-            Mode.noTarget(
-                Effects.Tap(EffectTarget.EnchantedCreature)
-                    .then(Effects.AddCounters("STUN", 3, EffectTarget.EnchantedCreature)),
-                "Don't promise a gift — tap enchanted creature and put three stun counters on it"
-            ),
-            // Mode 2: Gift a card — opponent draws a card, tap enchanted creature (no stun counters)
-            Mode.noTarget(
-                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
-                    .then(Effects.Tap(EffectTarget.EnchantedCreature))
-                    .then(Effects.GiftGiven()),
-                "Promise a gift — an opponent draws a card, tap enchanted creature"
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.Not(Conditions.GiftWasPromised),
+                    effect = Effects.AddCounters("STUN", 3, EffectTarget.EnchantedCreature)
+                )
             )
-        )
     }
 
     staticAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
@@ -26,7 +26,8 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * The gift is promised as you cast (CR 702.174a) — `gift(...)` supplies both the additional cost
  * and the "they draw a card" enters ability. The printed enters ability is an intervening-if
  * trigger (CR 603.4) on the same promise, so a Scrapshooter cast without the gift never triggers
- * and never asks for a target.
+ * and never asks for a target — which is what CR 702.174m requires: targets belonging to a
+ * gift-gated part of an ability are chosen only if the gift was promised.
  */
 val Scrapshooter = card("Scrapshooter") {
     manaCost = "{1}{G}{G}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
@@ -1,16 +1,14 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.gift
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
-import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.GiftKind
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 
@@ -24,6 +22,11 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * Reach
  * When this creature enters, if the gift was promised, destroy target artifact
  * or enchantment an opponent controls.
+ *
+ * The gift is promised as you cast (CR 702.174a) — `gift(...)` supplies both the additional cost
+ * and the "they draw a card" enters ability. The printed enters ability is an intervening-if
+ * trigger (CR 603.4) on the same promise, so a Scrapshooter cast without the gift never triggers
+ * and never asks for a target.
  */
 val Scrapshooter = card("Scrapshooter") {
     manaCost = "{1}{G}{G}"
@@ -35,26 +38,13 @@ val Scrapshooter = card("Scrapshooter") {
 
     keywords(Keyword.REACH)
 
-    // Gift modeled as a modal ETB triggered ability
+    gift(GiftKind.CARD)
+
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Patterns.Mechanic.giftSpell(
-            // Mode 1: No gift — do nothing
-            Mode.noTarget(
-                Effects.Composite(emptyList()),
-                "Don't promise a gift"
-            ),
-            // Mode 2: Gift a card — opponent draws, destroy target artifact or enchantment
-            Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
-                    .then(Effects.Destroy(EffectTarget.ContextTarget(0)))
-                    .then(Effects.GiftGiven()),
-                targetRequirements = listOf(
-                    TargetObject(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
-                ),
-                description = "Promise a gift — opponent draws a card, destroy target artifact or enchantment an opponent controls"
-            )
-        )
+        triggerCondition = Conditions.GiftWasPromised
+        target = TargetObject(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
@@ -29,7 +29,8 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * The gift is promised as you cast (CR 702.174a) — `gift(...)` supplies both the additional cost
  * and the "they create a tapped Fish" enters ability. The printed attach ability is an
  * intervening-if trigger (CR 603.4) on the same promise, so an unpromised cast never triggers and
- * never asks for a creature to attach to.
+ * never asks for a creature to attach to — which is what CR 702.174m requires: targets belonging
+ * to a gift-gated part of an ability are chosen only if the gift was promised.
  */
 val StarforgedSword = card("Starforged Sword") {
     manaCost = "{4}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
@@ -1,21 +1,18 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
-import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
-import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.gift
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GiftKind
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.RemoveKeywordStatic
-import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
-import com.wingedsheep.sdk.scripting.effects.Mode
-import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Starforged Sword
@@ -29,8 +26,10 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Equipped creature gets +3/+3 and loses flying.
  * Equip {3}
  *
- * Note: Gift is modeled as a modal ETB trigger. Mode 1 = no gift (do nothing),
- * Mode 2 = gift (opponent gets Fish token, attach to target creature you control).
+ * The gift is promised as you cast (CR 702.174a) — `gift(...)` supplies both the additional cost
+ * and the "they create a tapped Fish" enters ability. The printed attach ability is an
+ * intervening-if trigger (CR 603.4) on the same promise, so an unpromised cast never triggers and
+ * never asks for a creature to attach to.
  */
 val StarforgedSword = card("Starforged Sword") {
     manaCost = "{4}"
@@ -38,32 +37,13 @@ val StarforgedSword = card("Starforged Sword") {
     typeLine = "Artifact — Equipment"
     oracleText = "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they create a tapped 1/1 blue Fish creature token.)\nWhen this Equipment enters, if the gift was promised, attach this Equipment to target creature you control.\nEquipped creature gets +3/+3 and loses flying.\nEquip {3}"
 
-    // Gift modeled as a modal ETB triggered ability
+    gift(GiftKind.TAPPED_FISH)
+
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Patterns.Mechanic.giftSpell(
-            // Mode 1: No gift — do nothing
-            Mode.noTarget(
-                Effects.Composite(emptyList()),
-                "Don't promise a gift"
-            ),
-            // Mode 2: Gift — opponent gets tapped Fish token, attach to target creature
-            Mode.withTarget(
-                CreateTokenEffect(
-                    count = DynamicAmount.Fixed(1),
-                    power = 1,
-                    toughness = 1,
-                    colors = setOf(Color.BLUE),
-                    creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
-                    tapped = true,
-                    imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
-                ).then(Effects.AttachEquipment(EffectTarget.ContextTarget(0)))
-                    .then(Effects.GiftGiven()),
-                Targets.CreatureYouControl,
-                "Promise a gift — opponent creates a tapped 1/1 blue Fish token, attach to target creature you control"
-            )
-        )
+        triggerCondition = Conditions.GiftWasPromised
+        target = Targets.CreatureYouControl
+        effect = Effects.AttachEquipment(EffectTarget.ContextTarget(0))
     }
 
     // Equipped creature gets +3/+3

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -10014,6 +10014,12 @@
     "manaCost": "{2}{U}{U}",
     "typeLine": "Enchantment — Aura",
     "oracleText": "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they draw a card.)\nEnchant creature\nWhen this Aura enters, tap enchanted creature. If the gift wasn't promised, put three stun counters on it.\nYou control enchanted creature.",
+    "keywordAbilities": [
+        {
+            "type": "Gift",
+            "kind": "CARD"
+        }
+    ],
     "script": {
         "triggeredAbilities": [
             {
@@ -10023,61 +10029,61 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Modal",
-                    "modes": [
+                    "type": "Composite",
+                    "effects": [
                         {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "TapUntap",
-                                        "target": "EnchantedCreature"
-                                    },
-                                    {
-                                        "type": "AddCounters",
-                                        "counterType": "STUN",
-                                        "count": 3,
-                                        "target": "EnchantedCreature"
-                                    }
-                                ]
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
                             },
-                            "description": "Don't promise a gift — tap enchanted creature and put three stun counters on it"
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "ChosenOpponent"
+                            }
+                        },
+                        "GiftGiven"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "GIFT_PROMISED"
+                },
+                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player draws a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "EnchantedCreature"
                         },
                         {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "ChooseOpponentForSource",
-                                        "prompt": "Choose an opponent to receive the gift"
-                                    },
-                                    {
-                                        "type": "Composite",
-                                        "effects": [
-                                            {
-                                                "type": "DrawCards",
-                                                "count": {
-                                                    "type": "Fixed",
-                                                    "amount": 1
-                                                },
-                                                "target": {
-                                                    "type": "PlayerRef",
-                                                    "player": "ChosenOpponent"
-                                                }
-                                            },
-                                            {
-                                                "type": "TapUntap",
-                                                "target": "EnchantedCreature"
-                                            },
-                                            "GiftGiven"
-                                        ]
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Not",
+                                    "condition": {
+                                        "type": "CastChoiceMade",
+                                        "slot": "GIFT_PROMISED"
                                     }
-                                ]
+                                }
                             },
-                            "description": "Promise a gift — an opponent draws a card, tap enchanted creature"
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "STUN",
+                                "count": 3,
+                                "target": "EnchantedCreature"
+                            }
                         }
-                    ],
-                    "countsAsModalSpell": false
+                    ]
                 }
             }
         ],
@@ -15888,6 +15894,12 @@
     "keywords": [
         "REACH"
     ],
+    "keywordAbilities": [
+        {
+            "type": "Gift",
+            "kind": "CARD"
+        }
+    ],
     "script": {
         "triggeredAbilities": [
             {
@@ -15897,63 +15909,52 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Modal",
-                    "modes": [
+                    "type": "Composite",
+                    "effects": [
                         {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": []
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
                             },
-                            "description": "Don't promise a gift"
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "ChosenOpponent"
+                            }
                         },
-                        {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "ChooseOpponentForSource",
-                                        "prompt": "Choose an opponent to receive the gift"
-                                    },
-                                    {
-                                        "type": "Composite",
-                                        "effects": [
-                                            {
-                                                "type": "DrawCards",
-                                                "count": {
-                                                    "type": "Fixed",
-                                                    "amount": 1
-                                                },
-                                                "target": {
-                                                    "type": "PlayerRef",
-                                                    "player": "ChosenOpponent"
-                                                }
-                                            },
-                                            {
-                                                "type": "MoveToZone",
-                                                "target": {
-                                                    "type": "ContextTarget",
-                                                    "index": 0
-                                                },
-                                                "destination": "Graveyard",
-                                                "byDestruction": true
-                                            },
-                                            "GiftGiven"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "targetRequirements": [
-                                {
-                                    "type": "TargetObject",
-                                    "filter": {
-                                        "baseFilter": "artifact|enchantment ctrl:opponent"
-                                    }
-                                }
-                            ],
-                            "description": "Promise a gift — opponent draws a card, destroy target artifact or enchantment an opponent controls"
-                        }
-                    ],
-                    "countsAsModalSpell": false
+                        "GiftGiven"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "GIFT_PROMISED"
+                },
+                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player draws a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment ctrl:opponent"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "GIFT_PROMISED"
                 }
             }
         ]
@@ -17649,6 +17650,12 @@
     "manaCost": "{4}",
     "typeLine": "Artifact — Equipment",
     "oracleText": "Gift a tapped Fish (You may promise an opponent a gift as you cast this spell. If you do, when it enters, they create a tapped 1/1 blue Fish creature token.)\nWhen this Equipment enters, if the gift was promised, attach this Equipment to target creature you control.\nEquipped creature gets +3/+3 and loses flying.\nEquip {3}",
+    "keywordAbilities": [
+        {
+            "type": "Gift",
+            "kind": "TAPPED_FISH"
+        }
+    ],
     "script": {
         "triggeredAbilities": [
             {
@@ -17658,67 +17665,56 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Modal",
-                    "modes": [
+                    "type": "Composite",
+                    "effects": [
                         {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": []
-                            },
-                            "description": "Don't promise a gift"
-                        },
-                        {
-                            "effect": {
-                                "type": "Composite",
-                                "effects": [
-                                    {
-                                        "type": "ChooseOpponentForSource",
-                                        "prompt": "Choose an opponent to receive the gift"
-                                    },
-                                    {
-                                        "type": "Composite",
-                                        "effects": [
-                                            {
-                                                "type": "CreateToken",
-                                                "power": 1,
-                                                "toughness": 1,
-                                                "colors": [
-                                                    "BLUE"
-                                                ],
-                                                "creatureTypes": [
-                                                    "Fish"
-                                                ],
-                                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                                "controller": {
-                                                    "type": "PlayerRef",
-                                                    "player": "ChosenOpponent"
-                                                },
-                                                "tapped": true
-                                            },
-                                            "AttachEquipment",
-                                            "GiftGiven"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "targetRequirements": [
-                                {
-                                    "type": "TargetObject",
-                                    "filter": {
-                                        "baseFilter": "creature ctrl:you"
-                                    }
-                                }
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLUE"
                             ],
-                            "description": "Promise a gift — opponent creates a tapped 1/1 blue Fish token, attach to target creature you control"
-                        }
-                    ],
-                    "countsAsModalSpell": false
+                            "creatureTypes": [
+                                "Fish"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                            "controller": {
+                                "type": "PlayerRef",
+                                "player": "ChosenOpponent"
+                            },
+                            "tapped": true
+                        },
+                        "GiftGiven"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "GIFT_PROMISED"
+                },
+                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player creates a tapped 1/1 blue Fish creature token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "AttachEquipment",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "GIFT_PROMISED"
                 }
             }
         ],
         "activatedAbilities": [
             {
-                "id": "ability_2",
+                "id": "ability_3",
                 "cost": {
                     "type": "CostAtomWrapper",
                     "atom": {

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -10049,7 +10049,7 @@
                     "type": "CastChoiceMade",
                     "slot": "GIFT_PROMISED"
                 },
-                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player draws a card."
+                "descriptionOverride": "When this Aura enters, if the gift was promised, the chosen player draws a card."
             },
             {
                 "id": "ability_2",
@@ -15929,7 +15929,7 @@
                     "type": "CastChoiceMade",
                     "slot": "GIFT_PROMISED"
                 },
-                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player draws a card."
+                "descriptionOverride": "When this creature enters, if the gift was promised, the chosen player draws a card."
             },
             {
                 "id": "ability_2",
@@ -17691,7 +17691,7 @@
                     "type": "CastChoiceMade",
                     "slot": "GIFT_PROMISED"
                 },
-                "descriptionOverride": "When this permanent enters, if the gift was promised, the chosen player creates a tapped 1/1 blue Fish creature token."
+                "descriptionOverride": "When this Equipment enters, if the gift was promised, the chosen player creates a tapped 1/1 blue Fish creature token."
             },
             {
                 "id": "ability_2",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -22,6 +22,14 @@ internal fun BridgeBuilder.keywords() {
     // only marks the capability covered — the emitter declines (SCAFFOLD) because picking the right
     // ProtectionScope from the IR's quality node is a per-card read.
     supported("HexproofFrom", "keyword ability: hexproof from [quality] -> KeywordAbility.Hexproof(ProtectionScope.…) (CR 702.11b)")
+    // Gift a [something] (CR 702.174, Bloomburrow) — a PARAMETERIZED keyword ability (the gifted thing
+    // rides in the rule), so `supported` rather than `keyword`: there is no Keyword.GIFT enum member.
+    // On a permanent the engine has the whole mechanic: `gift(GiftKind.…)` adds the cast-time additional
+    // cost (a `CastWithGift` legal action per opponent) plus the derived "when this enters, if its gift
+    // cost was paid, …" trigger; on an instant/sorcery it's `Patterns.Mechanic.giftSpell(…)`. The emitter
+    // declines (SCAFFOLD): which GiftKind is listed, and how the card's *other* text branches on
+    // `Conditions.GiftWasPromised`, is a per-card read.
+    supported("Gift", "keyword ability: Gift a [something] -> gift(GiftKind.…) on permanents / Patterns.Mechanic.giftSpell on instants & sorceries (CR 702.174)")
     // Saddle N (CR 702.171) — a PARAMETERIZED keyword ability (the N count rides in the rule's args),
     // NOT a bare card keyword. It must be `supported`, not `keyword`: a `keyword` entry would make
     // `keywordLines` stamp a bare `keywords(Keyword.SADDLE)` on the card and drop the N, exactly the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -77,6 +77,18 @@ data class CastSpell(
      * `Conditions.WaterbendWasPaid`.
      */
     val wasWaterbendPaid: Boolean = false,
+    /**
+     * The opponent promised this spell's **gift** (CR 702.174a, Bloomburrow — "as an additional
+     * cost to cast this spell, you may choose an opponent"), or `null` when the gift wasn't
+     * promised. Only meaningful for a card carrying [com.wingedsheep.sdk.scripting.KeywordAbility.Gift].
+     *
+     * The promise is elected here, while casting — never later: the enumerator emits a
+     * `CastWithGift` variant per opponent, and on resolution the handler stamps
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED] plus the recipient in
+     * `ChoiceSlot.OPPONENT` onto the permanent, where the gift trigger and the
+     * "if the gift was(n't) promised" riders read it via `Conditions.GiftWasPromised`.
+     */
+    val giftRecipient: EntityId? = null,
     val damageDistribution: Map<EntityId, Int>? = null,
     val useAlternativeCost: Boolean = false,
     val chosenModes: List<Int> = emptyList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.handlers.actions.spell
 import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.giftKeyword
 
 import com.wingedsheep.engine.core.AlternativeCostType
 import com.wingedsheep.engine.core.CastSpell
@@ -218,6 +219,19 @@ class CastSpellHandler(
             SneakWindow.graveyardSneakGrantCost(state, action.playerId, cardRegistry) != null
         if (!inHand && !onTopOfLibrary && !mayPlayFromExile && !mayCastFromZone && !mayCastFromGraveyard && !hasFlashback && !hasHarmonize && !hasGraveyardCast && !hasForageFromGraveyard && !hasWarpFromGraveyard && !hasCommanderCast && !hasGraveyardSneak) {
             return "Card is not in your hand"
+        }
+
+        // Gift (CR 702.174a): the promise is an additional cost whose "payment" is choosing an
+        // opponent, so the recipient must be an opponent of the caster and the card must actually
+        // have gift.
+        action.giftRecipient?.let { recipient ->
+            val giftCard = cardRegistry.getCard(cardComponent.cardDefinitionId)
+            if (giftCard?.giftKeyword() == null) {
+                return "${cardComponent.name} has no gift cost to promise"
+            }
+            if (recipient !in state.getOpponents(action.playerId)) {
+                return "A gift can only be promised to an opponent"
+            }
         }
 
         // Memory Vessel: "they can't play cards from their hand" — hand-scoped, so casts from
@@ -2974,6 +2988,9 @@ class CastSpellHandler(
             // True when the spell's waterbend additional cost was paid (Avatar) — mandatory costs
             // always, optional "you may waterbend {N}" only when the player elected it.
             wasWaterbendPaid = cardDef?.script?.spellWaterbend?.let { !it.optional || action.wasWaterbendPaid } == true,
+            // Gift (CR 702.174a): the promised opponent, elected as part of casting. Only honored
+            // for a card that actually has gift — validate() rejects the flag otherwise.
+            giftRecipient = action.giftRecipient?.takeIf { cardDef?.giftKeyword() != null },
             wasWarped = wasWarped,
             wasEvoked = wasEvoked,
             wasImpending = wasImpending,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.dsl.giftKeyword
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
@@ -1546,7 +1547,56 @@ class CastSpellEnumerator : ActionEnumerator {
         // --- Casualty ---
         enumerateCasualty(context, hand, result)
 
-        return applySpellWaterbendMetadata(context, expandChoiceAdditionalCosts(context, result))
+        return expandGiftPromise(
+            context,
+            applySpellWaterbendMetadata(context, expandChoiceAdditionalCosts(context, result))
+        )
+    }
+
+    /**
+     * Post-process: offer the **gift** additional cost (CR 702.174a, Bloomburrow) as its own cast
+     * variant — "as an additional cost to cast this spell, you may choose an opponent".
+     *
+     * The promise costs nothing and changes neither the mana cost nor the targets, so each normal
+     * cast is simply cloned into a `CastWithGift` twin carrying the promised opponent (one per
+     * opponent, so multiplayer picks the recipient as part of the cost). Keeping it a *cast* choice
+     * is the whole point: a gift permanent's gift is a "when this enters, if its gift cost was paid"
+     * trigger (CR 702.174b), so asking at resolution would ask after the permanent already entered.
+     *
+     * The unpromised cast is kept alongside — gift is optional (CR 702.174a "you *may* choose").
+     */
+    private fun expandGiftPromise(
+        context: EnumerationContext,
+        actions: List<LegalAction>
+    ): List<LegalAction> {
+        val state = context.state
+        val out = mutableListOf<LegalAction>()
+        for (la in actions) {
+            out.add(la)
+            val cs = la.action as? CastSpell
+            val gift = if (cs != null && la.actionType == "CastSpell") {
+                val name = state.getEntity(cs.cardId)?.get<CardComponent>()?.name
+                name?.let { context.cardRegistry.getCard(it) }?.giftKeyword()
+            } else null
+            if (cs == null || gift == null) continue
+
+            val opponents = state.getOpponents(cs.playerId)
+            for (opponentId in opponents) {
+                val suffix = if (opponents.size == 1) {
+                    "Gift ${gift.kind.label}"
+                } else {
+                    val opponentName = state.getEntity(opponentId)
+                        ?.get<com.wingedsheep.engine.state.components.identity.PlayerComponent>()?.name
+                    "Gift ${gift.kind.label} to ${opponentName ?: "opponent"}"
+                }
+                out.add(la.copy(
+                    actionType = "CastWithGift",
+                    description = "${la.description} ($suffix)",
+                    action = cs.copy(giftRecipient = opponentId)
+                ))
+            }
+        }
+        return out
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -41,6 +41,26 @@ import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
  */
 class CastSpellEnumerator : ActionEnumerator {
 
+    companion object {
+        /**
+         * Every cast `actionType` a gift promise can ride along with (CR 702.174a). Gift is an
+         * *additional* cost, so it applies no matter which cost path pays the mana cost — a plain
+         * cast, an alternative cost (evoke / impending / miracle / …), a free cast, kicker, or a
+         * modal cast. `CastFaceDown` is excluded: a face-down permanent is cast as a 2/2 with no
+         * abilities and no name (CR 708.2), so it has no gift cost to promise.
+         */
+        private val GIFT_EXPANDABLE_CAST_TYPES = setOf(
+            "CastSpell",
+            "CastSpellMode",
+            "CastSpellModal",
+            "CastWithAlternativeCost",
+            "CastWithoutPayingManaCost",
+            "CastWithKicker",
+            "CastWithCasualty",
+            "CastWithConspire",
+        )
+    }
+
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
         val result = mutableListOf<LegalAction>()
         val state = context.state
@@ -1557,13 +1577,19 @@ class CastSpellEnumerator : ActionEnumerator {
      * Post-process: offer the **gift** additional cost (CR 702.174a, Bloomburrow) as its own cast
      * variant — "as an additional cost to cast this spell, you may choose an opponent".
      *
-     * The promise costs nothing and changes neither the mana cost nor the targets, so each normal
-     * cast is simply cloned into a `CastWithGift` twin carrying the promised opponent (one per
-     * opponent, so multiplayer picks the recipient as part of the cost). Keeping it a *cast* choice
-     * is the whole point: a gift permanent's gift is a "when this enters, if its gift cost was paid"
-     * trigger (CR 702.174b), so asking at resolution would ask after the permanent already entered.
+     * The promise costs nothing and changes neither the mana cost nor the targets, so each cast is
+     * simply cloned into a `CastWithGift` twin carrying the promised opponent (one per opponent, so
+     * multiplayer picks the recipient as part of the cost). Keeping it a *cast* choice is the whole
+     * point: a gift permanent's gift is a "when this enters, if its gift cost was paid" trigger
+     * (CR 702.174b), so asking at resolution would ask after the permanent already entered.
      *
      * The unpromised cast is kept alongside — gift is optional (CR 702.174a "you *may* choose").
+     *
+     * Every cost path is expanded, not just the plain cast: an additional cost is chosen and paid
+     * regardless of which alternative cost pays the mana (CR 601.2b, 601.2f–h), so a gift permanent
+     * cast for free (Omniscience) or for an alternative cost must still be promisable. Only
+     * *affordable* casts are expanded, so an unpayable cast doesn't spawn a greyed-out gift twin per
+     * opponent.
      */
     private fun expandGiftPromise(
         context: EnumerationContext,
@@ -1573,12 +1599,13 @@ class CastSpellEnumerator : ActionEnumerator {
         val out = mutableListOf<LegalAction>()
         for (la in actions) {
             out.add(la)
-            val cs = la.action as? CastSpell
-            val gift = if (cs != null && la.actionType == "CastSpell") {
-                val name = state.getEntity(cs.cardId)?.get<CardComponent>()?.name
-                name?.let { context.cardRegistry.getCard(it) }?.giftKeyword()
-            } else null
-            if (cs == null || gift == null) continue
+            val cs = la.action as? CastSpell ?: continue
+            if (!la.affordable ||
+                la.actionType !in GIFT_EXPANDABLE_CAST_TYPES ||
+                cs.giftRecipient != null
+            ) continue
+            val name = state.getEntity(cs.cardId)?.get<CardComponent>()?.name
+            val gift = name?.let { context.cardRegistry.getCard(it) }?.giftKeyword() ?: continue
 
             val opponents = state.getOpponents(cs.playerId)
             for (opponentId in opponents) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -116,6 +116,7 @@ class StackResolver(
         wasKicked: Boolean = false,
         wasBlightPaid: Boolean = false,
         wasWaterbendPaid: Boolean = false,
+        giftRecipient: EntityId? = null,
         wasWarped: Boolean = false,
         wasEvoked: Boolean = false,
         wasImpending: Boolean = false,
@@ -179,6 +180,7 @@ class StackResolver(
                 wasKicked = wasKicked,
                 wasBlightPaid = wasBlightPaid,
                 wasWaterbendPaid = wasWaterbendPaid,
+                giftRecipient = giftRecipient,
                 chosenModes = chosenModes,
                 modeTargetsOrdered = modeTargetsOrdered,
                 modeTargetRequirements = modeTargetRequirements,
@@ -1197,6 +1199,20 @@ class StackResolver(
                     bag = bag.withChoice(
                         com.wingedsheep.sdk.scripting.ChoiceSlot.WATERBEND_PAID,
                         com.wingedsheep.engine.state.components.battlefield.ChoiceValue.Flag
+                    )
+                }
+                // Gift (CR 702.174a–b): the promise was elected as an additional cost while casting,
+                // so the permanent carries both the flag and the promised opponent durably. Its gift
+                // trigger ("when this permanent enters, if its gift cost was paid, …") and any
+                // "if the gift was(n't) promised" rider read them back through
+                // Conditions.GiftWasPromised / Player.ChosenOpponent — no resolution-time question.
+                spellComponent.giftRecipient?.let { recipient ->
+                    bag = bag.withChoice(
+                        com.wingedsheep.sdk.scripting.ChoiceSlot.GIFT_PROMISED,
+                        com.wingedsheep.engine.state.components.battlefield.ChoiceValue.Flag
+                    ).withChoice(
+                        com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT,
+                        com.wingedsheep.engine.state.components.battlefield.ChoiceValue.EntityChoice(recipient)
                     )
                 }
                 if (spellComponent.additionalCostBlightAmount > 0) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -23,6 +23,13 @@ data class SpellOnStackComponent(
     val wasKicked: Boolean = false,  // For kicker costs
     val wasBlightPaid: Boolean = false,  // For BlightOrPay additional cost — true if blight path was taken
     val wasWaterbendPaid: Boolean = false,  // For optional spell waterbend additional cost (Avatar) — true if "you may waterbend {N}" was paid; readable via WaterbendWasPaid
+    /**
+     * The opponent promised this spell's gift additional cost (CR 702.174a), or null when the gift
+     * wasn't promised. A resolving permanent carries the fact onward in its cast-choices bag
+     * (ChoiceSlot.GIFT_PROMISED + ChoiceSlot.OPPONENT) so its gift trigger and
+     * "if the gift was(n't) promised" riders can read it — see StackResolver.
+     */
+    val giftRecipient: EntityId? = null,
     val chosenModes: List<Int> = emptyList(),  // For modal spells (700.2). Ordered; same index may repeat when allowRepeat.
     val modeTargetsOrdered: List<List<ChosenTarget>> = emptyList(),  // Per-mode chosen targets, aligned 1:1 with chosenModes
     val modeTargetRequirements: Map<Int, List<TargetRequirement>> = emptyMap(),  // Per-mode TargetRequirements for 608.2b re-validation at resolution

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1107,10 +1107,13 @@ class ClientStateTransformer(
         val wasBlightPaid = spellOnStack?.wasBlightPaid ?: false
 
         // Detect whether this spell promised a gift (Bloomburrow gift mechanic).
-        // Gift is modeled as a modal choice: the "promise" mode's effect tree contains
-        // GiftGivenEffect. Surface this to opponents so they can see at a glance that
-        // a gift is coming on resolution, rather than having to parse the mode description.
+        // Permanent spells carry the promise as the gift additional cost elected while casting
+        // (CR 702.174a — `giftRecipient`); instants and sorceries model it as a modal choice whose
+        // "promise" mode's effect tree contains GiftGivenEffect. Surface either to opponents so
+        // they can see at a glance that a gift is coming on resolution, rather than having to parse
+        // the mode description.
         val giftPromised = spellOnStack?.let { comp ->
+            if (comp.giftRecipient != null) return@let true
             if (comp.chosenModes.isEmpty()) return@let false
             val spellEffect = cardRegistry.getCard(cardComponent.cardDefinitionId)?.script?.spellEffect
                 ?: return@let false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftPromisedAtCastTimeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftPromisedAtCastTimeTest.kt
@@ -1,0 +1,350 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Gift on a **permanent** spell is promised as an additional cost while casting
+ * (CR 702.174a — "as an additional cost to cast this spell, you may choose an opponent"), and the
+ * gift itself is a "when this permanent enters, if its gift cost was paid, [effect]" trigger
+ * (CR 702.174b).
+ *
+ * Regression guard for the bug these tests were written for: Kitnap / Scrapshooter / Starforged
+ * Sword used to model the promise as a *resolution-time* modal choice on their enters-the-battlefield
+ * trigger, so the player was asked whether to give a gift **after** the permanent had already
+ * entered — long after the only legal moment to decide.
+ */
+class GiftPromisedAtCastTimeTest : ScenarioTestBase() {
+
+    /** The card id of [cardName] in the given player's hand. */
+    private fun TestGame.handCard(playerNumber: Int, cardName: String): EntityId {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getZone(playerId, Zone.HAND).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == cardName
+        }
+    }
+
+    private fun TestGame.stunCounters(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    init {
+        context("gift is elected while casting, never after the permanent enters") {
+
+            test("both a plain cast and a promise-a-gift cast are offered as legal actions") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scrapshooter")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val actions = game.getLegalActions(1)
+                    .filter { (it.action as? CastSpell)?.cardId == game.handCard(1, "Scrapshooter") }
+
+                withClue("gift is optional (CR 702.174a) — the unpromised cast must stay available") {
+                    actions.count { it.actionType == "CastSpell" } shouldBe 1
+                }
+                withClue("the promise must be offered as a cast option, naming what is gifted") {
+                    val giftAction = actions.single { it.actionType == "CastWithGift" }
+                    giftAction.description shouldBe "Cast Scrapshooter (Gift a card)"
+                    (giftAction.action as CastSpell).giftRecipient shouldBe game.player2Id
+                }
+            }
+
+            test("Kitnap with the gift promised: opponent draws, no stun counters, nothing asked at ETB") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Kitnap")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val handBefore = game.handSize(2)
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Kitnap"),
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        giftRecipient = game.player2Id
+                    )
+                )
+                withClue("casting with a promised gift should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the gift must not be a question asked after the Aura entered") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("gift a card (CR 702.174e) — the promised opponent draws") {
+                    game.handSize(2) shouldBe handBefore + 1
+                }
+                withClue("the printed rider only applies when the gift wasn't promised") {
+                    game.stunCounters(bears) shouldBe 0
+                }
+                withClue("the Aura's own effect still happens either way") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("Kitnap without the gift: three stun counters, no card given") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Kitnap")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val handBefore = game.handSize(2)
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Kitnap"),
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("no promise, no gift trigger (CR 702.174b intervening if)") {
+                    game.handSize(2) shouldBe handBefore
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.stunCounters(bears) shouldBe 3
+            }
+
+            test("Scrapshooter's destroy trigger only exists when the gift was promised") {
+                fun play(promise: Boolean): TestGame {
+                    val game = scenario()
+                        .withPlayers("Caster", "Opponent")
+                        .withCardInHand(1, "Scrapshooter")
+                        .withLandsOnBattlefield(1, "Forest", 3)
+                        .withCardOnBattlefield(2, "Sol Ring")
+                        .withCardInLibrary(2, "Forest")
+                        .withActivePlayer(1)
+                        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                        .build()
+
+                    game.execute(
+                        CastSpell(
+                            playerId = game.player1Id,
+                            cardId = game.handCard(1, "Scrapshooter"),
+                            giftRecipient = if (promise) game.player2Id else null
+                        )
+                    ).error shouldBe null
+                    game.resolveStack()
+                    // The promised cast's destroy trigger targets when it goes on the stack
+                    // (CR 603.3d) — pick the only legal artifact, then finish resolving.
+                    if (promise) {
+                        game.getPendingDecision().shouldNotBeNull()
+                        game.selectTargets(listOf(game.findPermanent("Sol Ring").shouldNotBeNull()))
+                        game.resolveStack()
+                    }
+                    return game
+                }
+
+                val unpromised = play(promise = false)
+                withClue("an unpromised Scrapshooter never triggers, so it never targets") {
+                    unpromised.hasPendingDecision() shouldBe false
+                    unpromised.isOnBattlefield("Sol Ring") shouldBe true
+                }
+
+                val promised = play(promise = true)
+                withClue("with the gift promised the artifact is destroyed and the opponent draws") {
+                    promised.isOnBattlefield("Sol Ring") shouldBe false
+                    promised.isInGraveyard(2, "Sol Ring") shouldBe true
+                    promised.handSize(2) shouldBe 1
+                }
+            }
+
+            test("Starforged Sword with the gift promised: tapped Fish for the opponent, sword attached") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Starforged Sword")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardOnBattlefield(1, "Savannah Lions")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lions = game.findPermanent("Savannah Lions").shouldNotBeNull()
+                val powerBefore = game.state.projectedState.getPower(lions)
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Starforged Sword"),
+                        giftRecipient = game.player2Id
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(lions))
+                game.resolveStack()
+
+                withClue("gift a tapped Fish (CR 702.174f) goes to the promised opponent") {
+                    val fish = game.findPermanent("Fish Token").shouldNotBeNull()
+                    game.state.projectedState.getController(fish) shouldBe game.player2Id
+                    game.state.getEntity(fish)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("the printed attach trigger fires off the same promise: sword attaches, +3/+3") {
+                    val sword = game.findPermanent("Starforged Sword").shouldNotBeNull()
+                    game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe lions
+                    game.state.projectedState.getPower(lions) shouldBe (powerBefore ?: 0) + 3
+                }
+            }
+
+            test("giving a gift with a permanent fires \"whenever you give a gift\" (CR 702.174c)") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scrapshooter")
+                    .withCardOnBattlefield(1, "Jolly Gerbils")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val casterHandBefore = game.handSize(1) - 1 // Scrapshooter leaves the hand
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Scrapshooter"),
+                        giftRecipient = game.player2Id
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the gift ability resolving is what gives the gift, so Gerbils draws") {
+                    game.handSize(1) shouldBe casterHandBefore + 1
+                }
+            }
+
+            test("a countered gift spell gives no gift") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scrapshooter")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInHand(2, "Dismiss")
+                    .withLandsOnBattlefield(2, "Island", 4)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(2)
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Scrapshooter"),
+                        giftRecipient = game.player2Id
+                    )
+                ).error shouldBe null
+                game.passPriority()
+                game.castSpellTargetingStackSpell(2, "Dismiss", "Scrapshooter").error shouldBe null
+                game.resolveStack()
+
+                withClue("Scrapshooter never entered, so its gift trigger never fired") {
+                    game.isInGraveyard(1, "Scrapshooter") shouldBe true
+                    // Dismiss drew its own card, so the opponent's hand is: before - Dismiss + draw.
+                    game.handSize(2) shouldBe handBefore
+                }
+            }
+
+            test("multiplayer: one cast variant per opponent, and only that opponent gets the gift") {
+                val driver = GameTestDriver()
+                driver.registerCards(TestCards.all + PredefinedTokens.allTokens)
+                val players = driver.initMultiplayer(List(3) { Deck.of("Forest" to 40) })
+                driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+                val caster = players[0]
+                val secondOpponent = players[2]
+                driver.giveMana(caster, Color.GREEN, 3)
+                val scrapshooter = driver.putCardInHand(caster, "Scrapshooter")
+
+                val giftActions = driver.legalActions(caster)
+                    .filter { it.actionType == "CastWithGift" }
+                withClue("the opponent is chosen as part of the gift cost (CR 702.174a)") {
+                    giftActions.map { (it.action as CastSpell).giftRecipient } shouldBe listOf(players[1], players[2])
+                    giftActions.map { it.description } shouldBe listOf(
+                        "Cast Scrapshooter (Gift a card to Player 2)",
+                        "Cast Scrapshooter (Gift a card to Player 3)"
+                    )
+                }
+
+                val handsBefore = players.associateWith { driver.state.getZone(it, Zone.HAND).size }
+                driver.submitSuccess(CastSpell(caster, scrapshooter, giftRecipient = secondOpponent))
+                var passes = 0
+                while (driver.state.stack.isNotEmpty() && driver.state.pendingDecision == null && passes++ < 30) {
+                    driver.passPriority(driver.priorityPlayer!!)
+                }
+
+                withClue("only the promised opponent draws") {
+                    driver.state.getZone(secondOpponent, Zone.HAND).size shouldBe handsBefore.getValue(secondOpponent) + 1
+                    driver.state.getZone(players[1], Zone.HAND).size shouldBe handsBefore.getValue(players[1])
+                }
+            }
+
+            test("a gift may only be promised to an opponent, and only by a card with gift") {
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardInHand(1, "Scrapshooter")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val toSelf = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Scrapshooter"),
+                        giftRecipient = game.player1Id
+                    )
+                )
+                toSelf.error shouldNotBe null
+
+                val noGiftCard = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.handCard(1, "Grizzly Bears"),
+                        giftRecipient = game.player2Id
+                    )
+                )
+                noGiftCard.error shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftPromisedAtCastTimeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftPromisedAtCastTimeTest.kt
@@ -72,6 +72,42 @@ class GiftPromisedAtCastTimeTest : ScenarioTestBase() {
                 }
             }
 
+            test("the promise rides a free cast too — an additional cost outlives the mana cost") {
+                // CR 601.2b / 601.2f–h: additional costs are chosen and paid whichever cost pays the
+                // mana cost. With Omniscience out and no Forests, the free cast is the only payable
+                // path, so it must be the one carrying the gift offer.
+                val game = scenario()
+                    .withPlayers("Caster", "Opponent")
+                    .withCardOnBattlefield(1, "Omniscience")
+                    .withCardInHand(1, "Scrapshooter")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scrapshooter = game.handCard(1, "Scrapshooter")
+                val giftActions = game.getLegalActions(1)
+                    .filter { it.actionType == "CastWithGift" && (it.action as? CastSpell)?.cardId == scrapshooter }
+
+                val freeGift = withClue("the free cast needs its own gift twin") {
+                    giftActions.single { (it.action as CastSpell).useWithoutPayingManaCost }
+                }
+                withClue("an unaffordable cast must not spawn a greyed-out gift twin per opponent") {
+                    giftActions.none { !(it.action as CastSpell).useWithoutPayingManaCost } shouldBe true
+                }
+
+                game.execute(freeGift.action).error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(game.findPermanent("Sol Ring").shouldNotBeNull()))
+                game.resolveStack()
+
+                withClue("promised on a free cast, the gift and its rider both happen") {
+                    game.handSize(2) shouldBe 1
+                    game.isOnBattlefield("Sol Ring") shouldBe false
+                }
+            }
+
             test("Kitnap with the gift promised: opponent draws, no stun counters, nothing asked at ETB") {
                 val game = scenario()
                     .withPlayers("Caster", "Opponent")

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -160,6 +160,20 @@ function buildActionOptions(
             impendingTime: impendingInfo.time,
           }
     )
+    // Any further cost variant the server offered (e.g. a gift promise per opponent — CR 702.174a)
+    // has to survive this branch too, or picking impending's sibling silently drops the option.
+    castActions
+      .filter((ca) => ca !== normalCast && ca !== impendingCast)
+      .forEach((ca, index) => {
+        options.push({
+          key: `cast-extra-${index}`,
+          label: ca.description,
+          manaCost: ca.manaCostString || cardInfo.manaCost || null,
+          isAvailable: ca.isAffordable !== false,
+          action: ca,
+          actionType: 'cast',
+        })
+      })
   } else if (castActions.length > 1) {
     // 1b. Multiple cast options (e.g., BlightOrPay — blight path vs pay path)
     castActions.forEach((ca, index) => {

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -119,6 +119,12 @@ export interface CastSpellAction {
    * resolving effect can branch on `WaterbendWasPaid`.
    */
   readonly wasWaterbendPaid?: boolean
+  /**
+   * The opponent promised this spell's gift additional cost (Bloomburrow gift — CR 702.174a), or
+   * absent when the gift wasn't promised. The server emits a `CastWithGift` variant of the normal
+   * cast per opponent; the client just plays the variant the player picked.
+   */
+  readonly giftRecipient?: EntityId
   /** Pre-chosen damage distribution for DividedDamageEffect spells (target ID -> damage amount) */
   readonly damageDistribution?: Record<EntityId, number>
   /**


### PR DESCRIPTION
## The bug

The gift choice should be made **while casting** — CR 702.174a makes it an additional cost ("as an additional cost to cast this spell, you may choose an opponent"), and on a permanent the gift itself is the triggered ability "when this permanent enters, if its gift cost was paid, \[effect\]" (CR 702.174b).

Our three **permanent** gift cards — Kitnap, Scrapshooter, Starforged Sword — modelled the promise as a modal choice on their enters-the-battlefield trigger, so the player was asked whether to give a gift *after* the permanent had already entered. Worse, for Scrapshooter and Starforged Sword the printed "if the gift was promised" ability collected its target inside the same mode, i.e. before the promise existed.

Instant/sorcery gift cards were already correct: their two-mode `ModalEffect` is resolved by the engine's cast-time mode picker. I verified **Long River's Pull** in the running client — both "Counter target creature spell" and "Gift a card — counter target spell" appear as cast options in the action menu, and nothing about the gift is asked afterwards. (Screenshot-verified, plus a Playwright spec below.)

## The fix

Gift becomes a real cast-time election:

- **SDK** — `KeywordAbility.Gift(GiftKind)` and `card { gift(kind) }` (`dsl/mechanics/GiftDsl.kt`). The helper adds the keyword *and* derives the CR 702.174b enters-ability: an intervening-if trigger (CR 603.4) gated on `Conditions.GiftWasPromised`, closing with `Effects.GiftGiven()` so "whenever you give a gift" still fires (CR 702.174c). `GiftKind` covers the rules' entire list (CR 702.174d–i — card, Food, tapped Fish, Treasure, Octopus, extra turn), each mapped to its defined effect, so the next gift permanent only names its kind.
- **No new condition type** — `Conditions.GiftWasPromised` is a facade over `CastChoiceMade(ChoiceSlot.GIFT_PROMISED)`. Cards gate printed abilities on it (Scrapshooter's destroy, Starforged Sword's attach) or on `Conditions.Not(...)` for "if the gift wasn't promised" (Kitnap's stun counters).
- **Engine** — `CastSpell.giftRecipient` + `SpellOnStackComponent.giftRecipient`; `CastSpellEnumerator.expandGiftPromise` clones each normal cast into a `CastWithGift` variant per opponent (gift changes neither cost nor targets, so cloning keeps cost/target enumeration in one place, and multiplayer picks the recipient as part of the cost); the handler validates the recipient is an opponent of a card that actually has gift; the resolving permanent carries `GIFT_PROMISED` + `OPPONENT` durably in its cast-choices bag.
- **Client-visible** — the stack's `giftPromised` badge reads the new flag, auto-pass counts `CastWithGift` as an instant-speed response, and the action menu already renders multiple cast variants, so the gift shows up as "Cast Kitnap (Gift a card)" with no client changes beyond the action type.
- **CardLinter** — the gift keyword declares both choice slots it writes.

## Tests

`GiftPromisedAtCastTimeTest` (rules-engine) — the cast-time offer alongside the plain cast, both branches of all three cards, the intervening-if (an unpromised Scrapshooter never triggers and never targets), "whenever you give a gift" through Jolly Gerbils, a countered gift spell giving nothing, recipient validation, and multiplayer per-opponent variants where only the promised opponent draws.

`e2e-scenarios/tests/general/gift-promised-at-cast-time.spec.ts` — pins the UI timing in a real browser for Kitnap (gift is a cast option; nothing asked once the Aura enters) and Long River's Pull (both modes offered while casting).

Verified: `:mtg-sdk:test`, `:mtg-sets:test` (BLB snapshot re-blessed — diff is exactly the three cards' reshape), `:rules-engine:test`, `:game-server:test`, `:ai:test`, `:mtgish-tooling:test`, `web-client` typecheck, and the two Playwright specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)