### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GingerbreadHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GingerbreadHunter.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gingerbread Hunter // Puny Snack
+ * {4}{G}
+ * Creature — Giant
+ * 5/5
+ * When this creature enters, create a Food token.
+ *
+ * Adventure: Puny Snack — {2}{B}, Instant — Adventure
+ * Target creature gets -2/-2 until end of turn.
+ *
+ * The Food token is the shared predefined artifact token behind [Effects.CreateFood]; Puny Snack
+ * is a plain until-end-of-turn [Effects.ModifyStats] on any target creature (not just an
+ * opponent's).
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val GingerbreadHunter = card("Gingerbread Hunter") {
+    manaCost = "{4}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Giant"
+    oracleText = "When this creature enters, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+    power = 5
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    adventure("Puny Snack") {
+        manaCost = "{2}{B}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Target creature gets -2/-2 until end of turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Creature)
+            effect = Effects.ModifyStats(-2, -2, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Milivoj Ćeran"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1783915065"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LordSkittersButcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LordSkittersButcher.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Lord Skitter's Butcher
+ * {2}{B}
+ * Creature — Rat Peasant
+ * 2/3
+ *
+ * When this creature enters, choose one —
+ * • Create a 1/1 black Rat creature token with "This token can't block."
+ * • You may sacrifice another creature. If you do, scry 2, then draw a card.
+ * • Creatures you control gain menace until end of turn.
+ *
+ * None of the modes target, so the mode is picked at resolution. Mode 2 is "**If** you do" (not
+ * "When you do"), so the payoff happens in the same resolution rather than as a reflexive trigger:
+ * a gather → choose-up-to-one → sacrifice pipeline carries the optional (choosing nothing *is* the
+ * "you may" no), and [Effects.IfYouDo] gates the scry+draw on a creature actually being sacrificed
+ * — the Midgar, City of Mako shape. `excludeSelf = true` enforces "another", and the choice is made
+ * on the battlefield (`useTargetingUI`) rather than in an overlay.
+ */
+val LordSkittersButcher = card("Lord Skitter's Butcher") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat Peasant"
+    oracleText = "When this creature enters, choose one —\n" +
+        "• Create a 1/1 black Rat creature token with \"This token can't block.\"\n" +
+        "• You may sacrifice another creature. If you do, scry 2, then draw a card.\n" +
+        "• Creatures you control gain menace until end of turn."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode(
+                effect = woeRatToken(),
+                description = "Create a 1/1 black Rat creature token with \"This token can't block.\""
+            ),
+            Mode(
+                effect = Effects.IfYouDo(
+                    action = Effects.Pipeline {
+                        val fodder = gather(
+                            GameObjectFilter.Creature,
+                            player = Player.You,
+                            excludeSelf = true
+                        )
+                        val chosen = chooseUpTo(
+                            1,
+                            from = fodder,
+                            useTargetingUI = true,
+                            prompt = "Choose another creature to sacrifice"
+                        )
+                        sacrifice(chosen)
+                    },
+                    ifYouDo = Effects.Composite(
+                        Patterns.Library.scry(2),
+                        Effects.DrawCards(1)
+                    )
+                ),
+                description = "You may sacrifice another creature. If you do, scry 2, then draw a card."
+            ),
+            Mode(
+                effect = Patterns.Group.grantKeywordToAll(
+                    Keyword.MENACE,
+                    GroupFilter.AllCreaturesYouControl
+                ),
+                description = "Creatures you control gain menace until end of turn."
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Leesha Hannigan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg?1783915105"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PollenShieldHare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PollenShieldHare.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Pollen-Shield Hare // Hare Raising
+ * {1}{W}
+ * Creature — Rabbit
+ * 2/2
+ * Creature tokens you control get +1/+1.
+ *
+ * Adventure: Hare Raising — {G}, Sorcery — Adventure
+ * Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the
+ * number of creatures you control.
+ *
+ * The anthem is a plain layer-7c [ModifyStats] over `Creature.youControl().token()`; the Hare
+ * itself is not a token, so it never pumps itself. On the Adventure, X is counted on resolution
+ * ([DynamicAmounts.creaturesYouControl]) and includes the target itself.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val PollenShieldHare = card("Pollen-Shield Hare") {
+    manaCost = "{1}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Rabbit"
+    oracleText = "Creature tokens you control get +1/+1."
+    power = 2
+    toughness = 2
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().token())
+        )
+    }
+
+    adventure("Hare Raising") {
+        manaCost = "{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target creature you control gains vigilance and gets +X/+X until end of " +
+            "turn, where X is the number of creatures you control. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.CreatureYouControl)
+            effect = Effects.Composite(
+                Effects.GrantKeyword(Keyword.VIGILANCE, t),
+                Effects.ModifyStats(
+                    DynamicAmounts.creaturesYouControl(),
+                    DynamicAmounts.creaturesYouControl(),
+                    t
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "233"
+        artist = "Olena Richards"
+        flavorText = "She can drive off any threat, from owl to hunter to Phyrexian monster."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1783915063"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RatcatcherTrainee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RatcatcherTrainee.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ratcatcher Trainee // Pest Problem
+ * {1}{R}
+ * Creature — Human Peasant
+ * 2/1
+ * During your turn, this creature has first strike.
+ *
+ * Adventure: Pest Problem — {2}{R}, Instant — Adventure
+ * Create two 1/1 black Rat creature tokens with "This token can't block."
+ *
+ * "During your turn" is a [ConditionalStaticAbility] keyword grant on [Filters.Self] gated by
+ * [Conditions.IsYourTurn] — the same shape as Tonberry's Chef's Knife. It is a continuous effect,
+ * not a trigger, so first strike appears/disappears as the turn changes (including mid-combat if
+ * the turn somehow ends between strike steps).
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val RatcatcherTrainee = card("Ratcatcher Trainee") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Peasant"
+    oracleText = "During your turn, this creature has first strike."
+    power = 2
+    toughness = 1
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.Self),
+            condition = Conditions.IsYourTurn,
+        )
+    }
+
+    adventure("Pest Problem") {
+        manaCost = "{2}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create two 1/1 black Rat creature tokens with \"This token can't block.\" " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = woeRatToken(DynamicAmount.Fixed(2))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Michele Giorgi"
+        flavorText = "\"Where do they keep coming from?!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1783915090"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ScaldingViper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ScaldingViper.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scalding Viper // Steam Clean
+ * {1}{R}
+ * Creature — Elemental Snake
+ * 2/1
+ * Whenever an opponent casts a spell with mana value 3 or less, this creature deals 1 damage to
+ * that player.
+ *
+ * Adventure: Steam Clean — {1}{U}, Sorcery — Adventure
+ * Return target nonland permanent to its owner's hand.
+ *
+ * The trigger is a cast watcher scoped to opponents ([Triggers.opponentCasts]) narrowed by mana
+ * value; "that player" is the caster ([Player.TriggeringPlayer]), not a target, so the ability
+ * never fizzles. Per the WOE rulings, a spell with {X} in its cost uses the chosen X when its mana
+ * value is computed, which is what the spell-on-stack the filter reads reports.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val ScaldingViper = card("Scalding Viper") {
+    manaCost = "{1}{R}"
+    colorIdentity = "RU"
+    typeLine = "Creature — Elemental Snake"
+    oracleText = "Whenever an opponent casts a spell with mana value 3 or less, " +
+        "this creature deals 1 damage to that player."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.Any.manaValueAtMost(3))
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    adventure("Steam Clean") {
+        manaCost = "{1}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Return target nonland permanent to its owner's hand. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.NonlandPermanent)
+            effect = Effects.ReturnToHand(t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "235"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1783915062"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2737,6 +2737,78 @@
     ]
 }
 
+// Gingerbread Hunter
+{
+    "name": "Gingerbread Hunter",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Milivoj Ćeran",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e77a8fd4-af5f-42b3-a87e-788baf2562dd.jpg?1783915065"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Puny Snack",
+            "manaCost": "{2}{B}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Target creature gets -2/-2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Gnawing Crescendo
 {
     "name": "Gnawing Crescendo",
@@ -3531,6 +3603,141 @@
     ]
 }
 
+// Lord Skitter's Butcher
+{
+    "name": "Lord Skitter's Butcher",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Rat Peasant",
+    "oracleText": "When this creature enters, choose one —\n• Create a 1/1 black Rat creature token with \"This token can't block.\"\n• You may sacrifice another creature. If you do, scry 2, then draw a card.\n• Creatures you control gain menace until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "BLACK"
+                                ],
+                                "creatureTypes": [
+                                    "Rat"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                                "staticAbilities": [
+                                    "CantBlock"
+                                ]
+                            },
+                            "description": "Create a 1/1 black Rat creature token with \"This token can't block.\""
+                        },
+                        {
+                            "effect": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "BattlefieldMatching",
+                                                    "filter": "creature",
+                                                    "player": "You",
+                                                    "excludeSelf": true
+                                                },
+                                                "storeAs": "gathered0"
+                                            },
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "gathered0",
+                                                "selection": {
+                                                    "type": "ChooseUpTo",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeSelected": "selected1",
+                                                "prompt": "Choose another creature to sacrifice",
+                                                "useTargetingUI": true
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "selected1",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Graveyard"
+                                                },
+                                                "moveType": "Sacrifice"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "Scry",
+                                            "count": 2
+                                        },
+                                        {
+                                            "type": "DrawCards",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "description": "You may sacrifice another creature. If you do, scry 2, then draw a card."
+                        },
+                        {
+                            "effect": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "GrantKeyword",
+                                    "keyword": "MENACE",
+                                    "target": "Self"
+                                }
+                            },
+                            "description": "Creatures you control gain menace until end of turn."
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Leesha Hannigan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21b31d2b-ef66-4e16-a75e-4e27eb5ebfe9.jpg?1783915105"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Merfolk Coralsmith
 {
     "name": "Merfolk Coralsmith",
@@ -4280,6 +4487,91 @@
     ]
 }
 
