### PR TITLE
Let the controller pick which opponent makes a Chooser.Opponent choice

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7507,6 +7507,18 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
     to hand). Use `ControllerOfTarget` for "destroy target permanent. Its controller searches/chooses…" where the
     targeted permanent's controller performs a follow-up (Magmatic Hellkite: destroy target nonbasic land, *its
     controller* searches for a basic). The same `chooser` set is accepted by `ChoosePileEffect`.
+  - **`Chooser.Opponent` in multiplayer.** "An opponent" is *one* opponent, and the controller of the spell or
+    ability picks which one (CR 601.7a / 602.3a for cast/activation-time choices; resolution-time choices follow the
+    same principle and cards say so in their rulings — Curator of Destinies: "You decide which opponent chooses the
+    pile"). The engine handles that for you: with several opponents the step first pauses on a `ChooseOptionDecision`
+    for the controller listing the opponents by name, then re-runs itself and presents the real choice to the named
+    opponent. With a sole opponent the choice is forced and nothing extra is prompted, so two-player games are
+    unaffected. Each "an opponent chooses" step in one resolution gets its own pick — the choice is
+    resolution-scoped, not recorded on the source. All of this lives in the engine's `ChooserResolution`, so any
+    effect carrying a `Chooser` inherits it; card definitions just say `Chooser.Opponent`. (For the durable,
+    cast-time "you may promise **an opponent** a gift"-style recipient choice, use
+    `Effects.ChooseOpponentForSource` + `Player.ChosenOpponent` instead — that one is stored on the source and
+    persists past the resolution.)
 
 **Linked exile**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -641,7 +641,14 @@ sealed interface SelectionRestriction {
 enum class Chooser {
     /** The controller of the spell/ability decides */
     Controller,
-    /** An opponent decides */
+    /**
+     * An opponent decides — *one* opponent, chosen by the controller of the spell or ability.
+     * The engine asks the controller which opponent decides whenever there is more than one
+     * (CR 601.7a / 602.3a, and rulings like Curator of Destinies' "You decide which opponent
+     * chooses the pile"); with a sole opponent the choice is forced and nothing is prompted, so
+     * two-player games never see the extra step. Each "an opponent chooses" step in a resolution
+     * gets its own pick.
+     */
     Opponent,
     /** The target player decides (resolved from context.targets[0]) */
     TargetPlayer,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CuratorOfDestinies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CuratorOfDestinies.kt
@@ -42,9 +42,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *     nobody is asked to split or choose between two empty piles. A 1–4 card library still splits.
  *  - "An opponent chooses" is a resolution-time choice, not a target, so it is
  *    [Chooser.Opponent] rather than a `TargetRequirement` (no shroud/targeting restrictions apply).
- *    Deviation worth naming: the ruling says *you* decide which opponent chooses. The engine's
- *    `Chooser.Opponent` resolves to the first opponent, which is exact in two-player games but
- *    does not let the controller pick the decider in multiplayer.
+ *    Per the ruling *you* decide which opponent chooses, which [Chooser.Opponent] handles: with
+ *    several opponents the engine first asks you which one picks a pile; with one it is forced.
  */
 val CuratorOfDestinies = card("Curator of Destinies") {
     manaCost = "{4}{U}{U}"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
@@ -45,3 +45,32 @@ data class ChooseOpponentForSourceContinuation(
     val controllerId: EntityId,
     val opponentIds: List<EntityId>
 ) : ContinuationFrame
+
+/**
+ * Resume after the controller picks *which* opponent makes a
+ * [com.wingedsheep.sdk.scripting.effects.Chooser.Opponent] decision (CR 601.7a / 602.3a and
+ * the matching resolution-time rulings — see
+ * [com.wingedsheep.engine.handlers.effects.ChooserResolution]).
+ *
+ * The resumer stamps the pick onto [baseContext] as
+ * [com.wingedsheep.engine.handlers.EffectContext.opponentDeciderId] and re-runs [effect], which
+ * then resolves its chooser straight to that opponent and pauses again with its own decision.
+ * Nothing durable is written: the stamp lives only on the re-run context, so a second
+ * "an opponent chooses" step in the same resolution asks again.
+ *
+ * @property controllerId The player picking the decider.
+ * @property sourceId The spell or permanent whose effect is being resolved (display only).
+ * @property opponentIds The option list shown, positionally aligned with the
+ *   [ChooseOptionDecision]'s options.
+ * @property effect The effect to re-execute once the decider is known.
+ * @property baseContext The context the effect was first executed with, including pipeline storage.
+ */
+@Serializable
+data class ChooseOpponentDeciderContinuation(
+    override val decisionId: String,
+    val controllerId: EntityId,
+    val sourceId: EntityId?,
+    val opponentIds: List<EntityId>,
+    val effect: com.wingedsheep.sdk.scripting.effects.Effect,
+    val baseContext: com.wingedsheep.engine.handlers.EffectContext
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -215,6 +215,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseNumberForSourceContinuation::class)
         subclass(ChooseOpponentForSourceContinuation::class)
+        subclass(ChooseOpponentDeciderContinuation::class)
         subclass(ConvertCountersToTokensContinuation::class)
         subclass(ChooseManaColorContinuation::class)
         subclass(ChooseColorForTargetContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -309,6 +309,20 @@ data class EffectContext(
     val chosenColor: Color? = null,
     /** Creature type chosen during casting (e.g., Aphetto Dredging) */
     val chosenCreatureType: String? = null,
+    /**
+     * The opponent the controller picked to make a
+     * [com.wingedsheep.sdk.scripting.effects.Chooser.Opponent] decision, when the game has more
+     * than one opponent to choose from (CR 601.7a / 602.3a and the matching resolution-time
+     * rulings). Set by
+     * [com.wingedsheep.engine.core.ChooseOpponentDeciderContinuation]'s resumer just before the
+     * effect is re-executed, and read back by
+     * [com.wingedsheep.engine.handlers.effects.ChooserResolution.resolve].
+     *
+     * Resolution-scoped on purpose: the stamp rides only the re-run context, so each separate
+     * "an opponent chooses" step gets its own prompt. Null in two-player games (a sole opponent
+     * is a forced choice, never asked) and before the pick is made.
+     */
+    val opponentDeciderId: EntityId? = null,
     // --- Zone state ---
     /** Zone the spell was cast from (e.g., HAND, GRAVEYARD for flashback) */
     val castFromZone: Zone? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -20,6 +20,7 @@ class ColorChoiceContinuationResumer(
         resumer(ChooseNumberThenContinuation::class, ::resumeChooseNumberThen),
         resumer(ChooseNumberForSourceContinuation::class, ::resumeChooseNumberForSource),
         resumer(ChooseOpponentForSourceContinuation::class, ::resumeChooseOpponentForSource),
+        resumer(ChooseOpponentDeciderContinuation::class, ::resumeChooseOpponentDecider),
         resumer(ChooseManaColorContinuation::class, ::resumeChooseManaColor),
         resumer(ChooseColorForTargetContinuation::class, ::resumeChooseColorForTarget),
         resumer(ChooseAnyColorTapBonusContinuation::class, ::resumeChooseAnyColorTapBonus)
@@ -115,6 +116,38 @@ class ColorChoiceContinuationResumer(
             container.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosen))
         }
         return checkForMore(newState, emptyList())
+    }
+
+    /**
+     * The controller picked which opponent makes a `Chooser.Opponent` decision (CR 601.7a /
+     * 602.3a and the matching resolution-time rulings). Stamp the pick onto the context and
+     * re-run the effect, which now resolves its chooser to that opponent and pauses with its
+     * own decision.
+     */
+    fun resumeChooseOpponentDecider(
+        state: GameState,
+        continuation: ChooseOpponentDeciderContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option choice response for the opponent-decider pick")
+        }
+        val chosen = continuation.opponentIds.getOrNull(response.optionIndex)
+            ?: return ExecutionResult.error(state, "Opponent choice index ${response.optionIndex} out of range")
+
+        val contextWithDecider = continuation.baseContext.copy(opponentDeciderId = chosen)
+        val effectResult = effectRunner.executeRemainingEffects(
+            state,
+            listOf(continuation.effect),
+            contextWithDecider
+        )
+
+        if (effectResult.isPaused) return effectResult.toExecutionResult()
+        // The re-run finished without pausing (nothing left to decide). Publish whatever it
+        // stored so the composite's remaining steps still see it.
+        val published = exposeCollectionsToNextFrame(effectResult.state, effectResult.updatedCollections)
+        return checkForMore(published, effectResult.events.toList())
     }
 
     fun resumeChooseManaColor(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ChooserResolution.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.core.ChooseOpponentDeciderContinuation
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.Effect
+import java.util.UUID
+
+/**
+ * The single place a [Chooser] becomes a concrete deciding player.
+ *
+ * Every executor whose effect carries a [Chooser] routes through [resolve] instead of
+ * re-deriving the mapping, so the variants stay in lockstep (they used to be three
+ * hand-copied `when` blocks that had already drifted — one silently returned `null` for
+ * `ControllerOfSelection` / `ControllerOfTarget`).
+ *
+ * ## "An opponent" in multiplayer
+ *
+ * [Chooser.Opponent] means *one* opponent decides, and the controller of the spell or
+ * ability picks which one. The Comprehensive Rules spell that out for choices made while a
+ * spell is cast (CR 601.7a) or an ability activated (CR 602.3a); resolution-time choices
+ * follow the same principle, and cards state it in their rulings — Curator of Destinies:
+ * "You decide which opponent chooses the pile while resolving [its] last ability."
+ *
+ * So with several opponents [resolve] does not pick one: it reports
+ * [Outcome.NeedsOpponentPick], and the executor pauses via [pauseForOpponentPick] to ask the
+ * controller. The pick is stamped onto [EffectContext.opponentDeciderId] and the *same effect*
+ * is re-executed, which then resolves straight through to that opponent. With a single
+ * opponent (every two-player game) the choice is forced and nothing is asked, so nothing
+ * about two-player play changes.
+ *
+ * The stamp is resolution-scoped, not durable: two separate "an opponent chooses" steps in
+ * one resolution each get their own prompt, because the composite's remaining-steps
+ * continuation carries the pre-pick context.
+ */
+object ChooserResolution {
+
+    sealed interface Outcome {
+        /** The deciding player is known. */
+        data class Resolved(val playerId: EntityId) : Outcome
+
+        /**
+         * `Chooser.Opponent` with more than one opponent: the controller must first pick
+         * which of [opponents] decides. Hand this to [pauseForOpponentPick].
+         */
+        data class NeedsOpponentPick(val opponents: List<EntityId>) : Outcome
+
+        /** No deciding player exists (no opponent, missing target, source gone, …). */
+        data class Unresolvable(val reason: String) : Outcome
+    }
+
+    /**
+     * Map [chooser] onto a deciding player.
+     *
+     * @param selectionCards the cards being selected from, for
+     *   [Chooser.ControllerOfSelection] — the controller of the first one decides. Pass the
+     *   collection the effect reads; empty is fine for every other chooser.
+     */
+    fun resolve(
+        state: GameState,
+        chooser: Chooser,
+        context: EffectContext,
+        selectionCards: List<EntityId> = emptyList()
+    ): Outcome = when (chooser) {
+        Chooser.Controller -> Outcome.Resolved(context.controllerId)
+
+        Chooser.Opponent -> {
+            val opponents = state.getOpponents(context.controllerId)
+            val alreadyPicked = context.opponentDeciderId
+            when {
+                opponents.isEmpty() -> Outcome.Unresolvable("No opponent to make the choice")
+                alreadyPicked != null && alreadyPicked in opponents -> Outcome.Resolved(alreadyPicked)
+                opponents.size == 1 -> Outcome.Resolved(opponents.single())
+                else -> Outcome.NeedsOpponentPick(opponents)
+            }
+        }
+
+        Chooser.TargetPlayer -> {
+            val playerId = context.targets.firstOrNull()?.let {
+                TargetResolutionUtils.run { it.toEntityId() }
+            }
+            playerId?.let { Outcome.Resolved(it) }
+                ?: Outcome.Unresolvable("No target player to make the choice")
+        }
+
+        Chooser.TriggeringPlayer -> context.triggeringEntityId?.let { Outcome.Resolved(it) }
+            ?: Outcome.Unresolvable("No triggering player to make the choice")
+
+        Chooser.SourceController -> {
+            val sourceId = context.sourceId
+            val controller = sourceId?.let { state.getEntity(it)?.get<ControllerComponent>()?.playerId }
+            controller?.let { Outcome.Resolved(it) }
+                ?: Outcome.Unresolvable("Source has no controller to make the choice")
+        }
+
+        Chooser.ControllerOfSelection -> {
+            val deriveFrom = selectionCards.firstOrNull()
+            val controller = deriveFrom?.let {
+                state.projectedState.getController(it)
+                    ?: state.getEntity(it)?.get<ControllerComponent>()?.playerId
+            }
+            controller?.let { Outcome.Resolved(it) }
+                ?: Outcome.Unresolvable("No card to derive the selection's controller from")
+        }
+
+        Chooser.ControllerOfTarget -> {
+            val targetId = context.targets.firstOrNull()?.let {
+                TargetResolutionUtils.run { it.toEntityId() }
+            }
+            // Fall back to the owner once the permanent has left the battlefield (e.g. it was
+            // destroyed earlier in the same resolution) — CR 608.2h last-known information.
+            val controller = targetId?.let {
+                state.getEntity(it)?.get<ControllerComponent>()?.playerId
+                    ?: state.getEntity(it)?.get<CardComponent>()?.ownerId
+            }
+            controller?.let { Outcome.Resolved(it) }
+                ?: Outcome.Unresolvable("No target to derive its controller from")
+        }
+    }
+
+    /**
+     * Ask the controller which of [opponents] makes the pending choice, then re-run [effect].
+     *
+     * [prompt] should name what the chosen opponent is about to do ("Choose which opponent
+     * chooses a pile"), since that is the only thing the deciding controller sees.
+     */
+    fun pauseForOpponentPick(
+        state: GameState,
+        opponents: List<EntityId>,
+        effect: Effect,
+        context: EffectContext,
+        prompt: String
+    ): EffectResult {
+        val decisionId = UUID.randomUUID().toString()
+        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = context.controllerId,
+            prompt = prompt,
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = opponents.map { playerName(state, it) }
+        )
+        val continuation = ChooseOpponentDeciderContinuation(
+            decisionId = decisionId,
+            controllerId = context.controllerId,
+            sourceId = context.sourceId,
+            opponentIds = opponents,
+            effect = effect,
+            baseContext = context
+        )
+        return EffectResult.paused(
+            state.withPendingDecision(decision).pushContinuation(continuation),
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = context.controllerId,
+                    decisionType = "CHOOSE_OPTION",
+                    prompt = prompt
+                )
+            )
+        )
+    }
+
+    private fun playerName(state: GameState, playerId: EntityId): String =
+        state.getEntity(playerId)?.get<PlayerComponent>()?.name ?: "Player ${playerId.value}"
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/OpponentGuessesTopCardKindExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/OpponentGuessesTopCardKindExecutor.kt
@@ -7,13 +7,10 @@ import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.DecisionRequestedEvent
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.ChooserResolution
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.OpponentGuessesTopCardKindEffect
 import java.util.UUID
 import kotlin.reflect.KClass
@@ -38,10 +35,26 @@ class OpponentGuessesTopCardKindExecutor : EffectExecutor<OpponentGuessesTopCard
         effect: OpponentGuessesTopCardKindEffect,
         context: EffectContext
     ): EffectResult {
-        val chooserId = resolveChooser(state, effect.chooser, context)
-            ?: return EffectResult.error(state, "No player for OpponentGuessesTopCardKind chooser")
-        val guesserId = resolveChooser(state, effect.guesser, context)
-            ?: return EffectResult.error(state, "No player for OpponentGuessesTopCardKind guesser")
+        // Both the framing choice and the guess may name "an opponent"; with several opponents the
+        // controller picks which one, and re-running this effect resolves both to that pick.
+        val chooserId = when (val outcome = ChooserResolution.resolve(state, effect.chooser, context)) {
+            is ChooserResolution.Outcome.Resolved -> outcome.playerId
+            is ChooserResolution.Outcome.NeedsOpponentPick -> return ChooserResolution.pauseForOpponentPick(
+                state, outcome.opponents, effect, context,
+                prompt = "Choose which opponent chooses land or nonland"
+            )
+            is ChooserResolution.Outcome.Unresolvable ->
+                return EffectResult.error(state, "OpponentGuessesTopCardKind chooser: ${outcome.reason}")
+        }
+        val guesserId = when (val outcome = ChooserResolution.resolve(state, effect.guesser, context)) {
+            is ChooserResolution.Outcome.Resolved -> outcome.playerId
+            is ChooserResolution.Outcome.NeedsOpponentPick -> return ChooserResolution.pauseForOpponentPick(
+                state, outcome.opponents, effect, context,
+                prompt = "Choose which opponent guesses"
+            )
+            is ChooserResolution.Outcome.Unresolvable ->
+                return EffectResult.error(state, "OpponentGuessesTopCardKind guesser: ${outcome.reason}")
+        }
 
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
@@ -82,22 +95,5 @@ class OpponentGuessesTopCardKindExecutor : EffectExecutor<OpponentGuessesTopCard
                 )
             )
         )
