### PR TITLE
Add three Foundations cards: Kellan, Vizier of the Menagerie, Pyromancer's Goggles

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -919,11 +919,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Mana
 
-- `AddMana(color, amount, restriction?, expiry?)` — add N of one color. `expiry` is a `ManaExpiry`
-  (default `END_OF_TURN`); set `END_OF_COMBAT` for firebending-style combat-duration mana that the
-  pool keeps through combat and discards when combat ends. Combat-duration mana is stored as an
-  `AnySpend` restricted entry (so it spends like any other mana) and cleared by
-  `CombatManager.endCombat`. See [ManaExpiry](#manaexpiry).
+- `AddMana(color, amount, restriction?, expiry?, riders?)` — add N of one color. `expiry` is a
+  `ManaExpiry` (default `END_OF_TURN`); set `END_OF_COMBAT` for firebending-style combat-duration mana
+  that the pool keeps through combat and discards when combat ends. Combat-duration mana is stored as
+  an `AnySpend` restricted entry (so it spends like any other mana) and cleared by
+  `CombatManager.endCombat`. See [ManaExpiry](#manaexpiry). `riders` is a `Set<ManaSpellRider>`
+  applied to whatever spell this mana ends up paying for (Pyromancer's Goggles tags its {R} with
+  `CopySpellWhenSpent`); as with `AddManaOfChoice`, riders without a `restriction` are stored under
+  `ManaRestriction.AnySpend` so the rider survives in the pool while the mana stays spendable on
+  anything. See [ManaSpellRider](#manaspellrider).
 - `AddColorlessMana(amount, restriction?)` — add colorless.
 - `RetainUnspentMana(vararg colors)` — "Until end of turn, you don't lose unspent mana of these colours
   as steps and phases end." The colour-filtered, single-player, turn-scoped one-shot cousin of the
@@ -4388,6 +4392,18 @@ staticAbility {
   `GroupFilter.AllCreaturesYouControl` for "spend mana as though it were mana of any color to activate
   abilities of creatures you control" (Agatha's Soul Cauldron). (Sharkey, Tyrant of the Shire — "Mana
   of any type can be spent to activate Sharkey's abilities" → `GroupFilter.source()`.)
+- `SpendAnyManaTypeForSpells(filter)` — the **spell-side sibling** of the above: the controller may
+  spend mana of any type on the mana cost of spells matching `filter` (a `GameObjectFilter`), relaxing
+  colored/hybrid/Phyrexian/colorless pips to generic per CR 118.14 / 609.4b. Scoped to spells cast by
+  *this permanent's controller* (the printed wording is always "**you** can spend …") and
+  **zone-agnostic** — hand, top of library, graveyard, exile alike. That zone-independence is why it's
+  a static rather than a flag on a cast permission: `MayPlayPermission.withAnyManaType` already covers
+  per-card "cast *that exiled card* with any mana" grants (Taster of Wares, Tinybones), but "any
+  creature spell you cast" isn't tied to one card in one zone. Only the mana portion is relaxed —
+  additional and alternative costs are untouched. Applied to affordability, the auto-tap solver and
+  payment validation, but deliberately **not** to the mana cost string sent to the client, so a
+  creature card still shows its printed `{2}{G}` instead of a misleading `{3}`. (Vizier of the
+  Menagerie — "You can spend mana of any type to cast creature spells" → `GameObjectFilter.Creature`.)
 - `PreventManaPoolEmptying` — mana pools don't empty between steps/phases. (Upwelling)
 - `ConvertEmptyingManaToRed` — "If you would lose unspent mana, that mana becomes red instead."
   The colour-converting cousin of `PreventManaPoolEmptying`: at every step/phase-end mana emptying
@@ -6491,7 +6507,7 @@ restriction matches the spell context.
   Creeping Peeper's "cast an enchantment spell, unlock a door, or turn a permanent face up" is
   `AnyOf(CardTypeSpellsOrAbilitiesOnly(ENCHANTMENT), UnlockDoorOnly, TurnPermanentsFaceUpOnly)`.
 
-### `ManaSpellRider`
+### `ManaSpellRider`<a id="manaspellrider"></a>
 
 Side-effects attached to mana that fire when the mana is spent on a spell. Orthogonal to
 `ManaRestriction`: the restriction controls *where* the mana may be spent; the rider
@@ -6499,11 +6515,23 @@ controls *what happens to the spell* when it is spent. The cast pipeline either 
 spell directly (e.g. stamps a component) or queues a triggered ability onto the stack above
 the spell when the rider needs the stack (typically because it requires a player decision).
 
+Attach riders via the `riders` parameter of `AddMana`, `AddManaOfChoice` or
+`AddManaOfSourceChosenSubtype`. The set of riders consumed by a payment is collected as a **list**,
+not a set — multiplicity is load-bearing, since two rider-carrying mana spent on one spell must fire
+the rider twice (Pyromancer's Goggles: "That many copies will be created").
+
 - `ManaSpellRider.MakesSpellUncounterable` — Cavern of Souls: stamps `CantBeCounteredComponent`
   on the spell at cast time.
 - `ManaSpellRider.ScryOnSharedTypeWithCommander(amount)` — Path of Ancestry: if the spell is
   a creature spell that shares a creature type with any of the controller's commanders,
   queues a `scry amount` triggered ability above the spell.
+- `ManaSpellRider.CopySpellWhenSpent(spellFilter)` — Pyromancer's Goggles
+  (`GameObjectFilter.InstantOrSorcery.withColor(Color.RED)`): if the cast spell matches
+  `spellFilter`, queues a `CopyTargetSpellEffect(TriggeringEntity)` triggered ability **above** the
+  spell, so the copy resolves first (CR 707.10) and its controller may choose new targets. Matching
+  happens at payment time against the spell's cast characteristics; a non-matching spell is a silent
+  no-op. Because the queued trigger's source is the *spell*, it still fires if the mana's producer
+  has already left the battlefield.
 
 ### `ManaExpiry`<a id="manaexpiry"></a>
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1842,16 +1842,28 @@ object Effects {
 
     /**
      * Add mana of a specific color.
+     *
+     * [riders] attaches side-effects that fire on whatever spell this mana ends up paying for
+     * (Pyromancer's Goggles: "When that mana is spent to cast a red instant or sorcery spell, copy
+     * that spell"). See [com.wingedsheep.sdk.scripting.effects.ManaSpellRider].
      */
-    fun AddMana(color: Color, amount: Int = 1, restriction: ManaRestriction? = null): Effect =
-        AddManaEffect(color, amount, restriction)
+    fun AddMana(
+        color: Color,
+        amount: Int = 1,
+        restriction: ManaRestriction? = null,
+        riders: Set<com.wingedsheep.sdk.scripting.effects.ManaSpellRider> = emptySet()
+    ): Effect = AddManaEffect(color, DynamicAmount.Fixed(amount), restriction, riders = riders)
 
     /**
      * Add a dynamic amount of mana of a specific color.
      * Used for effects like "Add {R} for each Goblin on the battlefield."
      */
-    fun AddMana(color: Color, amount: DynamicAmount, restriction: ManaRestriction? = null): Effect =
-        AddManaEffect(color, amount, restriction)
+    fun AddMana(
+        color: Color,
+        amount: DynamicAmount,
+        restriction: ManaRestriction? = null,
+        riders: Set<com.wingedsheep.sdk.scripting.effects.ManaSpellRider> = emptySet()
+    ): Effect = AddManaEffect(color, amount, restriction, riders = riders)
 
     /**
      * Add colorless mana.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -626,6 +626,43 @@ data class SpendAnyManaTypeForActivatedAbilities(
 }
 
 /**
+ * You can spend mana of any type to cast spells matching [filter] (CR 118.14 / 609.4b — the
+ * colored, hybrid, Phyrexian and colorless requirements of the spell's mana cost may each be paid
+ * with mana of any color or with colorless mana).
+ *
+ * The spell-side sibling of [SpendAnyManaTypeForActivatedAbilities]. Models Vizier of the
+ * Menagerie ("You can spend mana of any type to cast creature spells") with
+ * `filter = GameObjectFilter.Creature`.
+ *
+ * Scope: the relaxation applies to spells cast by *this permanent's controller* — the printed
+ * wording is always "**you** can spend …" — and to those spells **wherever they are cast from**
+ * (hand, top of library, graveyard, exile). That last part is why this is a static rather than a
+ * flag on a cast permission: the per-card
+ * [com.wingedsheep.engine.state.permissions.MayPlayPermission] already carries a `withAnyManaType`
+ * rider for "cast *that exiled card* with any mana" grants (Taster of Wares, Tinybones), but a
+ * blanket "any creature spell you cast" isn't tied to one card in one zone.
+ *
+ * Only the *mana* portion is relaxed; additional costs are untouched. The relaxation is applied to
+ * affordability checks, the auto-tap solver and payment validation — deliberately **not** to the
+ * mana cost the client displays, so a creature card still shows its printed `{2}{G}` rather than a
+ * misleading `{3}`.
+ *
+ * @property filter Which spells the caster may pay for with mana of any type.
+ */
+@SerialName("SpendAnyManaTypeForSpells")
+@Serializable
+data class SpendAnyManaTypeForSpells(
+    val filter: GameObjectFilter
+) : StaticAbility {
+    override val description: String =
+        "You can spend mana of any type to cast ${filter.description} spells"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Permanents matching [filter] entering the battlefield don't cause abilities to trigger
  * (CR 603.6 enters-the-battlefield triggers are suppressed).
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
@@ -92,7 +92,16 @@ data class AddManaEffect(
      * mana; [ManaExpiry.END_OF_COMBAT] is firebending-style mana that the pool keeps through
      * combat and discards when combat ends.
      */
-    val expiry: ManaExpiry = ManaExpiry.END_OF_TURN
+    val expiry: ManaExpiry = ManaExpiry.END_OF_TURN,
+    /**
+     * Side-effects attached to the produced mana — what happens to the *spell* this mana is
+     * eventually spent on (Pyromancer's Goggles: "When that mana is spent to cast a red instant or
+     * sorcery spell, copy that spell"). When non-empty, the mana is stored as restricted-mana
+     * entries so the rider set survives in the pool; with [restriction] null,
+     * [ManaRestriction.AnySpend] is used as a no-op marker so the mana still spends on anything.
+     * Mirrors [AddManaOfChoiceEffect.riders].
+     */
+    val riders: Set<ManaSpellRider> = emptySet()
 ) : Effect {
     constructor(color: Color, amount: Int, restriction: ManaRestriction? = null, expiry: ManaExpiry = ManaExpiry.END_OF_TURN) :
         this(color, DynamicAmount.Fixed(amount), restriction, expiry)
@@ -106,6 +115,7 @@ data class AddManaEffect(
         if (expiry == ManaExpiry.END_OF_COMBAT) {
             append(". Until end of combat, you don't lose this mana as steps and phases end")
         }
+        for (rider in riders) append(". ${rider.description}")
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaSpellRider.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaSpellRider.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting.effects
 
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -48,5 +49,30 @@ sealed interface ManaSpellRider {
     data class ScryOnSharedTypeWithCommander(val amount: Int = 1) : ManaSpellRider {
         override val description: String =
             "When that mana is spent to cast a creature spell that shares a creature type with your commander, scry $amount"
+    }
+
+    /**
+     * "When that mana is spent to cast a [spellFilter] spell, copy that spell and you may choose
+     * new targets for the copy." (Pyromancer's Goggles, with
+     * `spellFilter = GameObjectFilter.InstantOrSorcery.withColor(Color.RED)`.)
+     *
+     * On consumption the cast pipeline matches the spell against [spellFilter] using its cast
+     * characteristics. On a match, a triggered ability is placed on the stack **above** the spell
+     * that, on resolution, copies it (CR 707.10) — so the copy resolves before the original, which
+     * is the printed behavior. The copy's controller may choose new targets.
+     *
+     * The rider is a no-op when the spell doesn't match (e.g. the {R} paid for a creature spell).
+     * Consuming two riders copies the spell twice, one independent copy per rider.
+     *
+     * @property spellFilter Which cast spells the rider copies.
+     */
+    @SerialName("CopySpellWhenSpent")
+    @Serializable
+    data class CopySpellWhenSpent(
+        val spellFilter: GameObjectFilter
+    ) : ManaSpellRider {
+        override val description: String =
+            "When that mana is spent to cast a ${spellFilter.description} spell, copy that spell " +
+                "and you may choose new targets for the copy"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/VizierOfTheMenagerie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/VizierOfTheMenagerie.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells
+
+/**
+ * Vizier of the Menagerie
+ * {3}{G}
+ * Creature — Snake Cleric
+ * 3/4
+ *
+ * You may look at the top card of your library any time.
+ * You may cast creature spells from the top of your library.
+ * You can spend mana of any type to cast creature spells.
+ *
+ * Three independent statics, each already an engine concept:
+ *
+ * - [LookAtTopOfLibrary] — the private peek (revealed to the controller only, unlike Future
+ *   Sight's [com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary], which reveals to everyone).
+ * - [CastSpellTypesFromTopOfLibrary] filtered to creatures — a *cast* permission only, so ordinary
+ *   timing still applies: sorcery-speed unless the card itself has flash, and the card is not in
+ *   your hand, so it can't be cycled, discarded, or have its activated abilities used (rulings).
+ * - [SpendAnyManaTypeForSpells] filtered to creatures — deliberately **not** scoped to the
+ *   top-of-library permission. Per the ruling, "You may spend mana as though it were mana of any
+ *   type to cast any creature spell, not just creature spells that you cast from the top of your
+ *   library", so this is a zone-agnostic static that also relaxes creature spells cast from hand.
+ *   Only the *mana* portion is relaxed — additional and alternative costs are unaffected, matching
+ *   "You'll still pay all costs for that spell, including additional costs."
+ */
+val VizierOfTheMenagerie = card("Vizier of the Menagerie") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake Cleric"
+    power = 3
+    toughness = 4
+    oracleText = "You may look at the top card of your library any time.\n" +
+        "You may cast creature spells from the top of your library.\n" +
+        "You can spend mana of any type to cast creature spells."
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(GameObjectFilter.Creature)
+    }
+
+    staticAbility {
+        ability = SpendAnyManaTypeForSpells(GameObjectFilter.Creature)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "192"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg?1783936465"
+        ruling(
+            "2017-04-18",
+            "Vizier of the Menagerie lets you look at the top card of your library whenever you " +
+                "want (with one restriction—see below), even if you don't have priority. This action " +
+                "doesn't use the stack. Knowing what that card is becomes part of the information you " +
+                "have access to, just like you can look at the cards in your hand.",
+        )
+        ruling(
+            "2017-04-18",
+            "If the top card of your library changes while you're casting a spell, playing a land, " +
+                "or activating an ability, you can't look at the new top card until you finish doing " +
+                "so. This means that if you cast the top card of your library, you can't look at the " +
+                "next one until you're done paying for that spell.",
+        )
+        ruling(
+            "2017-04-18",
+            "Normally, Vizier of the Menagerie allows you to cast the top card of your library if " +
+                "it's a creature card, it's your main phase, and the stack is empty. If that creature " +
+                "card has flash, you'll be able to cast it any time you could cast an instant, even " +
+                "on an opponent's turn.",
+        )
+        ruling(
+            "2017-04-18",
+            "You may spend mana as though it were mana of any type to cast any creature spell, not " +
+                "just creature spells that you cast from the top of your library.",
+        )
+        ruling(
+            "2017-04-18",
+            "You'll still pay all costs for that spell, including additional costs. You may also pay " +
+                "alternative costs such as emerge or that of As Foretold.",
+        )
+        ruling(
+            "2017-04-18",
+            "The top card of your library isn't in your hand, so you can't cycle it, discard it, or " +
+                "activate any of its activated abilities.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KellanPlanarTrailblazer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KellanPlanarTrailblazer.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kellan, Planar Trailblazer
+ * {R}
+ * Legendary Creature — Human Faerie Scout
+ * 2/1
+ *
+ * {1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains "Whenever Kellan
+ * deals combat damage to a player, exile the top card of your library. You may play that card
+ * this turn."
+ * {2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.
+ *
+ * Implementation notes — a two-step self-upgrade chain, both steps modeled as ordinary activated
+ * abilities whose *whole* body is gated on Kellan's current creature type:
+ *
+ * - **The "If Kellan is a …" clause is a resolution-time state test, not an activation
+ *   restriction** (Scryfall ruling: "You can activate Kellan's abilities regardless of what
+ *   creature types he currently has. Each ability checks Kellan's creature types when it
+ *   resolves."). So each ability is freely activatable and its body is wrapped in a
+ *   [ConditionalEffect] over [Conditions.SourceHasSubtype] — which lowers to a
+ *   `Gate.WhenCondition` and evaluates the source against **projected** state, so step 2 sees the
+ *   Detective type that step 1's Layer-4 type change conferred. Activating out of order (or
+ *   twice) is legal and simply does nothing.
+ * - **The type changes replace, they don't add** (ruling: "Kellan's abilities overwrite its
+ *   existing creature types … He won't have the Scout creature type"), so both steps use
+ *   [Effects.SetCreatureSubtypes] rather than `AddCreatureType`. Step 1 dropping Scout for
+ *   Detective is also what makes the chain one-way: once step 1 has resolved, step 1 can never
+ *   apply again.
+ * - **Nothing here has a duration** (ruling: "Neither of these abilities have durations"), so
+ *   every grant is [Duration.Permanent] — it lasts until Kellan leaves the battlefield or a later
+ *   effect overwrites it. The 3/2 is [Effects.SetBasePowerAndToughness] (Layer 7b, *setting*),
+ *   which by ordinary layer/timestamp rules overwrites earlier set-P/T effects but leaves
+ *   +N/+N modifiers and counters (Layer 7c) intact — exactly the fourth ruling.
+ * - The granted trigger is the ordinary impulse-draw shape: [Triggers.DealsCombatDamageToPlayer]
+ *   (SELF binding, so it fires on Kellan's own combat damage) over
+ *   [Patterns.Exile.impulse], conferred onto Kellan itself by a one-shot
+ *   [GrantTriggeredAbilityEffect]. Both step-1 halves are permanent and independent: a later
+ *   effect that re-sets Kellan's types doesn't strip the granted trigger.
+ */
+val KellanPlanarTrailblazer = card("Kellan, Planar Trailblazer") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Faerie Scout"
+    power = 2
+    toughness = 1
+    oracleText = "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains " +
+        "\"Whenever Kellan deals combat damage to a player, exile the top card of your library. " +
+        "You may play that card this turn.\"\n" +
+        "{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike."
+
+    // {1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains "Whenever
+    // Kellan deals combat damage to a player, exile the top card of your library. You may play
+    // that card this turn."
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = ConditionalEffect(
+            condition = Conditions.SourceHasSubtype(Subtype.SCOUT),
+            effect = Effects.Composite(
+                Effects.SetCreatureSubtypes(
+                    subtypes = setOf(Subtype.HUMAN.value, Subtype.FAERIE.value, Subtype.DETECTIVE.value),
+                    target = EffectTarget.Self,
+                    duration = Duration.Permanent
+                ),
+                GrantTriggeredAbilityEffect(
+                    ability = TriggeredAbility.create(
+                        trigger = Triggers.DealsCombatDamageToPlayer.event,
+                        binding = Triggers.DealsCombatDamageToPlayer.binding,
+                        effect = Patterns.Exile.impulse(count = 1, storeAs = "kellanImpulseExiled"),
+                        descriptionOverride = "Whenever Kellan deals combat damage to a player, " +
+                            "exile the top card of your library. You may play that card this turn."
+                    ),
+                    target = EffectTarget.Self,
+                    duration = Duration.Permanent
+                )
+            )
+        )
+        description = "If Kellan is a Scout, it becomes a Human Faerie Detective and gains " +
+            "\"Whenever Kellan deals combat damage to a player, exile the top card of your " +
+            "library. You may play that card this turn.\""
+    }
+
+    // {2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = ConditionalEffect(
+            condition = Conditions.SourceHasSubtype(Subtype.DETECTIVE),
+            effect = Effects.Composite(
+                Effects.SetBasePowerAndToughness(
+                    power = 3,
+                    toughness = 2,
+                    target = EffectTarget.Self,
+                    duration = Duration.Permanent
+                ),
+                Effects.SetCreatureSubtypes(
+                    subtypes = setOf(Subtype.HUMAN.value, Subtype.FAERIE.value, Subtype.ROGUE.value),
+                    target = EffectTarget.Self,
+                    duration = Duration.Permanent
+                ),
+                Effects.GrantKeyword(
+                    keyword = Keyword.DOUBLE_STRIKE,
+                    target = EffectTarget.Self,
+                    duration = Duration.Permanent
+                )
+            )
+        )
+        description = "If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "91"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg?1783909101"
+        ruling(
+            "2024-11-08",
+            "Neither of these abilities have durations. If one of them resolves, it will remain in " +
+                "effect until the game ends, Kellan leaves the battlefield, or some subsequent effect " +
+                "changes its characteristics, whichever comes first.",
+        )
+        ruling(
+            "2024-11-08",
+            "Kellan's abilities overwrite its existing creature types. For example, once Kellan's " +
+                "first ability resolves, if he was a Scout when it resolved, Kellan will be a Human " +
+                "Faerie Detective. He won't have the Scout creature type.",
+        )
+        ruling(
+            "2024-11-08",
+            "You can activate Kellan's abilities regardless of what creature types he currently has. " +
+                "Each ability checks Kellan's creature types when it resolves. If Kellan doesn't have " +
+                "the appropriate creature type at that time, the ability will do nothing.",
+        )
+        ruling(
+            "2024-11-08",
+            "The effects from Kellan's abilities overwrite other effects that set power and/or " +
+                "toughness if and only if those effects existed before the ability resolved. They will " +
+                "not overwrite effects that modify power or toughness without setting it (whether from " +
+                "a static ability, counters, or a resolved spell or ability), nor will they overwrite " +
+                "effects that set power and toughness which come into existence after they resolve. " +
+                "Effects that switch the creature's power and toughness are always applied after any " +
+                "other power or toughness changing effects, including these two, regardless of the " +
+                "order in which they are created.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PyromancersGogglesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PyromancersGogglesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pyromancer's Goggles reprint in FDN. Canonical CardDefinition lives in ORI, its earliest
+ * real-expansion printing.
+ */
+val PyromancersGogglesReprint = Printing(
+    oracleId = "f76bcbfe-483f-4e63-8425-76feca1abf3e",
+    name = "Pyromancer's Goggles",
+    setCode = "FDN",
+    collectorNumber = "677",
+    scryfallId = "f340d8a4-196a-4433-807c-b7124e96e44f",
+    artist = "Kevin Sidharta",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f340d8a4-196a-4433-807c-b7124e96e44f.jpg?1783908905",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VizierOfTheMenagerieReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VizierOfTheMenagerieReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vizier of the Menagerie reprint in FDN. Canonical CardDefinition lives in AKH, its earliest
+ * real-expansion printing.
+ */
+val VizierOfTheMenagerieReprint = Printing(
+    oracleId = "4f890d42-e4f1-4eed-aa6c-718865de8927",
+    name = "Vizier of the Menagerie",
+    setCode = "FDN",
+    collectorNumber = "649",
+    scryfallId = "3010ec33-c3f6-42ce-ad5a-e149e5c9a805",
+    artist = "Victor Adame Minguez",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg?1783908914",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PyromancersGoggles.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PyromancersGoggles.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
+
+/**
+ * Pyromancer's Goggles
+ * {5}
+ * Legendary Artifact
+ *
+ * {T}: Add {R}. When that mana is spent to cast a red instant or sorcery spell, copy that spell
+ * and you may choose new targets for the copy.
+ *
+ * A mana ability carrying a [ManaSpellRider] — the rider machinery exists precisely so the
+ * "what happens to the spell this mana pays for" half doesn't have to be modeled as a separate
+ * ability. The {R} itself is **unrestricted** ("The mana produced by Pyromancer's Goggles can be
+ * spent on anything, not just a red instant or sorcery spell"), so the rider rides along on an
+ * `AnySpend` pool entry and simply no-ops when the mana pays for something else.
+ *
+ * How the rulings map onto [ManaSpellRider.CopySpellWhenSpent]:
+ *  - *"Any red instant or sorcery spell you spend the mana on will be copied, not just one that
+ *    requires targets"* — the rider is a plain filter match (`InstantOrSorcery` + red), with no
+ *    target requirement of its own.
+ *  - *"The delayed triggered ability will trigger whether Pyromancer's Goggles is still on the
+ *    battlefield or not"* — falls out for free: the trigger is built at payment time with the
+ *    **spell** as its source, so the Goggles' fate is irrelevant.
+ *  - *"If more than one red mana produced by a Pyromancer's Goggles is spent … That many copies
+ *    will be created"* — the consumed-rider collection is a list, not a set, so two spent
+ *    rider-carrying mana queue two independent copy triggers.
+ *  - *"The copy resolves before the original spell"* — the copy trigger goes on the stack above
+ *    the spell it copies (CR 707.10).
+ *  - *"The copy is created on the stack, so it's not 'cast'"*, same modes, same X, no additional
+ *    costs re-paid — all inherent to `CopyTargetSpellEffect`.
+ */
+val PyromancersGoggles = card("Pyromancer's Goggles") {
+    manaCost = "{5}"
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact"
+    oracleText = "{T}: Add {R}. When that mana is spent to cast a red instant or sorcery spell, " +
+        "copy that spell and you may choose new targets for the copy."
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(
+            color = Color.RED,
+            riders = setOf(
+                ManaSpellRider.CopySpellWhenSpent(
+                    GameObjectFilter.InstantOrSorcery.withColor(Color.RED)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "236"
+        artist = "James Paick"
+        flavorText = "\"I hope to meet Jaya Ballard someday. I think we'd get along.\"\n—Chandra Nalaar"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg?1783938309"
+        ruling(
+            "2024-11-08",
+            "The mana produced by Pyromancer's Goggles can be spent on anything, not just a red " +
+                "instant or sorcery spell.",
+        )
+        ruling(
+            "2024-11-08",
+            "Any red instant or sorcery spell you spend the mana on will be copied, not just one " +
+                "that requires targets.",
+        )
+        ruling(
+            "2024-11-08",
+            "The delayed triggered ability will trigger whether Pyromancer's Goggles is still on " +
+                "the battlefield or not.",
+        )
+        ruling(
+            "2024-11-08",
+            "If more than one red mana produced by a Pyromancer's Goggles is spent to cast a single " +
+                "red instant or sorcery spell, the delayed triggered ability associated with each " +
+                "mana spent will trigger. That many copies will be created. It doesn't matter if " +
+                "this red mana was produced by one Pyromancer's Goggles or by multiple Pyromancer's " +
+                "Goggles.",
+        )
+        ruling(
+            "2024-11-08",
+            "A copy is created even if the spell cast with the red mana produced by Pyromancer's " +
+                "Goggles has been countered or otherwise left the stack without resolving by the " +
+                "time that ability resolves. The copy resolves before the original spell.",
+        )
+        ruling(
+            "2024-11-08",
+            "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a " +
+                "player casts a spell won't trigger.",
+        )
+        ruling(
+            "2024-11-08",
+            "The copy will have the same targets as the spell it's copying unless you choose new " +
+                "ones. You may change any number of the targets, including all of them or none of " +
+                "them. The new targets must be legal.",
+        )
+        ruling(
+            "2024-11-08",
+            "If the copied spell is modal (that is, it says \"Choose one –\" or the like), the copy " +
+                "will have the same mode or modes. You can't choose a different one.",
+        )
+        ruling(
+            "2024-11-08",
+            "If the copied spell has an X whose value was determined as it was cast, the copy has " +
+                "the same value of X.",
+        )
+        ruling(
+            "2024-11-08",
+            "You can't choose to pay any additional costs for the copy. However, effects based on " +
+                "any additional costs that were paid for the original spell are copied as though " +
+                "those same costs were paid for the copy too.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -249,3 +249,63 @@
         "GREEN"
     ]
 }
+
+// Vizier of the Menagerie
+{
+    "name": "Vizier of the Menagerie",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Snake Cleric",
+    "oracleText": "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\nYou can spend mana of any type to cast creature spells.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": "creature"
+            },
+            {
+                "type": "SpendAnyManaTypeForSpells",
+                "filter": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "MYTHIC",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca204351-7a7e-4e4b-8c2b-f90fa0f9d724.jpg?1783936465",
+        "rulings": [
+            {
+                "date": "2017-04-18",
+                "text": "Vizier of the Menagerie lets you look at the top card of your library whenever you want (with one restriction—see below), even if you don't have priority. This action doesn't use the stack. Knowing what that card is becomes part of the information you have access to, just like you can look at the cards in your hand."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "If the top card of your library changes while you're casting a spell, playing a land, or activating an ability, you can't look at the new top card until you finish doing so. This means that if you cast the top card of your library, you can't look at the next one until you're done paying for that spell."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "Normally, Vizier of the Menagerie allows you to cast the top card of your library if it's a creature card, it's your main phase, and the stack is empty. If that creature card has flash, you'll be able to cast it any time you could cast an instant, even on an opponent's turn."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "You may spend mana as though it were mana of any type to cast any creature spell, not just creature spells that you cast from the top of your library."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "You'll still pay all costs for that spell, including additional costs. You may also pay alternative costs such as emerge or that of As Foretold."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "The top card of your library isn't in your hand, so you can't cycle it, discard it, or activate any of its activated abilities."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -4835,6 +4835,179 @@
     ]
 }
 
+// Kellan, Planar Trailblazer
+{
+    "name": "Kellan, Planar Trailblazer",
+    "manaCost": "{R}",
+    "typeLine": "Legendary Creature — Human Faerie Scout",
+    "oracleText": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": "Scout"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetCreatureSubtypes",
+                                "subtypes": [
+                                    "Human",
+                                    "Faerie",
+                                    "Detective"
+                                ]
+                            },
+                            {
+                                "type": "GrantTriggeredAbility",
+                                "ability": {
+                                    "id": "ability_2",
+                                    "trigger": {
+                                        "type": "DealsDamageEvent",
+                                        "damageType": "DamageCombat",
+                                        "recipient": "AnyPlayer"
+                                    },
+                                    "effect": {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "TopOfLibrary",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeAs": "kellanImpulseExiled"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "kellanImpulseExiled",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Exile"
+                                                }
+                                            },
+                                            {
+                                                "type": "GrantMayPlayFromExile",
+                                                "from": "kellanImpulseExiled"
+                                            }
+                                        ]
+                                    },
+                                    "descriptionOverride": "Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn."
+                                },
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\""
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": "Detective"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetBaseStats",
+                                "target": "Self",
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "SetCreatureSubtypes",
+                                "subtypes": [
+                                    "Human",
+                                    "Faerie",
+                                    "Rogue"
+                                ]
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "DOUBLE_STRIKE",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f46a9329-7b91-441d-8653-50c1152c9120.jpg?1783909101",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Neither of these abilities have durations. If one of them resolves, it will remain in effect until the game ends, Kellan leaves the battlefield, or some subsequent effect changes its characteristics, whichever comes first."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Kellan's abilities overwrite its existing creature types. For example, once Kellan's first ability resolves, if he was a Scout when it resolved, Kellan will be a Human Faerie Detective. He won't have the Scout creature type."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can activate Kellan's abilities regardless of what creature types he currently has. Each ability checks Kellan's creature types when it resolves. If Kellan doesn't have the appropriate creature type at that time, the ability will do nothing."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The effects from Kellan's abilities overwrite other effects that set power and/or toughness if and only if those effects existed before the ability resolved. They will not overwrite effects that modify power or toughness without setting it (whether from a static ability, counters, or a resolved spell or ability), nor will they overwrite effects that set power and toughness which come into existence after they resolve. Effects that switch the creature's power and toughness are always applied after any other power or toughness changing effects, including these two, regardless of the order in which they are created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Kiora, the Rising Tide
 {
     "name": "Kiora, the Rising Tide",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -563,6 +563,99 @@
     ]
 }
 
+// Pyromancer's Goggles
+{
+    "name": "Pyromancer's Goggles",
+    "manaCost": "{5}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{T}: Add {R}. When that mana is spent to cast a red instant or sorcery spell, copy that spell and you may choose new targets for the copy.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "riders": [
+                        {
+                            "type": "CopySpellWhenSpent",
+                            "spellFilter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsInstant",
+                                            "IsSorcery"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "RED"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "MYTHIC",
+        "artist": "James Paick",
+        "flavorText": "\"I hope to meet Jaya Ballard someday. I think we'd get along.\"\n—Chandra Nalaar",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/1163ce9f-cf22-422e-a4b5-0240b88e2816.jpg?1783938309",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "The mana produced by Pyromancer's Goggles can be spent on anything, not just a red instant or sorcery spell."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Any red instant or sorcery spell you spend the mana on will be copied, not just one that requires targets."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The delayed triggered ability will trigger whether Pyromancer's Goggles is still on the battlefield or not."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If more than one red mana produced by a Pyromancer's Goggles is spent to cast a single red instant or sorcery spell, the delayed triggered ability associated with each mana spent will trigger. That many copies will be created. It doesn't matter if this red mana was produced by one Pyromancer's Goggles or by multiple Pyromancer's Goggles."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A copy is created even if the spell cast with the red mana produced by Pyromancer's Goggles has been countered or otherwise left the stack without resolving by the time that ability resolves. The copy resolves before the original spell."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The copy is created on the stack, so it's not \"cast.\" Abilities that trigger when a player casts a spell won't trigger."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The copy will have the same targets as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. The new targets must be legal."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If the copied spell is modal (that is, it says \"Choose one –\" or the like), the copy will have the same mode or modes. You can't choose a different one."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If the copied spell has an X whose value was determined as it was cast, the copy has the same value of X."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can't choose to pay any additional costs for the copy. However, effects based on any additional costs that were paid for the original spell are copied as though those same costs were paid for the copy too."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Skyraker Giant
 {
     "name": "Skyraker Giant",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -21,16 +21,18 @@ import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
 /**
  * Result of a mana payment attempt.
  *
- * @property consumedRiders Union of [ManaSpellRider]s carried by the mana actually
- *   spent on this payment (from both restricted floating mana and freshly-tapped
- *   sources). The caller applies each rider to the spell as it goes on the stack —
- *   e.g. [ManaSpellRider.MakesSpellUncounterable] stamps `CantBeCounteredComponent`.
+ * @property consumedRiders Every [ManaSpellRider] carried by the mana actually spent on this
+ *   payment (from both restricted floating mana and freshly-tapped sources). The caller applies
+ *   each rider to the spell as it goes on the stack — e.g.
+ *   [ManaSpellRider.MakesSpellUncounterable] stamps `CantBeCounteredComponent`. A **list**, not a
+ *   set: two rider-carrying mana spent on one spell must fire the rider twice (Pyromancer's
+ *   Goggles copies the spell once per {R} spent), so identical riders must not be deduplicated.
  */
 data class PaymentResult(
     val state: GameState,
     val events: List<GameEvent>,
     val error: String?,
-    val consumedRiders: Set<ManaSpellRider> = emptySet(),
+    val consumedRiders: List<ManaSpellRider> = emptyList(),
     /**
      * Provenance of the mana actually spent on this payment — which producing-source subtypes and
      * which producing sources contributed (see [SpentManaProvenance]). Combines mana pulled from the
@@ -379,7 +381,7 @@ class CastPaymentProcessor(
         }
 
         // Tap lands for remaining cost (using xRemainingToPay instead of full xValue)
-        var solutionConsumedRiders: Set<ManaSpellRider> = emptySet()
+        var solutionConsumedRiders: List<ManaSpellRider> = emptyList()
         if (!remainingCost.isEmpty() || xRemainingToPay > 0) {
             val solution = manaSolver.solve(currentState, playerId, remainingCost, xRemainingToPay, excludeSources = excludeSources, spellContext = spellContext, xManaRestriction = xManaRestriction)
                 ?: return PaymentResult(currentState, events, "Not enough mana to auto-pay")
@@ -519,17 +521,18 @@ class CastPaymentProcessor(
     }
 
     /**
-     * Union of [ManaSpellRider]s carried by restricted mana entries that disappeared
-     * during payment (present in [before], gone from [after] after multiset
-     * subtraction). Used to detect that e.g. Cavern of Souls' floating restricted
-     * mana was spent on the cast.
+     * Every [ManaSpellRider] carried by restricted mana entries that disappeared during payment
+     * (present in [before], gone from [after] after multiset subtraction). Used to detect that
+     * e.g. Cavern of Souls' floating restricted mana was spent on the cast. Multiplicity is
+     * preserved — two spent entries carrying the same rider yield it twice (Pyromancer's
+     * Goggles), so this returns a list rather than a set.
      */
     private fun ridersConsumedDuringPayment(
         before: List<RestrictedManaEntry>,
         after: List<RestrictedManaEntry>
-    ): Set<ManaSpellRider> {
+    ): List<ManaSpellRider> {
         val remaining = after.toMutableList()
-        val consumed = mutableSetOf<ManaSpellRider>()
+        val consumed = mutableListOf<ManaSpellRider>()
         for (entry in before) {
             val idx = remaining.indexOfFirst { it == entry }
             if (idx >= 0) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1061,16 +1061,26 @@ class CastSpellHandler(
     }
 
     /**
-     * True if the spell is being cast via a [com.wingedsheep.engine.state.permissions.MayPlayPermission]
-     * that allows mana of any type to be spent. The card must currently be in a zone a may-play
-     * permission can grant casting from — exile (the card's owner's, which may be an opponent —
-     * e.g. Taster of Wares leaves the exiled card in the revealing player's exile) or a graveyard
-     * (per-card grants that leave the card in the graveyard — e.g. Tinybones, the Pickpocket lets
-     * you cast a targeted nonland permanent card from the damaged player's graveyard). An active
-     * permission must be granted to the casting player with its condition gate open, and the
-     * `withAnyManaType` flag must be set on at least one of those active permissions.
+     * True if mana of any type may be spent on this spell's mana cost (CR 118.14 / 609.4b). Two
+     * independent sources:
+     *
+     * 1. A [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells] static controlled by the
+     *    caster whose filter matches the card — the blanket "you can spend mana of any type to cast
+     *    [these] spells" (Vizier of the Menagerie). Zone-agnostic, so it is checked first and covers
+     *    hand and top-of-library casts too.
+     * 2. A [com.wingedsheep.engine.state.permissions.MayPlayPermission] carrying the
+     *    `withAnyManaType` rider. That is a *per-card* grant, so the card must currently be in a
+     *    zone a may-play permission can grant casting from — exile (the card's owner's, which may be
+     *    an opponent — e.g. Taster of Wares leaves the exiled card in the revealing player's exile)
+     *    or a graveyard (per-card grants that leave the card in the graveyard — e.g. Tinybones, the
+     *    Pickpocket lets you cast a targeted nonland permanent card from the damaged player's
+     *    graveyard). An active permission must be granted to the casting player with its condition
+     *    gate open, and the `withAnyManaType` flag must be set on at least one of them.
      */
     private fun isCastWithAnyManaType(state: GameState, action: CastSpell): Boolean {
+        if (castPermissionUtils.canSpendAnyManaTypeForSpell(state, action.playerId, action.cardId)) {
+            return true
+        }
         val inGrantableZone = state.turnOrder.any { ownerId ->
             action.cardId in state.getZone(ZoneKey(ownerId, Zone.EXILE)) ||
                 action.cardId in state.getZone(ZoneKey(ownerId, Zone.GRAVEYARD))
@@ -3961,6 +3971,60 @@ class CastSpellHandler(
 
         is com.wingedsheep.sdk.scripting.effects.ManaSpellRider.ScryOnSharedTypeWithCommander ->
             buildScryOnSharedTypeWithCommanderTrigger(state, action, cardComponent, rider.amount)
+
+        is com.wingedsheep.sdk.scripting.effects.ManaSpellRider.CopySpellWhenSpent ->
+            buildCopySpellRiderTrigger(state, action, cardComponent, rider.spellFilter)
+    }
+
+    /**
+     * Pyromancer's Goggles' rider: if the cast spell matches [spellFilter], queue a copy trigger
+     * above the spell. Otherwise no-op (the {R} was spent on something else).
+     *
+     * The trigger resolves *before* the spell it copies, which is the printed behavior — the copy
+     * is put onto the stack above the original and resolves first (CR 707.10). The copy's controller
+     * may choose new targets, handled by [CopyTargetSpellEffect]'s own retarget pause.
+     *
+     * The spell is matched with [PredicateEvaluator] against its stack characteristics — projected
+     * *battlefield* state doesn't apply to an object on the stack, but the evaluator still reads
+     * color/type off the spell's [CardComponent], which is what "a red instant or sorcery spell"
+     * needs. Matching happens now, at payment time, not at trigger resolution.
+     */
+    private fun buildCopySpellRiderTrigger(
+        state: GameState,
+        action: CastSpell,
+        cardComponent: CardComponent,
+        spellFilter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+    ): Pair<GameState, List<PendingTrigger>> {
+        val matches = predicateEvaluator.matches(
+            state,
+            state.projectedState,
+            action.cardId,
+            spellFilter,
+            PredicateContext(controllerId = action.playerId)
+        )
+        if (!matches) return state to emptyList()
+
+        val copyAbility = TriggeredAbility(
+            id = AbilityId.generate(),
+            trigger = SdkGameEvent.SpellCastEvent(player = Player.You),
+            binding = TriggerBinding.SELF,
+            effect = com.wingedsheep.sdk.scripting.effects.CopyTargetSpellEffect(
+                target = com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity
+            ),
+            activeZone = Zone.STACK,
+            descriptionOverride = "Copy ${cardComponent.name}. You may choose new targets for the copy."
+        )
+        val pending = PendingTrigger(
+            ability = copyAbility,
+            sourceId = action.cardId,
+            sourceName = cardComponent.name,
+            controllerId = action.playerId,
+            triggerContext = TriggerContext(
+                triggeringEntityId = action.cardId,
+                triggeringPlayerId = action.playerId
+            )
+        )
+        return state to listOf(pending)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaExecutor.kt
@@ -35,7 +35,12 @@ class AddManaExecutor(
             val manaPool = container.get<ManaPoolComponent>() ?: ManaPoolComponent()
             val updatedPool = when {
                 effect.restriction != null ->
-                    manaPool.addRestricted(effect.color, amount, effect.restriction!!, expiry = effect.expiry)
+                    manaPool.addRestricted(effect.color, amount, effect.restriction!!, effect.riders, expiry = effect.expiry)
+                effect.riders.isNotEmpty() ->
+                    // Rider-carrying mana (Pyromancer's Goggles): stored as an AnySpend restricted
+                    // entry so the rider set survives in the pool while the mana itself stays
+                    // spendable on anything. Mirrors AddManaOfChoiceExecutor.
+                    manaPool.addRestricted(effect.color, amount, ManaRestriction.AnySpend, effect.riders, expiry = effect.expiry)
                 effect.expiry != ManaExpiry.END_OF_TURN ->
                     // Combat-duration (firebending) mana: spendable anywhere, but tagged so the
                     // pool discards it when combat ends. Stored as an AnySpend restricted entry
@@ -48,7 +53,7 @@ class AddManaExecutor(
         }
 
         // Treasure tagging only applies to ordinary, plain-counter mana (the `add` branch above).
-        if (effect.restriction == null && effect.expiry == ManaExpiry.END_OF_TURN) {
+        if (effect.restriction == null && effect.riders.isEmpty() && effect.expiry == ManaExpiry.END_OF_TURN) {
             newState = ManaProvenanceTracker.tagAddedMana(newState, context.controllerId, context.sourceId, amount)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -251,8 +251,14 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     } else {
                         topCardComponent.manaCost
                     }
+                    // "You can spend mana of any type to cast [these] spells" (Vizier of the
+                    // Menagerie — whose own second ability is what makes a creature spell castable
+                    // from here in the first place). Relaxed for payment only; the displayed
+                    // `manaCostString` below stays the printed cost.
+                    val topPayableCost = context.castPermissionUtils
+                        .relaxSpellCostColorsIfAny(state, playerId, topCardId, topEffectiveCost)
                     val cachedSources = context.availableManaSources
-                    val canAfford = context.manaSolver.canPay(state, playerId, topEffectiveCost, precomputedSources = cachedSources)
+                    val canAfford = context.manaSolver.canPay(state, playerId, topPayableCost, precomputedSources = cachedSources)
                     if (canAfford) {
                         val targetReqs = buildList {
                             addAll(topCardDef?.script?.targetRequirements ?: emptyList())
@@ -268,7 +274,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                             ((availableSources - fixedCost) / xSymbolCount).coerceAtLeast(0)
                         } else null
                         val autoTapPreview = if (context.skipAutoTapPreview) null else {
-                            context.manaSolver.solve(state, playerId, topEffectiveCost, precomputedSources = cachedSources)
+                            context.manaSolver.solve(state, playerId, topPayableCost, precomputedSources = cachedSources)
                                 ?.sources?.map { it.entityId }
                         }
 
@@ -431,7 +437,12 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     } else {
                         baseEffectiveCost
                     }
-                    var effectiveCost = if (permissions.any { it.withAnyManaType }) {
+                    // Mana of any type: either the may-play permission itself carries the rider
+                    // (Taster of Wares, Tinybones) or a blanket static covers this spell wherever
+                    // it is cast from (Vizier of the Menagerie).
+                    val anyManaType = permissions.any { it.withAnyManaType } ||
+                        context.castPermissionUtils.canSpendAnyManaTypeForSpell(state, playerId, cardId)
+                    var effectiveCost = if (anyManaType) {
                         baseCost.relaxColors()
                     } else {
                         baseCost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -471,24 +471,30 @@ class CastSpellEnumerator : ActionEnumerator {
                 cardTypes = cardComponent.typeLine.cardTypes,
             )
 
+            // "You can spend mana of any type to cast [these] spells" (Vizier of the Menagerie):
+            // relax the colored requirements for *payment* only. `effectiveCost` stays the printed
+            // cost so the client keeps showing {2}{G} rather than a misleading {3}.
+            val payableCost = context.castPermissionUtils
+                .relaxSpellCostColorsIfAny(state, playerId, cardId, effectiveCost)
+
             // For Convoke/Delve spells, check if affordable with alternative payment help
             val cachedSources = context.availableManaSources
             val canAfford = if (hasConvoke && convokeCreatures != null && convokeCreatures.isNotEmpty()) {
-                context.manaSolver.canPay(state, playerId, effectiveCost, spellContext = spellContext, precomputedSources = cachedSources) ||
-                    context.costUtils.canAffordWithConvoke(state, playerId, effectiveCost, convokeCreatures, precomputedSources = cachedSources)
+                context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
+                    context.costUtils.canAffordWithConvoke(state, playerId, payableCost, convokeCreatures, precomputedSources = cachedSources)
             } else if (hasDelve && delveCards != null && delveCards.isNotEmpty()) {
-                context.manaSolver.canPay(state, playerId, effectiveCost, spellContext = spellContext, precomputedSources = cachedSources) ||
-                    context.costUtils.canAffordWithDelve(state, playerId, effectiveCost, delveCards, precomputedSources = cachedSources)
+                context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
+                    context.costUtils.canAffordWithDelve(state, playerId, payableCost, delveCards, precomputedSources = cachedSources)
             } else if (mandatoryWaterbend) {
-                // effectiveCost already includes the mandatory waterbend {N}; taps can cover up to {N}.
-                context.manaSolver.canPay(state, playerId, effectiveCost, spellContext = spellContext, precomputedSources = cachedSources) ||
+                // payableCost already includes the mandatory waterbend {N}; taps can cover up to {N}.
+                context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
                     context.costUtils.canAffordWithWaterbend(
-                        state, playerId, effectiveCost,
+                        state, playerId, payableCost,
                         waterbendPermanents.take(spellWaterbend!!.amount),
                         precomputedSources = cachedSources
                     )
             } else {
-                context.manaSolver.canPay(state, playerId, effectiveCost, spellContext = spellContext, precomputedSources = cachedSources)
+                context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources)
             }
 
             // Check alternative casting cost affordability (e.g., Jodah's {W}{U}{B}{R}{G})
@@ -711,10 +717,12 @@ class CastSpellEnumerator : ActionEnumerator {
             // `CastPaymentProcessor.explicitPay` taps only the minimum subset needed
             // after the alt-payment reduction is actually applied.
             val autoTapPreview = if (context.skipAutoTapPreview) null else {
+                // Solve against `payableCost`, not `effectiveCost` — under Vizier of the Menagerie
+                // the off-color solve is exactly what the player will actually tap.
                 val costForPreview = if (hasDelve && minDelveNeeded != null && minDelveNeeded > 0) {
-                    effectiveCost.reduceGeneric(minDelveNeeded)
+                    payableCost.reduceGeneric(minDelveNeeded)
                 } else {
-                    effectiveCost
+                    payableCost
                 }
                 context.manaSolver.solve(state, playerId, costForPreview, precomputedSources = cachedSources)
                     ?.sources?.map { it.entityId }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -1282,6 +1282,53 @@ class CastPermissionUtils(
     }
 
     /**
+     * True when a [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells] static controlled by
+     * [playerId] matches the card [cardId] they are casting — i.e. mana of any type may be spent on
+     * that spell's mana cost (Vizier of the Menagerie: "You can spend mana of any type to cast
+     * creature spells"). Callers relax the cost via
+     * [com.wingedsheep.sdk.core.ManaCost.relaxColors] when this returns true (CR 118.14 / 609.4b).
+     *
+     * Zone-agnostic by design: the printed wording covers every creature spell you cast, so this is
+     * consulted for hand casts, top-of-library casts and may-play casts alike. The card is matched
+     * against the filter in projected state, so a permanent that is only a creature *because* of a
+     * continuous effect still counts.
+     */
+    fun canSpendAnyManaTypeForSpell(state: GameState, playerId: EntityId, cardId: EntityId): Boolean {
+        val projected = state.projectedState
+        for (granterId in state.getBattlefield()) {
+            val granter = state.getEntity(granterId) ?: continue
+            if (granter.has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>()) continue
+            if (projected.getController(granterId) != playerId) continue
+            val card = granter.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val classLevel = granter.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel
+            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+                val any = ability as? com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells ?: continue
+                val matches = predicateEvaluator.matches(
+                    state, projected, cardId, any.filter,
+                    PredicateContext(controllerId = playerId, sourceId = granterId)
+                )
+                if (matches) return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * [cost] with its colored/hybrid/Phyrexian/colorless requirements relaxed to generic when
+     * [canSpendAnyManaTypeForSpell] holds for this cast, otherwise [cost] unchanged. Use for
+     * affordability checks, the auto-tap solver and payment — **not** for the cost string shown to
+     * the client, which must stay the printed cost.
+     */
+    fun relaxSpellCostColorsIfAny(
+        state: GameState,
+        playerId: EntityId,
+        cardId: EntityId,
+        cost: ManaCost
+    ): ManaCost =
+        if (canSpendAnyManaTypeForSpell(state, playerId, cardId)) cost.relaxColors() else cost
+
+    /**
      * Get activated abilities granted to an entity by static abilities on battlefield permanents.
      */
     fun getStaticGrantedActivatedAbilities(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -851,6 +851,7 @@ class StaticAbilityHandler(
             // CastSpellEnumerator / PlayLandHandler):
             is CantCastSpellsSharingColorWithLastCast,
             is CastSpellTypesFromTopOfLibrary,
+            is com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells,
             is GrantAdditionalLandDrop,
             is GrantFlashToSpellType,
             is GrantMayCastFromLinkedExile,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -218,7 +218,7 @@ data class ManaSolution(
      * ability contributes [ManaSpellRider.MakesSpellUncounterable] when tapped for
      * a color, but its colorless `{T}: Add {C}` ability does not).
      */
-    val consumedRiders: Set<ManaSpellRider> = emptySet(),
+    val consumedRiders: List<ManaSpellRider> = emptyList(),
     /**
      * For a color-restricted `{X}` cost ("spend only [colors] on X"), the per-color
      * breakdown of mana this solution allocated to the X portion specifically. Empty
@@ -775,9 +775,12 @@ class ManaSolver(
             genericRemaining--
         }
 
-        val consumedRiders: Set<ManaSpellRider> = usedSources.flatMapTo(mutableSetOf()) { source ->
-            val color = manaProduced[source.entityId]?.color ?: return@flatMapTo emptySet()
-            source.colorRiders[color] ?: emptySet()
+        // A List, not a Set: multiplicity is load-bearing. Two rider-carrying sources spent on
+        // one spell fire the rider twice (Pyromancer's Goggles: "That many copies will be
+        // created"), so identical riders must not collapse.
+        val consumedRiders: List<ManaSpellRider> = usedSources.flatMap { source ->
+            val color = manaProduced[source.entityId]?.color ?: return@flatMap emptyList()
+            source.colorRiders[color]?.toList() ?: emptyList()
         }
         return ManaSolution(
             usedSources,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanPlanarTrailblazerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanPlanarTrailblazerScenarioTest.kt
@@ -1,0 +1,197 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.KellanPlanarTrailblazer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kellan, Planar Trailblazer (FDN #91).
+ *
+ * {1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains "Whenever Kellan
+ *   deals combat damage to a player, exile the top card of your library. You may play that card
+ *   this turn."
+ * {2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.
+ *
+ * The interesting parts of the card are all about *when* the "If Kellan is a …" clause is checked
+ * and how permanent its consequences are, so that's what these cover:
+ *  - step 1 replaces the Scout type (it doesn't add Detective alongside it) and confers a working
+ *    combat-damage impulse trigger;
+ *  - the type gate is a resolution-time state test, so activating step 2 out of order is legal and
+ *    simply fizzles into a no-op;
+ *  - step 2 after step 1 sets base 3/2, replaces Detective with Rogue, and grants double strike;
+ *  - none of it has a duration, so all of it survives the turn ending.
+ */
+class KellanPlanarTrailblazerScenarioTest : FunSpec({
+
+    val becomeDetectiveId = KellanPlanarTrailblazer.activatedAbilities[0].id
+    val becomeRogueId = KellanPlanarTrailblazer.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KellanPlanarTrailblazer))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Resolve Kellan's first ability, leaving him a Human Faerie Detective. */
+    fun becomeDetective(driver: GameTestDriver, you: EntityId, kellan: EntityId) {
+        driver.giveMana(you, Color.RED, 2)
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = kellan, abilityId = becomeDetectiveId)
+        )
+        driver.bothPass()
+    }
+
+    test("first ability replaces Scout with Human Faerie Detective") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        driver.state.projectedState.hasSubtype(kellan, Subtype.SCOUT.value) shouldBe true
+
+        becomeDetective(driver, you, kellan)
+
+        val projected = driver.state.projectedState
+        projected.hasSubtype(kellan, Subtype.DETECTIVE.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.HUMAN.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.FAERIE.value) shouldBe true
+        // The types are *replaced*, not added to — Scout is gone, which is what makes the chain
+        // one-way (the first ability can never apply a second time).
+        projected.hasSubtype(kellan, Subtype.SCOUT.value) shouldBe false
+        // Still a vanilla 2/1 at this point — only the second ability changes the body.
+        projected.getPower(kellan) shouldBe 2
+        projected.getToughness(kellan) shouldBe 1
+    }
+
+    test("granted trigger impulse-exiles the top card when Kellan connects") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        driver.removeSummoningSickness(kellan)
+        becomeDetective(driver, you, kellan)
+
+        driver.getExile(you).size shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(kellan), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+        driver.bothPass() // resolve the granted combat-damage trigger
+
+        driver.getLifeTotal(opponent) shouldBe 18
+        // "exile the top card of your library. You may play that card this turn."
+        driver.getExile(you).size shouldBe 1
+    }
+
+    test("without the first ability there is no combat-damage trigger") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        driver.removeSummoningSickness(kellan)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(kellan), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+        driver.bothPass()
+
+        driver.getLifeTotal(opponent) shouldBe 18
+        driver.getExile(you).size shouldBe 0
+    }
+
+    test("second ability activated out of order resolves as a no-op") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        driver.giveMana(you, Color.RED, 3)
+
+        // Activating is legal regardless of Kellan's current types — the check happens on
+        // resolution, and a Scout simply isn't a Detective.
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = kellan, abilityId = becomeRogueId)
+        )
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(kellan) shouldBe 2
+        projected.getToughness(kellan) shouldBe 1
+        projected.hasSubtype(kellan, Subtype.SCOUT.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.ROGUE.value) shouldBe false
+        projected.hasKeyword(kellan, Keyword.DOUBLE_STRIKE) shouldBe false
+    }
+
+    test("second ability after the first makes a 3/2 Human Faerie Rogue with double strike") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        becomeDetective(driver, you, kellan)
+
+        driver.giveMana(you, Color.RED, 3)
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = kellan, abilityId = becomeRogueId)
+        )
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(kellan) shouldBe 3
+        projected.getToughness(kellan) shouldBe 2
+        projected.hasSubtype(kellan, Subtype.ROGUE.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.HUMAN.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.FAERIE.value) shouldBe true
+        projected.hasSubtype(kellan, Subtype.DETECTIVE.value) shouldBe false
+        projected.hasKeyword(kellan, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+
+    test("neither ability has a duration — the upgrades survive the turn ending") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kellan = driver.putCreatureOnBattlefield(you, "Kellan, Planar Trailblazer")
+        becomeDetective(driver, you, kellan)
+        driver.giveMana(you, Color.RED, 3)
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = kellan, abilityId = becomeRogueId)
+        )
+        driver.bothPass()
+
+        // Roll into the opponent's turn and back — Permanent duration must not be cleaned up.
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val projected = driver.state.projectedState
+        projected.getPower(kellan) shouldBe 3
+        projected.getToughness(kellan) shouldBe 2
+        projected.hasSubtype(kellan, Subtype.ROGUE.value) shouldBe true
+        projected.hasKeyword(kellan, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PyromancersGogglesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PyromancersGogglesScenarioTest.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ori.cards.PyromancersGoggles
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pyromancer's Goggles (canonical ORI #236, reprinted FDN #677).
+ *
+ * {T}: Add {R}. When that mana is spent to cast a red instant or sorcery spell, copy that spell
+ * and you may choose new targets for the copy.
+ *
+ * Covers the new [com.wingedsheep.sdk.scripting.effects.ManaSpellRider.CopySpellWhenSpent] rider
+ * and the `riders` parameter on `AddMana`. The spells here are deliberately **targetless** so the
+ * copy resolves without a retarget pause and the "did it happen twice?" assertion is unambiguous —
+ * per the ruling, "Any red instant or sorcery spell you spend the mana on will be copied, not just
+ * one that requires targets."
+ *
+ * The negative cases pin the filter down on both axes: colour (a colourless instant whose generic
+ * cost the {R} really does pay, so the rider is consumed and must then no-op) and card type (a red
+ * creature spell). Together with the positive case they show the rider rides along on every cast the
+ * mana pays for but fires only on a match — which is what "the mana can be spent on anything, not
+ * just a red instant or sorcery spell" means.
+ */
+class PyromancersGogglesScenarioTest : FunSpec({
+
+    val gogglesAbilityId = PyromancersGoggles.activatedAbilities[0].id
+
+    /** A red instant with no targets: the copy is observable purely as a second life gain. */
+    val redInstant = CardDefinition(
+        name = "Test Red Ember",
+        manaCost = ManaCost.parse("{R}"),
+        typeLine = TypeLine.parse("Instant"),
+        oracleText = "You gain 2 life.",
+        script = CardScript.spell(effect = Effects.GainLife(2))
+    )
+
+    /**
+     * A *colourless* instant with a generic cost, so the Goggles' {R} genuinely pays for it and the
+     * rider is consumed — but the spell isn't red, so the rider must no-op. This is the case that
+     * pins down "the mana can be spent on anything".
+     */
+    val colorlessInstant = CardDefinition(
+        name = "Test Grey Ripple",
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.parse("Instant"),
+        oracleText = "You gain 2 life.",
+        script = CardScript.spell(effect = Effects.GainLife(2))
+    )
+
+    val redCreature = CardDefinition.creature(
+        name = "Test Red Imp",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1,
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(PyromancersGoggles, redInstant, colorlessInstant, redCreature)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Tap the Goggles, putting one rider-carrying {R} into the pool. */
+    fun tapGoggles(driver: GameTestDriver, you: com.wingedsheep.sdk.model.EntityId, goggles: com.wingedsheep.sdk.model.EntityId) {
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = goggles, abilityId = gogglesAbilityId)
+        )
+    }
+
+    test("a red instant paid with the Goggles' mana is copied — the effect happens twice") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val goggles = driver.putPermanentOnBattlefield(you, "Pyromancer's Goggles")
+        val ember = driver.putCardInHand(you, "Test Red Ember")
+        tapGoggles(driver, you, goggles)
+
+        driver.castSpell(you, ember).error shouldBe null
+        // The copy trigger sits above the spell; drain the whole stack.
+        driver.bothPass()
+        driver.bothPass()
+        driver.bothPass()
+
+        // 20 + 2 (copy) + 2 (original) — the copy resolves first, then the original.
+        driver.getLifeTotal(you) shouldBe 24
+    }
+
+    test("without the Goggles' mana the same spell resolves once") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ember = driver.putCardInHand(you, "Test Red Ember")
+        driver.giveMana(you, Color.RED, 1)
+
+        driver.castSpell(you, ember).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe 22
+    }
+
+    test("the mana spends on a nonred instant, which is not copied") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val goggles = driver.putPermanentOnBattlefield(you, "Pyromancer's Goggles")
+        val ripple = driver.putCardInHand(you, "Test Grey Ripple")
+        tapGoggles(driver, you, goggles)
+
+        // "The mana produced by Pyromancer's Goggles can be spent on anything, not just a red
+        // instant or sorcery spell." The {R} pays this {1} cost, so the rider *is* consumed — and
+        // must then no-op, because the spell isn't red.
+        driver.castSpell(you, ripple).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe 22
+    }
+
+    test("a red creature spell paid with the Goggles' mana is not copied") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val goggles = driver.putPermanentOnBattlefield(you, "Pyromancer's Goggles")
+        val imp = driver.putCardInHand(you, "Test Red Imp")
+        tapGoggles(driver, you, goggles)
+
+        driver.castSpell(you, imp).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        // One Imp, not two — the rider filter is instant-or-sorcery only.
+        driver.getCreatures(you).count { driver.getCardName(it) == "Test Red Imp" } shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VizierOfTheMenagerieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VizierOfTheMenagerieScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.akh.cards.VizierOfTheMenagerie
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Vizier of the Menagerie (canonical AKH #192, reprinted FDN #649).
+ *
+ * You may look at the top card of your library any time.
+ * You may cast creature spells from the top of your library.
+ * You can spend mana of any type to cast creature spells.
+ *
+ * These cover the new [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells] static. Its
+ * load-bearing property is that it is **zone-agnostic** and **type-filtered**: per the rulings it
+ * relaxes the colored pips of *any* creature spell you cast — not just one cast off the top of your
+ * library — and leaves noncreature spells alone. Casting is exercised with a pool that has *no*
+ * green mana at all, so a successful cast can only mean the relaxation applied.
+ */
+class VizierOfTheMenagerieScenarioTest : FunSpec({
+
+    // A green creature that plainly cannot be cast off-color without the Vizier.
+    val greenBear = CardDefinition.creature(
+        name = "Test Green Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+    )
+
+    val greenSorcery = CardDefinition(
+        name = "Test Green Sorcery",
+        manaCost = ManaCost.parse("{1}{G}"),
+        typeLine = com.wingedsheep.sdk.core.TypeLine.parse("Sorcery"),
+        oracleText = "Do nothing.",
+        script = com.wingedsheep.sdk.model.CardScript.spell(
+            effect = com.wingedsheep.sdk.dsl.Effects.GainLife(1)
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VizierOfTheMenagerie, greenBear, greenSorcery))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("a green creature spell in hand is castable with only blue mana") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Vizier of the Menagerie")
+        val bear = driver.putCardInHand(you, "Test Green Bear")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        driver.legalActions(you).any {
+            it.actionType == "CastSpell" && it.description.contains("Test Green Bear")
+        } shouldBe true
+
+        driver.castSpell(you, bear).error shouldBe null
+        driver.bothPass()
+
+        driver.findPermanent(you, "Test Green Bear") shouldBe
+            driver.getCreatures(you).single { driver.getCardName(it) == "Test Green Bear" }
+    }
+
+    test("without the Vizier the same off-color cast is not offered") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInHand(you, "Test Green Bear")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        driver.legalActions(you).any {
+            it.actionType == "CastSpell" && it.description.contains("Test Green Bear")
+        } shouldBe false
+    }
+
+    test("the relaxation is creature-only — a green sorcery stays uncastable off-color") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Vizier of the Menagerie")
+        driver.putCardInHand(you, "Test Green Sorcery")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        driver.legalActions(you).any {
+            it.actionType == "CastSpell" && it.description.contains("Test Green Sorcery")
+        } shouldBe false
+    }
+
+    test("the displayed mana cost stays the printed cost, not the relaxed one") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Vizier of the Menagerie")
+        driver.putCardInHand(you, "Test Green Bear")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        val cast = driver.legalActions(you).single {
+            it.actionType == "CastSpell" && it.description.contains("Test Green Bear")
+        }
+        cast.manaCostString shouldBe "{1}{G}"
+    }
+
+    test("a green creature on top of the library is castable with only blue mana") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Vizier of the Menagerie")
+        val bear = driver.putCardOnTopOfLibrary(you, "Test Green Bear")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        val fromLibrary = driver.legalActions(you).singleOrNull {
+            it.actionType == "CastSpell" &&
+                it.description.contains("Test Green Bear") &&
+                it.sourceZone == "LIBRARY"
+        }
+        require(fromLibrary != null) { "Expected a library cast for the top creature card" }
+
+        driver.castSpell(you, bear).error shouldBe null
+        driver.bothPass()
+
+        driver.getCreatures(you).any { driver.getCardName(it) == "Test Green Bear" } shouldBe true
+    }
+
+    test("a noncreature card on top of the library is not castable from there") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Vizier of the Menagerie")
+        driver.putCardOnTopOfLibrary(you, "Test Green Sorcery")
+        driver.giveMana(you, Color.BLUE, 2)
+
+        driver.legalActions(you).any {
+            it.actionType == "CastSpell" && it.sourceZone == "LIBRARY"
+        } shouldBe false
+    }
+})


### PR DESCRIPTION
Works through part of the remaining Foundations tail. Foundations was at 97% with 8 missing, and everything left needs some amount of engine support — these three needed the least, ranging from none to one new SDK primitive each.

## Cards

### Kellan, Planar Trailblazer — FDN #91 (canonical FDN)
Pure authoring, no SDK change.

Both activated abilities wrap their whole body in a `ConditionalEffect` over `Conditions.SourceHasSubtype`. Per the ruling, the *"If Kellan is a …"* clause is a **resolution-time state test, not an activation restriction** — so both abilities are freely activatable and activating the second one out of order legally resolves as a no-op. The condition evaluates against projected state, so step 2 sees the Detective type that step 1's Layer-4 type change conferred.

Types are *replaced* (`SetCreatureSubtypes`), not added — dropping Scout for Detective is what makes the chain one-way. Nothing has a duration, so every grant is `Duration.Permanent`, and the 3/2 is a Layer 7b *set*, which overwrites earlier set-P/T effects but leaves counters and +N/+N modifiers alone.

### Vizier of the Menagerie — canonical AKH #192, FDN #649 reprint row
New static: **`SpendAnyManaTypeForSpells(filter)`** — the spell-side sibling of the existing `SpendAnyManaTypeForActivatedAbilities`.

It's deliberately **zone-agnostic**, because the ruling is explicit: *"You may spend mana as though it were mana of any type to cast **any** creature spell, not just creature spells that you cast from the top of your library."* That's why it can't be a flag on a cast permission — `MayPlayPermission.withAnyManaType` already covers per-card "cast *that exiled card* with any mana" grants, but "any creature spell you cast" isn't tied to one card in one zone.

Wired through the single `isCastWithAnyManaType` chokepoint in `CastSpellHandler` (which already fed both validation and payment) plus the affordability and auto-tap paths in `CastSpellEnumerator` and `CastFromZoneEnumerator`.

One deliberate UX call: the relaxation is applied to affordability, the solver, and payment, but **not** to the mana cost string sent to the client. The pre-existing may-play path does relax the display, which is fine for a single exiled card, but Vizier would rewrite the cost of *every* creature spell in your hand — a player seeing "Llanowar Elves — {1}" is worse than one seeing the printed cost. There's a test pinning this.

### Pyromancer's Goggles — canonical ORI #236, FDN #677 reprint row
New rider: **`ManaSpellRider.CopySpellWhenSpent(spellFilter)`**, plus a `riders` parameter on `AddManaEffect` (previously only `AddManaOfChoice` could carry riders).

The rulings map onto the design cleanly, and two of them fall out for free:
- *"The delayed triggered ability will trigger whether Pyromancer's Goggles is still on the battlefield or not"* — the trigger is built at payment time with the **spell** as its source, so the Goggles' fate is irrelevant.
- *"The copy resolves before the original spell"* — the copy trigger is queued above the spell (CR 707.10).
- The {R} itself is unrestricted (*"can be spent on anything"*), so it rides on an `AnySpend` pool entry and no-ops when spent elsewhere.

## One shared fix
Consumed mana riders are now collected as a **`List`, not a `Set`**. Multiplicity is load-bearing: *"If more than one red mana produced by a Pyromancer's Goggles is spent to cast a single red instant or sorcery spell … That many copies will be created."* Identical riders previously collapsed into a single set element, so the second copy was silently lost. `MakesSpellUncounterable` applied twice is idempotent, so nothing else changes.

## Verification
- 16 new scenario tests across the three cards, all passing — including the display-cost assertion, the creature-only / instant-or-sorcery-only filter negatives, and a case where the Goggles' {R} really does pay a colourless instant's generic cost so the rider is consumed and must then no-op.
- Full `just test` green (all modules), plus `CardLintTest`, `FacadeBoundaryTest` and `CardDefinitionSnapshotTest` run explicitly.
- Card snapshot goldens re-blessed: the diff is **additions only**, exactly the three new cards — nothing else moved, which is the check that the shared SDK/mana changes didn't perturb the rest of the corpus.
- `just check-card-printing` clean for all three (canonical in earliest real printing, reprint rows present).
- Foundations: 254 → 255 implemented. The 7 still missing each need genuinely new engine capability — triggered-ability emblems (Kaito), asymmetric face-down piles (Curator of Destinies), dynamic spell-copy counts (Thousand-Year Storm), stash-counter play-from-exile (Tinybones) — i.e. `add-feature` work rather than card authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)