### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CurseOfTheWerefox.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CurseOfTheWerefox.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Curse of the Werefox
+ * {2}{G}
+ * Sorcery
+ * Create a Monster Role token attached to target creature you control. When you do, that creature
+ * fights up to one target creature you don't control.
+ *
+ * The fight is a **reflexive** triggered ability (CR 603.12, and the 2023-09-01 ruling): its target
+ * isn't chosen when the sorcery is cast, but when the reflexive ability goes on the stack after the
+ * Role is created — so opponents get a chance to respond in between, and the Role's +1/+1 is already
+ * applied (and any older Role already fell off as an SBA) by the time the creatures fight.
+ *
+ * Wiring: the spell's own target is snapshotted into a pipeline collection *before* the reflexive
+ * effect runs, because the reflexive resolution replaces `EffectContext.targets` with the reflexive
+ * target. So the fight reads its first combatant from [EffectTarget.PipelineTarget] and its second
+ * from the reflexive `ContextTarget(0)`. `optional = true` on the reflexive requirement is the
+ * "up to one" — declining simply skips the fight.
+ */
+val CurseOfTheWerefox = card("Curse of the Werefox") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a Monster Role token attached to target creature you control. When you do, " +
+        "that creature fights up to one target creature you don't control. (If you control another " +
+        "Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample. " +
+        "Creatures that fight each deal damage equal to their power to the other.)"
+
+    spell {
+        val host = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Pipeline(
+            descriptionOverride = "Create a Monster Role token attached to target creature you " +
+                "control. When you do, that creature fights up to one target creature you don't control."
+        ) {
+            val enchanted = gather(CardSource.ChosenTargets, name = "roleHost")
+            run(
+                ReflexiveTriggerEffect(
+                    action = Effects.CreateRoleToken("Monster Role", host),
+                    optional = false,
+                    reflexiveEffect = Effects.Fight(
+                        EffectTarget.PipelineTarget(enchanted.key),
+                        EffectTarget.ContextTarget(0)
+                    ),
+                    reflexiveTargetRequirements = listOf(
+                        TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+                    ),
+                    descriptionOverride = "When you do, that creature fights up to one target " +
+                        "creature you don't control."
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg?1783915083"
+        ruling(
+            "2023-09-01",
+            "You don't choose a target for the creature to fight at the time you cast this spell. " +
+                "Rather, a second \"reflexive\" ability triggers when you create a Monster Role token " +
+                "attached to the creature that was targeted by the spell. You choose a target for that " +
+                "ability as it goes on the stack. Each player may respond to this triggered ability as normal."
+        )
+        ruling(
+            "2023-09-01",
+            "If you can't attach a Monster Role token to the target creature you control when Curse of " +
+                "the Werefox resolves, the reflexive trigger that causes the fight won't happen."
+        )
+        ruling(
+            "2023-09-01",
+            "If the creature you control already has a Role that you control attached to it, that Role " +
+                "will be put into its owner's graveyard as a state-based action after the Monster Role " +
+                "is attached to it but before the reflexive triggered ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FellHorseman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FellHorseman.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fell Horseman // Deathly Ride
+ * {3}{B}
+ * Creature — Zombie Knight
+ * 3/3
+ * When this creature dies, put it on the bottom of its owner's library.
+ *
+ * Adventure: Deathly Ride — {1}{B}, Sorcery — Adventure
+ * Return target creature card from your graveyard to your hand.
+ *
+ * The death trigger moves the card from the graveyard, so it only finds the card if it's still
+ * there when the trigger resolves (2023-09-01 ruling) — [Effects.PutOnBottomOfLibrary] resolves
+ * [EffectTarget.Self] to wherever the card actually is and no-ops if it has since moved on. Same
+ * shape as Chaos, the Endless.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val FellHorseman = card("Fell Horseman") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Knight"
+    oracleText = "When this creature dies, put it on the bottom of its owner's library."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.PutOnBottomOfLibrary(EffectTarget.Self)
+    }
+
+    adventure("Deathly Ride") {
+        manaCost = "{1}{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Return target creature card from your graveyard to your hand. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+            effect = Effects.Move(t, Zone.HAND)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "92"
+        artist = "Igor Krstic"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1783915106"
+        ruling(
+            "2023-09-01",
+            "Fell Horseman will be put on the bottom of its owner's library only if it's still in " +
+                "the graveyard when its ability resolves. If it leaves the graveyard before that point, " +
+                "it will stay in whatever zone it's in, even if it's returned to the graveyard before " +
+                "the ability resolves."
+        )
+        ruling(
+            "2023-09-01",
+            "An adventurer card is a permanent card in every zone except the stack, as well as while " +
+                "on the stack if not cast as an Adventure. Ignore its alternative characteristics in " +
+                "those cases."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FerociousWerefox.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FerociousWerefox.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ferocious Werefox // Guard Change
+ * {3}{G}
+ * Creature — Elf Fox Warrior
+ * 4/3
+ * Trample
+ *
+ * Adventure: Guard Change — {1}{G}, Instant — Adventure
+ * Create a Monster Role token attached to target creature you control.
+ * (Enchanted creature gets +1/+1 and has trample.)
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val FerociousWerefox = card("Ferocious Werefox") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Fox Warrior"
+    oracleText = "Trample"
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    adventure("Guard Change") {
+        manaCost = "{1}{G}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a Monster Role token attached to target creature you control. " +
+            "(If you control another Role on it, put that one into the graveyard. Enchanted creature " +
+            "gets +1/+1 and has trample.) " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target creature you control", Targets.CreatureYouControl)
+            effect = Effects.CreateRoleToken("Monster Role", t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Caroline Gariba"
+        flavorText = "Each night, the elves of Redtooth Keep transform into feral, monstrous beasts."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1783915082"
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each " +
+                "of those Roles except the one with the most recent timestamp is put into its owner's " +
+                "graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "In rare cases, a spell or ability might attempt to create a Role token enchanting a " +
+                "permanent that it can't legally enchant (because of an ability like protection from " +
+                "enchantments). In such cases, the Role token isn't created."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HollowScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HollowScavenger.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hollow Scavenger // Bakery Raid
+ * {2}{G}
+ * Creature — Wolf
+ * 3/2
+ * {1}, Sacrifice a Food: This creature gets +2/+2 until end of turn. Activate only once each turn.
+ *
+ * Adventure: Bakery Raid — {G}, Sorcery — Adventure
+ * Create a Food token.
+ *
+ * "Sacrifice a Food" matches any Food artifact, not just Food tokens (2024-11-08 ruling) — the cost
+ * filter is subtype-based (`GameObjectFilter.Any.withSubtype("Food")`), so Tough Cookie and friends
+ * are legal fodder too.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile — the Food it left behind then
+ * feeds the creature's own pump ability.)
+ */
+val HollowScavenger = card("Hollow Scavenger") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "{1}, Sacrifice a Food: This creature gets +2/+2 until end of turn. " +
+        "Activate only once each turn."
+    power = 3
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Sacrifice(GameObjectFilter.Any.withSubtype("Food"))
+        )
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    adventure("Bakery Raid") {
+        manaCost = "{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create a Food token. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.CreateFood(1)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Michele Giorgi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1783915081"
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+        )
+        ruling(
+            "2024-11-08",
+            "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food " +
+                "token to activate its own ability and also to activate this ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ToughCookie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ToughCookie.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tough Cookie
+ * {1}{G}
+ * Artifact Creature — Food Golem
+ * 2/2
+ * When this creature enters, create a Food token.
+ * {2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.
+ * {2}, {T}, Sacrifice this creature: You gain 3 life.
+ *
+ * The animate clause is a plain [Effects.BecomeCreature] with a fixed 4/4 and no `removeTypes`, so
+ * the target keeps every type and subtype it already had (2023-09-01 ruling) and keeps its
+ * abilities — a Food token animated this way is still a Food that can be sacrificed for life.
+ * Tough Cookie itself is a Food, so its own last ability is the Food sacrifice outlet.
+ */
+val ToughCookie = card("Tough Cookie") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Food Golem"
+    oracleText = "When this creature enters, create a Food token. (It's an artifact with " +
+        "\"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "{2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.\n" +
+        "{2}, {T}, Sacrifice this creature: You gain 3 life."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        val t = target(
+            "target noncreature artifact you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.notCreature().youControl()))
+        )
+        effect = Effects.BecomeCreature(
+            target = t,
+            power = 4,
+            toughness = 4,
+            addTypes = setOf("ARTIFACT")
+        )
+        description = "{2}{G}: Until end of turn, target noncreature artifact you control becomes " +
+            "a 4/4 artifact creature."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "Milivoj Ćeran"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg?1783915075"
+        ruling(
+            "2023-09-01",
+            "As Tough Cookie's second ability resolves, the target permanent keeps any other types " +
+                "and subtypes it had before it became an artifact creature."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1240,6 +1240,91 @@
     ]
 }
 
+// Curse of the Werefox
+{
+    "name": "Curse of the Werefox",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a Monster Role token attached to target creature you control. When you do, that creature fights up to one target creature you don't control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample. Creatures that fight each deal damage equal to their power to the other.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "roleHost"
+                },
+                {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "CreateRoleToken",
+                        "roleName": "Monster Role",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "Fight",
+                        "target1": {
+                            "type": "PipelineTarget",
+                            "collectionName": "roleHost"
+                        },
+                        "target2": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "When you do, that creature fights up to one target creature you don't control."
+                }
+            ],
+            "descriptionOverride": "Create a Monster Role token attached to target creature you control. When you do, that creature fights up to one target creature you don't control."
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89148458-1fd6-48ef-a2d9-7b434c9723ec.jpg?1783915083",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You don't choose a target for the creature to fight at the time you cast this spell. Rather, a second \"reflexive\" ability triggers when you create a Monster Role token attached to the creature that was targeted by the spell. You choose a target for that ability as it goes on the stack. Each player may respond to this triggered ability as normal."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you can't attach a Monster Role token to the target creature you control when Curse of the Werefox resolves, the reflexive trigger that causes the fight won't happen."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If the creature you control already has a Role that you control attached to it, that Role will be put into its owner's graveyard as a state-based action after the Monster Role is attached to it but before the reflexive triggered ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cursed Courtier
 {
     "name": "Cursed Courtier",
@@ -2137,6 +2222,145 @@
     ]
 }
 
+// Fell Horseman
+{
+    "name": "Fell Horseman",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Knight",
+    "oracleText": "When this creature dies, put it on the bottom of its owner's library.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Library",
+                    "placement": "Bottom"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "artist": "Igor Krstic",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43bb3890-4013-48be-8cb5-54fd8fd8ec52.jpg?1783915106",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Fell Horseman will be put on the bottom of its owner's library only if it's still in the graveyard when its ability resolves. If it leaves the graveyard before that point, it will stay in whatever zone it's in, even if it's returned to the graveyard before the ability resolves."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "An adventurer card is a permanent card in every zone except the stack, as well as while on the stack if not cast as an Adventure. Ignore its alternative characteristics in those cases."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Deathly Ride",
+            "manaCost": "{1}{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Return target creature card from your graveyard to your hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target creature card in your graveyard"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+// Ferocious Werefox
+{
+    "name": "Ferocious Werefox",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Fox Warrior",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Caroline Gariba",
+        "flavorText": "Each night, the elves of Redtooth Keep transform into feral, monstrous beasts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac1907e8-0713-47dd-ac42-bf1323c5bec0.jpg?1783915082",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "In rare cases, a spell or ability might attempt to create a Role token enchanting a permanent that it can't legally enchant (because of an ability like protection from enchantments). In such cases, the Role token isn't created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Guard Change",
+            "manaCost": "{1}{G}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a Monster Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.) (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Monster Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Flick a Coin
 {
     "name": "Flick a Coin",
@@ -2704,6 +2928,92 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Hollow Scavenger
+{
+    "name": "Hollow Scavenger",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "{1}, Sacrifice a Food: This creature gets +2/+2 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "Food"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Michele Giorgi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ad345b6-7077-4dd2-b515-c774a3185fe4.jpg?1783915081",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food token to activate its own ability and also to activate this ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Bakery Raid",
+            "manaCost": "{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        }
     ]
 }
 
@@ -6596,6 +6906,125 @@
         "artist": "Julia Metzger",
         "flavorText": "Where an ouphe makes its home, the land blooms with color and joy.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0a6349a-beff-4abd-b005-86d27c1e2957.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tough Cookie
+{
+    "name": "Tough Cookie",
+    "manaCost": "{1}{G}",
+    "typeLine": "Artifact Creature — Food Golem",
+    "oracleText": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.\n{2}, {T}, Sacrifice this creature: You gain 3 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target noncreature artifact you control"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "addTypes": [
+                        "ARTIFACT"
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsArtifact",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsCreature"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "target noncreature artifact you control"
+                    }
+                ],
+                "descriptionOverride": "{2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "Milivoj Ćeran",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7aa37f85-5336-4372-97a2-9c8b00798c7a.jpg?1783915075",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "As Tough Cookie's second ability resolves, the target permanent keeps any other types and subtypes it had before it became an artifact creature."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CurseOfTheWerefoxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CurseOfTheWerefoxScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Curse of the Werefox (WOE #167) — {2}{G} Sorcery.
+ *
+ * "Create a Monster Role token attached to target creature you control. When you do, that creature
+ *  fights up to one target creature you don't control."
+ *
+ * The fight is a reflexive trigger (CR 603.12): the fight's target is chosen after the Role is
+ * created, so the +1/+1 from the Monster Role is already applied when damage is dealt. The card
+ * snapshots the spell's own target into a pipeline collection before the reflexive runs, because
+ * the reflexive resolution rebinds `ContextTarget` to the reflexive target.
+ */
+class CurseOfTheWerefoxScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the enchanted creature fights with the Monster Role bonus already applied") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Curse of the Werefox")
+                .withCardOnBattlefield(1, "Grizzly Bears")     // 2/2
+                .withCardOnBattlefield(2, "Centaur Courser")   // 3/3
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val courser = game.findPermanent("Centaur Courser")!!
+
+            game.castSpell(1, "Curse of the Werefox", bears).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Monster Role landed before the reflexive trigger asks for its target") {
+                game.findPermanent("Monster Role") shouldNotBe null
+                game.state.projectedState.getPower(bears) shouldBe 3
+            }
+
+            val decision = game.getPendingDecision()
+            decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+            game.selectTargets(listOf(courser))
+            game.resolveStack()
+
+            withClue("a 3/3 Bears and a 3/3 Courser fought — both died") {
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isOnBattlefield("Centaur Courser") shouldBe false
+            }
+        }
+
+        test("\"up to one\" — declining the fight target leaves the Role behind and nothing fights") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Curse of the Werefox")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Centaur Courser")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Curse of the Werefox", bears).error shouldBe null
+            game.resolveStack()
+
+            game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+            game.skipTargets()
+            game.resolveStack()
+
+            withClue("no fight happened; the Role stays attached") {
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                game.isOnBattlefield("Centaur Courser") shouldBe true
+                game.findPermanent("Monster Role") shouldNotBe null
+                game.state.projectedState.getPower(bears) shouldBe 3
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FellHorsemanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FellHorsemanScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fell Horseman // Deathly Ride (WOE #92).
+ *
+ * Creature face: {3}{B} 3/3 Zombie Knight — "When this creature dies, put it on the bottom of its
+ * owner's library."
+ * Adventure face: Deathly Ride {1}{B}, Sorcery — Adventure — "Return target creature card from
+ * your graveyard to your hand."
+ */
+class FellHorsemanScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("dying puts it on the bottom of its owner's library instead of leaving it in the graveyard") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Fell Horseman")
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val horseman = game.findPermanent("Fell Horseman")!!
+
+            game.castSpell(2, "Lightning Bolt", horseman).error shouldBe null
+            game.resolveStack()
+
+            withClue("the dies trigger relocated the card out of the graveyard") {
+                game.isInGraveyard(1, "Fell Horseman") shouldBe false
+            }
+            withClue("it went to the bottom of its owner's library") {
+                game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).last() shouldBe horseman
+            }
+        }
+
+        test("Deathly Ride returns a creature card from your graveyard and exiles the card for later") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Fell Horseman")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val horseman = game.findCardsInHand(1, "Fell Horseman").single()
+            val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+
+            // faceIndex = 0 is the Adventure face (CR 715).
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = horseman,
+                    targets = listOf(ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD)),
+                    faceIndex = 0
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("Grizzly Bears came back to hand") {
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+            }
+            withClue("the Adventure exiled itself rather than going to the graveyard (CR 715.3d)") {
+                game.isInExile(1, "Fell Horseman") shouldBe true
+                game.isInGraveyard(1, "Fell Horseman") shouldBe false
+            }
+            withClue("the creature face is castable from exile") {
+                game.state.mayPlayPermissions.any {
+                    horseman in it.cardIds && it.controllerId == game.player1Id
+                } shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FerociousWerefoxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FerociousWerefoxScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ferocious Werefox // Guard Change (WOE #170).
+ *
+ * Creature face: {3}{G} 4/3 Elf Fox Warrior with trample.
+ * Adventure face: Guard Change {1}{G}, Instant — Adventure — "Create a Monster Role token attached
+ * to target creature you control." (Enchanted creature gets +1/+1 and has trample.)
+ */
+class FerociousWerefoxScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("Guard Change attaches a Monster Role, giving the host +1/+1 and trample") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Ferocious Werefox")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val werefox = game.findCardsInHand(1, "Ferocious Werefox").single()
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            // faceIndex = 0 is the Adventure face (CR 715).
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = werefox,
+                    targets = listOf(ChosenTarget.Permanent(bears)),
+                    faceIndex = 0
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("a Monster Role token is attached to Grizzly Bears") {
+                game.findPermanent("Monster Role") shouldNotBe null
+            }
+            withClue("the enchanted 2/2 is now a 3/3 with trample") {
+                game.state.projectedState.getPower(bears) shouldBe 3
+                game.state.projectedState.getToughness(bears) shouldBe 3
+                game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+            }
+            withClue("the Adventure exiled itself (CR 715.3d)") {
+                game.isInExile(1, "Ferocious Werefox") shouldBe true
+            }
+        }
+
+        test("the creature face can be cast from exile afterwards as a 4/3 trampler") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Ferocious Werefox")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val werefox = game.findCardsInHand(1, "Ferocious Werefox").single()
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = werefox,
+                    targets = listOf(ChosenTarget.Permanent(bears)),
+                    faceIndex = 0
+                )
+            ).error shouldBe null
+            game.resolveStack()
+            game.isInExile(1, "Ferocious Werefox") shouldBe true
+
+            // Cast the creature face from exile — {3}{G}.
+            game.execute(CastSpell(playerId = game.player1Id, cardId = werefox)).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Werefox is on the battlefield as a 4/3 trampler") {
+                game.isOnBattlefield("Ferocious Werefox") shouldBe true
+                game.state.projectedState.getPower(werefox) shouldBe 4
+                game.state.projectedState.getToughness(werefox) shouldBe 3
+                game.state.projectedState.hasKeyword(werefox, Keyword.TRAMPLE) shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HollowScavengerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HollowScavengerScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Hollow Scavenger // Bakery Raid (WOE #174).
+ *
+ * Creature face: {2}{G} 3/2 Wolf — "{1}, Sacrifice a Food: This creature gets +2/+2 until end of
+ * turn. Activate only once each turn."
+ * Adventure face: Bakery Raid {G}, Sorcery — Adventure — "Create a Food token."
+ */
+class HollowScavengerScenarioTest : ScenarioTestBase() {
+
+    private val pumpAbilityId by lazy {
+        cardRegistry.requireCard("Hollow Scavenger").activatedAbilities[0].id
+    }
+
+    init {
+        test("Bakery Raid creates a Food token and exiles the card for later") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Hollow Scavenger")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val scavenger = game.findCardsInHand(1, "Hollow Scavenger").single()
+
+            // faceIndex = 0 is the Adventure face (CR 715).
+            game.execute(CastSpell(playerId = game.player1Id, cardId = scavenger, faceIndex = 0))
+                .error shouldBe null
+            game.resolveStack()
+
+            withClue("a Food token entered under the caster's control") {
+                game.findPermanent("Food") shouldNotBe null
+            }
+            withClue("the Adventure exiled itself (CR 715.3d)") {
+                game.isInExile(1, "Hollow Scavenger") shouldBe true
+                game.isInGraveyard(1, "Hollow Scavenger") shouldBe false
+            }
+        }
+
+        test("sacrificing a Food pumps it +2/+2, and the ability can only be activated once a turn") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hollow Scavenger", summoningSickness = false)
+                .withCardOnBattlefield(1, "Food")
+                .withCardOnBattlefield(1, "Food")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val scavenger = game.findPermanent("Hollow Scavenger")!!
+            val foods = game.findPermanents("Food")
+            foods.size shouldBe 2
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = scavenger,
+                    abilityId = pumpAbilityId,
+                    costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(foods[0]))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Food was eaten and the Wolf is a 5/4 until end of turn") {
+                game.isOnBattlefield("Food") shouldBe true // the second Food is untouched
+                game.findPermanents("Food").size shouldBe 1
+                game.state.projectedState.getPower(scavenger) shouldBe 5
+                game.state.projectedState.getToughness(scavenger) shouldBe 4
+            }
+
+            withClue("\"Activate only once each turn\" blocks the second activation") {
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = scavenger,
+                        abilityId = pumpAbilityId,
+                        costPayment = AdditionalCostPayment(
+                            sacrificedPermanents = listOf(game.findPermanents("Food").single())
+                        )
+                    )
+                ).error shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToughCookieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToughCookieScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tough Cookie (WOE #193) — {1}{G} Artifact Creature — Food Golem 2/2.
+ *
+ * "When this creature enters, create a Food token.
+ *  {2}{G}: Until end of turn, target noncreature artifact you control becomes a 4/4 artifact creature.
+ *  {2}, {T}, Sacrifice this creature: You gain 3 life."
+ */
+class ToughCookieScenarioTest : ScenarioTestBase() {
+
+    private val animateAbilityId by lazy {
+        cardRegistry.requireCard("Tough Cookie").activatedAbilities[0].id
+    }
+    private val sacrificeAbilityId by lazy {
+        cardRegistry.requireCard("Tough Cookie").activatedAbilities[1].id
+    }
+
+    init {
+        test("entering the battlefield creates a Food token") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Tough Cookie")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Tough Cookie").error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Tough Cookie") shouldBe true
+            withClue("the enters trigger made a Food") {
+                game.findPermanent("Food") shouldNotBe null
+            }
+        }
+
+        test("the animate ability turns a Food token into a 4/4 that is still a Food") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Tough Cookie", summoningSickness = false)
+                .withCardOnBattlefield(1, "Food")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cookie = game.findPermanent("Tough Cookie")!!
+            val food = game.findPermanent("Food")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = cookie,
+                    abilityId = animateAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(food))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Food became a 4/4 artifact creature") {
+                game.state.projectedState.isCreature(food) shouldBe true
+                game.state.projectedState.getPower(food) shouldBe 4
+                game.state.projectedState.getToughness(food) shouldBe 4
+            }
+            withClue("it kept its other types and subtypes (2023-09-01 ruling)") {
+                game.state.projectedState.hasSubtype(food, "Food") shouldBe true
+            }
+        }
+
+        test("the animate ability can't target a creature artifact — including Tough Cookie itself") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Tough Cookie", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cookie = game.findPermanent("Tough Cookie")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = cookie,
+                    abilityId = animateAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(cookie))
+                )
+            ).error shouldNotBe null
+        }
+
+        test("{2}, {T}, sacrifice: gain 3 life — Tough Cookie is its own Food outlet") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Tough Cookie", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withLifeTotal(1, 20)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cookie = game.findPermanent("Tough Cookie")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = cookie,
+                    abilityId = sacrificeAbilityId
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.getLifeTotal(1) shouldBe 23
+            game.isInGraveyard(1, "Tough Cookie") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Five WOE cards, all composed from existing SDK facades — no engine or SDK changes.

