### PR TITLE
Add Curator of Destinies to Foundations

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CuratorOfDestinies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CuratorOfDestinies.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Curator of Destinies
+ * {4}{U}{U}
+ * Creature — Sphinx
+ * 5/5
+ * This spell can't be countered.
+ * Flying
+ * When this creature enters, look at the top five cards of your library and separate them into a
+ * face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into
+ * your hand and the other into your graveyard.
+ *
+ * A "divvy" (CR 700.3) with one concealed pile — the mirror image of Sauron's Ransom, where the
+ * *opponent* looks and splits and *you* choose. Here you look and split, and an opponent chooses.
+ * Composed entirely from existing pipeline steps; the information asymmetry is masking, not a
+ * bespoke decision type:
+ *  1. Gather the top five with the default [com.wingedsheep.sdk.scripting.effects.LookAudience.Controller]
+ *     — "look at" is a private look for you only, so the opponent never sees the whole five.
+ *  2. You separate them: the cards you select become the face-up pile, the rest the face-down pile.
+ *     `chooseAnyNumber` allows 0 and 5, matching the ruling that a 5/0 split is legal either way.
+ *  3. Re-gather the face-up pile with `revealed = true` so the split becomes public knowledge —
+ *     that persisted reveal is what lets the opponent actually see the face-up pile when choosing.
+ *     (`reveal` only emits a `CardsRevealedEvent`; it doesn't persist visibility.) The face-down
+ *     pile is never revealed, so it renders to the opponent as opaque card backs — they see only
+ *     its size.
+ *  4. An opponent picks a pile; it goes to your hand (still unrevealed — per the ruling you don't
+ *     have to show a face-down pile that ends up in your hand) and the other to your graveyard,
+ *     where it becomes public anyway.
+ *
+ * Edge cases:
+ *  - Empty/short library: `ifNotEmpty` skips the whole ability when the gather comes up empty, so
+ *     nobody is asked to split or choose between two empty piles. A 1–4 card library still splits.
+ *  - "An opponent chooses" is a resolution-time choice, not a target, so it is
+ *    [Chooser.Opponent] rather than a `TargetRequirement` (no shroud/targeting restrictions apply).
+ *    Deviation worth naming: the ruling says *you* decide which opponent chooses. The engine's
+ *    `Chooser.Opponent` resolves to the first opponent, which is exact in two-player games but
+ *    does not let the controller pick the decider in multiplayer.
+ */
+val CuratorOfDestinies = card("Curator of Destinies") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 5
+    toughness = 5
+    oracleText = "This spell can't be countered.\n" +
+        "Flying\n" +
+        "When this creature enters, look at the top five cards of your library and separate them " +
+        "into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put " +
+        "that pile into your hand and the other into your graveyard."
+
+    cantBeCountered = true
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Pipeline {
+            // "look at the top five cards of your library"
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(5)), name = "looked")
+            ifNotEmpty(looked) {
+                // "and separate them into a face-down pile and a face-up pile."
+                val piles = chooseAnyNumberSplit(
+                    from = looked,
+                    chooser = Chooser.Controller,
+                    prompt = "Separate the top five cards into a face-up pile and a face-down pile. " +
+                        "The cards you select are placed face up; the rest stay face down.",
+                    selectedLabel = "Face-up pile",
+                    remainderLabel = "Face-down pile",
+                    showAllCards = true,
+                    alwaysPrompt = true,
+                    name = "faceUp",
+                    remainderName = "faceDown"
+                )
+                // The face-up pile is public from here on; the face-down pile stays hidden.
+                val faceUp = gather(piles.selected.asSource, revealed = true, name = "faceUpRevealed")
+                // "An opponent chooses one of those piles."
+                val picked = choosePile(
+                    pileA = faceUp,
+                    pileB = piles.remainder,
+                    pileALabel = "Face-up pile",
+                    pileBLabel = "Face-down pile",
+                    chooser = Chooser.Opponent,
+                    prompt = "Choose a pile. That pile goes to your opponent's hand; the other goes " +
+                        "to their graveyard."
+                )
+                // "Put that pile into your hand and the other into your graveyard."
+                toHand(picked.chosen)
+                toGraveyard(picked.other)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Ralph Horsley"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg?1783909120"
+        ruling(
+            "2024-11-08",
+            "A spell or ability that counters spells can still target Curator of Destinies. When " +
+                "that spell or ability resolves, Curator of Destinies won't be countered, but any " +
+                "additional effects of the countering spell or ability will still happen."
+        )
+        ruling(
+            "2024-11-08",
+            "You may split the cards into one pile of five and one pile of zero. The pile of five " +
+                "cards could be the face-up pile or the face-down pile. The opponent may choose the " +
+                "empty pile to be put into your hand."
+        )
+        ruling(
+            "2024-11-08",
+            "You decide which opponent chooses the pile while resolving Curator of Destinies's last ability."
+        )
+        ruling(
+            "2024-11-08",
+            "If the opponent chooses the face-down pile to be put into your hand, you don't have to " +
+                "reveal the cards in that pile."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1922,6 +1922,133 @@
     ]
 }
 
