### PR TITLE
Record every seat's deck in multiplayer game history

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -101,6 +101,12 @@ Flyway migration `V2__match_stats.sql` extends the stats schema:
 | `tournaments` | tournaments + settings (format, mode, set codes, player count, rounds, winner) and a `status` (`IN_PROGRESS` / `COMPLETED` / `ABANDONED`); `ended_at` is null while in progress |
 | `tournament_participants` | a seat in a tournament with placement (0 until it finishes) + W/L/D |
 
+Participant and deck rows are written for **every** seat, however many there are: a Free-for-All pod or
+a team game records three to six decks the same way a duel records two. The decklist comes from
+`GameSession.getStartingDeckList()`, which prefers the seat's live submitted deck and falls back to the
+copy frozen into the replay setup at game start — so nothing that happens to a player's *socket* during
+a long multiplayer game (reconnects, a restart, giving up a seat) can leave their deck out of history.
+
 Flyway migration `V3__admin_role.sql` adds `users.is_admin` (boolean, default false) — the per-account
 admin flag (see **Admin access** below).
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -269,10 +269,8 @@ class ConnectionHandler(
                 val gameSession = gameRepository.findById(gameSessionId!!)
                 logger.info("Reconnecting to game: found=${gameSession != null}, isStarted=${gameSession?.isStarted}, seats=${gameSession?.getPlayers()?.map { it.playerId.value }}")
                 if (gameSession != null) {
-                    // Remove old player session if exists, then associate new one
-                    if (gameSession.getPlayerSession(identity.playerId) != null) {
-                        gameSession.removePlayer(identity.playerId)
-                    }
+                    // Swap the live socket into the seat this player already has. Don't un-seat them
+                    // first — that would hand back their deck and sideboard mid-game.
                     gameSession.associatePlayer(playerSession)
 
                     // Re-sync the spectator-count badge for the reconnecting player.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -287,9 +287,8 @@ class FreeForAllHandler(
                 gameNumber = lobby.ffaGamesPlayed + 1,
                 players = gameSession.seatInfos(identity.playerId),
             ))