-    }
-
-    private fun resolveChooser(
-        state: GameState,
-        chooser: Chooser,
-        context: EffectContext
-    ): EntityId? = when (chooser) {
-        Chooser.Controller -> context.controllerId
-        Chooser.Opponent -> state.getOpponents(context.controllerId).firstOrNull()
-        Chooser.TargetPlayer -> context.targets.firstOrNull()?.let {
-            TargetResolutionUtils.run { it.toEntityId() }
-        }
-        Chooser.TriggeringPlayer -> context.triggeringEntityId
-        Chooser.SourceController -> context.sourceId?.let { sourceId ->
-            state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
-        }
-        else -> null
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ChoosePileExecutor.kt
@@ -2,13 +2,11 @@ package com.wingedsheep.engine.handlers.effects.library
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.ChooserResolution
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
-import com.wingedsheep.sdk.scripting.effects.Chooser
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -16,9 +14,9 @@ import kotlin.reflect.KClass
  * Executor for [ChoosePileEffect].
  *
  * Reads two named card collections from the pipeline, presents a binary
- * [ChooseOptionDecision] to the configured [Chooser], and (on response)
- * routes the picked pile to [ChoosePileEffect.storeChosenAs] and the other
- * to [ChoosePileEffect.storeOtherAs].
+ * [ChooseOptionDecision] to the player [ChooserResolution] derives from the effect's
+ * [com.wingedsheep.sdk.scripting.effects.Chooser], and (on response) routes the picked pile to
+ * [ChoosePileEffect.storeChosenAs] and the other to [ChoosePileEffect.storeOtherAs].
  */
 class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
 
@@ -32,36 +30,18 @@ class ChoosePileExecutor : EffectExecutor<ChoosePileEffect> {
         val pileA = context.pipeline.storedCollections[effect.pileA] ?: emptyList()
         val pileB = context.pipeline.storedCollections[effect.pileB] ?: emptyList()
 
-        val deciderId = when (effect.chooser) {
-            Chooser.Controller -> context.controllerId
-            Chooser.Opponent -> state.getOpponents(context.controllerId).firstOrNull()
-                ?: return EffectResult.error(state, "No opponent for ChoosePile chooser")
-            Chooser.TargetPlayer -> context.targets.firstOrNull()?.let {
-                TargetResolutionUtils.run { it.toEntityId() }
-            } ?: return EffectResult.error(state, "No target player for ChoosePile chooser")
-            Chooser.TriggeringPlayer -> context.triggeringEntityId
-                ?: return EffectResult.error(state, "No triggering player for ChoosePile chooser")
-            Chooser.SourceController -> {
-                val sourceId = context.sourceId
-                    ?: return EffectResult.error(state, "No source entity for ChoosePile chooser")
-                state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
-                    ?: return EffectResult.error(state, "Source entity has no ControllerComponent for ChoosePile chooser")
-            }
-            Chooser.ControllerOfSelection -> {
-                val deriveFrom = (pileA + pileB).firstOrNull()
-                    ?: return EffectResult.error(state, "No card to derive controller for ChoosePile ControllerOfSelection chooser")
-                state.projectedState.getController(deriveFrom)
-                    ?: state.getEntity(deriveFrom)?.get<ControllerComponent>()?.playerId
-                    ?: return EffectResult.error(state, "Could not resolve controller for ChoosePile ControllerOfSelection chooser")
-            }
-            Chooser.ControllerOfTarget -> {
-                val targetId = context.targets.firstOrNull()?.let {
-                    TargetResolutionUtils.run { it.toEntityId() }
-                } ?: return EffectResult.error(state, "No target for ChoosePile ControllerOfTarget chooser")
-                state.getEntity(targetId)?.get<ControllerComponent>()?.playerId
-                    ?: state.getEntity(targetId)?.get<CardComponent>()?.ownerId
-                    ?: return EffectResult.error(state, "Could not resolve controller for ChoosePile ControllerOfTarget chooser")
-            }
+        val deciderId = when (
+            val outcome = ChooserResolution.resolve(state, effect.chooser, context, pileA + pileB)
+        ) {
+            is ChooserResolution.Outcome.Resolved -> outcome.playerId
+            // "An opponent chooses one of those piles" — with several opponents the controller
+            // says which one, then this same effect runs again for the pile choice itself.
+            is ChooserResolution.Outcome.NeedsOpponentPick -> return ChooserResolution.pauseForOpponentPick(
+                state, outcome.opponents, effect, context,
+                prompt = "Choose which opponent chooses a pile"
+            )
+            is ChooserResolution.Outcome.Unresolvable ->
+                return EffectResult.error(state, "ChoosePile chooser: ${outcome.reason}")
         }
 
         val sourceName = context.sourceId?.let { sourceId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.ChooserResolution
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -97,39 +98,25 @@ class SelectFromCollectionExecutor(
             }
         }
 
-        // Resolve who makes the decision
-        val decidingPlayerId = when (effect.chooser) {
-            Chooser.Controller -> null // null = default to controller in createDecision
-            Chooser.Opponent -> state.getOpponents(context.controllerId).firstOrNull()
-                ?: return EffectResult.error(state, "No opponent for Opponent chooser")
-            Chooser.TargetPlayer -> context.targets.firstOrNull()?.let {
-                TargetResolutionUtils.run { it.toEntityId() }
-            } ?: return EffectResult.error(state, "No target player for TargetPlayer chooser")
-            Chooser.TriggeringPlayer -> context.triggeringEntityId
-                ?: return EffectResult.error(state, "No triggering player for TriggeringPlayer chooser")
-            Chooser.SourceController -> {
-                val sourceId = context.sourceId
-                    ?: return EffectResult.error(state, "No source entity for SourceController chooser")
-                state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
-                    ?: return EffectResult.error(state, "Source entity has no ControllerComponent for SourceController chooser")
-            }
-            Chooser.ControllerOfSelection -> {
-                val deriveFrom = eligibleCards.firstOrNull() ?: cards.firstOrNull()
-                    ?: return EffectResult.error(state, "No card to derive controller for ControllerOfSelection chooser")
-                state.projectedState.getController(deriveFrom)
-                    ?: state.getEntity(deriveFrom)?.get<ControllerComponent>()?.playerId
-                    ?: return EffectResult.error(state, "Could not resolve controller for ControllerOfSelection chooser")
-            }
-            Chooser.ControllerOfTarget -> {
-                val targetId = context.targets.firstOrNull()?.let {
-                    TargetResolutionUtils.run { it.toEntityId() }
-                } ?: return EffectResult.error(state, "No target for ControllerOfTarget chooser")
-                // Controller of the targeted permanent; fall back to its owner once it has
-                // left the battlefield (e.g. destroyed earlier in the same resolution).
-                state.getEntity(targetId)?.get<ControllerComponent>()?.playerId
-                    ?: state.getEntity(targetId)?.get<CardComponent>()?.ownerId
-                    ?: return EffectResult.error(state, "Could not resolve controller for ControllerOfTarget chooser")
-            }
+        // Resolve who makes the decision. `null` = default to the controller in createDecision.
+        val decidingPlayerId = when (
+            val outcome = ChooserResolution.resolve(
+                state,
+                effect.chooser,
+                context,
+                selectionCards = eligibleCards.ifEmpty { cards }
+            )
+        ) {
+            is ChooserResolution.Outcome.Resolved ->
+                if (effect.chooser == Chooser.Controller) null else outcome.playerId
+            // "An opponent chooses…" with several opponents: the controller says which one, then
+            // this same effect runs again and presents the selection to them.
+            is ChooserResolution.Outcome.NeedsOpponentPick -> return ChooserResolution.pauseForOpponentPick(
+                state, outcome.opponents, effect, context,
+                prompt = "Choose which opponent makes this choice"
+            )
+            is ChooserResolution.Outcome.Unresolvable ->
+                return EffectResult.error(state, "SelectFromCollection chooser: ${outcome.reason}")
         }
 
         // OnePerColor(matchControllerPermanentColors = true) narrows eligibility to

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/OpponentDeciderChoiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/OpponentDeciderChoiceTest.kt
@@ -1,0 +1,276 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PipelineState
+import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * `Chooser.Opponent` means one opponent decides, and the controller of the spell or ability
+ * picks which one. The Comprehensive Rules state that for choices made as a spell is cast
+ * (CR 601.7a) or an ability activated (CR 602.3a); resolution-time choices follow the same
+ * principle and cards spell it out in their rulings — Curator of Destinies: "You decide which
+ * opponent chooses the pile while resolving [its] last ability."
+ *
+ * Before this, every `Chooser.Opponent` step silently handed the decision to the *first*
+ * opponent. These tests pin the shared behavior in
+ * [com.wingedsheep.engine.handlers.effects.ChooserResolution]: an extra controller prompt when
+ * there is a real choice, and no prompt at all when there is only one opponent.
+ */
+class OpponentDeciderChoiceTest : FunSpec({
+
+    /** Registry with the full card pool, so gathered cards have real definitions. */
+    fun registry(): CardRegistry = CardRegistry().apply { register(TestCards.all) }
+
+    fun initGame(registry: CardRegistry, playerCount: Int): Pair<GameState, List<EntityId>> {
+        val deck = Deck(cards = List(40) { "Mountain" })
+        val result = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = (1..playerCount).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    /** A source permanent under [controller] to hang the resolving effect off. */
+    fun GameState.withSource(controller: EntityId, sourceId: EntityId): GameState {
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = "Mountain",
+                name = "Divvy Source",
+                manaCost = ManaCost.parse("{4}{U}{U}"),
+                typeLine = TypeLine.parse("Creature — Sphinx"),
+                ownerId = controller
+            ),
+            ControllerComponent(controller)
+        )
+        return withEntity(sourceId, container).addToZone(ZoneKey(controller, Zone.BATTLEFIELD), sourceId)
+    }
+
+    /** Two cards from [owner]'s library, one per pile. */
+    fun twoPiles(state: GameState, owner: EntityId): Pair<List<EntityId>, List<EntityId>> {
+        val library = state.getZone(ZoneKey(owner, Zone.LIBRARY))
+        return listOf(library[0]) to listOf(library[1])
+    }
+
+    test("multiplayer ChoosePile: the controller picks which opponent chooses a pile") {
+        val registry = registry()
+        val (initial, players) = initGame(registry, playerCount = 4)
+        val sourceId = EntityId.generate()
+        val state = initial.withSource(players[0], sourceId)
+        val (pileA, pileB) = twoPiles(state, players[0])
+
+        val effect = ChoosePileEffect(
+            pileA = "faceUp",
+            pileB = "faceDown",
+            pileALabel = "Face-up pile",
+            pileBLabel = "Face-down pile",
+            chooser = Chooser.Opponent,
+            storeChosenAs = "chosen",
+            storeOtherAs = "other"
+        )
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = players[0],
+            pipeline = PipelineState(storedCollections = mapOf("faceUp" to pileA, "faceDown" to pileB))
+        )
+
+        // First pause: the CONTROLLER is asked which opponent decides, one option per opponent.
+        val first = EffectExecutorRegistry(cardRegistry = registry).execute(state, effect, context)
+        first.isPaused shouldBe true
+        val deciderPick = first.state.pendingDecision
+        deciderPick.shouldNotBeNull()
+        deciderPick.shouldBeInstanceOf<ChooseOptionDecision>()
+        deciderPick.playerId shouldBe players[0]
+        deciderPick.options shouldContainExactly listOf("Player 2", "Player 3", "Player 4")
+
+        // Pick the SECOND opponent (players[2]) — the pre-fix behavior always used players[1].
+        val processor = ActionProcessor(registry)
+        val afterPick = processor.process(
+            first.state,
+            SubmitDecision(players[0], OptionChosenResponse(deciderPick.id, optionIndex = 1))
+        ).result
+
+        // Second pause: the pile choice itself, now owned by the chosen opponent.
+        val pileChoice = afterPick.newState.pendingDecision
+        pileChoice.shouldNotBeNull()
+        pileChoice.shouldBeInstanceOf<ChooseOptionDecision>()
+        pileChoice.playerId shouldBe players[2]
+        pileChoice.options shouldContainExactly listOf("Face-up pile", "Face-down pile")
+    }
+
+    test("two-player ChoosePile: the sole opponent is forced, with no extra prompt") {
+        val registry = registry()
+        val (initial, players) = initGame(registry, playerCount = 2)
+        val sourceId = EntityId.generate()
+        val state = initial.withSource(players[0], sourceId)
+        val (pileA, pileB) = twoPiles(state, players[0])
+
+        val effect = ChoosePileEffect(
+            pileA = "faceUp",
+            pileB = "faceDown",
+            pileALabel = "Face-up pile",
+            pileBLabel = "Face-down pile",
+            chooser = Chooser.Opponent,
+            storeChosenAs = "chosen",
+            storeOtherAs = "other"
+        )
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = players[0],
+            pipeline = PipelineState(storedCollections = mapOf("faceUp" to pileA, "faceDown" to pileB))
+        )
+
+        val result = EffectExecutorRegistry(cardRegistry = registry).execute(state, effect, context)
+        result.isPaused shouldBe true
+        val decision = result.state.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        // Straight to the pile choice, owned by the only opponent — no decider prompt in between.
+        decision.playerId shouldBe players[1]
+        decision.options shouldContainExactly listOf("Face-up pile", "Face-down pile")
+    }
+
+    test("the pick is shared vocabulary: SelectFromCollection routes to the chosen opponent too") {
+        val registry = registry()
+        val (initial, players) = initGame(registry, playerCount = 3)
+        val sourceId = EntityId.generate()
+        val state = initial.withSource(players[0], sourceId)
+        val cards = state.getZone(ZoneKey(players[0], Zone.LIBRARY)).take(3)
+
+        val effect = SelectFromCollectionEffect(
+            from = "looked",
+            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+            chooser = Chooser.Opponent,
+            storeSelected = "picked",
+            storeRemainder = "rest",
+            prompt = "Choose a card"
+        )
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = players[0],
+            pipeline = PipelineState(storedCollections = mapOf("looked" to cards))
+        )
+
+        val first = EffectExecutorRegistry(cardRegistry = registry).execute(state, effect, context)
+        first.isPaused shouldBe true
+        val deciderPick = first.state.pendingDecision
+        deciderPick.shouldNotBeNull()
+        deciderPick.shouldBeInstanceOf<ChooseOptionDecision>()
+        deciderPick.playerId shouldBe players[0]
+        deciderPick.options shouldContainExactly listOf("Player 2", "Player 3")
+
+        val afterPick = ActionProcessor(registry).process(
+            first.state,
+            SubmitDecision(players[0], OptionChosenResponse(deciderPick.id, optionIndex = 1))
+        ).result
+
+        val selection = afterPick.newState.pendingDecision
+        selection.shouldNotBeNull()
+        selection.shouldBeInstanceOf<SelectCardsDecision>()
+        selection.playerId shouldBe players[2]
+    }
+
+    test("each opponent-chooses step gets its own pick — the first is not reused") {
+        val registry = registry()
+        val (initial, players) = initGame(registry, playerCount = 3)
+        val sourceId = EntityId.generate()
+        val state = initial.withSource(players[0], sourceId)
+        val cards = state.getZone(ZoneKey(players[0], Zone.LIBRARY)).take(4)
+
+        // Two independent "an opponent chooses" selections in one composite.
+        val step = { from: String, into: String ->
+            SelectFromCollectionEffect(
+                from = from,
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Opponent,
+                storeSelected = into,
+                storeRemainder = "${into}Rest",
+                prompt = "Choose a card"
+            )
+        }
+        val composite = com.wingedsheep.sdk.scripting.effects.CompositeEffect(
+            listOf(step("first", "firstPick"), step("second", "secondPick"))
+        )
+        val context = EffectContext(
+            sourceId = sourceId,
+            controllerId = players[0],
+            pipeline = PipelineState(
+                storedCollections = mapOf("first" to cards.take(2), "second" to cards.drop(2))
+            )
+        )
+
+        val processor = ActionProcessor(registry)
+        val first = EffectExecutorRegistry(cardRegistry = registry).execute(state, composite, context)
+
+        // Step 1: decider pick, then the selection itself.
+        val pick1 = first.state.pendingDecision
+        pick1.shouldNotBeNull()
+        pick1.shouldBeInstanceOf<ChooseOptionDecision>()
+        pick1.playerId shouldBe players[0]
+        var current = processor.process(
+            first.state,
+            SubmitDecision(players[0], OptionChosenResponse(pick1.id, optionIndex = 0))
+        ).result.newState
+
+        val selection1 = current.pendingDecision
+        selection1.shouldNotBeNull()
+        selection1.shouldBeInstanceOf<SelectCardsDecision>()
+        selection1.playerId shouldBe players[1]
+        current = processor.process(
+            current,
+            SubmitDecision(
+                players[1],
+                com.wingedsheep.engine.core.CardsSelectedResponse(selection1.id, listOf(cards[0]))
+            )
+        ).result.newState
+
+        // Step 2 must ask the controller again rather than reusing opponent 1.
+        val pick2 = current.pendingDecision
+        pick2.shouldNotBeNull()
+        pick2.shouldBeInstanceOf<ChooseOptionDecision>()
+        pick2.playerId shouldBe players[0]
+        pick2.options shouldContainExactly listOf("Player 2", "Player 3")
+
+        // And a different opponent can be named for it.
+        current = processor.process(
+            current,
+            SubmitDecision(players[0], OptionChosenResponse(pick2.id, optionIndex = 1))
+        ).result.newState
+        val selection2 = current.pendingDecision
+        selection2.shouldNotBeNull()
+        selection2.shouldBeInstanceOf<SelectCardsDecision>()
+        selection2.playerId shouldBe players[2]
+    }
+})


