### PR TITLE
Add Chandra, Flameshaper with activation-time divided damage

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -509,13 +509,30 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   and marked-damage-aware) that `target1` deals **to `target2`** is stored into that pipeline number
   variable for a following effect to read via `DynamicAmount.VariableReference` — e.g. The Last Agni Kai:
   `Fight(yours, theirs, "excess") then AddMana(RED, VariableReference("excess"))`.
-- `DividedDamageEffect(totalDamage, minTargets, maxTargets, dynamicTotal?)` — "N damage divided as you
+- `Effects.DividedDamage(total, minTargets, maxTargets, dynamicTotal?)` — "N damage divided as you
   choose among target ..." The targets come from the ability's target requirement; pair with
-  `TargetCreature(count, minCount)` (Forked Lightning, Skirk Volcanist) or, for "any number of target"
-  + a dynamic total, a `TargetObject(optional = true, dynamicMaxCount = ..., filter = ...)`. Set
-  `dynamicTotal` (a `DynamicAmount`) for totals computed when the ability resolves/goes on the stack —
-  Ureni, the Song Unending: `dynamicTotal = DynamicAmounts.landsYouControl()`. Works for creatures and
-  planeswalkers (`GameObjectFilter.CreatureOrPlaneswalker`); zero chosen targets ⇒ no-op.
+  `TargetCreature(count, minCount)` (Forked Lightning, Skirk Volcanist) or, for "any number of target",
+  a `TargetObject(unlimited = true, dynamicMaxCount = ..., filter = ...)`. Set `dynamicTotal` (a
+  `DynamicAmount`) for totals computed when the ability resolves/goes on the stack — Ureni, the Song
+  Unending: `dynamicTotal = DynamicAmounts.landsYouControl()`. Works for creatures and planeswalkers
+  (`GameObjectFilter.CreatureOrPlaneswalker`); zero chosen targets ⇒ no-op.
+
+  **Always cap the target count at the total.** Each chosen target must be assigned at least 1 damage
+  (CR 601.2d), so a requirement that lets the player pick more targets than there is damage leaves them
+  with no legal division to submit. Pass `dynamicMaxCount` alongside `unlimited` — a
+  `DynamicAmount.Fixed(total)` for a fixed total (Chandra, Flameshaper: 8 damage ⇒ at most 8 targets),
+  or the same `DynamicAmount` that drives `dynamicTotal` when the total is board-derived (Ureni). The
+  cap and `unlimited` compose: the client is offered `min(legal targets, cap)`.
+
+  **The division is chosen at announcement, never at resolution** (CR 601.2d). It rides on the action
+  (`CastSpell.damageDistribution` / `ActivateAbility.damageDistribution`), is locked onto the stack
+  object, and is honored verbatim when the effect resolves — so a target removed in response costs that
+  target's share and the survivors keep exactly what they were assigned (the total is *not* re-divided).
+  The engine surfaces `requiresDamageDistribution` / `totalDamageToDistribute` / `minDamagePerTarget` on
+  the legal action for both spells and activated abilities, and the client collects the division right
+  after targeting. When no division is supplied (a single target, or a non-interactive controller such
+  as the built-in AI) the executor deals the whole total to a lone target, or asks for the division at
+  resolution via a `DistributeDecision`.
 - `DamageCantBePreventedThisTurn()` — "Damage can't be prevented this turn." Turn-scoped one-shot that
   sets a `GameState` flag (cleared at the next turn boundary), shutting off all damage prevention for
   the rest of the turn — prevention shields, prevention/replacement-of-damage effects, and protection's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -84,6 +84,7 @@ import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.effects.GrantDamageBonusEffect
 import com.wingedsheep.sdk.scripting.effects.DamageCantBePreventedThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
 import com.wingedsheep.sdk.scripting.effects.EachPlayerReturnsPermanentToHandEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -261,6 +262,37 @@ object Effects {
      */
     fun DealXDamage(target: EffectTarget): Effect =
         DealDamageEffect(DynamicAmount.XValue, target)
+
+    /**
+     * "N damage divided as you choose among …" (Arc Lightning, Chandra, Flameshaper's −4).
+     *
+     * The targets among which the total is split come from the ability's own target requirement,
+     * not from here — so the requirement decides whether the wording is "1, 2, or 3 target
+     * creatures" (`TargetCreature(count = 3, minCount = 1)`) or "any number of target creatures
+     * and/or planeswalkers" (`TargetObject(unlimited = true, …)`). Because each chosen target must
+     * be assigned at least 1 damage (CR 601.2d), cap the requirement's target count at the total:
+     * pass `dynamicMaxCount = DynamicAmount.Fixed(total)` on an `unlimited` requirement, or let a
+     * board-derived cap do it when the total itself is dynamic.
+     *
+     * The division is chosen as the spell is cast / the ability is activated, never at resolution;
+     * if a target becomes illegal in between, its share is simply not dealt and the rest keep what
+     * they were assigned.
+     *
+     * @param total Fixed total to divide. Ignored when [dynamicTotal] is supplied.
+     * @param dynamicTotal Total computed at resolution instead ("X damage …, where X is the number
+     *        of lands you control" — Ureni, the Song Unending).
+     */
+    fun DividedDamage(
+        total: Int = 0,
+        minTargets: Int = 1,
+        maxTargets: Int = 3,
+        dynamicTotal: DynamicAmount? = null
+    ): Effect = DividedDamageEffect(
+        totalDamage = total,
+        minTargets = minTargets,
+        maxTargets = maxTargets,
+        dynamicTotal = dynamicTotal
+    )
 
     /**
      * Install a turn-duration replacement that adds [bonus] to every noncombat damage instance

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ChandraFlameshaper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ChandraFlameshaper.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Chandra, Flameshaper
+ * {5}{R}{R}
+ * Legendary Planeswalker — Chandra
+ * Loyalty 6
+ *
+ * +2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card
+ *     this turn.
+ * +1: Create a token that's a copy of target creature you control, except it has haste and
+ *     "At the beginning of the end step, sacrifice this token."
+ * −4: Chandra deals 8 damage divided as you choose among any number of target creatures and/or
+ *     planeswalkers.
+ *
+ * Modeling notes:
+ *  - The +2 is **not** a mana ability (printed ruling): it has other effects and is a loyalty
+ *    ability, so it uses the stack. That falls out for free — `isManaAbility` is author-declared
+ *    and left off, so the enumerator treats it as an ordinary non-mana ability.
+ *  - "Exile the top three … Choose one. You may play that card" is a gather → exile → choose →
+ *    grant pipeline, with the play permission granted only to the *chosen* card; the other two stay
+ *    exiled with no permission. The choice happens after the move, so the player is picking among
+ *    cards that are already in exile. Same shape as End-Blaze Epiphany, expressed with the inline
+ *    pipeline builder.
+ *  - The +1 is Electroduplicate's clause verbatim: [Effects.CreateTokenCopyOfTarget] with
+ *    `addedKeywords = HASTE` and `sacrificeAtStep = Step.END` (any player's end step — the token
+ *    can attack once and then dies). All the copy-a-copy / copy-a-token rulings are the copy
+ *    machinery's, not this card's.
+ *  - The −4 divides a fixed 8 among "any number of target" creatures and/or planeswalkers of *any*
+ *    controller. Each chosen target must be assigned at least 1 damage (CR 601.2d), so the
+ *    requirement carries `dynamicMaxCount = 8` on top of `unlimited` — otherwise the player could
+ *    pick a ninth target and have no legal division to submit. The division itself is chosen as the
+ *    ability is activated, not at resolution; removal in response therefore costs that target's
+ *    share rather than letting the damage be re-aimed (see the printed rulings below).
+ */
+val ChandraFlameshaper = card("Chandra, Flameshaper") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Planeswalker — Chandra"
+    startingLoyalty = 6
+    oracleText = "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may " +
+        "play that card this turn.\n" +
+        "+1: Create a token that's a copy of target creature you control, except it has haste and " +
+        "\"At the beginning of the end step, sacrifice this token.\"\n" +
+        "−4: Chandra deals 8 damage divided as you choose among any number of target creatures " +
+        "and/or planeswalkers."
+
+    // +2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one.
+    //     You may play that card this turn.
+    loyaltyAbility(+2) {
+        effect = Effects.Pipeline {
+            run(Effects.AddMana(Color.RED, 3))
+            val exiled = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(3)))
+            exile(exiled)
+            val chosen = chooseExactly(
+                1,
+                from = exiled,
+                prompt = "Choose a card you may play this turn",
+            )
+            run(Effects.GrantMayPlayFromExile(chosen.key))
+        }
+    }
+
+    // +1: Create a token that's a copy of target creature you control, except it has haste and
+    //     "At the beginning of the end step, sacrifice this token."
+    loyaltyAbility(+1) {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateTokenCopyOfTarget(
+            creature,
+            addedKeywords = setOf(Keyword.HASTE),
+            sacrificeAtStep = Step.END,
+        )
+    }
+
+    // −4: Chandra deals 8 damage divided as you choose among any number of target creatures
+    //     and/or planeswalkers.
+    loyaltyAbility(-4) {
+        target(
+            "any number of target creatures and/or planeswalkers",
+            TargetObject(
+                unlimited = true,
+                filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker),
+                dynamicMaxCount = DynamicAmount.Fixed(8),
+                id = "target creatures and/or planeswalkers",
+            ),
+        )
+        effect = Effects.DividedDamage(total = 8, minTargets = 1, maxTargets = 8)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "81"
+        artist = "Mark Winters"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg?1783909105"
+
+        ruling("2024-11-08", "Chandra's first ability is not a mana ability. It uses the stack and players can respond to it.")
+        ruling("2024-11-08", "You pay all costs and follow all timing rules for cards played with the permission granted by Chandra's first ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty.")
+        ruling("2024-11-08", "The token created by Chandra's second ability copies exactly what was printed on the original creature and nothing else, with the listed exceptions (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on. If it is a Vehicle, it is not crewed.")
+        ruling("2024-11-08", "If the copied creature is a token, the token that's created copies the original characteristics of that token as stated by the effect that created the token, with the listed exceptions.")
+        ruling("2024-11-08", "If the copied creature is copying something else, then the token enters as whatever that creature copied, with the listed exceptions.")
+        ruling("2024-11-08", "Any enters abilities of the copied creature will trigger when the token enters. Any \"as [this permanent] enters\" or \"[this permanent] enters with\" abilities of the copied creature will also work.")
+        ruling("2024-11-08", "You choose the targets and how damage will be divided as you activate Chandra's last ability. Each chosen target must receive at least 1 damage.")
+        ruling("2024-11-08", "If some of the targets of Chandra's last ability become illegal, the original division of damage still applies, but the damage that would have been dealt to illegal targets isn't dealt at all.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1442,6 +1442,177 @@
     ]
 }
 
