### PR TITLE
Add Liliana, Dreadhorde General with a choose-one-per-category pipeline step

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1256,6 +1256,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   composite step can read the count via `DynamicAmounts.permanentsSacrificedThisWay()` — e.g.
   "Sacrifice any number of lands. Reveal the top X cards … where X is the number of lands
   sacrificed this way" (Hew the Entwood; same shape as Scapeshift).
+- "Each player chooses \<one permanent per category\> they control, then \<does something to\> the
+  rest" is a **pipeline composition**, not an effect type — see `chooseOnePerCategory` / `exclude` in
+  §5.5. Liliana, Dreadhorde General's −9 is
+  `gather(Permanent.opponentControls())` → `chooseOnePerCategory(…, Filters.PermanentTypes)` →
+  `sacrifice(exclude(pool, kept))`; swapping the last step gives Consuming Tide's "returns the rest
+  to their hands", and swapping the category list gives Cataclysm / Divine Reckoning. For "all
+  permanents matching a filter are sacrificed by their controllers" with no choice at all, use
+  `Effects.SacrificeAll(filter)` instead.
 - "Return a permanent you control [to its owner's hand]" is a pipeline composition, not an effect type:
   `GatherCards(BattlefieldMatching(filter, Player.You, excludeSelf?))` →
   `SelectFromCollection(ChooseExactly(1), useTargetingUI = true)` → `MoveCollection(→ HAND)` (the
@@ -1963,7 +1971,8 @@ with cards):
 | `gather(source)` / `gather(filter, player?, …)` (battlefield shorthand) | `GatherCardsEffect` |
 | `gatherUntilMatch(filter, …)` → `(match, revealed)` | `GatherUntilMatchEffect` |
 | `chooseExactly(n, from)` / `chooseUpTo` / `chooseAnyNumber` / `chooseRandom` / `selectAll` (+ `…Split` variants returning `(selected, remainder)`) | `SelectFromCollectionEffect` |
-| `filter(from, filter)` / `filterSplit(…)` → `(matching, rest)` | `FilterCollectionEffect` |
+| `filter(from, filter)` / `filterSplit(…)` → `(matching, rest)` / `exclude(from, minus)` (set difference via `CollectionFilter.ExcludeOtherCollection`) | `FilterCollectionEffect` |
+| `chooseOnePerCategory(from, categories)` | `ChooseOnePerCategoryEffect` |
 | `move(from, destination, …)` / `moveTracked(…)` / sugar `destroy`, `sacrifice`, `exile`, `toHand`, `toGraveyard`, `toLibraryTop`, `toLibraryBottom` | `MoveCollectionEffect` |
 | `reveal(from, …)` | `RevealCollectionEffect` |
 | `captureControllers(from)` | `CaptureControllersEffect` |
@@ -1977,6 +1986,28 @@ with cards):
 | `ifNotEmpty(slot, filter?, minSize?) { … } orElse { … }` | `ConditionalOnCollectionEffect` |
 | `whenMatches(slot, filter)` (returns a `Condition`, adds no step) | `CollectionContainsMatch` |
 | `run(effect)` | any other `Effect`, verbatim |
+
+**`chooseOnePerCategory(from, categories)`** — "…chooses a permanent they control of each permanent
+type…". Each *controller* represented in `from` picks one of their own members for every filter in
+`categories`, and all picks land in the returned slot. Choosers are asked in **APNAP order**
+(CR 101.4) — the choosers are derived from the pool's controllers, so the "each player" / "each
+opponent" scoping lives in the `gather`, not in the step. A category the chooser controls nothing of
+is skipped, a category with one candidate resolves itself without a prompt, and **one permanent may
+be the pick for several categories** (an artifact creature spared as both the artifact and the
+creature) — which is why this is a sequence of one-of-each choices and not a single
+`SelectionRestriction.OnePerCardType` selection, under which that permanent could claim only one of
+its types. The step moves nothing; pair it with `exclude` for "the rest" and any move step for their
+fate:
+
+```kotlin
+// Liliana, Dreadhorde General −9: "Each opponent chooses a permanent they control of each
+// permanent type and sacrifices the rest."
+effect = Effects.Pipeline {
+    val atRisk = gather(GameObjectFilter.Permanent.opponentControls())
+    val kept = chooseOnePerCategory(atRisk, Filters.PermanentTypes)
+    sacrifice(exclude(atRisk, kept))
+}
+```
 
 `run(...)` keeps the builder open: non-pipeline effects (a `ShuffleLibraryEffect`, a damage effect)
 interleave without the builder needing a verb for everything. Optional secondary outputs
@@ -2394,6 +2425,12 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   card that satisfies more than one clause is counted once).
 - `Filters.Permanent` — permanent card.
 - `Filters.NonlandPermanent` — nonland permanent.
+- `Filters.PermanentTypes` — a `List<GameObjectFilter>`, one per **permanent type** (CR 110.4), in the
+  order the rules list them: artifact, creature, enchantment, land, planeswalker. The canonical
+  expansion of "of each permanent type" — feed it to `chooseOnePerCategory` (§5.5) as in Liliana,
+  Dreadhorde General's −9. CR 110.4
+  names six types; *battle* is absent because the engine has no `CardType.BATTLE` yet, so adding
+  battles means adding the filter here and every "each permanent type" card picks it up.
 - `Filters.WithSubtype(subtype)` — card of a given subtype.
 - `GameObjectFilter.Multicolored` — multicolored card (two or more colors; `CardPredicate.IsMulticolored`).
 - `CardPredicate.IsColored` — one or more colors (the complement of `IsColorless`). Used for "a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
