### PR TITLE
Add Kaito, Cunning Infiltrator to Foundations

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KaitoCunningInfiltrator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KaitoCunningInfiltrator.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kaito, Cunning Infiltrator
+ * {1}{U}{U}
+ * Legendary Planeswalker — Kaito
+ * Loyalty 3
+ *
+ * Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.
+ * +1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.
+ * −2: Create a 2/1 blue Ninja creature token.
+ * −9: You get an emblem with "Whenever a player casts a spell, you create a 2/1 blue Ninja creature token."
+ *
+ * Modeling notes:
+ *  - The static-loyalty trigger is the Fynn/Ultimecia shape: a `dealsDamage` trigger with an ANY
+ *    binding and a `Creature.youControl()` source filter, so it fires for *any* creature you
+ *    control (including Kaito himself if some effect animates him), once per damaging creature per
+ *    combat-damage event (CR 603.2).
+ *  - The +1 target is genuinely optional (`optional = true`, count 1). Choosing no target still
+ *    loots — a composite keeps resolving past a sub-effect that can't do anything (CR 608.2). But
+ *    choosing a target that has become illegal by resolution counters the whole ability, so no
+ *    draw/discard happens; that's the printed ruling and falls out of normal targeting rules.
+ *  - The −9 emblem is a *triggered*-ability emblem, so it uses
+ *    [Effects.CreateGlobalTriggeredAbility] with [com.wingedsheep.sdk.scripting.Duration.Permanent]
+ *    (the Sarkhan/Sephiroth shape) rather than [Effects.CreatePermanentEmblem], which only carries
+ *    static P/T + keyword modifications. Global grants aren't attached to an entity and aren't
+ *    zone-checked, so the emblem survives Kaito leaving the battlefield.
+ *  - Per the printed ruling, the emblem's trigger goes on the stack above the spell that caused it,
+ *    so the token arrives before that spell resolves. That's automatic: the trigger is put on the
+ *    stack the next time a player would receive priority, i.e. on top of the still-unresolved spell.
+ */
+val KaitoCunningInfiltrator = card("Kaito, Cunning Infiltrator") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Planeswalker — Kaito"
+    startingLoyalty = 3
+    oracleText = "Whenever a creature you control deals combat damage to a player, put a loyalty " +
+        "counter on Kaito.\n" +
+        "+1: Up to one target creature you control can't be blocked this turn. Draw a card, then " +
+        "discard a card.\n" +
+        "−2: Create a 2/1 blue Ninja creature token.\n" +
+        "−9: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja " +
+        "creature token.\""
+
+    // Both the −2 and the emblem make the same token.
+    val ninjaToken = Effects.CreateToken(
+        power = 2,
+        toughness = 1,
+        colors = setOf(Color.BLUE),
+        creatureTypes = setOf("Ninja"),
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg?1783908590",
+    )
+
+    // Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(Counters.LOYALTY, 1, EffectTarget.Self)
+        description = "Whenever a creature you control deals combat damage to a player, put a " +
+            "loyalty counter on Kaito."
+    }
+
+    // +1: Up to one target creature you control can't be blocked this turn.
+    //     Draw a card, then discard a card.
+    loyaltyAbility(+1) {
+        val creature = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature) then
+            Patterns.Hand.loot()
+    }
+
+    // −2: Create a 2/1 blue Ninja creature token.
+    loyaltyAbility(-2) {
+        effect = ninjaToken
+    }
+
+    // −9: You get an emblem with "Whenever a player casts a spell, you create a 2/1 blue Ninja
+    //     creature token."
+    loyaltyAbility(-9) {
+        effect = Effects.CreateGlobalTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.AnyPlayerCastsSpell.event,
+                binding = Triggers.AnyPlayerCastsSpell.binding,
+                effect = ninjaToken,
+                descriptionOverride = "Whenever a player casts a spell, you create a 2/1 blue " +
+                    "Ninja creature token.",
+            ),
+            descriptionOverride = "Whenever a player casts a spell, you create a 2/1 blue Ninja " +
+                "creature token.",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "44"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg?1783909117"
+
+        ruling("2024-11-08", "You don't have to choose a target for Kaito's first loyalty ability. However, if you do and that target is illegal when the ability tries to resolve, it won't resolve and none of its effects will happen. You won't draw or discard. The loyalty counter that was added to Kaito to pay the cost of the ability will remain on Kaito, however.")
+        ruling("2024-11-08", "The ability of the emblem created by Kaito's last ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -4835,6 +4835,191 @@
     ]
 }
 