+// Chandra, Flameshaper
+{
+    "name": "Chandra, Flameshaper",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Legendary Planeswalker — Chandra",
+    "oracleText": "+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n+1: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n−4: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 2
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "RED",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected3",
+                            "prompt": "Choose a card you may play this turn"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "selected3"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    },
+                    "addedKeywords": [
+                        "HASTE"
+                    ],
+                    "sacrificeAtStep": "END"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -4
+                },
+                "effect": {
+                    "type": "DividedDamage",
+                    "totalDamage": 8,
+                    "maxTargets": 8
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "unlimited": true,
+                        "filter": {
+                            "baseFilter": "creature|planeswalker"
+                        },
+                        "id": "any number of target creatures and/or planeswalkers",
+                        "dynamicMaxCount": {
+                            "type": "Fixed",
+                            "amount": 8
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "MYTHIC",
+        "artist": "Mark Winters",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a22d21ec-0fb3-4574-a803-6442ec13167e.jpg?1783909105",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Chandra's first ability is not a mana ability. It uses the stack and players can respond to it."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You pay all costs and follow all timing rules for cards played with the permission granted by Chandra's first ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "The token created by Chandra's second ability copies exactly what was printed on the original creature and nothing else, with the listed exceptions (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on. If it is a Vehicle, it is not crewed."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If the copied creature is a token, the token that's created copies the original characteristics of that token as stated by the effect that created the token, with the listed exceptions."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If the copied creature is copying something else, then the token enters as whatever that creature copied, with the listed exceptions."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Any enters abilities of the copied creature will trigger when the token enters. Any \"as [this permanent] enters\" or \"[this permanent] enters with\" abilities of the copied creature will also work."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You choose the targets and how damage will be divided as you activate Chandra's last ability. Each chosen target must receive at least 1 damage."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If some of the targets of Chandra's last ability become illegal, the original division of damage still applies, but the damage that would have been dealt to illegal targets isn't dealt at all."
+            }
+        ]
+    },
+    "startingLoyalty": 6,
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Claws Out
 {
     "name": "Claws Out",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -269,6 +269,14 @@ sealed interface PaymentStrategy {
  * @property targets Chosen targets for the ability's effect
  * @property costPayment Payment choices for costs (sacrifice, etc.)
  * @property manaColorChoice Color chosen for "add one mana of any color" abilities
+ * @property damageDistribution Pre-chosen damage distribution for a
+ *           [com.wingedsheep.sdk.scripting.effects.DividedDamageEffect] ability (target ID ->
+ *           damage amount). The activated-ability twin of [CastSpell.damageDistribution]: CR 601.2d
+ *           has the division chosen **as the ability is activated**, not when it resolves, so
+ *           opponents responding by removing a target lose that damage entirely rather than letting
+ *           the controller re-divide (Chandra, Flameshaper's −4). Omitted for every other ability;
+ *           when omitted for a divided-damage ability the executor falls back to a resolution-time
+ *           `DistributeDecision`, which is how non-interactive controllers (the built-in AI) divide.
  */
 @Serializable
 @SerialName("ActivateAbility")
@@ -283,6 +291,7 @@ data class ActivateAbility(
     val repeatCount: Int = 1,
     val paymentStrategy: PaymentStrategy = PaymentStrategy.AutoPay,
     val alternativePayment: AlternativePaymentChoice? = null,
+    val damageDistribution: Map<EntityId, Int>? = null,
     /**
      * Internal resume marker for "… of an opponent's choice" targets (Cuombajj Witches). On the
      * first pass the handler pauses to let an opponent pick the opponent-chosen target(s); the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.toEntityId
 import com.wingedsheep.engine.handlers.effects.bend.BendEvents
 import com.wingedsheep.engine.mechanics.mana.AlternativePaymentHandler
 import com.wingedsheep.engine.mechanics.mana.IntrinsicManaAbilities
@@ -68,6 +69,7 @@ import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap
 import com.wingedsheep.sdk.scripting.TappedForManaType
 import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
@@ -454,6 +456,29 @@ class ActivateAbilityHandler(
             // for it during execute(); don't reject that here either.
             if (exilePermanentsCost == null && controllerTargetReqs.any { it.effectiveMinCount > 0 }) {
                 return "This ability requires a target"
+            }
+        }
+
+        // Validate a client-supplied divided-damage division (Chandra, Flameshaper's −4). The
+        // division is chosen as the ability is activated (CR 601.2d), so it arrives on the action
+        // rather than being asked for at resolution. Absence is legal — the executor then raises a
+        // resolution-time DistributeDecision, which is how non-interactive controllers divide — but
+        // anything present must be a well-formed division of exactly the printed total.
+        val distribution = action.damageDistribution
+        if (distribution != null) {
+            val dividedDamage = ability.effect as? DividedDamageEffect
+                ?: return "This ability does not divide damage among its targets"
+            val chosenTargetIds = action.targets.map { it.toEntityId() }.toSet()
+            if (distribution.keys != chosenTargetIds) {
+                return "Damage distribution targets must match chosen targets"
+            }
+            val totalDistributed = distribution.values.sum()
+            if (totalDistributed != dividedDamage.totalDamage) {
+                return "Total distributed damage ($totalDistributed) must equal ${dividedDamage.totalDamage}"
+            }
+            // CR 601.2d: each target in the division must be assigned at least 1 damage.
+            if (distribution.values.any { it < 1 }) {
+                return "Each target must receive at least 1 damage"
             }
         }
 
@@ -1555,7 +1580,10 @@ class ActivateAbilityHandler(
             abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
                 cardComponent.cardDefinitionId, ability.id
             ),
-            granterId = staticGranterId
+            granterId = staticGranterId,
+            // Lock in the activation-time damage division (CR 601.2d) so removal in response
+            // can't hand the controller a fresh division at resolution.
+            damageDistribution = action.damageDistribution
         )
 
         // Apply text-changing effects to the target requirements for resolution-time re-validation

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DividedDamageExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/damage/DividedDamageExecutor.kt
@@ -22,12 +22,11 @@ import kotlin.reflect.KClass
  *
  * "Deal X damage divided as you choose among N targets"
  *
- * Per MTG rules, damage distribution must be chosen as part of targeting (at cast time),
- * not when the spell resolves. This executor uses the pre-supplied distribution from
- * the EffectContext.
- *
- * If there's only one target, deal all damage directly (no distribution needed).
- * If there are multiple targets, use the pre-supplied damageDistribution from context.
+ * Per MTG rules the division is chosen as the spell is cast / the ability is activated (CR 601.2d),
+ * not when it resolves, so this executor prefers the pre-supplied `context.damageDistribution` —
+ * dealing each surviving target exactly its announced share and dropping the share of any target
+ * that became illegal in the meantime. Only when no division was announced (a single target, or a
+ * non-interactive controller) does it deal the whole total or ask for the division at resolution.
  */
 class DividedDamageExecutor(
     private val decisionHandler: DecisionHandler,
@@ -56,25 +55,19 @@ class DividedDamageExecutor(
             else EffectResult.error(state, "No targets for divided damage")
         }
 
-        // If there's only one target, deal all damage directly
-        if (targets.size == 1) {
-            return dealDamageToTarget(state, targets.first(), total, context.sourceId)
-        }
-
-        // Multiple targets - use pre-supplied distribution from context
         val distribution = context.damageDistribution
-        if (distribution == null) {
-            // Fallback: This shouldn't happen with proper flow, but handle gracefully
-            // by creating a decision (legacy behavior)
-            return createDistributionDecision(state, effect, context, targets, total)
-        }
+        if (distribution != null) {
+            // The division was locked in when the spell/ability was announced (CR 601.2d), so it is
+            // honored verbatim — never re-divided at resolution. `context.targets` has already had
+            // targets that became illegal dropped (CR 608.2b); their share is simply not dealt, and
+            // the survivors keep exactly what they were assigned. This is why the assigned shares
+            // can sum to less than [total] and must not be recomputed from the surviving count.
+            val stillLegal = targets.toSet()
+            var currentState = state
+            val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
 
-        // Deal damage to each target per the distribution
-        var currentState = state
-        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
-
-        for ((targetId, amount) in distribution) {
-            if (amount > 0) {
+            for ((targetId, amount) in distribution) {
+                if (amount <= 0 || targetId !in stillLegal) continue
                 val result = dealDamageToTarget(currentState, targetId, amount, context.sourceId)
                 if (!result.isSuccess) {
                     return result
@@ -82,9 +75,17 @@ class DividedDamageExecutor(
                 currentState = result.newState
                 events.addAll(result.events)
             }
+
+            return EffectResult.success(currentState, events)
         }
 
-        return EffectResult.success(currentState, events)
+        // No division was announced. A single target takes the whole total with nothing to divide;
+        // otherwise fall back to asking for the division now (the path non-interactive controllers
+        // and engine-direct actions take).
+        if (targets.size == 1) {
+            return dealDamageToTarget(state, targets.first(), total, context.sourceId)
+        }
+        return createDistributionDecision(state, effect, context, targets, total)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -875,6 +875,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         // work to do (e.g. the trigger we wanted to copy isn't on top yet).
                         val holdPriorityForTopOfStack = ability.holdPriority &&
                             state.stack.lastOrNull()?.let { it in firstReqInfo.validTargets } == true
+                        // "N damage divided as you choose among …" — the division is part of
+                        // activating the ability (CR 601.2d), so flag it here and let the client
+                        // collect it after targeting, exactly as the cast path does for spells
+                        // (Chandra, Flameshaper's −4).
+                        val dividedDamage = ability.effect as? DividedDamageEffect
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
                             description = displayDescription,
@@ -897,7 +902,10 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             convokeCreatures = abilityConvokeCreatures,
                             hasWaterbend = ability.hasWaterbend,
                             waterbendPermanents = abilityWaterbendPermanents,
-                            holdPriority = holdPriorityForTopOfStack
+                            holdPriority = holdPriorityForTopOfStack,
+                            requiresDamageDistribution = dividedDamage != null,
+                            totalDamageToDistribute = dividedDamage?.totalDamage,
+                            minDamagePerTarget = if (dividedDamage != null) 1 else null
                         ))
                     }
                 } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -272,9 +272,19 @@ class TargetEnumerationUtils(
                 // number of legal targets on the board, so the client offers all of them.
                 // A board-state `dynamicMaxCount` (anything but XValue, which is unbound
                 // until the X is chosen and so is surfaced via [xConstrainsCount]) is
-                // resolved here so the UI caps at the right number immediately.
+                // resolved here so the UI caps at the right number immediately — including
+                // *alongside* `unlimited`, where the wording is "any number of target …" but
+                // the effect still bounds how many targets are usable (Chandra, Flameshaper's
+                // "8 damage divided as you choose among any number of target creatures and/or
+                // planeswalkers" — each target needs at least 1 damage, so at most 8). Without
+                // the cap the player could pick a ninth target and then be unable to produce a
+                // legal division.
                 maxTargets = when {
-                    req.unlimited -> validTargets.size
+                    req.unlimited ->
+                        minOf(
+                            validTargets.size,
+                            resolveStaticDynamicMax(state, req, playerId, sourceId) ?: validTargets.size
+                        )
                     else -> resolveStaticDynamicMax(state, req, playerId, sourceId) ?: req.count
                 },
                 validTargets = validTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2437,6 +2437,7 @@ class StackResolver(
             lastKnownSourceCounters = abilityComponent.lastKnownSourceCounters,
             lastKnownSourceSnapshot = abilityComponent.lastKnownSourceSnapshot,
             lastKnownSourceAttachments = abilityComponent.lastKnownSourceAttachments,
+            damageDistribution = abilityComponent.damageDistribution,
             pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(activatedReqs, alignedActivatedTargets))
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -263,7 +263,14 @@ data class ActivatedAbilityOnStackComponent(
      * granter via [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource] — e.g. Trusty
      * Boomerang's "Return [this Equipment] to its owner's hand". Null for non-granted abilities.
      */
-    val granterId: EntityId? = null
+    val granterId: EntityId? = null,
+    /**
+     * Division chosen at activation for a `DividedDamageEffect` ability (target -> damage), locked
+     * onto the stack object so responding removal can't make the controller re-divide (CR 601.2d).
+     * Mirrors [SpellOnStackComponent.damageDistribution]. Null for every other ability, and for a
+     * divided-damage ability whose controller left the division to resolution time.
+     */
+    val damageDistribution: Map<EntityId, Int>? = null
 ) : Component {
     val hasTargets: Boolean = false  // Will be updated based on effect
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraFlameshaperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraFlameshaperScenarioTest.kt
@@ -1,0 +1,369 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.ChandraFlameshaper
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Chandra, Flameshaper (FDN, {5}{R}{R}, Loyalty 6).
+ *
+ *   +2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that
+ *       card this turn.
+ *   +1: Create a token that's a copy of target creature you control, except it has haste and
+ *       "At the beginning of the end step, sacrifice this token."
+ *   −4: Chandra deals 8 damage divided as you choose among any number of target creatures and/or
+ *       planeswalkers.
+ *
+ * The −4 is the engine-interesting half: it's the first *activated* ability to divide damage, so
+ * the division rides on the `ActivateAbility` action and is locked onto the stack object at
+ * activation (CR 601.2d) rather than being asked for at resolution. The tests below pin that
+ * timing, the printed "illegal targets lose their share, the rest keep theirs" ruling, and the
+ * target-count cap that keeps the division satisfiable.
+ */
+class ChandraFlameshaperScenarioTest : ScenarioTestBase() {
+
+    private val plusTwo = ChandraFlameshaper.activatedAbilities[0].id
+    private val plusOne = ChandraFlameshaper.activatedAbilities[1].id
+    private val minusFour = ChandraFlameshaper.activatedAbilities[2].id
+
+    init {
+        context("Chandra, Flameshaper") {
+
+            test("+2 adds {R}{R}{R}, exiles three, and grants play permission to the chosen card only") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chandra,
+                        abilityId = plusTwo,
+                    )
+                ).error shouldBe null
+
+                withClue("the printed ruling: the +2 is NOT a mana ability — it uses the stack") {
+                    game.state.stack.size shouldBe 1
+                }
+
+                game.resolveStack()
+
+                // "Choose one" — exactly the three freshly exiled cards are on offer.
+                val choice = game.getPendingDecision()
+                withClue("resolution paused to choose one of the exiled cards: $choice") {
+                    (choice is SelectCardsDecision) shouldBe true
+                }
+                choice as SelectCardsDecision
+                choice.options.size shouldBe 3
+
+                val chosen = choice.options.first()
+                game.selectCards(listOf(chosen)).error shouldBe null
+                game.resolveStack()
+
+                withClue("added {R}{R}{R}") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.red shouldBe 3
+                }
+                withClue("three cards left the library for exile, one is still there") {
+                    game.librarySize(1) shouldBe 1
+                    game.state.getExile(game.player1Id).size shouldBe 3
+                }
+                withClue("only the chosen card may be played — the other two stay stranded in exile") {
+                    val playable = game.state.mayPlayPermissions.flatMap { it.cardIds }.toSet()
+                    playable shouldBe setOf(chosen)
+                }
+                withClue("+2 put two loyalty counters on Chandra") {
+                    loyalty(game, chandra) shouldBe 8
+                }
+            }
+
+            test("+1 copies a creature you control with haste, and the token is sacrificed at the end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chandra,
+                        abilityId = plusOne,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val copies = game.findPermanents("Grizzly Bears")
+                withClue("the original plus its token copy") {
+                    copies.size shouldBe 2
+                }
+                val token = copies.first { it != bears }
+                withClue("the copy is a 2/2 Grizzly Bears with haste bolted on") {
+                    game.state.projectedState.getPower(token) shouldBe 2
+                    game.state.projectedState.getToughness(token) shouldBe 2
+                    game.state.projectedState.hasKeyword(token, Keyword.HASTE) shouldBe true
+                }
+                withClue("the original didn't gain haste — only the copy did") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe false
+                }
+                withClue("+1 put one loyalty counter on Chandra") {
+                    loyalty(game, chandra) shouldBe 7
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("'at the beginning of the end step, sacrifice this token' fired") {
+                    game.findPermanents("Grizzly Bears") shouldBe listOf(bears)
+                }
+            }
+
+            test("−4 divides 8 damage among three targets exactly as announced") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardOnBattlefield(2, "Savannah Lions")   // 2/1
+                    .withCardOnBattlefield(2, "Grizzly Bears")    // 2/2
+                    .withCardOnBattlefield(2, "Centaur Courser")  // 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+                val lions = game.findPermanent("Savannah Lions")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chandra,
+                        abilityId = minusFour,
+                        targets = listOf(
+                            ChosenTarget.Permanent(lions),
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(courser),
+                        ),
+                        damageDistribution = mapOf(lions to 1, bears to 2, courser to 5),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("1 to the 2/1, 2 to the 2/2, 5 to the 3/3 — all lethal, no distribute prompt") {
+                    game.hasPendingDecision() shouldBe false
+                    game.findPermanent("Savannah Lions") shouldBe null
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.findPermanent("Centaur Courser") shouldBe null
+                }
+                withClue("−4 removed four loyalty counters") {
+                    loyalty(game, chandra) shouldBe 2
+                }
+            }
+
+            test("−4 rejects a division that doesn't spend exactly 8, or that starves a target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val targets = listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(courser))
+
+                withClue("a division summing to less than 8 is illegal") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = chandra,
+                            abilityId = minusFour,
+                            targets = targets,
+                            damageDistribution = mapOf(bears to 2, courser to 3),
+                        )
+                    ).error shouldNotBe null
+                }
+                withClue("every chosen target must get at least 1 damage (CR 601.2d)") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = chandra,
+                            abilityId = minusFour,
+                            targets = targets,
+                            damageDistribution = mapOf(bears to 0, courser to 8),
+                        )
+                    ).error shouldNotBe null
+                }
+                withClue("the division must cover exactly the chosen targets") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = chandra,
+                            abilityId = minusFour,
+                            targets = targets,
+                            damageDistribution = mapOf(bears to 8),
+                        )
+                    ).error shouldNotBe null
+                }
+                withClue("no illegal activation went through — Chandra still has her 6 loyalty") {
+                    loyalty(game, chandra) shouldBe 6
+                }
+            }
+
+            test("−4: a target that leaves in response loses its share; survivors keep theirs") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardOnBattlefield(2, "Grizzly Bears")     // 2/2 — removed in response
+                    .withCardOnBattlefield(2, "Force of Nature")   // 5/5 — survives 2, dies to 8
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val force = game.findPermanent("Force of Nature")!!
+
+                // Announce 6 to the Bears, 2 to the 5/5. The division is locked in now.
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chandra,
+                        abilityId = minusFour,
+                        targets = listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(force)),
+                        damageDistribution = mapOf(bears to 6, force to 2),
+                    )
+                ).error shouldBe null
+
+                // The opponent removes the Bears while the ability waits on the stack.
+                game.state = game.state.moveToZone(
+                    bears,
+                    ZoneKey(game.player2Id, Zone.BATTLEFIELD),
+                    ZoneKey(game.player2Id, Zone.GRAVEYARD),
+                )
+
+                game.resolveStack()
+
+                withClue("the Bears' 6 damage is simply not dealt — it is NOT re-aimed at the 5/5") {
+                    game.hasPendingDecision() shouldBe false
+                    game.findPermanent("Force of Nature") shouldNotBe null
+                    game.damageOn(force) shouldBe 2
+                }
+            }
+
+            test("−4 can put all 8 damage on a single planeswalker") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                    .withCardOnBattlefield(2, "Kaito, Cunning Infiltrator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+                val kaito = game.findPermanent("Kaito, Cunning Infiltrator")!!
+                seedLoyalty(game, kaito, 3)
+
+                // A single target needs no division — the whole total lands on it.
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = chandra,
+                        abilityId = minusFour,
+                        targets = listOf(ChosenTarget.Permanent(kaito)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("8 damage stripped Kaito's 3 loyalty and he died to the 0-loyalty SBA") {
+                    game.findPermanent("Kaito, Cunning Infiltrator") shouldBe null
+                }
+            }
+
+            test("−4 offers at most 8 targets, since each one needs a damage point") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Flameshaper")
+                repeat(10) { builder.withCardOnBattlefield(2, "Grizzly Bears") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Flameshaper")!!
+                seedLoyalty(game, chandra, 6)
+
+                val minusFourAction = game.getLegalActions(1).single {
+                    it.actionInfoAbilityId() == minusFour
+                }
+                withClue("ten Bears plus Chandra herself are legal targets ('creatures and/or planeswalkers', any controller), but 8 damage can only be split 8 ways") {
+                    minusFourAction.validTargets?.size shouldBe 11
+                    minusFourAction.targetCount shouldBe 8
+                }
+                withClue("the client is told to collect a division of 8, min 1 each") {
+                    minusFourAction.requiresDamageDistribution shouldBe true
+                    minusFourAction.totalDamageToDistribute shouldBe 8
+                    minusFourAction.minDamagePerTarget shouldBe 1
+                }
+            }
+        }
+    }
+
+    private fun seedLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        // The scenario builder drops permanents straight onto the battlefield without running the
+        // "enters with its starting loyalty" step, so seed it explicitly.
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun TestGame.damageOn(id: EntityId): Int =
+        state.getEntity(id)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.DamageComponent>()
+            ?.amount ?: 0
+
+    private fun com.wingedsheep.engine.view.LegalActionInfo.actionInfoAbilityId(): AbilityId? =
+        (action as? ActivateAbility)?.abilityId
+}

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -280,10 +280,10 @@ export interface XSelectionState {
  * Damage distribution state for DividedDamageEffect spells.
  */
 export interface DamageDistributionState {
-  /** The action info containing the spell being cast */
+  /** The action info containing the spell being cast or the ability being activated */
   actionInfo: LegalActionInfo
-  /** The action with targets already set */
-  action: import('../../types').CastSpellAction
+  /** The action with targets already set (a divided-damage spell or activated ability) */
+  action: import('../../types').CastSpellAction | import('../../types').ActivateAbilityAction
   /** Card name for display */
   cardName: string
   /** Selected target entity IDs */

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -497,7 +497,7 @@ export function mergeResult(
     }
 
     case 'damageDistribution': {
-      if (action.type === 'CastSpell') {
+      if (action.type === 'CastSpell' || action.type === 'ActivateAbility') {
         return { ...action, damageDistribution: result.distribution }
       }
       return action

--- a/web-client/src/store/slices/ui/pipelineSlice.ts
+++ b/web-client/src/store/slices/ui/pipelineSlice.ts
@@ -7,7 +7,7 @@
  * current subscriptions.
  */
 import type { SliceCreator, ActionPipelineState, PhaseResult } from '../types'
-import type { CastSpellAction, EntityId, LegalActionInfo } from '@/types'
+import type { ActivateAbilityAction, CastSpellAction, EntityId, LegalActionInfo } from '@/types'
 import { computePhases, mergeResult, enterPhase } from './pipelinePhases'
 import type { PipelineStoreMethods } from './pipelinePhases'
 import {
@@ -218,7 +218,10 @@ export const createPipelineSlice: SliceCreator<PipelineSlice> = (set, get) => ({
       actionInfo.totalDamageToDistribute &&
       result.selectedTargets.length > 1
     ) {
-      const cardName = actionInfo.description.replace('Cast ', '')
+      // Spells read "Cast <name>", activated abilities "Activate <name>: …" — strip either verb so
+      // the modal header names the source (Chandra, Flameshaper's −4 divides damage the same way
+      // Arc Lightning does).
+      const cardName = actionInfo.description.replace(/^(Cast|Activate) /, '')
       const minPerTarget = actionInfo.minDamagePerTarget ?? 1
       const initialDistribution: Record<string, number> = {}
       for (const targetId of result.selectedTargets) {
@@ -235,7 +238,7 @@ export const createPipelineSlice: SliceCreator<PipelineSlice> = (set, get) => ({
 
       get().startDamageDistribution({
         actionInfo,
-        action: mergedAction as CastSpellAction,
+        action: mergedAction as CastSpellAction | ActivateAbilityAction,
         cardName,
         targetIds: [...result.selectedTargets],
         totalDamage: actionInfo.totalDamageToDistribute,

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -173,6 +173,12 @@ export interface ActivateAbilityAction {
   readonly paymentStrategy?: PaymentStrategy
   /** Alternative payment choices (e.g., convoke for abilities like Heirloom Epic) */
   readonly alternativePayment?: AlternativePaymentChoice
+  /**
+   * Pre-chosen damage distribution for a "N damage divided as you choose" ability
+   * (target ID -> damage amount). Chosen as the ability is activated, not at resolution, so
+   * removal in response can't let the player re-divide (Chandra, Flameshaper's −4).
+   */
+  readonly damageDistribution?: Record<EntityId, number>
 }
 
 // =============================================================================


### PR DESCRIPTION
Random FDN pick (`/add-random-card foundations`, `jot -r` index 1 of 5 missing) landed on **Chandra, Flameshaper** — FDN is now **259/262**.

She turned out to need real engine work: her −4 is the first card whose *activated* ability divides damage among its targets. Divided damage was wired for spells (`CastSpell.damageDistribution`) and for triggered abilities (`TriggerDamageDistributionContinuation`), but nothing carried a division for an activated ability, so it fell through to the executor's resolution-time `DistributeDecision` fallback. That's observably wrong: with the division chosen at resolution, an opponent who kills a target in response hands the controller a free re-aim.

## The card

```
{5}{R}{R} · Legendary Planeswalker — Chandra · Loyalty 6 · Mythic
+2: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.
+1: Create a token that's a copy of target creature you control, except it has haste and
    "At the beginning of the end step, sacrifice this token."
−4: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.
```

- **+2** — `Effects.Pipeline { }`: gather top 3 → exile → `chooseExactly(1)` → grant may-play on **the chosen card only**; the other two stay stranded in exile. Not a mana ability (printed ruling) — that falls out for free, since `isManaAbility` is author-declared.
- **+1** — Electroduplicate's clause verbatim: `CreateTokenCopyOfTarget(addedKeywords = HASTE, sacrificeAtStep = END)`. No new machinery.
- **−4** — `Effects.DividedDamage(total = 8)` over a `TargetObject(unlimited = true, dynamicMaxCount = Fixed(8))`, any controller.

## Engine: activation-time division (CR 601.2d)

Mirrors the cast path end to end, no new decision type or UI:

| Layer | Change |
|---|---|
| Action | `ActivateAbility.damageDistribution` |
| Enumerator | `ActivatedAbilityEnumerator` sets `requiresDamageDistribution` / `totalDamageToDistribute` / `minDamagePerTarget` |
| Handler | `ActivateAbilityHandler.validate()` shape-checks a supplied division (exact total, ≥ 1 each, keys == chosen targets) |
| Stack | `ActivatedAbilityOnStackComponent.damageDistribution` |
| Resolution | `StackResolver.resolveActivatedAbility` feeds it into `EffectContext` |
| Client | the existing damage-distribution phase now applies to `ActivateAbility` too |

Absence of a division stays legal — the executor then raises the resolution-time `DistributeDecision`, which is how non-interactive controllers (the built-in AI, engine-direct actions) divide. Rejecting it instead would have broken AI-controlled Chandra for no safety gain, since the risk is a *malformed* division, not a missing one.

## Two correctness fixes it exposed — both hit spells today

1. **`DividedDamageExecutor` ignored resolution-time target legality.** It iterated the locked-in division directly, so it tried to damage targets the resolver had already dropped; and because the `targets.size == 1` shortcut ran first, a 3-target division that decayed to one survivor gave that survivor **the whole total** instead of its assigned share. Arc Lightning for 3 with two targets killed in response dealt 3 to the last one. Now the division is honored verbatim against the still-legal set — the departed target's share is simply not dealt, exactly as Chandra's printed ruling says.

2. **`dynamicMaxCount` was ignored on an `unlimited` requirement.** `req.unlimited -> validTargets.size` short-circuited the cap, so with 8 damage and ten legal creatures the client would offer all ten; picking nine left the player with no legal division to submit and no way forward but to back out. Now the two compose: `min(legal targets, cap)`.

## SDK

Adds the missing **`Effects.DividedDamage`** facade — several cards (Arc Lightning, Electrolyze, Fight with Fire, Ureni, …) construct the raw `DividedDamageEffect` today, against the facade rule in AGENTS.md. New card uses the facade; migrating the pre-existing raw users is left as a separate mechanical cleanup (the facade emits an identical tree, so it's golden-neutral). The SDK reference now documents the announcement-time contract and the **cap-the-target-count** rule that divided damage always needs.

## Tests

`ChandraFlameshaperScenarioTest` — 7 cases, all green:

- +2 adds {R}{R}{R}, uses the stack, exiles three, grants play permission to **exactly** the chosen card
- +1's copy is a 2/2 with haste (original does **not** gain haste), and is sacrificed at the end step
- −4 divides 8 three ways exactly as announced, with no resolution-time prompt
- −4 rejects a short division, a starved target, and a division that doesn't cover the chosen targets — none of which burns loyalty
- **−4 with a target removed while the ability is on the stack**: announce 6/2, the 6 is lost, the 5/5 takes exactly 2 and lives (it would have died to a re-aimed 8)
- −4 puts all 8 on a lone planeswalker (the no-division single-target path)
- −4 offers 11 legal targets but caps `targetCount` at 8

`just test` green · `npm run typecheck` + 183 client tests green · `just check-card-printing "Chandra, Flameshaper"` ok (FDN is the earliest real printing; `pfdn` is promo) · card snapshot re-blessed and purely additive — only Chandra's tree, no unrelated card moved.

## Not done

The mtgish emitter scaffolds this card on `activated-cost` (it can't render planeswalker loyalty costs). Teaching it loyalty abilities would unlock drafts for every planeswalker, but that's a generator feature well beyond this card — left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)