+// Pollen-Shield Hare
+{
+    "name": "Pollen-Shield Hare",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Rabbit",
+    "oracleText": "Creature tokens you control get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature token ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "RARE",
+        "artist": "Olena Richards",
+        "flavorText": "She can drive off any threat, from owl to hunter to Phyrexian monster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/139f31f5-28f0-4e90-abdf-3f6ed0992dea.jpg?1783915063"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Hare Raising",
+            "manaCost": "{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target creature you control gains vigilance and gets +X/+X until end of turn, where X is the number of creatures you control. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature"
+                            },
+                            "toughnessModifier": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Protective Parents
 {
     "name": "Protective Parents",
@@ -4536,6 +4828,73 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ratcatcher Trainee
+{
+    "name": "Ratcatcher Trainee",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "During your turn, this creature has first strike.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Michele Giorgi",
+        "flavorText": "\"Where do they keep coming from?!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f4c0959-a107-4d61-9e51-256b2955f6ba.jpg?1783915090"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Pest Problem",
+            "manaCost": "{2}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create two 1/1 black Rat creature tokens with \"This token can't block.\" (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        }
     ]
 }
 
@@ -5263,6 +5622,87 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Scalding Viper
+{
+    "name": "Scalding Viper",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Elemental Snake",
+    "oracleText": "Whenever an opponent casts a spell with mana value 3 or less, this creature deals 1 damage to that player.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtMost",
+                                "max": 3
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "RARE",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58e72bfb-6f64-4647-afb6-b5ad4737121c.jpg?1783915062"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Steam Clean",
+            "manaCost": "{1}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Return target nonland permanent to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch8ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch8ScenarioTest.kt
@@ -1,0 +1,382 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for a batch of Wilds of Eldraine cards implemented together. All five compose
+ * existing SDK primitives, so these tests pin the *composition* — the parts that could plausibly be
+ * wired wrong:
+ *
+ *  - Ratcatcher Trainee // Pest Problem ({1}{R} 2/1) — a `ConditionalStaticAbility` keyword grant
+ *    gated on `IsYourTurn`: first strike must appear and disappear with the turn, not stick.
+ *  - Gingerbread Hunter // Puny Snack ({4}{G} 5/5) — ETB Food, and a -2/-2 Adventure that must
+ *    actually kill a 2/2.
+ *  - Scalding Viper // Steam Clean ({1}{R} 2/1) — a cast watcher with a mana-value threshold; the
+ *    threshold and the "opponent only" scoping are the risky bits.
+ *  - Pollen-Shield Hare // Hare Raising ({1}{W} 2/2) — a token-only anthem (the nontoken Hare must
+ *    not pump itself or nontoken creatures), plus an Adventure whose X counts creatures at
+ *    resolution.
+ *  - Lord Skitter's Butcher ({2}{B} 2/3) — a three-mode ETB whose middle mode is an
+ *    "if you do" sacrifice: declining must cost nothing.
+ */
+class WoeCardsBatch8ScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ratcatcher Trainee — first strike only during your turn") {
+            test("has first strike on your turn and loses it on the opponent's") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ratcatcher Trainee", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val trainee = game.findPermanent("Ratcatcher Trainee")!!
+                withClue("during your turn") {
+                    game.state.projectedState.hasKeyword(trainee, Keyword.FIRST_STRIKE) shouldBe true
+                }
+
+                val opponentsTurn = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ratcatcher Trainee", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val theirTurn = opponentsTurn.findPermanent("Ratcatcher Trainee")!!
+                withClue("during the opponent's turn the grant is off") {
+                    opponentsTurn.state.projectedState.hasKeyword(theirTurn, Keyword.FIRST_STRIKE) shouldBe false
+                }
+            }
+
+            test("Pest Problem creates two Rat tokens and exiles the card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Ratcatcher Trainee")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // faceIndex = 0 is the Adventure face; the creature face casts with faceIndex = null.
+                val cardId = game.findCardsInHand(1, "Ratcatcher Trainee").first()
+                game.execute(CastSpell(game.player1Id, cardId, emptyList(), faceIndex = 0))
+                    .isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("two Rats, not one") {
+                    game.findAllPermanents("Rat Token").size shouldBe 2
+                }
+                withClue("resolving the Adventure exiles the card so it can be cast as a creature later") {
+                    game.isInExile(1, "Ratcatcher Trainee") shouldBe true
+                }
+            }
+        }
+
+        context("Gingerbread Hunter // Puny Snack") {
+            test("the creature face is a 5/5 that makes a Food on entry") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gingerbread Hunter")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gingerbread Hunter").error shouldBe null
+                game.resolveStack()
+
+                val hunter = game.findPermanent("Gingerbread Hunter")!!
+                game.state.projectedState.getPower(hunter) shouldBe 5
+                game.state.projectedState.getToughness(hunter) shouldBe 5
+                withClue("the ETB made exactly one Food") {
+                    game.findAllPermanents("Food").size shouldBe 1
+                }
+            }
+
+            test("Puny Snack's -2/-2 kills a 2/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gingerbread Hunter")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Gingerbread Hunter").first()
+                game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(bears)), faceIndex = 0)
+                ).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("a 2/2 hit by -2/-2 dies to state-based actions") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("the Adventure card is exiled, castable as the Giant later") {
+                    game.isInExile(1, "Gingerbread Hunter") shouldBe true
+                }
+            }
+        }
+
+        context("Scalding Viper — 1 damage on an opponent's cheap spell") {
+            fun viperGame(opponentCard: String) = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Scalding Viper", summoningSickness = false)
+                .withCardInHand(2, opponentCard)
+                .withLandsOnBattlefield(2, "Forest", 6)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("an opponent's mana value 2 spell pings them for 1") {
+                val game = viperGame("Grizzly Bears")
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("the caster took 1 damage") { game.getLifeTotal(2) shouldBe 19 }
+                withClue("the Viper's controller is untouched") { game.getLifeTotal(1) shouldBe 20 }
+            }
+
+            test("a mana value 6 spell is above the threshold — no damage") {
+                val game = viperGame("Craw Wurm")
+
+                game.castSpell(2, "Craw Wurm").error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(2) shouldBe 20
+            }
+
+            test("your own cheap spell doesn't trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scalding Viper", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(1) shouldBe 20
+                game.getLifeTotal(2) shouldBe 20
+            }
+
+            test("Steam Clean bounces a nonland permanent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Scalding Viper")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Scalding Viper").first()
+                game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(bears)), faceIndex = 0)
+                ).isSuccess shouldBe true
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+                game.isInExile(1, "Scalding Viper") shouldBe true
+            }
+        }
+
+        context("Pollen-Shield Hare — the anthem hits tokens only") {
+            test("Rat tokens get +1/+1 while the Hare and a nontoken 2/2 do not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pollen-Shield Hare", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Ratcatcher Trainee")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val trainee = game.findCardsInHand(1, "Ratcatcher Trainee").first()
+                game.execute(CastSpell(game.player1Id, trainee, emptyList(), faceIndex = 0))
+                    .isSuccess shouldBe true
+                game.resolveStack()
+
+                val rat = game.findPermanent("Rat Token")!!
+                withClue("a 1/1 token becomes 2/2") {
+                    game.state.projectedState.getPower(rat) shouldBe 2
+                    game.state.projectedState.getToughness(rat) shouldBe 2
+                }
+
+                val hare = game.findPermanent("Pollen-Shield Hare")!!
+                withClue("the Hare is not a token, so it doesn't pump itself") {
+                    game.state.projectedState.getPower(hare) shouldBe 2
+                    game.state.projectedState.getToughness(hare) shouldBe 2
+                }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("a nontoken creature you control is unaffected") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("Hare Raising grants vigilance and +X/+X for the creatures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Pollen-Shield Hare")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.findCardsInHand(1, "Pollen-Shield Hare").first()
+                game.execute(
+                    CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(bears)), faceIndex = 0)
+                ).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("two creatures you control → +2/+2 on a 2/2") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+                withClue("…and vigilance") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+
+        context("Lord Skitter's Butcher — three-mode ETB") {
+            fun butcherGame() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Lord Skitter's Butcher")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun ScenarioTestBase.TestGame.castAndChooseMode(index: Int) {
+                castSpell(1, "Lord Skitter's Butcher").error shouldBe null
+                if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+                val modeDecision = getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB; got ${getPendingDecision()}")
+                submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = index))
+            }
+
+            test("mode 0 creates a Rat token") {
+                val game = butcherGame()
+                game.castAndChooseMode(0)
+                game.resolveStack()
+
+                game.findAllPermanents("Rat Token").size shouldBe 1
+            }
+
+            test("mode 1 — sacrificing another creature scries 2 and draws") {
+                val game = butcherGame()
+                val handBefore = game.handSize(1)
+                game.castAndChooseMode(1)
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val sacChoice = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected the sacrifice selection; got ${game.getPendingDecision()}")
+                withClue("the Butcher itself is not offered — 'another creature'") {
+                    sacChoice.options.contains(game.findPermanent("Lord Skitter's Butcher")) shouldBe false
+                }
+                game.selectCards(listOf(bears)).error shouldBe null
+
+                withClue("the chosen creature was sacrificed") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+
+                val scry = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected the scry 2 selection; got ${game.getPendingDecision()}")
+                withClue("scry 2 looks at the top two cards") { scry.options.size shouldBe 2 }
+                game.skipSelection().error shouldBe null // keep both on top
+                if (game.getPendingDecision() is ReorderLibraryDecision) game.keepLibraryOrder()
+                game.resolveStack()
+
+                withClue("the Butcher (cast from hand) left, and the draw added one card") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                game.librarySize(1) shouldBe 2
+            }
+
+            test("mode 1 — declining the sacrifice costs nothing and draws nothing") {
+                val game = butcherGame()
+                val handBefore = game.handSize(1)
+                game.castAndChooseMode(1)
+
+                game.getPendingDecision() shouldNotBe null
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("no sacrifice happened") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("no draw happened — the Butcher just left hand for the battlefield") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+                game.librarySize(1) shouldBe 3
+            }
+
+            test("mode 2 gives your creatures menace until end of turn") {
+                val game = butcherGame()
+                game.castAndChooseMode(2)
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.state.projectedState.hasKeyword(bears, Keyword.MENACE) shouldBe true
+                val butcher = game.findPermanent("Lord Skitter's Butcher")!!
+                withClue("the Butcher is a creature you control too") {
+                    game.state.projectedState.hasKeyword(butcher, Keyword.MENACE) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five WOE cards, all pure card authoring — no engine or SDK changes.

| Card | Shape |
|---|---|
| **Ratcatcher Trainee // Pest Problem** ({1}{R} 2/1) | `ConditionalStaticAbility` first-strike grant on `Filters.Self` gated by `Conditions.IsYourTurn`; the Adventure makes two Rat tokens via the shared `woeRatToken(2)` helper. |
| **Gingerbread Hunter // Puny Snack** ({4}{G} 5/5) | ETB `Effects.CreateFood()`; the Adventure is a -2/-2 until end of turn. |
| **Scalding Viper // Steam Clean** ({1}{R} 2/1) | `Triggers.opponentCasts(Any.manaValueAtMost(3))` → 1 damage to `Player.TriggeringPlayer` (not a target, so it never fizzles); the Adventure bounces a nonland permanent. |
| **Pollen-Shield Hare // Hare Raising** ({1}{W} 2/2) | Anthem over `Creature.youControl().token()`; the Adventure grants vigilance and `+X/+X` where X is `DynamicAmounts.creaturesYouControl()`, counted at resolution. |
| **Lord Skitter's Butcher** ({2}{B} 2/3) | Three-mode ETB. Mode 2 is "**If** you do", not "When you do", so it resolves in one pass: a gather → choose-up-to-one → sacrifice pipeline carries the optional and `Effects.IfYouDo` gates the scry+draw — the Midgar, City of Mako shape. `excludeSelf = true` enforces "another", and `useTargetingUI` puts the pick on the battlefield rather than in an overlay. |

## Notes

- **Bargain and Celebration are still unimplemented**, so cards using them were deliberately left out — those are `add-feature` work, not card authoring.
- **A Tale for the Ages** was on the shortlist but needs an "is enchanted" filter predicate (there's `StatePredicate.IsEquipped` but no Aura sibling); swapped for Pollen-Shield Hare to keep this PR authoring-only. Worth an `add-feature` pass — it unlocks a few WOE cards.
- The mtgish emitter renders A Tale for the Ages at `AUTO` tier but **silently drops the "enchanted" restriction**, emitting a plain `Creature.youControl()` anthem. Per the tooling's own rule it should decline to `SCAFFOLD` rather than emit a lossy approximation — flagging, not fixing, here.

## Testing

- `WoeCardsBatch8ScenarioTest` — 14 tests pinning the composition: the turn-gated keyword appearing *and* disappearing, the mana-value threshold (2 pings, 6 doesn't) plus opponent-only scoping, the anthem skipping nontokens and the Hare itself, and both branches of the optional sacrifice.
- WOE card snapshot re-blessed; the diff is additive only (0 deletions, no other card moved).
- `just test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)