@@ -106,6 +106,26 @@ object Filters {
     val NonlandPermanent: GameObjectFilter = GameObjectFilter.NonlandPermanent
 
     /**
+     * One filter per **permanent type** (CR 110.4), in the order the rules list them — the
+     * canonical expansion of "of each permanent type" (Liliana, Dreadhorde General's −9).
+     *
+     * CR 110.4 names six permanent types; battle is omitted because the engine has no `Battle`
+     * card type yet (see [com.wingedsheep.sdk.core.CardType]). When battles land, add the filter
+     * here and every card reading "each permanent type" picks it up.
+     *
+     * A permanent with several types satisfies each of them, and one that has lost all its
+     * permanent types (CR 110.4c) satisfies none — both fall out of matching each filter
+     * independently.
+     */
+    val PermanentTypes: List<GameObjectFilter> = listOf(
+        GameObjectFilter.Artifact,
+        GameObjectFilter.Creature,
+        GameObjectFilter.Enchantment,
+        GameObjectFilter.Land,
+        GameObjectFilter.Planeswalker
+    )
+
+    /**
      * Card with a specific subtype.
      */
     fun WithSubtype(subtype: String): GameObjectFilter = GameObjectFilter.Any.withSubtype(subtype)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.effects.CaptureControllersEffect
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardOrder
 import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ChooseOnePerCategoryEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseOptionEffect
 import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
 import com.wingedsheep.sdk.scripting.effects.Chooser
@@ -459,6 +460,26 @@ class PipelineBuilder private constructor(private val shared: Shared) {
         name = name, remainderName = null, withRemainder = false
     ).selected
 
+    /**
+     * Each controller of a permanent in [from] picks one of their own for every filter in
+     * [categories] ([ChooseOnePerCategoryEffect]) — "chooses a permanent they control of each
+     * permanent type". Choosers are asked in APNAP order and one permanent may cover several
+     * categories. Returns the collection of everyone's picks; feed it to [exclude] for "the rest".
+     */
+    fun chooseOnePerCategory(
+        from: CollectionSlot,
+        categories: List<GameObjectFilter>,
+        name: String? = null
+    ): CollectionSlot {
+        val slot = CollectionSlot(slotKey("kept", nextIndex(), name))
+        steps += ChooseOnePerCategoryEffect(
+            from = from.key,
+            categories = categories,
+            storeAs = slot.key
+        )
+        return slot
+    }
+
     // =========================================================================
     // Filter / partition (no player choice)
     // =========================================================================
@@ -500,6 +521,14 @@ class PipelineBuilder private constructor(private val shared: Shared) {
         name: String? = null,
         restName: String? = null
     ): FilterSlots = filterSplit(from, CollectionFilter.MatchesFilter(filter), name, restName)
+
+    /**
+     * Set difference: the members of [from] that are **not** in [minus]
+     * ([CollectionFilter.ExcludeOtherCollection]). The "…and \<does something to\> the rest"
+     * half of a choose-then-punish pipeline — pair with [chooseOnePerCategory] or a select step.
+     */
+    fun exclude(from: CollectionSlot, minus: CollectionSlot, name: String? = null): CollectionSlot =
+        filter(from, CollectionFilter.ExcludeOtherCollection(minus.key), name)
 
     // =========================================================================
     // Capture / store

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -1716,6 +1716,62 @@ data class FilterCollectionEffect(
 }
 
 /**
+ * "…chooses a \<permanent of each category\> they control…" — each permanent's **controller** picks
+ * one member of [from] for every filter in [categories], and all the picks land in [storeAs].
+ *
+ * The choosers are the distinct controllers of the permanents in [from], asked in APNAP order
+ * (CR 101.4) so the active player picks first and each later player chooses knowing what came
+ * before. Per chooser, the categories are offered in list order over just the members of [from]
+ * they control: a category they control nothing of is skipped, a category with a single candidate
+ * resolves itself without a prompt, and **one permanent may be the pick for several categories** —
+ * an artifact creature can be spared as both the artifact and the creature, which is why this is a
+ * sequence of one-of-each choices rather than a single restricted selection
+ * ([SelectionRestriction.OnePerCardType] would let that permanent claim only one of its types).
+ *
+ * This step only *chooses*; it moves nothing. Pair it with
+ * [CollectionFilter.ExcludeOtherCollection] to get "the rest", then any move step to decide their
+ * fate — which is what makes the whole family authorable from atoms:
+ *
+ * ```kotlin
+ * // Liliana, Dreadhorde General −9: "…and sacrifices the rest"
+ * Effects.Pipeline {
+ *     val atRisk = gather(GameObjectFilter.Permanent.controlledByOpponent())
+ *     val kept = chooseOnePerCategory(atRisk, Filters.PermanentTypes)
+ *     sacrifice(exclude(atRisk, kept))
+ * }
+ * ```
+ *
+ * Swapping the last step gives Consuming Tide ("returns the rest to their hands"); swapping the
+ * category list gives Cataclysm and Divine Reckoning.
+ *
+ * @property from Collection to choose from — every candidate, across all affected players.
+ * @property categories One filter per choice each controller makes, in the order they are offered.
+ * @property storeAs Collection receiving every player's picks (deduplicated).
+ */
+@SerialName("ChooseOnePerCategory")
+@Serializable
+data class ChooseOnePerCategoryEffect(
+    val from: String,
+    val categories: List<GameObjectFilter>,
+    val storeAs: String
+) : Effect {
+    init {
+        require(categories.isNotEmpty()) {
+            "ChooseOnePerCategoryEffect needs at least one category; with none it chooses nothing."
+        }
+    }
+
+    override val description: String =
+        "each player chooses ${categories.joinToString(", ") { it.description }} they control"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newCategories = categories.map { it.applyTextReplacement(replacer) }
+        val changed = newCategories.indices.any { newCategories[it] !== categories[it] }
+        return if (changed) copy(categories = newCategories) else this
+    }
+}
+
+/**
  * Evaluate a [DynamicAmount] once and store it in pipeline `storedNumbers` under [name].
  * Subsequent effects in the same composite can read it via
  * [DynamicAmount.VariableReference] so the value does not drift when earlier sub-effects

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -178,6 +178,7 @@ object CardLinter {
         put("Behold" to "storeAs", write(Space.COLLECTION))
         put("BeholdOrPay" to "storeAs", write(Space.COLLECTION))
         put("ChooseEntity" to "storeAs", write(Space.COLLECTION))
+        put("ChooseOnePerCategory" to "storeAs", write(Space.COLLECTION))
         put("StoreNumber" to "name", write(Space.NUMBER))
         put("FlipCoins" to "storeHeadsAs", write(Space.NUMBER))
         put("ForEachCapturedController" to "countVariable", write(Space.NUMBER))
@@ -195,6 +196,7 @@ object CardLinter {
             "ChoosePile", "MoveCollection", "GrantMayPlayFromExile", "GrantPlayWithoutPayingCost",
             "MakePlotted",
             "GrantPlayWithAdditionalCost", "GrantPlayWithCostIncrease", "FilterCollection",
+            "ChooseOnePerCategory",
             "StoreCardName", "CastFromCollectionWithoutPayingCost",
             "CastAnyNumberFromCollectionWithoutPayingCost", "ExileFromStorage",
             "CopyCollectionIntoCollection", "RecordChosenLinkedExile",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LilianaDreadhordeGeneralReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LilianaDreadhordeGeneralReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liliana, Dreadhorde General reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in War of the Spark (its earliest printing);
+ * this file contributes only presentation data.
+ */
+val LilianaDreadhordeGeneralReprint = Printing(
+    oracleId = "5e958212-6a5b-4288-8d31-f1572619d7dc",
+    name = "Liliana, Dreadhorde General",
+    setCode = "FDN",
+    collectorNumber = "176",
+    scryfallId = "cb28d217-795e-4320-a032-cd713f7ecc8a",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb28d217-795e-4320-a032-cd713f7ecc8a.jpg?1783909073",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/LilianaDreadhordeGeneral.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/LilianaDreadhordeGeneral.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Liliana, Dreadhorde General
+ * {4}{B}{B}
+ * Legendary Planeswalker — Liliana
+ * Starting Loyalty: 6
+ *
+ * Whenever a creature you control dies, draw a card.
+ * +1: Create a 2/2 black Zombie creature token.
+ * −4: Each player sacrifices two creatures of their choice.
+ * −9: Each opponent chooses a permanent they control of each permanent type and sacrifices
+ *     the rest.
+ *
+ * The two sacrifice abilities are both "every affected player chooses, then the sacrifices happen"
+ * (CR 101.4), so both resolve in APNAP order — via [Player.ActivePlayerFirst] for the −4 and via
+ * `chooseOnePerCategory`'s own APNAP walk for the −9 — the active player picks first and each later
+ * player chooses knowing what came before.
+ *
+ * The −9 uses [Filters.PermanentTypes] rather than a hand-written type list: one pick per permanent
+ * type the opponent controls, where a permanent with several types can be the pick for each of them
+ * (an artifact creature can be both the surviving artifact and the surviving creature).
+ */
+val LilianaDreadhordeGeneral = card("Liliana, Dreadhorde General") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Planeswalker — Liliana"
+    startingLoyalty = 6
+    oracleText = "Whenever a creature you control dies, draw a card.\n" +
+        "+1: Create a 2/2 black Zombie creature token.\n" +
+        "−4: Each player sacrifices two creatures of their choice.\n" +
+        "−9: Each opponent chooses a permanent they control of each permanent type and " +
+        "sacrifices the rest."
+
+    // Whenever a creature you control dies, draw a card.
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        effect = Effects.DrawCards(1)
+    }
+
+    // +1: Create a 2/2 black Zombie creature token.
+    loyaltyAbility(+1) {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg?1783933352"
+        )
+    }
+
+    // −4: Each player sacrifices two creatures of their choice.
+    // A player who controls only one creature sacrifices just that one (the executor auto-takes
+    // everything when the board is at or under the required count).
+    loyaltyAbility(-4) {
+        effect = Effects.Sacrifice(
+            filter = GameObjectFilter.Creature,
+            count = 2,
+            target = EffectTarget.PlayerRef(Player.ActivePlayerFirst)
+        )
+    }
+
+    // −9: Each opponent chooses a permanent they control of each permanent type and sacrifices
+    // the rest.
+    //
+    // Gather → choose-one-per-type → sacrifice the difference. The pool is scoped by the filter
+    // rather than the gather's `player` (which resolves to a single player), so "each opponent" is
+    // one control predicate; `chooseOnePerCategory` then asks each of those opponents in APNAP
+    // order, and `exclude` is the "the rest" half.
+    loyaltyAbility(-9) {
+        effect = Effects.Pipeline {
+            val atRisk = gather(GameObjectFilter.Permanent.opponentControls())
+            val kept = chooseOnePerCategory(atRisk, Filters.PermanentTypes)
+            sacrifice(exclude(atRisk, kept))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "97"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg?1783933442"
+
+        ruling("2024-01-12", "If Liliana dies at the same time as one or more creatures you control, her first ability triggers for each of those creatures.")
+        ruling("2024-01-12", "If Liliana somehow becomes a creature and dies, her first ability will trigger.")
+        ruling("2024-01-12", "As Liliana's second loyalty ability resolves, first the player whose turn it is chooses two creatures they control, then each other player in turn order does the same, knowing the choices made before them. Then all the chosen creatures are sacrificed at the same time. If any player can choose only one creature, that player does so.")
+        ruling("2024-01-12", "As Liliana's last ability resolves, the next opponent in turn order (or, if it's somehow an opponent's turn, that opponent) makes all of their choices for it, then each other opponent in turn order does the same, knowing the choices made before them. Then all the unchosen permanents are sacrificed at the same time.")
+        ruling("2024-01-12", "The permanent types are artifact, creature, enchantment, land, and planeswalker. Supertypes, like legendary, aren't permanent types.")
+        ruling("2024-01-12", "While making choices for Liliana's last ability, if a permanent has more than one permanent type, it can count for any of them. For example, you could choose an artifact creature as the artifact you're sparing, another creature as the creature, and an enchantment creature as the enchantment. Similarly, you could choose an enchantment creature as both the creature and the enchantment that you're sparing, even if you control another creature and/or another enchantment.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -287,6 +287,184 @@
     ]
 }
 
+// Liliana, Dreadhorde General
+{
+    "name": "Liliana, Dreadhorde General",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Legendary Planeswalker — Liliana",
+    "oracleText": "Whenever a creature you control dies, draw a card.\n+1: Create a 2/2 black Zombie creature token.\n−4: Each player sacrifices two creatures of their choice.\n−9: Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/3/935d1421-0d26-468f-aa86-488b0ba25e77.jpg?1783933352"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -4
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "count": 2,
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "ActivePlayerFirst"
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -9
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "permanent ctrl:opponent"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "ChooseOnePerCategory",
+                            "from": "gathered0",
+                            "categories": [
+                                {
+                                    "cardPredicates": [
+                                        "IsArtifact"
+                                    ]
+                                },
+                                {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ]
+                                },
+                                {
+                                    "cardPredicates": [
+                                        "IsEnchantment"
+                                    ]
+                                },
+                                {
+                                    "cardPredicates": [
+                                        "IsLand"
+                                    ]
+                                },
+                                {
+                                    "cardPredicates": [
+                                        "IsPlaneswalker"
+                                    ]
+                                }
+                            ],
+                            "storeAs": "kept1"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "ExcludeOtherCollection",
+                                "otherCollectionName": "kept1"
+                            },
+                            "storeMatching": "matching2"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "matching2",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Sacrifice"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d75ebba8-34ca-47a0-bf13-8318ad73b343.jpg?1783933442",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "If Liliana dies at the same time as one or more creatures you control, her first ability triggers for each of those creatures."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "If Liliana somehow becomes a creature and dies, her first ability will trigger."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "As Liliana's second loyalty ability resolves, first the player whose turn it is chooses two creatures they control, then each other player in turn order does the same, knowing the choices made before them. Then all the chosen creatures are sacrificed at the same time. If any player can choose only one creature, that player does so."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "As Liliana's last ability resolves, the next opponent in turn order (or, if it's somehow an opponent's turn, that opponent) makes all of their choices for it, then each other opponent in turn order does the same, knowing the choices made before them. Then all the unchosen permanents are sacrificed at the same time."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "The permanent types are artifact, creature, enchantment, land, and planeswalker. Supertypes, like legendary, aren't permanent types."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "While making choices for Liliana's last ability, if a permanent has more than one permanent type, it can count for any of them. For example, you could choose an artifact creature as the artifact you're sparing, another creature as the creature, and an enchantment creature as the enchantment. Similarly, you could choose an enchantment creature as both the creature and the enchantment that you're sparing, even if you control another creature and/or another enchantment."
+            }
+        ]
+    },
+    "startingLoyalty": 6,
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spellgorger Weird
 {
     "name": "Spellgorger Weird",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -58,6 +58,15 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     effect("LoseLife", "LoseLife")
 
     effect("SacrificePermanent", "Sacrifice")
+    // "chooses a permanent they control of each permanent type" (Liliana, Dreadhorde General's −9) —
+    // the ChooseOnePerCategory pipeline step over Filters.PermanentTypes. The IR follows this action
+    // with `SacrificeEachPermanent(ExceptFor(ThePermanentsChosenThisWay))`, which is the
+    // exclude → sacrifice tail of the same pipeline; that trio is *deliberately left unmapped*,
+    // because those three tags appear on 100+ cards in shapes this step does not cover and mapping
+    // them here would score all of them as coverable. Recovering the pair (which would also unlock
+    // Cataclysm / Divine Reckoning / Tragic Arrogance) is its own emitter pass.
+    effect("ChooseAPermanentOfEachPermanentTypeAvailable", "ChooseOnePerCategory",
+        "one pick per permanent type — chooseOnePerCategory(pool, Filters.PermanentTypes)")
     effect("CounterSpell", "Counter")
     // "Counter target spell, activated ability, or triggered ability" (Overcharged Amalgam's exploit
     // payoff, Teferi's Response). Same CounterEffect as CounterSpell, but its target dispatches at

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.ChooseOnePerCategoryEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import kotlinx.serialization.Serializable
@@ -29,6 +30,31 @@ data class SacrificeContinuation(
     val remainingPlayers: List<EntityId> = emptyList(),
     val filter: GameObjectFilter? = null,
     val count: Int = 1
+) : ContinuationFrame
+
+/**
+ * Resume after a player picked the one permanent they keep for a single category of a
+ * [ChooseOnePerCategoryEffect] — "chooses a permanent they control of each permanent type".
+ *
+ * The step publishes nothing until every chooser has answered every category (CR 101.4), so the
+ * frame carries the whole in-progress tally.
+ *
+ * @property storedCollections The resolving pipeline's collections, re-published on completion so
+ *   the downstream "…the rest" steps see both the pool and the picks.
+ * @property pendingPlayers The choosers that still have picks to make, the current one first.
+ * @property categoryIndex Index into `effect.categories` that the pending decision answers.
+ * @property picks Every pick made so far, across all choosers.
+ */
+@Serializable
+data class ChooseOnePerCategoryContinuation(
+    override val decisionId: String,
+    val effect: ChooseOnePerCategoryEffect,
+    val sourceId: EntityId?,
+    val sourceName: String?,
+    val storedCollections: Map<String, List<EntityId>>,
+    val pendingPlayers: List<EntityId>,
+    val categoryIndex: Int,
+    val picks: List<EntityId>
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -272,6 +272,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseOptionPipelineContinuation::class)
         subclass(NoteCreatureTypePipelineContinuation::class)
         subclass(ChoosePileContinuation::class)
+        subclass(ChooseOnePerCategoryContinuation::class)
         subclass(ChooseGuessKindContinuation::class)
         subclass(GuessTopCardKindContinuation::class)
         subclass(SelectTargetPipelineContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.library.CascadeExecutor
+import com.wingedsheep.engine.handlers.effects.library.ChooseOnePerCategoryExecutor
 import com.wingedsheep.engine.handlers.effects.library.CastFromCollectionWithoutPayingCostExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -39,6 +40,7 @@ class LibraryAndZoneContinuationResumer(
         resumer(PutOnBottomOfLibraryContinuation::class, ::resumePutOnBottomOfLibrary),
         resumer(PutFromHandContinuation::class, ::resumePutFromHand),
         resumer(SelectFromCollectionContinuation::class, ::resumeSelectFromCollection),
+        resumer(ChooseOnePerCategoryContinuation::class, ::resumeChooseOnePerCategory),
         resumer(ChoosePileContinuation::class, ::resumeChoosePile),
         resumer(SelectTargetPipelineContinuation::class, ::resumeSelectTargetPipeline),
         resumer(MoveCollectionAuraTargetContinuation::class, ::resumeMoveCollectionAuraTarget),
@@ -564,6 +566,43 @@ class LibraryAndZoneContinuationResumer(
         val newState = exposeCollectionsToNextFrame(state, updatedCollections)
 
         return checkForMore(newState, emptyList())
+    }
+
+    /**
+     * Resume after one chooser answered one category of a
+     * [com.wingedsheep.sdk.scripting.effects.ChooseOnePerCategoryEffect] ("chooses a permanent they
+     * control of each permanent type"): record the pick and re-enter the collect loop, which either
+     * asks the next question or — once every chooser is done — publishes the picks so the
+     * downstream "…the rest" steps can act on them.
+     */
+    fun resumeChooseOnePerCategory(
+        state: GameState,
+        continuation: ChooseOnePerCategoryContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(state, "Expected card selection response for ChooseOnePerCategory")
+        }
+
+        val result = ChooseOnePerCategoryExecutor().collectPicks(
+            state = state,
+            effect = continuation.effect,
+            storedCollections = continuation.storedCollections,
+            pendingPlayers = continuation.pendingPlayers,
+            startCategory = continuation.categoryIndex + 1,
+            picks = continuation.picks + response.selectedCards,
+            sourceId = continuation.sourceId
+        )
+
+        if (result.isPaused) {
+            return ExecutionResult.paused(result.state, result.pendingDecision!!, result.events)
+        }
+
+        // Republish the pipeline's collections alongside the picks so the consumer frame sees both
+        // the original pool and the kept set.
+        val merged = continuation.storedCollections + result.updatedCollections
+        return checkForMore(exposeCollectionsToNextFrame(result.state, merged), result.events)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -82,22 +82,7 @@ class SacrificeAndPayContinuationResumer(
             events.addAll(transitionResult.events)
         }
 
-        // Inject snapshots into the underlying EffectContinuation (if any) so a sibling
-        // effect after this paused sacrifice can read `context.sacrificedPermanents`
-        // (Rise of the Witch-king "if you sacrificed a creature this way…" rider).
-        // Mirrors CreatureTypeChoiceContinuationResumer's "walk the stack and patch the
-        // captured effectContext" pattern.
-        newState = newState.copy(continuationStack = newState.continuationStack.map { frame ->
-            if (frame is EffectContinuation) {
-                frame.copy(
-                    effectContext = frame.effectContext.copy(
-                        sacrificedPermanents = frame.effectContext.sacrificedPermanents + snapshots
-                    )
-                )
-            } else {
-                frame
-            }
-        })
+        newState = withSacrificeSnapshots(newState, snapshots)
 
         // If there are remaining players (from "each opponent" effects), process them
         if (continuation.remainingPlayers.isNotEmpty() && continuation.filter != null) {
@@ -106,22 +91,8 @@ class SacrificeAndPayContinuationResumer(
                 newState, continuation.remainingPlayers, continuation.filter,
                 continuation.count, continuation.sourceId
             )
-            val resultStateWithSnaps = if (result.updatedSacrificedPermanents.isNotEmpty()) {
-                result.state.copy(continuationStack = result.state.continuationStack.map { frame ->
-                    if (frame is EffectContinuation) {
-                        frame.copy(
-                            effectContext = frame.effectContext.copy(
-                                sacrificedPermanents = frame.effectContext.sacrificedPermanents +
-                                    result.updatedSacrificedPermanents
-                            )
-                        )
-                    } else {
-                        frame
-                    }
-                })
-            } else {
-                result.state
-            }
+            val resultStateWithSnaps =
+                withSacrificeSnapshots(result.state, result.updatedSacrificedPermanents)
             val allEvents = events + result.events
             return if (result.isPaused) {
                 // Another player needs a decision — return paused with combined events
@@ -132,6 +103,31 @@ class SacrificeAndPayContinuationResumer(
         }
 
         return checkForMore(newState, events)
+    }
+
+    /**
+     * Publish [snapshots] of just-sacrificed permanents onto the enclosing [EffectContinuation]s so
+     * a sibling effect resolving after this paused sacrifice can read
+     * `context.sacrificedPermanents` (Rise of the Witch-king's "if you sacrificed a creature this
+     * way…" rider). Mirrors `CreatureTypeChoiceContinuationResumer`'s "walk the stack and patch the
+     * captured effectContext" pattern.
+     */
+    private fun withSacrificeSnapshots(
+        state: GameState,
+        snapshots: List<com.wingedsheep.engine.state.components.stack.EntitySnapshot>
+    ): GameState {
+        if (snapshots.isEmpty()) return state
+        return state.copy(continuationStack = state.continuationStack.map { frame ->
+            if (frame is EffectContinuation) {
+                frame.copy(
+                    effectContext = frame.effectContext.copy(
+                        sacrificedPermanents = frame.effectContext.sacrificedPermanents + snapshots
+                    )
+                )
+            } else {
+                frame
+            }
+        })
     }
 
     fun resumeExileMultiZone(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -287,6 +287,10 @@ object TargetResolutionUtils {
             }
             is EffectTarget.PlayerRef -> when (effectTarget.player) {
                 Player.Each -> state.activePlayers
+                // The APNAP-ordered flavour of Player.Each (CR 101.4) — for effects whose
+                // per-player choices are made in turn order starting with the active player
+                // ("each player sacrifices two creatures of their choice").
+                Player.ActivePlayerFirst -> state.apnapOrder
                 Player.EachOpponent -> state.getOpponents(context.controllerId)
                 else -> resolvePlayerRef(effectTarget.player, context, state)
                     ?.let { listOf(it) } ?: emptyList()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -201,10 +201,7 @@ class ForEachExecutor(
     private fun resolvePlayers(player: Player, state: GameState, context: EffectContext): List<EntityId> {
         return when (player) {
             Player.Each -> state.activePlayers
-            Player.ActivePlayerFirst -> {
-                val activePlayer = state.activePlayerId ?: return state.activePlayers
-                listOf(activePlayer) + state.activePlayers.filter { it != activePlayer }
-            }
+            Player.ActivePlayerFirst -> state.apnapOrder
             Player.You -> listOf(context.controllerId)
             Player.EachOpponent -> state.getOpponents(context.controllerId)
             // Distinct owners of the cards still in the source's linked-exile pile. Resolve to

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOnePerCategoryExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChooseOnePerCategoryExecutor.kt
@@ -1,0 +1,213 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.ChooseOnePerCategoryContinuation
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ChooseOnePerCategoryEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ChooseOnePerCategoryEffect] — "…chooses a permanent they control of each permanent
+ * type…" (Liliana, Dreadhorde General's −9; the same step backs Cataclysm and Divine Reckoning).
+ *
+ * A pure *choosing* step: it collects one pick per category from each controller represented in the
+ * source collection and publishes them all to `storeAs`. Nothing moves zones — the caller composes
+ * `exclude(pool, kept)` plus a move step to decide what happens to the rest, which is what lets the
+ * same choice drive "sacrifices the rest" (Liliana) and "returns the rest to their hands"
+ * (Consuming Tide).
+ *
+ * Two rules drive the structure:
+ *
+ * - **One choice per category, not one restricted selection.** The oracle wording is a sequence of
+ *   picks, which is what allows a single permanent to be the pick for several categories — an
+ *   artifact creature spared as both the artifact and the creature. A one-shot selection with
+ *   `SelectionRestriction.OnePerCardType` would let it claim only one of its types.
+ * - **All choices before anything happens (CR 101.4).** Choosers are asked in APNAP order, each
+ *   knowing the picks made before them, and the collection is published only once the last pick is
+ *   in. The in-progress tally rides on [ChooseOnePerCategoryContinuation] across the pauses.
+ *
+ * A category the chooser controls nothing of is skipped and a category with a single candidate
+ * resolves itself, so a board with one permanent per type asks nothing at all.
+ */
+class ChooseOnePerCategoryExecutor(
+    private val decisionHandler: DecisionHandler = DecisionHandler()
+) : EffectExecutor<ChooseOnePerCategoryEffect> {
+
+    override val effectType: KClass<ChooseOnePerCategoryEffect> = ChooseOnePerCategoryEffect::class
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    override fun execute(
+        state: GameState,
+        effect: ChooseOnePerCategoryEffect,
+        context: EffectContext
+    ): EffectResult {
+        val collections = context.pipeline.storedCollections
+        val pool = collections[effect.from]
+            ?: return EffectResult.error(
+                state, "No collection named '${effect.from}' in storedCollections"
+            )
+
+        return collectPicks(
+            state = state,
+            effect = effect,
+            storedCollections = collections,
+            pendingPlayers = choosersInApnapOrder(state, pool),
+            startCategory = 0,
+            picks = emptyList(),
+            sourceId = context.sourceId
+        )
+    }
+
+    /**
+     * Walk [pendingPlayers] (the first resuming at [startCategory], the rest from the top), asking
+     * for one pick per satisfiable category. Pauses on the first category that needs a real
+     * decision; once every pick is in, publishes them under `effect.storeAs`.
+     *
+     * Shared with `SacrificeAndPayContinuationResumer` so a resumed pick re-enters the same loop.
+     */
+    fun collectPicks(
+        state: GameState,
+        effect: ChooseOnePerCategoryEffect,
+        storedCollections: Map<String, List<EntityId>>,
+        pendingPlayers: List<EntityId>,
+        startCategory: Int,
+        picks: List<EntityId>,
+        sourceId: EntityId?
+    ): EffectResult {
+        val pool = storedCollections[effect.from].orEmpty()
+        val accumulated = picks.toMutableList()
+
+        for ((offset, playerId) in pendingPlayers.withIndex()) {
+            val firstCategory = if (offset == 0) startCategory else 0
+            for (categoryIndex in firstCategory until effect.categories.size) {
+                val candidates = candidatesFor(state, pool, playerId, effect, categoryIndex, sourceId)
+                if (candidates.isEmpty()) continue
+                // Every candidate is already being kept for an earlier category — the pick is
+                // forced, so don't ask.
+                if (candidates.all { it in accumulated }) continue
+
+                if (candidates.size == 1) {
+                    accumulated += candidates
+                    continue
+                }
+
+                return pauseForChoice(
+                    state = state,
+                    effect = effect,
+                    storedCollections = storedCollections,
+                    playerId = playerId,
+                    candidates = candidates,
+                    categoryIndex = categoryIndex,
+                    pendingPlayers = pendingPlayers.drop(offset),
+                    picks = accumulated,
+                    sourceId = sourceId
+                )
+            }
+        }
+
+        return EffectResult.success(state)
+            .copy(updatedCollections = mapOf(effect.storeAs to accumulated.distinct()))
+    }
+
+    /**
+     * The distinct controllers of [pool] in APNAP order (CR 101.4). Deriving the choosers from the
+     * collection rather than a `Player` parameter keeps the scoping where it belongs — in the
+     * `gather` that built the pool — so the same step serves "each player", "each opponent" and a
+     * single target player.
+     */
+    private fun choosersInApnapOrder(state: GameState, pool: List<EntityId>): List<EntityId> {
+        val controllers = pool.mapNotNull { controllerOf(state, it) }.toHashSet()
+        return state.apnapOrder.filter { it in controllers }
+    }
+
+    /**
+     * The members of [pool] that [playerId] controls and that match the category at
+     * [categoryIndex]. The category filters are controller-agnostic (`Artifact`, `Creature`, …) —
+     * the control scoping comes from the pool split, so each chooser only ever sees their own
+     * permanents.
+     */
+    private fun candidatesFor(
+        state: GameState,
+        pool: List<EntityId>,
+        playerId: EntityId,
+        effect: ChooseOnePerCategoryEffect,
+        categoryIndex: Int,
+        sourceId: EntityId?
+    ): List<EntityId> {
+        val category = effect.categories[categoryIndex]
+        val projected = state.projectedState
+        val predicateContext = PredicateContext(controllerId = playerId, sourceId = sourceId)
+        return pool.filter { id ->
+            controllerOf(state, id) == playerId &&
+                predicateEvaluator.matches(state, projected, id, category, predicateContext)
+        }
+    }
+
+    /** Projected control first, so control-changing effects decide who chooses. */
+    private fun controllerOf(state: GameState, entityId: EntityId): EntityId? =
+        state.projectedState.getController(entityId)
+            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+
+    private fun pauseForChoice(
+        state: GameState,
+        effect: ChooseOnePerCategoryEffect,
+        storedCollections: Map<String, List<EntityId>>,
+        playerId: EntityId,
+        candidates: List<EntityId>,
+        categoryIndex: Int,
+        pendingPlayers: List<EntityId>,
+        picks: List<EntityId>,
+        sourceId: EntityId?
+    ): EffectResult {
+        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+        val noun = effect.categories[categoryIndex].description
+        val article = if (noun.firstOrNull()?.lowercaseChar() in setOf('a', 'e', 'i', 'o', 'u')) {
+            "an"
+        } else {
+            "a"
+        }
+
+        val decisionResult = decisionHandler.createCardSelectionDecision(
+            state = state,
+            playerId = playerId,
+            sourceId = sourceId,
+            sourceName = sourceName,
+            prompt = "Choose $article $noun to keep",
+            options = candidates,
+            minSelections = 1,
+            maxSelections = 1,
+            ordered = false,
+            phase = DecisionPhase.RESOLUTION,
+            // On-battlefield selection: the chooser is picking among permanents already in play,
+            // where counters, auras and duplicates matter (see the UX rules in AGENTS.md).
+            useTargetingUI = true
+        )
+
+        val continuation = ChooseOnePerCategoryContinuation(
+            decisionId = decisionResult.pendingDecision!!.id,
+            effect = effect,
+            sourceId = sourceId,
+            sourceName = sourceName,
+            storedCollections = storedCollections,
+            pendingPlayers = pendingPlayers,
+            categoryIndex = categoryIndex,
+            picks = picks
+        )
+
+        return EffectResult.paused(
+            decisionResult.state.pushContinuation(continuation),
+            decisionResult.pendingDecision,
+            decisionResult.events
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -95,6 +95,7 @@ class LibraryExecutors(
         SelectTargetPipelineExecutor(targetFinder = targetFinder ?: TargetFinder()),
         MoveCollectionExecutor(cardRegistry = cardRegistry, targetFinder = targetFinder),
         FilterCollectionExecutor(),
+        ChooseOnePerCategoryExecutor(),
         PutOnTopOrBottomOfLibraryExecutor(),
         StoreNumberExecutor(),
         StoreCardNameExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -53,10 +53,11 @@ class AnyPlayerMayPayExecutor(
         val sourceCard = sourceContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Source has no card component")
 
-        // Get players in APNAP order
-        val activePlayer = state.activePlayerId
-            ?: return EffectResult.error(state, "No active player")
-        val apnapOrder = listOf(activePlayer) + state.turnOrder.filter { it != activePlayer }
+        // Get players in APNAP order (CR 101.4), skipping anyone who has left the game
+        if (state.activePlayerId == null) {
+            return EffectResult.error(state, "No active player")
+        }
+        val apnapOrder = state.apnapOrder
 
         // Scope to the players the effect offers the choice to ("any opponent may…" vs
         // "any player may…"), preserving APNAP order. Opponents are relative to the controller.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -473,6 +473,25 @@ data class GameState(
         }
 
     /**
+     * [activePlayers] rotated into **APNAP order** (CR 101.4): the active player first, then the
+     * remaining players in turn order starting from the one after them. This is the order in which
+     * players make simultaneous choices — "each player sacrifices a creature" asks the active
+     * player first, then each nonactive player in turn order, and only then do the sacrifices
+     * happen.
+     *
+     * Note this is a *rotation*, not "active player prepended to seat order": with seats [A, B, C]
+     * and B active the order is [B, C, A], not [B, A, C]. Falls back to plain turn order when
+     * there is no active player (before the first turn begins).
+     */
+    val apnapOrder: List<EntityId>
+        get() {
+            val ordered = activePlayers
+            val active = activePlayerId ?: return ordered
+            val index = ordered.indexOf(active)
+            return if (index <= 0) ordered else ordered.drop(index) + ordered.take(index)
+        }
+
+    /**
      * Opponents of a player, in turn order, excluding players who have lost or left the
      * game. There is deliberately no single-opponent helper: any code that needs one
      * specific opponent must say which one (a chosen target, an iteration, or the

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LilianaDreadhordeGeneralScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LilianaDreadhordeGeneralScenarioTest.kt
@@ -1,0 +1,320 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.war.cards.LilianaDreadhordeGeneral
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Liliana, Dreadhorde General (WAR #97, reprinted in Foundations #176; {4}{B}{B}, Loyalty 6).
+ *
+ *   Whenever a creature you control dies, draw a card.
+ *   +1: Create a 2/2 black Zombie creature token.
+ *   −4: Each player sacrifices two creatures of their choice.
+ *   −9: Each opponent chooses a permanent they control of each permanent type and sacrifices
+ *       the rest.
+ *
+ * The −9 is the interesting one and drives most of these tests: it is a *sequence* of one pick per
+ * permanent type, so a permanent with two types can be spared twice over, a type the opponent
+ * controls one of asks nothing, and the controller's own board is never touched. The −4 pins the
+ * APNAP choice order (CR 101.4) and the "can only choose one, so choose one" ruling, and both
+ * sacrifice abilities double as coverage for the draw trigger.
+ */
+class LilianaDreadhordeGeneralScenarioTest : ScenarioTestBase() {
+
+    private val plusOne = LilianaDreadhordeGeneral.activatedAbilities[0].id
+    private val minusFour = LilianaDreadhordeGeneral.activatedAbilities[1].id
+    private val minusNine = LilianaDreadhordeGeneral.activatedAbilities[2].id
+
+    init {
+        context("Liliana, Dreadhorde General") {
+
+            test("+1 creates a 2/2 black Zombie token") {
+                val game = boardWithLiliana(loyalty = 6)
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = plusOne)
+                ).error shouldBe null
+                game.resolveStack()
+
+                val token = game.findPermanent("Zombie Token")
+                withClue("the +1 created a token") { token shouldNotBe null }
+                val projected = game.state.projectedState
+                withClue("2/2 black Zombie") {
+                    projected.getProjectedValues(token!!)?.power shouldBe 2
+                    projected.getProjectedValues(token)?.toughness shouldBe 2
+                    projected.isCreature(token) shouldBe true
+                }
+                loyalty(game, liliana) shouldBe 7
+            }
+
+            test("−9 asks nothing when each opponent controls exactly one of each permanent type") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // One permanent per type: artifact, creature, enchantment, land, planeswalker.
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sigil of the New Dawn")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardOnBattlefield(2, "Domri, Anarch of Bolas")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+                seedLoyalty(game, liliana, 9)
+                seedLoyalty(game, game.findPermanent("Domri, Anarch of Bolas")!!, 3)
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = minusNine)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("every category had exactly one candidate, so nothing was asked") {
+                    game.getPendingDecision() shouldBe null
+                }
+                withClue("and nothing was sacrificed") {
+                    game.graveyardSize(2) shouldBe 0
+                    game.findPermanents("Sol Ring").size shouldBe 1
+                    game.findPermanents("Sigil of the New Dawn").size shouldBe 1
+                    game.findPermanent("Domri, Anarch of Bolas") shouldNotBe null
+                }
+                withClue("the ability only hits opponents — your own creature stays too") {
+                    game.findPermanents("Grizzly Bears").map { controllerOf(game, it) }.toSet() shouldBe
+                        setOf(game.player1Id, game.player2Id)
+                }
+                loyalty(game, liliana) shouldBe 0
+            }
+
+            test("−9 keeps the chosen permanent of each type and sacrifices everything else") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+                    // Two creatures and two artifacts, so both of those types need a real choice;
+                    // the single land is spared without asking.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Wall of Air")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Jayemdae Tome")
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+                seedLoyalty(game, liliana, 9)
+                val keptArtifact = game.findPermanent("Sol Ring")!!
+                val keptCreature = game.findPermanent("Wall of Air")!!
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = minusNine)
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Artifact first (the CR 110.4 order Filters.PermanentTypes follows), then creature.
+                val artifactChoice = game.getPendingDecision()
+                withClue("paused for the opponent's artifact pick: $artifactChoice") {
+                    (artifactChoice is SelectCardsDecision) shouldBe true
+                    (artifactChoice as SelectCardsDecision).playerId shouldBe game.player2Id
+                    artifactChoice.options.toSet() shouldBe
+                        setOf(keptArtifact, game.findPermanent("Jayemdae Tome")!!)
+                }
+                withClue("nothing has been sacrificed while choices are still being made") {
+                    game.graveyardSize(2) shouldBe 0
+                }
+                game.selectCards(listOf(keptArtifact)).error shouldBe null
+
+                val creatureChoice = game.getPendingDecision()
+                withClue("then the creature pick: $creatureChoice") {
+                    (creatureChoice is SelectCardsDecision) shouldBe true
+                    (creatureChoice as SelectCardsDecision).options.toSet() shouldBe
+                        setOf(keptCreature, game.findPermanent("Grizzly Bears")!!)
+                }
+                game.selectCards(listOf(keptCreature)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the unchosen artifact and creature were sacrificed; the land survived") {
+                    graveyardNames(game, 2).sorted() shouldContainExactly
+                        listOf("Grizzly Bears", "Jayemdae Tome")
+                    game.findPermanent("Sol Ring") shouldNotBe null
+                    game.findPermanent("Wall of Air") shouldNotBe null
+                    game.findPermanent("Forest") shouldNotBe null
+                }
+            }
+
+            test("−9 lets one artifact creature be both the artifact and the creature spared") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+                    .withCardOnBattlefield(2, "Ornithopter")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+                seedLoyalty(game, liliana, 9)
+                val thopter = game.findPermanent("Ornithopter")!!
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = minusNine)
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Artifact: Ornithopter or Sol Ring.
+                game.selectCards(listOf(thopter)).error shouldBe null
+                // Creature: Ornithopter or Grizzly Bears — the artifact creature is offered again,
+                // so a single permanent can cover both types.
+                val creatureChoice = game.getPendingDecision()
+                withClue("Ornithopter is still a legal creature pick: $creatureChoice") {
+                    (creatureChoice is SelectCardsDecision) shouldBe true
+                    (creatureChoice as SelectCardsDecision).options.contains(thopter) shouldBe true
+                }
+                game.selectCards(listOf(thopter)).error shouldBe null
+                game.resolveStack()
+
+                withClue("only the artifact creature survived") {
+                    game.findPermanent("Ornithopter") shouldNotBe null
+                    graveyardNames(game, 2).sorted() shouldContainExactly
+                        listOf("Grizzly Bears", "Sol Ring")
+                }
+            }
+
+            test("−4: the active player chooses first (APNAP), then everyone sacrifices two") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Wall of Air")
+                    .withCardOnBattlefield(1, "Ornithopter")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Wall of Air")
+                    .withCardOnBattlefield(2, "Ornithopter")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+                seedLoyalty(game, liliana, 6)
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = minusFour)
+                ).error shouldBe null
+                game.resolveStack()
+
+                val first = game.getPendingDecision()
+                withClue("the active player (Liliana's controller) chooses first: $first") {
+                    (first is SelectCardsDecision) shouldBe true
+                }
+                first as SelectCardsDecision
+                first.playerId shouldBe game.player1Id
+                first.minSelections shouldBe 2
+                game.selectCards(first.options.take(2)).error shouldBe null
+
+                val second = game.getPendingDecision()
+                withClue("then the nonactive player: $second") {
+                    (second is SelectCardsDecision) shouldBe true
+                }
+                second as SelectCardsDecision
+                second.playerId shouldBe game.player2Id
+                game.selectCards(second.options.take(2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("each player is down to one creature") {
+                    game.graveyardSize(1) shouldBe 2
+                    game.graveyardSize(2) shouldBe 2
+                }
+                withClue("two of your creatures died, so the draw trigger fired twice") {
+                    game.handSize(1) shouldBe 2
+                    game.librarySize(1) shouldBe 0
+                }
+                loyalty(game, liliana) shouldBe 2
+            }
+
+            test("−4: a player with a single creature sacrifices just that one, unprompted") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Wall of Air")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val liliana = game.findPermanent("Liliana, Dreadhorde General")!!
+                seedLoyalty(game, liliana, 6)
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = liliana, abilityId = minusFour)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("neither player had a choice to make") {
+                    game.getPendingDecision() shouldBe null
+                }
+                withClue("both lone creatures went to the graveyard") {
+                    graveyardNames(game, 1) shouldContainExactly listOf("Grizzly Bears")
+                    graveyardNames(game, 2) shouldContainExactly listOf("Wall of Air")
+                }
+                withClue("your creature dying drew you a card") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+
+    /** A minimal board: Liliana under player 1's control with [loyalty] loyalty counters. */
+    private fun boardWithLiliana(loyalty: Int): TestGame {
+        val game = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Liliana, Dreadhorde General")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+        seedLoyalty(game, game.findPermanent("Liliana, Dreadhorde General")!!, loyalty)
+        return game
+    }
+
+    /**
+     * The scenario builder drops permanents straight onto the battlefield without running the
+     * "enters with its starting loyalty" step, so planeswalkers need their counters seeded (a
+     * planeswalker on 0 loyalty is put into its owner's graveyard by a state-based action).
+     */
+    private fun seedLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun controllerOf(game: TestGame, id: EntityId): EntityId? =
+        game.state.getEntity(id)
+            ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+            ?.playerId
+
+    private fun graveyardNames(game: TestGame, playerNumber: Int): List<String> {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getGraveyard(playerId).mapNotNull { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name
+        }
+    }
+}


### PR DESCRIPTION
Random FDN pick (`/add-random-card foundations`, index 3 of 6). Canonical `CardDefinition` lands in **War of the Spark** (its earliest real printing); **Foundations #176** gets a `Printing` row. `just check-card-printing` passes clean.

FDN: **257 → 258 / 262**.

## The −9

> Each opponent chooses a permanent they control of each permanent type and sacrifices the rest.

This needed new engine capability. The first cut was a single `SacrificeAllExceptChosenEffect` that encoded the whole ability; that was rewritten into one **atomic** pipeline step plus existing atoms:

```kotlin
loyaltyAbility(-9) {
    effect = Effects.Pipeline {
        val atRisk = gather(GameObjectFilter.Permanent.opponentControls())
        val kept = chooseOnePerCategory(atRisk, Filters.PermanentTypes)
        sacrifice(exclude(atRisk, kept))
    }
}
```

`ChooseOnePerCategoryEffect` only *chooses* — it moves nothing. "The rest" is `CollectionFilter.ExcludeOtherCollection`, which already existed; their fate is any move step. That is the reusability win: swapping the last step gives **Consuming Tide** ("returns the rest to their hands"), swapping the category list gives **Cataclysm** / **Divine Reckoning**. The monolithic version could only ever sacrifice. `exclude(from, minus)` is new builder sugar over the existing filter step.

**Why a sequence of one-of-each choices, not one restricted selection.** The printed ruling lets a single permanent be the pick for several types — an artifact creature spared as both the artifact *and* the creature. `SelectionRestriction.OnePerCardType` cannot express that: under it the artifact creature claims both types at once and no separate creature could be spared.

The choosers are derived from the pool's controllers, so "each player" vs "each opponent" scoping lives in the `gather`. They are asked in APNAP order (CR 101.4) and the picks are published only once the last one is in — nothing leaves the battlefield mid-choice.

## Also in here

- **`Filters.PermanentTypes`** — the CR 110.4 permanent-type list in one place. Battle is omitted because the engine has no `CardType.BATTLE`; when it lands, one edit here updates every "each permanent type" card.
- **`GameState.apnapOrder`** — replaces three divergent local copies. Two prepended the active player to seat order instead of *rotating*, so with seats `[A, B, C]` and `B` active they produced `[B, A, C]` rather than `[B, C, A]` — wrong for 3+ players. The `AnyPlayerMayPay` copy also read `turnOrder` directly, so it did not skip players who had left the game.
- **`Player.ActivePlayerFirst` now resolves in `resolvePlayerTargets`**, so the −4 asks the active player first as its ruling requires (`Player.Each` resolves to seat order, which puts the wrong player first whenever the controller is not seat 0).
- **mtgish bridge** — the −9's unique IR tag maps to the new step. Its co-occurring `SacrificeEachPermanent` / `ExceptFor` / `ThePermanentsChosenThisWay` tags are **left unmapped on purpose**: they appear on 100+ corpus cards in shapes this step does not cover, so claiming them would score all of those as coverable. Recovering the pair (which would also unlock Cataclysm / Divine Reckoning) is its own emitter pass. No emitter handler for the same reason — the card stays SCAFFOLD tier.

## Verification

- `LilianaDreadhordeGeneralScenarioTest` — 6 tests: the +1 token's characteristics; the −9 asking **nothing** when each type has a single candidate; keeping the chosen one per type and sacrificing the rest (asserting nothing is in the graveyard while choices are still being made); one artifact creature covering two categories; the −4's APNAP order plus the draw trigger firing once per creature; a lone creature sacrificed unprompted.
- `just test`, `just test-server`, `:mtgish-tooling:test` — green. `just coverage-verify POR` — GATE PASS.
- `SerializationPolymorphicRegistrationTest` caught the unregistered continuation frame; registered.
- WAR card snapshot re-blessed — diff is Liliana only, no other card moved.

No frontend work needed: the per-category pick reuses the existing on-battlefield targeting selection UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)