+// Curator of Destinies
+{
+    "name": "Curator of Destinies",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "This spell can't be countered.\nFlying\nWhen this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "looked",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "looked",
+                                        "selection": "ChooseAnyNumber",
+                                        "storeSelected": "faceUp",
+                                        "storeRemainder": "faceDown",
+                                        "prompt": "Separate the top five cards into a face-up pile and a face-down pile. The cards you select are placed face up; the rest stay face down.",
+                                        "selectedLabel": "Face-up pile",
+                                        "remainderLabel": "Face-down pile",
+                                        "showAllCards": true,
+                                        "alwaysPrompt": true
+                                    },
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromVariable",
+                                            "variableName": "faceUp"
+                                        },
+                                        "storeAs": "faceUpRevealed",
+                                        "revealed": true
+                                    },
+                                    {
+                                        "type": "ChoosePile",
+                                        "pileA": "faceUpRevealed",
+                                        "pileB": "faceDown",
+                                        "pileALabel": "Face-up pile",
+                                        "pileBLabel": "Face-down pile",
+                                        "chooser": "Opponent",
+                                        "storeChosenAs": "chosenPile4",
+                                        "storeOtherAs": "otherPile4",
+                                        "prompt": "Choose a pile. That pile goes to your opponent's hand; the other goes to their graveyard."
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "chosenPile4",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "otherPile4",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "RARE",
+        "artist": "Ralph Horsley",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9ff79da7-c3f7-4541-87a0-503544c699b5.jpg?1783909120",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A spell or ability that counters spells can still target Curator of Destinies. When that spell or ability resolves, Curator of Destinies won't be countered, but any additional effects of the countering spell or ability will still happen."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You may split the cards into one pile of five and one pile of zero. The pile of five cards could be the face-up pile or the face-down pile. The opponent may choose the empty pile to be put into your hand."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You decide which opponent chooses the pile while resolving Curator of Destinies's last ability."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If the opponent chooses the face-down pile to be put into your hand, you don't have to reveal the cards in that pile."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dauntless Veteran
 {
     "name": "Dauntless Veteran",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CuratorOfDestiniesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CuratorOfDestiniesScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.CuratorOfDestinies
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Curator of Destinies: on ETB you look at your top five and split them into a face-down and a
+ * face-up pile; an opponent chooses a pile; that pile goes to your hand, the other to your
+ * graveyard.
+ *
+ * The mirror image of Sauron's Ransom — here *you* look and split and the *opponent* chooses — so
+ * these tests pin the reverse visibility: the opponent never sees the whole five, only the pile you
+ * turned face up. Visibility is expressed through [RevealedToComponent], the engine's record of what
+ * a player may see in a hidden zone.
+ */
+class CuratorOfDestiniesScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CuratorOfDestinies)
+        return driver
+    }
+
+    fun GameTestDriver.revealedTo(card: EntityId, player: EntityId): Boolean =
+        state.getEntity(card)?.get<RevealedToComponent>()?.isRevealedTo(player) == true
+
+    /** Empty a player's library, so the "look at the top five" gather comes up with nothing. */
+    fun GameTestDriver.emptyLibrary(playerId: EntityId) {
+        val libraryZone = ZoneKey(playerId, Zone.LIBRARY)
+        var newState = state
+        for (cardId in state.getZone(libraryZone)) {
+            newState = newState.removeFromZone(libraryZone, cardId).withoutEntity(cardId)
+        }
+        replaceState(newState)
+    }
+
+    /**
+     * Casts Curator from hand with mana granted, resolves it onto the battlefield, then resolves
+     * the ETB trigger it put on the stack.
+     */
+    fun GameTestDriver.castCurator(active: EntityId) {
+        val spell = putCardInHand(active, "Curator of Destinies")
+        giveMana(active, Color.BLUE, 2)
+        giveColorlessMana(active, 4)
+        castSpell(active, spell).isSuccess shouldBe true
+        bothPass() // Curator resolves; its ETB trigger goes on the stack
+        bothPass() // the ETB trigger resolves
+    }
+
+    test("you look and split; only the face-up pile is shown to the opponent; the opponent's pick goes to your hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack a known top five (top first as pushed last).
+        val c1 = driver.putCardOnTopOfLibrary(active, "Island")
+        val c2 = driver.putCardOnTopOfLibrary(active, "Forest")
+        val c3 = driver.putCardOnTopOfLibrary(active, "Mountain")
+        val c4 = driver.putCardOnTopOfLibrary(active, "Plains")
+        val c5 = driver.putCardOnTopOfLibrary(active, "Swamp")
+        // Library from top: c5, c4, c3, c2, c1, <deck...>
+
+        driver.castCurator(active)
+
+        val handAfterCast = driver.getHandSize(active)
+        val graveBefore = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size
+
+        // 1. You — the controller — look at the top five and separate them. The look is private:
+        //    the opponent has been shown none of the five.
+        driver.isPaused shouldBe true
+        val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        split.playerId shouldBe active
+        split.options.size shouldBe 5
+        listOf(c1, c2, c3, c4, c5).forEach { driver.revealedTo(it, active) shouldBe true }
+        listOf(c1, c2, c3, c4, c5).forEach { driver.revealedTo(it, opponent) shouldBe false }
+
+        // Put c5 and c4 face up; c3, c2 and c1 stay face down.
+        driver.submitDecision(active, CardsSelectedResponse(split.id, listOf(c5, c4)))
+
+        // 2. An opponent chooses a pile. Now — and only now — the face-up pile is visible to them;
+        //    the face-down pile is not.
+        driver.isPaused shouldBe true
+        val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        choose.playerId shouldBe opponent
+        driver.revealedTo(c5, opponent) shouldBe true
+        driver.revealedTo(c4, opponent) shouldBe true
+        listOf(c1, c2, c3).forEach { driver.revealedTo(it, opponent) shouldBe false }
+        choose.optionCardIds?.get(0) shouldBe listOf(c5, c4)
+        choose.optionCardIds?.get(1) shouldBe listOf(c3, c2, c1)
+
+        // The opponent picks the face-up pile → it goes to your hand, the rest to your graveyard.
+        driver.submitDecision(opponent, OptionChosenResponse(choose.id, 0))
+        driver.isPaused shouldBe false
+
+        val hand = driver.state.getZone(ZoneKey(active, Zone.HAND))
+        hand.contains(c5) shouldBe true
+        hand.contains(c4) shouldBe true
+        driver.getHandSize(active) shouldBe handAfterCast + 2
+
+        val grave = driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD))
+        listOf(c1, c2, c3).forEach { grave.contains(it) shouldBe true }
+        grave.size shouldBe graveBefore + 3
+    }
+
+    test("the opponent may pick the face-down pile; a 5/0 split into an empty face-up pile is legal") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val c1 = driver.putCardOnTopOfLibrary(active, "Island")
+        val c2 = driver.putCardOnTopOfLibrary(active, "Forest")
+        val c3 = driver.putCardOnTopOfLibrary(active, "Mountain")
+        val c4 = driver.putCardOnTopOfLibrary(active, "Plains")
+        val c5 = driver.putCardOnTopOfLibrary(active, "Swamp")
+        val all = listOf(c1, c2, c3, c4, c5)
+
+        driver.castCurator(active)
+        val handAfterCast = driver.getHandSize(active)
+
+        // Select nothing → an empty face-up pile and all five face down (a legal 5/0 split).
+        val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(active, CardsSelectedResponse(split.id, emptyList()))
+
+        // Nothing was turned face up, so the opponent sees none of the five when choosing.
+        val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        choose.playerId shouldBe opponent
+        all.forEach { driver.revealedTo(it, opponent) shouldBe false }
+
+        // They pick the face-down pile of five → all five go to your hand, still unrevealed to them.
+        val faceDownOption = choose.optionCardIds?.entries?.first { it.value.size == 5 }?.key ?: 1
+        driver.submitDecision(opponent, OptionChosenResponse(choose.id, faceDownOption))
+        driver.isPaused shouldBe false
+
+        val hand = driver.state.getZone(ZoneKey(active, Zone.HAND))
+        all.forEach { hand.contains(it) shouldBe true }
+        driver.getHandSize(active) shouldBe handAfterCast + 5
+        all.forEach { driver.revealedTo(it, opponent) shouldBe false }
+    }
+
+    test("an empty library asks nobody to split or choose piles") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.emptyLibrary(active)
+
+        val handBefore = driver.getHandSize(active)
+        driver.castCurator(active)
+
+        // The gather comes up empty, so the ability finishes without asking anyone anything, and
+        // no cards move. The Curator itself still entered the battlefield.
+        driver.isPaused shouldBe false
+        driver.getHandSize(active) shouldBe handBefore
+        driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)).size shouldBe 0
+        driver.state.getZone(ZoneKey(active, Zone.BATTLEFIELD)).size shouldBe 1
+    }
+
+    test("Curator of Destinies can't be countered") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val curator = driver.putCardInHand(active, "Curator of Destinies")
+        val counter = driver.putCardInHand(opponent, "Counterspell")
+        driver.giveMana(active, Color.BLUE, 2)
+        driver.giveColorlessMana(active, 4)
+        driver.giveMana(opponent, Color.BLUE, 2)
+
+        driver.castSpell(active, curator).isSuccess shouldBe true
+        driver.stackSize shouldBe 1
+        driver.passPriority(active)
+
+        // The opponent may still target the spell (per the 2024-11-08 ruling) …
+        val curatorOnStack = driver.getTopOfStack()!!
+        driver.submit(
+            CastSpell(
+                playerId = opponent,
+                cardId = counter,
+                targets = listOf(ChosenTarget.Spell(curatorOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.stackSize shouldBe 2
+
+        // … but Counterspell resolves without countering it.
+        driver.bothPass()
+        driver.stackSize shouldBe 1
+        driver.getTopOfStackName() shouldBe "Curator of Destinies"
+
+        // Curator resolves and enters, so its ETB trigger asks the controller to split.
+        driver.bothPass()
+        driver.bothPass()
+        val split = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        split.playerId shouldBe active
+        driver.findPermanent(active, "Curator of Destinies") shouldNotBe null
+    }
+})


### PR DESCRIPTION
## What

Implements **Curator of Destinies** (FDN #34) — `{4}{U}{U}` 5/5 Sphinx, can't be countered, flying, with an ETB "divvy" (CR 700.3):

> When this creature enters, look at the top five cards of your library and separate them into a face-down pile and a face-up pile. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.

Picked at random from the FDN missing list via `/add-random-card foundations`.

## No new engine capability needed

The standing triage said this card was blocked on "split piles with information asymmetry". That turned out to be stale — it's the **mirror image of Sauron's Ransom** (there the opponent looks and splits and you choose; here you look and split and an opponent chooses), and the asymmetry is masking, not a bespoke decision type. Composed entirely from existing pipeline steps:

1. `gather(TopOfLibrary(5))` with the default `LookAudience.Controller` — a private look, so the opponent never sees all five.
2. `chooseAnyNumberSplit` — you partition them into the face-up pile (selected) and face-down pile (remainder). `chooseAnyNumber` allows 0 and 5, matching the ruling that a 5/0 split is legal either way.
3. Re-gather the face-up pile with `revealed = true`, which persists the reveal to every player. That is what lets the opponent actually *see* the face-up pile when choosing — `reveal` only emits a `CardsRevealedEvent` without persisting visibility.
4. `choosePile(chooser = Chooser.Opponent)` → `toHand(chosen)` / `toGraveyard(other)`.

The whole ability is wrapped in `ifNotEmpty` so an empty library asks nobody to split or choose between two empty piles.

## UX

No client changes. `ChooseOptionDecisionUI` already appends pile sizes to the option labels ("Face-up pile (2)" / "Face-down pile (3)") and previews only the cards present in the viewer's masked state — so the opponent sees the face-up pile's cards and just a count for the face-down pile. `ClientStateTransformer` gates library card detail on `RevealedToComponent`, which is exactly what step 3 stamps.

## Tests

`CuratorOfDestiniesScenarioTest` — 4 cases, all green:
- you look and split; only the face-up pile becomes visible to the opponent; their pick goes to your hand and the rest to your graveyard
- the opponent may pick the face-down pile; an empty face-up pile (5/0 split) is legal
- an empty library asks nobody to split or choose
- Counterspell can target it but doesn't counter it (per the 2024-11-08 ruling)

`just test` is green; the `FDN.json` card snapshot golden shows only this card added. `just check-card-printing "Curator of Destinies"` confirms FDN is the earliest real printing, so it gets the canonical `CardDefinition`. FDN is now 260/262.

## Known deviation

The ruling says *you* decide which opponent chooses the pile. `Chooser.Opponent` resolves to the first opponent — exact in two-player games, arbitrary in multiplayer. Documented in the card's KDoc; a resolution-time "controller picks a player" mechanism doesn't exist in the SDK yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)