### PR DESCRIPTION
Follow-up to the **Known deviation** in #1410.

## The gap

"An opponent chooses" names *one* opponent, and the controller of the spell or ability decides which one. The Comprehensive Rules state that for choices made as a spell is cast (CR 601.7a) or an ability activated (CR 602.3a); resolution-time choices follow the same principle and cards spell it out in their rulings — Curator of Destinies: *"You decide which opponent chooses the pile while resolving [its] last ability."*

Every `Chooser.Opponent` step silently handed the decision to the **first** opponent — exact in two-player games, arbitrary in multiplayer.

## Fixed at the seam, not per card

The mapping from `Chooser` to a player existed as three hand-copied `when` blocks (`ChoosePileExecutor`, `SelectFromCollectionExecutor`, `OpponentGuessesTopCardKindExecutor`) that had already drifted — the guess executor silently returned `null` for `ControllerOfSelection` / `ControllerOfTarget`. Rather than bolt a card-level workaround on Curator, this collapses them into one resolver and fixes the rule there, so every existing and future `Chooser.Opponent` card inherits it.

- **New `ChooserResolution`** (rules-engine) — the single place a `Chooser` becomes a deciding player. Returns `Resolved` / `NeedsOpponentPick` / `Unresolvable`.
- With several opponents it reports `NeedsOpponentPick`; the executor pauses on a `ChooseOptionDecision` for the controller listing the opponents by name. `ChooseOpponentDeciderContinuation`'s resumer stamps the pick onto `EffectContext.opponentDeciderId` and **re-runs the same effect**, which then resolves straight through to that opponent and pauses with its own real decision. This mirrors the existing `ChooseManaColorContinuation` pattern (re-run the effect with the choice stamped on the context).
- A **sole opponent stays a forced choice with no prompt**, so two-player play is byte-identical.
- The stamp is **resolution-scoped**, not written to the source: two separate "an opponent chooses" steps in one resolution each get their own pick, which is what the rules want. (The durable, cast-time counterpart — "you may promise **an opponent** a gift" — keeps using `Effects.ChooseOpponentForSource` + `Player.ChosenOpponent`, which persists on the source.)