+// Kaito, Cunning Infiltrator
+{
+    "name": "Kaito, Cunning Infiltrator",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Planeswalker — Kaito",
+    "oracleText": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.\n+1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.\n−2: Create a 2/1 blue Ninja creature token.\n−9: You get an emblem with \"Whenever a player casts a spell, you create a 2/1 blue Ninja creature token.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "loyalty",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "CANT_BE_BLOCKED",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "up to one target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Ninja"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg?1783908590"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -9
+                },
+                "effect": {
+                    "type": "CreateGlobalTriggeredAbility",
+                    "ability": {
+                        "id": "ability_5",
+                        "trigger": {
+                            "type": "SpellCastEvent",
+                            "player": "Each"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 1,
+                            "colors": [
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Ninja"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/a/e/aeec04b1-475c-4e55-b72f-327ea5258146.jpg?1783908590"
+                        },
+                        "descriptionOverride": "Whenever a player casts a spell, you create a 2/1 blue Ninja creature token."
+                    },
+                    "descriptionOverride": "Whenever a player casts a spell, you create a 2/1 blue Ninja creature token."
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "MYTHIC",
+        "artist": "Evyn Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5dabdea9-2015-49b9-853d-4f7e1262eab3.jpg?1783909117",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "You don't have to choose a target for Kaito's first loyalty ability. However, if you do and that target is illegal when the ability tries to resolve, it won't resolve and none of its effects will happen. You won't draw or discard. The loyalty counter that was added to Kaito to pay the cost of the ability will remain on Kaito, however."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The ability of the emblem created by Kaito's last ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving."
+            }
+        ]
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Kellan, Planar Trailblazer
 {
     "name": "Kellan, Planar Trailblazer",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaitoCunningInfiltratorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaitoCunningInfiltratorScenarioTest.kt
@@ -1,0 +1,285 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.KaitoCunningInfiltrator
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.core.SelectCardsDecision
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Kaito, Cunning Infiltrator (FDN, {1}{U}{U}, Loyalty 3).
+ *
+ *   Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.
+ *   +1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.
+ *   −2: Create a 2/1 blue Ninja creature token.
+ *   −9: You get an emblem with "Whenever a player casts a spell, you create a 2/1 blue Ninja creature token."
+ *
+ * Covers the passive loyalty trigger (and that it ignores creatures you *don't* control), the +1's
+ * genuinely-optional target (both with and without a target chosen — the loot happens either way),
+ * the −2 token's exact characteristics, and the −9 emblem: it outlives Kaito dying to the 0-loyalty
+ * state-based action and fires for spells cast by *either* player.
+ */
+class KaitoCunningInfiltratorScenarioTest : ScenarioTestBase() {
+
+    private val plusOne = KaitoCunningInfiltrator.activatedAbilities[0].id
+    private val minusTwo = KaitoCunningInfiltrator.activatedAbilities[1].id
+    private val minusNine = KaitoCunningInfiltrator.activatedAbilities[2].id
+
+    init {
+        context("Kaito, Cunning Infiltrator") {
+
+            test("a creature you control connecting puts a loyalty counter on Kaito") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                // The scenario builder drops permanents straight onto the battlefield without
+                // running the "enters with its starting loyalty" step, so seed it explicitly.
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 3))
+                }
+                loyalty(game, kaito) shouldBe 3
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+
+                withClue("Bears dealt 2 combat damage to the opponent") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("the passive trigger added one loyalty counter") {
+                    loyalty(game, kaito) shouldBe 4
+                }
+            }
+
+            test("a creature an opponent controls connecting does NOT bump Kaito's loyalty") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                // The scenario builder drops permanents straight onto the battlefield without
+                // running the "enters with its starting loyalty" step, so seed it explicitly.
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 3))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // Attack the player, not Kaito, so no loyalty is removed by combat damage either.
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+
+                withClue("the opponent's Bears connected") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+                withClue("'a creature you control' filtered out the opponent's attacker") {
+                    loyalty(game, kaito) shouldBe 3
+                }
+            }
+
+            test("+1 makes the target unblockable and loots") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                // The scenario builder drops permanents straight onto the battlefield without
+                // running the "enters with its starting loyalty" step, so seed it explicitly.
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 3))
+                }
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Bears is blockable before the ability") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+                }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = kaito,
+                        abilityId = plusOne,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Draw a card, then discard a card — the discard asks which card to pitch.
+                val discard = game.getPendingDecision()
+                withClue("resolution paused on the loot's discard: $discard") {
+                    (discard is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf((discard as SelectCardsDecision).options.first())).error shouldBe null
+                game.resolveStack()
+
+                withClue("target can't be blocked this turn") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+                withClue("drew one and discarded one: hand size unchanged, graveyard grew") {
+                    game.handSize(1) shouldBe 1
+                    game.graveyardSize(1) shouldBe 1
+                    game.librarySize(1) shouldBe 0
+                }
+                withClue("+1 paid a loyalty counter onto Kaito") {
+                    loyalty(game, kaito) shouldBe 4
+                }
+            }
+
+            test("+1 with no target chosen still loots") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                // The scenario builder drops permanents straight onto the battlefield without
+                // running the "enters with its starting loyalty" step, so seed it explicitly.
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 3))
+                }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = kaito,
+                        abilityId = plusOne,
+                        targets = emptyList(),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val discard = game.getPendingDecision()
+                withClue("'up to one' with zero targets still reaches the loot: $discard") {
+                    (discard is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf((discard as SelectCardsDecision).options.first())).error shouldBe null
+                game.resolveStack()
+
+                withClue("drew one and discarded one") {
+                    game.handSize(1) shouldBe 1
+                    game.graveyardSize(1) shouldBe 1
+                }
+                loyalty(game, kaito) shouldBe 4
+            }
+
+            test("−2 creates a 2/1 blue Ninja token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                // The scenario builder drops permanents straight onto the battlefield without
+                // running the "enters with its starting loyalty" step, so seed it explicitly.
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 3))
+                }
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = kaito, abilityId = minusTwo)
+                ).error shouldBe null
+                game.resolveStack()
+
+                val token = game.findPermanent("Ninja Token")
+                withClue("the −2 created a token") { token shouldNotBe null }
+                val projected = game.state.projectedState
+                withClue("2/1 blue Ninja") {
+                    projected.getProjectedValues(token!!)?.power shouldBe 2
+                    projected.getProjectedValues(token)?.toughness shouldBe 1
+                    projected.isCreature(token) shouldBe true
+                }
+                withClue("−2 removed two loyalty counters") {
+                    loyalty(game, kaito) shouldBe 1
+                }
+            }
+
+            test("−9 emblem outlives Kaito and makes a Ninja whenever any player casts a spell") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kaito, Cunning Infiltrator")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                game.state = game.state.updateEntity(kaito) { c ->
+                    c.with(CountersComponent().withAdded(CounterType.LOYALTY, 9))
+                }
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = kaito, abilityId = minusNine)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Kaito hit 0 loyalty and died, but the emblem is a global grant") {
+                    game.findPermanent("Kaito, Cunning Infiltrator") shouldBe null
+                    game.state.globalGrantedTriggeredAbilities.size shouldBe 1
+                }
+
+                // Your own spell triggers it.
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                withClue("you cast a spell → one Ninja token") {
+                    game.findPermanents("Ninja Token").size shouldBe 1
+                }
+
+                // So does an opponent's spell ("whenever a player casts a spell").
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.state = game.state.copy(activePlayerId = game.player2Id, priorityPlayerId = game.player2Id)
+                game.castSpell(2, "Hill Giant").error shouldBe null
+                game.resolveStack()
+                withClue("the opponent casting a spell also makes you a Ninja") {
+                    game.findPermanents("Ninja Token").size shouldBe 2
+                }
+                withClue("the emblem's tokens are yours, not the caster's") {
+                    game.findPermanents("Ninja Token").forEach { token ->
+                        controllerOf(game, token) shouldBe game.player1Id
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun controllerOf(game: TestGame, id: EntityId): EntityId? =
+        game.state.getEntity(id)
+            ?.get<ControllerComponent>()
+            ?.playerId
+}


### PR DESCRIPTION
Rolled at random from the FDN missing list. **FDN goes 255 → 256 / 262.**

## Kaito, Cunning Infiltrator — {1}{U}{U}, Legendary Planeswalker — Kaito, Loyalty 3

> Whenever a creature you control deals combat damage to a player, put a loyalty counter on Kaito.
> +1: Up to one target creature you control can't be blocked this turn. Draw a card, then discard a card.
> −2: Create a 2/1 blue Ninja creature token.
> −9: You get an emblem with "Whenever a player casts a spell, you create a 2/1 blue Ninja creature token."

## No SDK change needed

The FDN triage note had this card down as blocked on "emblems that grant a *triggered* ability".
That capability already exists — `Effects.CreateGlobalTriggeredAbility` (the Sarkhan / Sephiroth
shape) — it's `Effects.CreatePermanentEmblem` that's limited to static P/T + keyword grants. So
this is pure card authoring: one new card file plus its scenario test.

| Clause | Composed from |
|---|---|
| passive loyalty trigger | `Triggers.dealsDamage(Combat, AnyPlayer, Creature.youControl(), ANY)` + `Effects.AddCounters(LOYALTY, 1, Self)` |
| +1 evasion | `Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, …)` on an `optional = true` target |
| +1 loot | `Patterns.Hand.loot()` |
| −2 / emblem token | `Effects.CreateToken(2, 1, BLUE, "Ninja")` |
| −9 emblem | `Effects.CreateGlobalTriggeredAbility(Duration.Permanent)` wrapping `Triggers.AnyPlayerCastsSpell` |

## Rules details worth a look

- **"Up to one target"** — `optional = true` gives `effectiveMinCount = 0`, which the client's
  `BattlefieldTargetingUI` already renders as a declinable on-battlefield selection
  (`canDecline = minTargets === 0`). Declining still loots, because `CompositeEffect` keeps
  resolving past a sub-effect that can't do anything (CR 608.2). Choosing a target that has
  *become* illegal counters the whole ability, so no draw/discard — the printed 2024-11-08 ruling,
  and it falls out of normal targeting rules rather than needing special-casing.
- **Emblem survives Kaito** — activating −9 from 9 loyalty drops him to 0 and he dies to the
  state-based action, but global grants live on `GameState.globalGrantedTriggeredAbilities` with
  a controller id and aren't zone-checked, so the emblem persists. It surfaces to the client as a
  "Kaito Cunning Infiltrator Emblem" player-effect badge via the existing transformer path.
- **"a player casts a spell"** is `Player.Each`, so an opponent's spell also makes *you* a Ninja
  (the token's controller is the emblem's controller, not the caster) — asserted in the test.
- **Loyalty ability button labels** come from parsing the card's own `oracleText` loyalty lines,
  so the printed text (including the U+2212 minus signs) is what players see. Verified byte-for-byte
  against Scryfall.

## Verification

- `KaitoCunningInfiltratorScenarioTest` — 6 tests, all passing: the trigger fires for your
  creature and *not* for an opponent's attacker; +1 with a target and with no target; the −2
  token's P/T / color / type; the emblem outliving Kaito and firing for either player's spell.
- `:mtg-sets:test` — 332 tests, 0 failures (`CardLintTest`, `FacadeBoundaryTest`,
  `CardDefinitionSnapshotTest` re-blessed — the FDN golden diff is purely additive and touches
  only this card).
- `just check-card-printing "Kaito, Cunning Infiltrator"` — ok, canonical is in FDN, the earliest
  real printing.
- Every field re-checked against `api.scryfall.com/cards/named?...&set=fdn`; both image URLs
  return HTTP 200.

## Not done

The mtgish emitter still scaffolds this card (`unrecovered: ['PutCounters']`). Teaching it to
render loyalty-counter `PutCounters` would unlock auto-drafts across other planeswalkers, but
that's emitter work rather than part of this card, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)