-            if (gameSession.getPlayerSession(identity.playerId) != null) {
-                gameSession.removePlayer(identity.playerId)
-            }
+            // Reseat in one step rather than remove-then-add: a pod's games run long enough that
+            // mid-game reconnects are routine, and each one must not cost the seat its decklist.
             gameSession.associatePlayer(playerSession)
             when {
                 gameSession.isAwaitingBottomCards(identity.playerId) -> {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -708,7 +708,9 @@ class GamePlayHandler(
                     participants = gameSession.getPlayers().map { player ->
                         val identity = sessionRegistry.getIdentityByWsId(player.webSocketSession.id)
                         val isAi = persistenceInfo[player.playerId]?.isAi == true
-                        val deckList = gameSession.getDeckList(player.playerId)
+                        // Every seat's starting deck — read through the replay-setup fallback so a
+                        // seat whose live entry went missing still lands in history with its deck.
+                        val deckList = gameSession.getStartingDeckList(player.playerId)
                         val profile = deckList?.let { deckProfiler.profile(it, gameSession.quickGameSetCode) }
                         // Count copies by canonical card name (strip any "#collector" pin).
                         val deckCards = deckList
@@ -1114,7 +1116,7 @@ class GamePlayHandler(
         if (aiPlayers.isEmpty()) return
 
         for ((aiPlayerId, pi) in aiPlayers) {
-            val deckList = gameSession.getDeckList(aiPlayerId)
+            val deckList = gameSession.getStartingDeckList(aiPlayerId)
                 ?.groupingBy { it }?.eachCount()
             aiGameManager.wireAiForGame(
                 gameSession = gameSession,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -935,9 +935,8 @@ class LobbyHandler(
                         gameSessionId = activePlayerMatch.gameSessionId!!,
                         opponentName = opponentName
                     ))
-                    if (gs.getPlayerSession(identity.playerId) != null) {
-                        gs.removePlayer(identity.playerId)
-                    }
+                    // Reseat in place — un-seating first would drop the submitted deck and sideboard,
+                    // blanking this seat's deck in match history and breaking sideboarding.
                     gs.associatePlayer(playerSession)
                     when {
                         gs.isAwaitingBottomCards(identity.playerId) -> {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -316,13 +316,22 @@ class GameSession(
     }
 
     /**
-     * Remove a player from the session.
+     * Un-seat a player: they give up their chair in this session.
+     *
+     * Before the game starts that also releases their submitted deck and sideboard — the seat is free
+     * for someone else. Once the game is under way the decklist stops being live state and becomes
+     * part of the historical record (match history reads every seat's deck at game over, and the AI is
+     * re-wired from it after a restart), so it is kept. That distinction matters because "un-seat then
+     * re-seat" is a tempting way to swap in a reconnecting player's new socket — see [associatePlayer],
+     * which does that in one step without disturbing the seat at all.
      */
     fun removePlayer(playerId: EntityId) {
         players[playerId]?.currentGameSessionId = null
         players.remove(playerId)
-        deckLists.remove(playerId)
-        sideboards.remove(playerId)
+        if (!isStarted) {
+            deckLists.remove(playerId)
+            sideboards.remove(playerId)
+        }
     }
 
     /**
@@ -1408,6 +1417,19 @@ class GameSession(
     /** Get deck list for a specific player. Used by engine AI to know the opponent's deck. */
     fun getDeckList(playerId: EntityId): List<String>? = deckLists[playerId]
 
+    /**
+     * The deck a seat *started the game with*, for anything that has to describe the game after the
+     * fact (match-history recording, re-wiring an AI after a restart). Prefers the live submitted
+     * deck and falls back to the copy frozen into the replay setup at [startGame], which is captured
+     * once and never mutated for the life of the session — so a seat's deck can still be reported
+     * even if its live entry was dropped (a pre-game leave, or a reseat bug like the one that used to
+     * blank multiplayer decks). Null only for sessions that never recorded a setup (dev scenario /
+     * hotseat) and have no live deck either.
+     */
+    fun getStartingDeckList(playerId: EntityId): List<String>? =
+        deckLists[playerId]
+            ?: replaySetup?.players?.firstOrNull { it.playerId == playerId.value }?.deck?.cards
+
     // =========================================================================
     // Persistence Support (for Redis caching)
     // =========================================================================
@@ -1489,7 +1511,12 @@ class GameSession(
     }
 
     /**
-     * Associate a player identity with this session (for reconnection after restore).
+     * Seat this player session — either a first association after a restore, or a reconnecting player
+     * being put back in the chair they already had.
+     *
+     * Seats are keyed by [PlayerSession.playerId], so this replaces any existing entry in place and
+     * leaves everything that describes the seat (deck, sideboard, commander, per-player log) alone.
+     * It is the whole reconnect operation on its own: don't call [removePlayer] first.
      */
     fun associatePlayer(playerSession: PlayerSession) {
         players[playerSession.playerId] = playerSession

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/SeatDeckRetentionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/SeatDeckRetentionTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * A seat's decklist has to survive everything that can happen to its *socket* during a game, because
+ * match history reads it at game over — a lost decklist shows up in a player's profile as a game whose
+ * deck was never recorded. This bit multiplayer hardest: a Free-for-All pod runs long enough that
+ * several seats reconnect at least once, and the reconnect path used to un-seat the player (dropping
+ * their deck and sideboard) before re-seating them, leaving history with only the decks of the players
+ * who happened never to reconnect.
+ */
+class SeatDeckRetentionTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    /** A started [count]-seat session; seat i plays i+30 Forests so the decks are distinguishable. */
+    private fun startedSession(count: Int): Pair<GameSession, List<EntityId>> {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = count)
+        val ids = (1..count).map { EntityId.of("player-$it") }
+        ids.forEachIndexed { i, id ->
+            session.addPlayer(
+                PlayerSession(mockWs("ws$i"), id, "Player${i + 1}"),
+                mapOf("Forest" to 30 + i),
+                sideboard = mapOf("Mountain" to 2),
+            )
+        }
+        session.startGame()
+        return session to ids
+    }
+
+    init {
+        test("reseating a reconnecting player keeps their deck and sideboard") {
+            val (session, ids) = startedSession(4)
+            val reconnecting = ids[1]
+
+            session.associatePlayer(PlayerSession(mockWs("ws-new"), reconnecting, "Player2"))
+
+            session.getPlayers() shouldHaveSize 4
+            session.getPlayerSession(reconnecting)!!.webSocketSession.id shouldBe "ws-new"
+            session.getDeckList(reconnecting).shouldNotBeNull() shouldHaveSize 31
+            session.getSideboardsForPersistence()[reconnecting].shouldNotBeNull() shouldHaveSize 2
+        }
+
+        test("every seat still reports its starting deck after the whole pod reconnects") {
+            val (session, ids) = startedSession(4)
+
+            ids.forEachIndexed { i, id ->
+                session.associatePlayer(PlayerSession(mockWs("ws-new$i"), id, "Player${i + 1}"))
+            }
+
+            ids.forEachIndexed { i, id ->
+                session.getStartingDeckList(id).shouldNotBeNull() shouldHaveSize 30 + i
+            }
+        }
+
+        test("a seat un-seated mid-game keeps its deck; before the game starts it hands it back") {
+            val (started, startedIds) = startedSession(3)
+            started.removePlayer(startedIds[2])
+            started.getStartingDeckList(startedIds[2]).shouldNotBeNull() shouldHaveSize 32
+
+            val pregame = GameSession(cardRegistry = cardRegistry, maxPlayers = 3)
+            val leaver = EntityId.of("player-x")
+            pregame.addPlayer(PlayerSession(mockWs("wsx"), leaver, "Leaver"), mapOf("Forest" to 40))
+            pregame.removePlayer(leaver)
+            pregame.getDeckList(leaver) shouldBe null
+        }
+    }
+}

--- a/web-client/src/components/deck/GameDeckView.tsx
+++ b/web-client/src/components/deck/GameDeckView.tsx
@@ -217,7 +217,12 @@ export function SeatDeckColumn({
   )
 }
 
-/** Both seats' decks side by side — the body of the recent-games / admin deck modal. */
+/**
+ * Every seat's deck side by side — the body of the recent-games / admin deck modal. Seat count is
+ * whatever the game had: two for a duel, three to six for a multiplayer pod. The grid keeps every
+ * column the same width, so a pod that doesn't divide evenly into the row wraps into aligned columns
+ * instead of stretching its last seat across the full width.
+ */
 export function GameDeckColumns({
   participants,
   renderActions,
@@ -236,9 +241,8 @@ export function GameDeckColumns({
 
 const styles: Record<string, React.CSSProperties> = {
   muted: { margin: '6px 0 0', color: '#888', fontSize: 13 },
-  columns: { display: 'flex', gap: 16, flexWrap: 'wrap' },
+  columns: { display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' },
   col: {
-    flex: '1 1 320px',
     minWidth: 0,
     backgroundColor: '#171723',
     border: '1px solid #2a2a3e',

--- a/web-client/src/components/profile/DeckViewModal.tsx
+++ b/web-client/src/components/profile/DeckViewModal.tsx
@@ -1,7 +1,11 @@
 /**
- * Modal that shows both seats' decklists for one finished game from the user's history. Opened from
- * the recent-games table so a player can review what they (and their opponent) actually played. The
- * decks come straight from the recorded match — the server only returns games the user took part in.
+ * Modal that shows every seat's decklist for one finished game from the user's history. Opened from
+ * the recent-games table so a player can review what they (and everyone they played against) actually
+ * played. The decks come straight from the recorded match — the server only returns games the user
+ * took part in.
+ *
+ * Multiplayer games (Free-for-All pods, team games) can seat three to six players, so the modal grows
+ * once there are more than two decks to show rather than squeezing a whole pod into two columns.
  */
 import { useEffect, useState } from 'react'
 import type React from 'react'
@@ -33,16 +37,27 @@ export function DeckViewModal({
     }
   }, [gameId])
 
+  const seats = decks?.participants.length ?? 0
+  const multiplayer = seats > 2
+
   return (
     <div style={styles.backdrop} onClick={onClose} role="presentation">
-      <div style={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
+      <div
+        style={multiplayer ? { ...styles.modal, ...styles.modalWide } : styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal
+      >
         <div style={styles.header}>
           <h2 style={styles.title}>Game decks</h2>
           <button type="button" style={styles.close} onClick={onClose} aria-label="Close">
             ✕
           </button>
         </div>
-        <p style={styles.muted}>vs {opponentLabel}</p>
+        <p style={styles.muted}>
+          vs {opponentLabel}
+          {multiplayer && <span style={styles.dim}> · {seats}-player game</span>}
+        </p>
 
         {error ? (
           <p style={styles.error}>{error}</p>
@@ -74,6 +89,8 @@ const styles: Record<string, React.CSSProperties> = {
     padding: 16,
     zIndex: 1000,
   },
+  // Two decks fit side by side here; a pod of 3–6 gets the wider frame below so each seat still
+  // lands on a full column instead of wrapping into a narrow two-up grid.
   modal: {
     width: 'min(820px, 100%)',
     maxHeight: '85vh',
@@ -83,10 +100,12 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 14,
     padding: '20px 22px',
   },
+  modalWide: { width: 'min(1320px, 100%)' },
   header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
   title: { margin: 0, color: '#fff', fontSize: 20 },
   close: { background: 'none', border: 'none', color: '#999', cursor: 'pointer', fontSize: 18 },
   muted: { margin: '4px 0 0', color: '#888', fontSize: 13 },
+  dim: { color: '#666' },
   error: { margin: '8px 0 0', color: '#ff6b6b', fontSize: 13 },
   columnsWrap: { marginTop: 14 },
 }


### PR DESCRIPTION
## The problem

Multiplayer games in a profile's game history showed decks for only some of their seats — usually two
of a three- or four-player pod. The seats themselves were all recorded; their decklists weren't.

## Why

The reconnect paths put a returning player back in their chair with `removePlayer(id)` followed by
`associatePlayer(session)`. That reads like a socket swap, but `removePlayer` also drops the seat's
submitted deck **and** sideboard, and nothing ever puts them back. From a player's first reconnect
onwards their seat had no decklist, so match-history recording — which reads every seat's deck at game
over — stored nothing for it.

Free-for-All pods were hit hardest: their games run long, the client auto-reconnects on any blip
(`feature_ws_auto_recovery`), and the only decks that survived were those of the players who happened
never to reconnect. The same wipe silently broke between-games sideboarding for those seats.

## The fix

- **Reseat in one step** at all three reconnect sites (`ConnectionHandler`, `FreeForAllHandler`,
  `LobbyHandler`). `associatePlayer` already replaces the seat in place — the preceding remove was pure
  loss.
- **`removePlayer` only releases the deck/sideboard before the game starts.** Once play is under way the
  decklist stops being live state and becomes part of the historical record, so it is kept. This closes
  the bug class rather than just the three call sites.
- **Recording reads `GameSession.getStartingDeckList()`**, which prefers the live deck and falls back to
  the copy frozen into the replay setup at `startGame` — never mutated for the life of the session. A
  seat's deck now reaches history regardless of what happened to its socket (reconnect, server restart,
  giving up a seat). The AI re-wire after a restart reads the same accessor.
- **Deck viewer**: the modal widens for a 3–6 seat game, and the seat columns became a uniform grid, so
  a pod no longer stretches its last seat across the full width. Two-player games are unchanged.

## Verification

`just test-server` green, plus a new `SeatDeckRetentionTest` covering: a reseat keeps deck + sideboard;
all four seats of a pod still report their starting deck after everyone reconnects; a mid-game
un-seating keeps the deck while a pre-game one still hands it back. `npm run typecheck` clean.

Shots are from the local stack against the accounts DB, with a seeded 4-seat Free-for-All game
(`GAME_SERVER_URL=http://localhost:8081`). All four decks render:

![4-player deck viewer](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-deck-history-screenshots/decks-multiplayer.png)

Two-player games keep the narrow two-column modal:

![duel deck viewer](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-deck-history-screenshots/decks-duel.png)

The `multiplayer-deck-history-screenshots` branch is throwaway — it only carries these PNGs so they
stay out of the diff.

## Note

Already-recorded games can't be backfilled — the decks were never written. This only fixes games from
here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