Inside `ForEachEffect(IterationSpace.Players)` the prompt goes to the iterated player, matching how `Chooser.Opponent` already resolves relative to the rebound `controllerId` (Bend or Break: an opponent *of each separating player* chooses that player's pile).

## No new SDK vocabulary, no client or AI work

Nothing was added to the `Chooser` enum and no card definition changed shape — this is a behavior correction inside an existing capability. `ChooseOptionDecision` is already rendered by `ChooseOptionDecisionUI` and answered by the AI's `ChooseOptionHandler` / `DecisionResponder`, so the new prompt works end to end for free. mtgish Step 8b doesn't apply: there's no new SDK primitive or IR tag to register.

Curator of Destinies needed **no code change** — only its "Known deviation" KDoc paragraph removed, since the ruling is now honored.

## Tests

`OpponentDeciderChoiceTest` (`rules-engine`, 4 cases, all green):
- 4-player `ChoosePile`: the controller is asked first (options `Player 2/3/4`), and picking the *second* opponent routes the pile decision to `players[2]` — the pre-fix behavior always used `players[1]`.
- 2-player `ChoosePile`: straight to the pile choice owned by the sole opponent, with no decider prompt in between.
- The same flow through `SelectFromCollection`, proving the pick is shared vocabulary rather than a `ChoosePile` special case.
- Two `Chooser.Opponent` selections in one composite: the second asks the controller again instead of reusing the first pick, and a different opponent can be named.

`just test` is green; `just test-class OpponentDeciderChoiceTest` confirms the new class runs (4 PASSED). Docs updated in `card-sdk-language-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)