| Card | Text |
|---|---|
| **Fell Horseman // Deathly Ride** (#92) | 3/3 Zombie Knight, "when this dies, put it on the bottom of its owner's library"; Adventure returns a creature card from your graveyard to hand |
| **Hollow Scavenger // Bakery Raid** (#174) | `{1}, Sacrifice a Food: +2/+2 until end of turn. Activate only once each turn`; Adventure creates a Food |
| **Ferocious Werefox // Guard Change** (#170) | 4/3 trample; Adventure creates a Monster Role attached to a creature you control |
| **Curse of the Werefox** (#167) | Monster Role on a creature you control, then a reflexive "when you do, that creature fights up to one target creature you don't control" |
| **Tough Cookie** (#193) | Food Golem: ETB Food; `{2}{G}` animates a noncreature artifact you control into a 4/4; `{2},{T}, Sac: gain 3 life` |

### Notes

**Curse of the Werefox** is the only non-obvious wiring. The fight is a reflexive triggered ability (CR 603.12) — its target is chosen after the Role is created, so the Role's +1/+1 is already applied when damage is dealt, and opponents get a window in between. Reflexive resolution rebinds `EffectContext.targets` to the reflexive target, so the spell's own target is snapshotted into a pipeline collection first (`gather(CardSource.ChosenTargets)`); the fight then reads its first combatant from `EffectTarget.PipelineTarget` and its second from `ContextTarget(0)`. `optional = true` on the reflexive requirement is the "up to one" — declining just skips the fight, with the Role staying put.

**Tough Cookie's** animate passes no `removeTypes`, so the target keeps every type, subtype and ability it had (per the 2023-09-01 ruling) — an animated Food is still a sacrificeable Food.

Skipped Bargain and Celebration cards from this set: both need new SDK capability (a cast-time additional cost, and a "two or more nonland permanents entered under your control this turn" condition), which is `add-feature` territory rather than card authoring.

### Verification

- 12 new scenario tests in `rules-engine` covering both faces of each Adventure, the once-per-turn restriction, the reflexive fight (taken and declined), and the animate targeting restriction — all pass.
- `just build` (full suite) green.
- WOE card snapshot re-blessed; diff is purely additive.
- `just check-card-printing` clean for all five (WOE is the earliest real printing in every case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)