### PR TITLE
Add Celebration (Wilds of Eldraine) support to the engine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5931,9 +5931,22 @@ default to "you" so card authors don't need to pass it explicitly.
   even if the artifact is destroyed before combat). Captured types are read from the
   *projected* state at the moment of entry, so a permanent that's an artifact via a
   continuous effect at ETB (Mycosynth Lattice, etc.) also counts. Backed by the per-player
-  `PermanentTypesEnteredBattlefieldThisTurnComponent`, cleared by `CleanupPhaseManager` at
-  end of turn. Every battlefield entry must go through `BattlefieldEntry.place` for this
+  `PermanentsEnteredUnderControlThisTurnComponent` entry log, cleared by `CleanupPhaseManager`
+  at end of turn. Every battlefield entry must go through `BattlefieldEntry.place` for this
   tracker to stay in sync. Shortcut: `Conditions.ArtifactEnteredBattlefieldThisTurn`.
+- `Celebration` / `NonlandPermanentsEnteredThisTurn(atLeast = 1, player = Player.You)` — the
+  **Celebration** ability word (Wilds of Eldraine; CR 207.2c — italic flavor with no rules
+  meaning, so there is no keyword, only this condition): "if two or more nonland permanents
+  entered the battlefield under your control this turn". Composes through
+  `Compare(TurnTracking(player, TurnTracker.NONLAND_PERMANENTS_ENTERED), GTE, Fixed(atLeast))`
+  over the same per-player entry log as `PermanentTypeEnteredBattlefieldThisTurn`, so it is a
+  pure past-event check: the permanents need not still be on the battlefield or still be yours
+  (WOE release notes). Tokens count; lands — including land creatures — never do. It's a
+  threshold, not a count: a third entry adds nothing. Dual-mode, which is what the mechanic
+  needs — the printed cards use it both as an intervening-'if' `triggerCondition` (CR 603.4;
+  Pests of Honor, Lady of Laughter, Ash, Party Crasher) and as a `ConditionalStaticAbility` gate
+  (Armory Mice, Grand Ball Guest, Gallant Pie-Wielder). Use
+  `DynamicAmounts.nonlandPermanentsEnteredUnderControlThisTurn(player)` for the raw count.
 - `YouDescendedThisTurn(atLeast = 1)` — CR 700.11 gate: at least `atLeast` nontoken
   permanent cards were put into your graveyard from *any* zone this turn (battlefield,
   hand, library, stack, exile). Tokens do not count, even though they briefly enter the
@@ -6717,6 +6730,13 @@ this turn").
   opponent-gift effects), so it differs from `LANDS_PLAYED`. Backs
   `DynamicAmounts.landsEnteredUnderControlThisTurn(player)` — e.g. Bioengineered Future's
   "for each land that entered the battlefield under your control this turn."
+- `NONLAND_PERMANENTS_ENTERED` — the complement of `LANDS_ENTERED_UNDER_CONTROL` over the same
+  per-player entry log: nonland permanents that entered the battlefield under the player's control
+  this turn. Tokens count; a permanent that is both a land and a creature does not (it's a land).
+  One count per *entry event*, so a permanent that leaves and re-enters counts twice (CR 400.7 — a
+  new object each time), and an entry stays counted after the permanent leaves or changes
+  controller. Backs `DynamicAmounts.nonlandPermanentsEnteredUnderControlThisTurn(player)` and,
+  at a threshold of two, the **Celebration** ability word — see `Conditions.Celebration`.
 - `FOOD_SACRIFICED` — Food tokens sacrificed.
 - `CARDS_LEFT_GRAVEYARD` — cards leaving your graveyard.
 - `DESCENDED` — number of times a player has descended this turn (CR 700.11) — i.e.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1237,6 +1237,41 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.VoidCondition
 
     /**
+     * Celebration: "if two or more nonland permanents entered the battlefield under your control
+     * this turn". Backs the Celebration ability word from Wilds of Eldraine (CR 207.2c — an
+     * ability word is italic flavor with no rules meaning, so there is no keyword; only this
+     * condition).
+     *
+     * Pure past-event check (per the WOE rulings): the permanents need not still be on the
+     * battlefield or still be yours. Tokens count; lands do not (nor does a land creature).
+     * Crossing the threshold is all that matters — a third entry changes nothing.
+     *
+     * Works in both shapes the mechanic ships in:
+     *  - `triggerCondition = Conditions.Celebration` for the intervening-'if' triggers (CR 603.4 —
+     *    checked at trigger time *and* on resolution): Pests of Honor, Lady of Laughter, Ash,
+     *    Party Crasher, …
+     *  - a `ConditionalStaticAbility` gate for the "as long as …" statics (re-evaluated every
+     *    projection): Armory Mice, Grand Ball Guest, Gallant Pie-Wielder, …
+     */
+    val Celebration: ConditionInterface =
+        NonlandPermanentsEnteredThisTurn(atLeast = 2)
+
+    /**
+     * "If [atLeast] or more nonland permanents entered the battlefield under [player]'s control
+     * this turn" — the general form behind [Celebration], for wordings with a different threshold
+     * or a player other than the controller.
+     */
+    fun NonlandPermanentsEnteredThisTurn(
+        atLeast: Int = 1,
+        player: Player = Player.You
+    ): ConditionInterface =
+        trackerAtLeast(
+            com.wingedsheep.sdk.scripting.values.TurnTracker.NONLAND_PERMANENTS_ENTERED,
+            atLeast,
+            player,
+        )
+
+    /**
      * If an opponent lost life this turn (from any source).
      * Used for cards like Hired Claw: "Activate only if an opponent lost life this turn"
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -419,11 +419,20 @@ object DynamicAmounts {
      * "The number of lands that entered the battlefield under [player]'s control this turn"
      * (Bioengineered Future). Counts every land ETB under the player — land drops, Lander
      * search, Cultivate-style "put a land onto the battlefield" effects — not just land
-     * drops. Reads the per-player [LandsEnteredUnderControlThisTurnComponent] populated by
+     * drops. Reads the per-player permanent-entry log populated by
      * `PermanentEntryTracker`.
      */
     fun landsEnteredUnderControlThisTurn(player: Player = Player.You): DynamicAmount =
         DynamicAmount.TurnTracking(player, TurnTracker.LANDS_ENTERED_UNDER_CONTROL)
+
+    /**
+     * "The number of nonland permanents that entered the battlefield under [player]'s control this
+     * turn" — the complement of [landsEnteredUnderControlThisTurn] over the same per-player entry
+     * log. Tokens count; a land creature does not. The threshold form is the Celebration ability
+     * word (`Conditions.Celebration`); this is the raw count for "for each …" scaling.
+     */
+    fun nonlandPermanentsEnteredUnderControlThisTurn(player: Player = Player.You): DynamicAmount =
+        DynamicAmount.TurnTracking(player, TurnTracker.NONLAND_PERMANENTS_ENTERED)
 
     /**
      * "The number of [other] [subtype]s that entered the battlefield under [player]'s control

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -71,6 +71,20 @@ enum class TurnTracker {
      * control this turn" wording (Bioengineered Future).
      */
     LANDS_ENTERED_UNDER_CONTROL,
+    /**
+     * Number of **nonland** permanents that entered the battlefield under the player's control
+     * this turn — the complement of [LANDS_ENTERED_UNDER_CONTROL] over the same per-player entry
+     * log. Tokens count (they're permanents); a permanent that is both a land and a creature does
+     * not (it's a land). Entries are counted per *entry event*, so a permanent that leaves and
+     * re-enters counts twice (CR 400.7 — it's a new object each time), and an entry stays counted
+     * even after the permanent leaves the battlefield or changes controller.
+     *
+     * `Compare(TurnTracking(You, NONLAND_PERMANENTS_ENTERED), GTE, Fixed(2))` is the **Celebration**
+     * ability word (Wilds of Eldraine, CR 207.2c — flavor only, no keyword): "two or more nonland
+     * permanents entered the battlefield under your control this turn". Reach for it via
+     * `Conditions.Celebration`.
+     */
+    NONLAND_PERMANENTS_ENTERED,
     /** Indicator (0 or 1) that the player sacrificed at least one Food this turn. */
     FOOD_SACRIFICED,
     /** Total cards that left the player's graveyard this turn (Bonecache Overseer). */
@@ -136,6 +150,7 @@ enum class TurnTracker {
         COUNTERS_PUT_ON_CREATURE -> "whether ${player.description} put a counter on a creature this turn"
         LANDS_PLAYED -> "the number of lands ${player.description} played this turn"
         LANDS_ENTERED_UNDER_CONTROL -> "the number of lands that entered the battlefield under ${player.possessive} control this turn"
+        NONLAND_PERMANENTS_ENTERED -> "the number of nonland permanents that entered the battlefield under ${player.possessive} control this turn"
         FOOD_SACRIFICED -> "whether ${player.description} sacrificed a Food this turn"
         CARDS_LEFT_GRAVEYARD -> "the number of cards that left ${player.possessive} graveyard this turn"
         DESCENDED -> "the number of times ${player.description} descended this turn"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArmoryMice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArmoryMice.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Armory Mice
+ * {1}{W}
+ * Creature — Mouse
+ * 3/1
+ *
+ * Celebration — This creature gets +0/+2 as long as two or more nonland permanents entered the
+ * battlefield under your control this turn.
+ *
+ * The static half of the Celebration ability word (CR 207.2c — italic flavor, no rules meaning):
+ * a [ConditionalStaticAbility] gated on [Conditions.Celebration], so the bonus is re-evaluated
+ * every projection and appears the instant the second nonland permanent enters.
+ */
+val ArmoryMice = card("Armory Mice") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Mouse"
+    power = 3
+    toughness = 1
+    oracleText = "Celebration — This creature gets +0/+2 as long as two or more nonland " +
+        "permanents entered the battlefield under your control this turn."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 0, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.Celebration,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Chris Seaman"
+        flavorText = "They help ensure that the forges of the dwarves are always squeaky clean."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg?1783915136"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PestsOfHonor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PestsOfHonor.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pests of Honor
+ * {2}{W}
+ * Creature — Mouse
+ * 2/2
+ *
+ * Celebration — At the beginning of combat on your turn, if two or more nonland permanents
+ * entered the battlefield under your control this turn, put a +1/+1 counter on this creature.
+ *
+ * The triggered half of the Celebration ability word (CR 207.2c — italic flavor, no rules
+ * meaning): an intervening-'if' clause (CR 603.4), so [Conditions.Celebration] is checked both
+ * when the begin-combat step starts and again as the ability resolves.
+ */
+val PestsOfHonor = card("Pests of Honor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Mouse"
+    power = 2
+    toughness = 2
+    oracleText = "Celebration — At the beginning of combat on your turn, if two or more nonland " +
+        "permanents entered the battlefield under your control this turn, put a +1/+1 counter " +
+        "on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.Celebration
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "At the beginning of combat on your turn, if two or more nonland " +
+            "permanents entered the battlefield under your control this turn, put a +1/+1 " +
+            "counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "310"
+        artist = "Quintin Gleim"
+        flavorText = "They dash—then dine."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg?1783915040"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,56 @@
     ]
 }
 
+// Armory Mice
+{
+    "name": "Armory Mice",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Mouse",
+    "oracleText": "Celebration — This creature gets +0/+2 as long as two or more nonland permanents entered the battlefield under your control this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 0,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Chris Seaman",
+        "flavorText": "They help ensure that the forges of the dwarves are always squeaky clean.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b041949-6fb6-40a6-9329-f209be537219.jpg?1783915136"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ashiok's Reaper
 {
     "name": "Ashiok's Reaper",
@@ -4225,6 +4275,60 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Pests of Honor
+{
+    "name": "Pests of Honor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Mouse",
+    "oracleText": "Celebration — At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "310",
+        "rarity": "UNCOMMON",
+        "artist": "Quintin Gleim",
+        "flavorText": "They dash—then dine.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/5671c2a0-51e8-4d5e-8409-87abd6c0a8ab.jpg?1783915040"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -168,6 +168,15 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // OTJ crime (CR Outlaws of Thunder Junction) — "you've committed a crime this turn" ->
     // Conditions.YouCommittedCrimeThisTurn, gating a cost reduction or a resolution-time effect.
     supported("CommitedACrimeThisTurn", "predicate: player has committed a crime this turn (YouCommittedCrimeThisTurn)")
+    // Celebration (WOE ability word, CR 207.2c) — "if two or more nonland permanents entered the
+    // battlefield under your control this turn". Backed by the per-player permanent-entry log
+    // (TurnTracker.NONLAND_PERMANENTS_ENTERED) behind Conditions.Celebration, which is dual-mode, so
+    // it serves both the intervening-'if' triggers and the "as long as" conditional statics. The
+    // emitter renders the bare nonland-permanent + You shape; a narrower permanent filter scaffolds.
+    supported(
+        "NumberPermanentsEnteredTheBattlefieldUnderPlayersControlThisTurn",
+        "condition: N or more [nonland] permanents entered the battlefield under your control this turn (Conditions.Celebration)"
+    )
     // Delirium (ability word) — "there are four or more card types among cards in your graveyard."
     // Both the static "as long as …" gate (NumCardTypesInGraveyardIs) and the activated-ability
     // "Activate only if …" gate (ThereAreNumberCardTypesInPlayersGraveyard) map to Conditions.Delirium(N)

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2457,6 +2457,32 @@ private fun EmitCtx.singleInterveningIfDsl(cond: JsonObject): String? {
             }
         }
     }
+    // Celebration (WOE ability word, CR 207.2c) — "if two or more nonland permanents entered the
+    // battlefield under your control this turn":
+    //   NumberPermanentsEnteredTheBattlefieldUnderPlayersControlThisTurn(
+    //     GreaterThanOrEqualTo N, And(IsNonCardtype Land, IsPermanent), You)
+    // -> Conditions.Celebration (N = 2, the printed threshold) / Conditions.NonlandPermanentsEnteredThisTurn(N).
+    // Only the You scope, a GTE comparison, and exactly the bare "nonland permanent" filter render —
+    // a narrower filter (a card type, a subtype) would need a per-type entry tracker we don't have,
+    // so it declines -> SCAFFOLD rather than silently widening to "any nonland permanent".
+    if (cond.strField("_Condition") == "NumberPermanentsEnteredTheBattlefieldUnderPlayersControlThisTurn") {
+        val condArgs = cond["args"].asArr
+        val cmp = condArgs?.getOrNull(0) as? JsonObject
+        val filt = condArgs?.getOrNull(1) as? JsonObject
+        val player = (condArgs?.getOrNull(2) as? JsonObject)?.strField("_Player")
+        val arms = filt?.takeIf { it.strField("_Permanents") == "And" }
+            ?.get("args").asArr?.filterIsInstance<JsonObject>().orEmpty()
+        val bareNonlandPermanent = arms.size == 2 &&
+            arms.any { it.strField("_Permanents") == "IsNonCardtype" && it.field("args").asStr() == "Land" } &&
+            arms.any { it.strField("_Permanents") == "IsPermanent" && it.size == 1 }
+        if (player == "You" && cmp?.strField("_Comparison") == "GreaterThanOrEqualTo" && bareNonlandPermanent) {
+            val n = findInteger(cmp["args"])
+            if (n is Int) {
+                return if (n == 2) "Conditions.Celebration"
+                else "Conditions.NonlandPermanentsEnteredThisTurn($n)"
+            }
+        }
+    }
     // "if it's tapped" — PermanentPassesFilter(<subject>, IsTapped) over a bare IsTapped filter (no
     // other clause). Two subjects render:
     //  - Ref_TargetPermanent (the ability's first targeted permanent) -> Conditions.TargetIsTapped()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -50,13 +50,11 @@ import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComp
 import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
-import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent
-import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
@@ -666,12 +664,6 @@ class CleanupPhaseManager(
                 }
                 if (result.has<SacrificedFoodThisTurnComponent>()) {
                     result = result.without<SacrificedFoodThisTurnComponent>()
-                }
-                if (result.has<PermanentTypesEnteredBattlefieldThisTurnComponent>()) {
-                    result = result.without<PermanentTypesEnteredBattlefieldThisTurnComponent>()
-                }
-                if (result.has<LandsEnteredUnderControlThisTurnComponent>()) {
-                    result = result.without<LandsEnteredUnderControlThisTurnComponent>()
                 }
                 if (result.has<PermanentsEnteredUnderControlThisTurnComponent>()) {
                     result = result.without<PermanentsEnteredUnderControlThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -537,8 +537,6 @@ val engineSerializersModule = SerializersModule {
         subclass(PlayerCantPlayFromHandComponent::class)
         subclass(PlayerShroudComponent::class)
         subclass(SacrificedFoodThisTurnComponent::class)
-        subclass(PermanentTypesEnteredBattlefieldThisTurnComponent::class)
-        subclass(LandsEnteredUnderControlThisTurnComponent::class)
         subclass(PermanentsEnteredUnderControlThisTurnComponent::class)
         subclass(SpellsCantBeCounteredComponent::class)
         subclass(FlashGrantsThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1001,10 +1001,10 @@ class ConditionEvaluator(
         ctx: ConditionEvaluationContext
     ): Boolean {
         val playerId = resolvePlayer(state, condition.player, ctx) ?: return false
-        val tracker = state.getEntity(playerId)
-            ?.get<com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent>()
+        val log = state.getEntity(playerId)
+            ?.get<com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent>()
             ?: return false
-        return condition.cardType in tracker.cardTypes
+        return log.countOfType(condition.cardType) > 0
     }
 
     private fun evaluatePermanentLeftBattlefieldThisTurnCtx(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -497,8 +497,13 @@ class DynamicAmountEvaluator(
                     }
                     TurnTracker.LANDS_ENTERED_UNDER_CONTROL -> playerIds.sumOf { playerId ->
                         state.getEntity(playerId)
-                            ?.get<com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent>()
-                            ?.count ?: 0
+                            ?.get<com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent>()
+                            ?.countOfType(com.wingedsheep.sdk.core.CardType.LAND) ?: 0
+                    }
+                    TurnTracker.NONLAND_PERMANENTS_ENTERED -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent>()
+                            ?.countNonland() ?: 0
                     }
                     TurnTracker.FOOD_SACRIFICED -> playerIds.count { playerId ->
                         state.getEntity(playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
@@ -3,37 +3,37 @@ package com.wingedsheep.engine.handlers.effects
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent
 import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
-import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
-import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.model.EntityId
 
 /**
- * Records the entry of a permanent for per-player, per-turn "an X entered the battlefield
- * under your control this turn" tracking (e.g. Mechan Shieldmate).
+ * Records the entry of a permanent into the per-player, per-turn entry log
+ * ([PermanentsEnteredUnderControlThisTurnComponent]) that backs every "an X entered the
+ * battlefield under your control this turn" reader — the Celebration ability word (WOE), the
+ * land-entry count (Bioengineered Future), the card-type-entered condition (Mechan Shieldmate)
+ * and the subtype-entry count (Geralf, the Fleshwright).
  *
  * Cleared at end of turn by [com.wingedsheep.engine.core.CleanupPhaseManager].
  *
- * Two sanctioned recording paths keep this tracker in sync:
+ * Two sanctioned recording paths keep this log in sync:
  *  - The standard zone-change pipeline ([ZoneTransitionService.moveToZone]) calls [record]
  *    itself, right after wiring the entering permanent's controller.
  *  - Every *other* (ad-hoc) battlefield insertion — token creation, land play, permanent-
  *    spell resolution, returns from linked exile, etc. — must go through
  *    [BattlefieldEntry.place] rather than calling `state.addToZone(...)` directly.
  *
- * The type-set tracker ([PermanentTypesEnteredBattlefieldThisTurnComponent]) merges into a
- * [Set], so it is safe (idempotent) if an entry is ever recorded twice. The land-count
- * tracker ([LandsEnteredUnderControlThisTurnComponent]) is **not** idempotent — it bumps
- * unconditionally when the entering permanent's types include `LAND`. Both sanctioned
- * recording paths call [record] exactly once per ETB; the count would skew if a future
+ * [record] appends **one entry per call**, deliberately without deduplicating on entity id: a
+ * permanent that leaves the battlefield and returns is a new object (CR 400.7) and its second
+ * entry is a second event that "a permanent entered the battlefield" abilities see. Both
+ * sanctioned recording paths call [record] exactly once per ETB; the log would skew if a future
  * call site introduced double-recording.
  *
- * Types are read from the **projected** state (post-layer), not the printed type line, so
- * a permanent that is an artifact by continuous effect at the moment of entry is recorded
- * as having entered as an artifact. The record itself is permanent for the rest of the
- * turn — once recorded, it stays true even if the permanent later leaves the battlefield
- * or changes type.
+ * Types and subtypes are read from the **projected** state (post-layer), not the printed type
+ * line, so a permanent that is an artifact by continuous effect at the moment of entry is
+ * recorded as having entered as an artifact. The record is permanent for the rest of the turn —
+ * once logged, it stays even if the permanent later leaves the battlefield, changes type, or
+ * changes controller.
  */
 object PermanentEntryTracker {
 
@@ -59,36 +59,13 @@ object PermanentEntryTracker {
         if (cardTypes.isEmpty()) return stamped
         val subtypes = stamped.projectedState.getSubtypes(entityId)
         return stamped.updateEntity(controllerId) { container ->
-            val typeMerged = run {
-                val existing = container.get<PermanentTypesEnteredBattlefieldThisTurnComponent>()
-                    ?: PermanentTypesEnteredBattlefieldThisTurnComponent()
-                val merged = existing.cardTypes + cardTypes
-                if (merged == existing.cardTypes) container
-                else container.with(PermanentTypesEnteredBattlefieldThisTurnComponent(merged))
-            }
-            // Per-permanent entry list, keyed by entityId so a (theoretical) double-record is
-            // idempotent. Backs subtype-keyed "for each [type] that entered this turn" counts.
-            val perPermanentMerged = run {
-                val existing = typeMerged.get<PermanentsEnteredUnderControlThisTurnComponent>()
-                    ?: PermanentsEnteredUnderControlThisTurnComponent()
-                if (existing.entries.any { it.entityId == entityId }) typeMerged
-                else typeMerged.with(
-                    PermanentsEnteredUnderControlThisTurnComponent(
-                        existing.entries + EnteredPermanentRecord(entityId, subtypes)
-                    )
+            val existing = container.get<PermanentsEnteredUnderControlThisTurnComponent>()
+                ?: PermanentsEnteredUnderControlThisTurnComponent()
+            container.with(
+                PermanentsEnteredUnderControlThisTurnComponent(
+                    existing.entries + EnteredPermanentRecord(entityId, cardTypes, subtypes)
                 )
-            }
-            // Lands need a *count*, not just presence, for "for each land that entered
-            // this turn" dynamic amounts (Bioengineered Future). Two unrelated lands
-            // entering both bump the counter; the set-based type tracker above sees them
-            // as a single LAND entry.
-            if (CardType.LAND in cardTypes) {
-                val landExisting = perPermanentMerged.get<LandsEnteredUnderControlThisTurnComponent>()
-                    ?: LandsEnteredUnderControlThisTurnComponent()
-                perPermanentMerged.with(LandsEnteredUnderControlThisTurnComponent(landExisting.count + 1))
-            } else {
-                perPermanentMerged
-            }
+            )
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1165,69 +1165,54 @@ data class PlayerDescendedThisTurnComponent(val count: Int = 0) : Component
 data object FlippedCoinsThisTurnComponent : Component
 
 /**
- * Tracks which card types have entered the battlefield under this player's control this turn.
- * Populated by `BattlefieldEntry.place` (via `PermanentEntryTracker.record`) from the projected
- * types at the moment of entry, so a permanent that's an artifact-by-effect at ETB is recorded
- * just like a printed artifact. Once recorded, the entry is insensitive to later state changes
- * — the entry of an artifact remains recorded even if the permanent is destroyed, loses its
- * artifact type, or changes controllers later in the turn.
- *
- * Cleared at end of turn by CleanupPhaseManager.
- *
- * Used for conditions like Mechan Shieldmate's "as long as an artifact entered the battlefield
- * under your control this turn".
- */
-@Serializable
-data class PermanentTypesEnteredBattlefieldThisTurnComponent(
-    val cardTypes: Set<com.wingedsheep.sdk.core.CardType> = emptySet()
-) : Component
-
-/**
- * Tracks the number of lands that have entered the battlefield under this player's control
- * during the current turn. Counts every ETB regardless of how the land arrived — normal land
- * drops, Lander-token search, Cultivate-style "put a land onto the battlefield" effects,
- * gift-a-land effects, etc. — so it diverges from `LandDropsComponent` (which only counts
- * the from-hand action).
- *
- * Populated by `PermanentEntryTracker.record` whenever the entering permanent's projected
- * types include `LAND`. Cleared at end of turn by [CleanupPhaseManager].
- *
- * Used for `DynamicAmount.TurnTracking(player, TurnTracker.LANDS_ENTERED_UNDER_CONTROL)` —
- * e.g. Bioengineered Future's "for each land that entered the battlefield under your
- * control this turn".
- */
-@Serializable
-data class LandsEnteredUnderControlThisTurnComponent(val count: Int = 0) : Component
-
-/**
- * One permanent that entered the battlefield under a player's control this turn, captured for
- * subtype-keyed "for each [creature type] that entered the battlefield under your control this
- * turn" counts (Geralf, the Fleshwright). [subtypes] is snapshotted from the **projected** state
- * at the instant of entry, so a permanent that was a Zombie when it entered still counts even
- * after it leaves the battlefield or loses the type (CR 603.10 last-known style — the entry event
- * is what matters, not current state). [entityId] lets a triggered ability exclude the permanent
- * that caused it to trigger ("each *other* Zombie", and simultaneous entries per the 2024-04-12
- * ruling).
+ * One permanent that entered the battlefield under a player's control this turn. [cardTypes] and
+ * [subtypes] are snapshotted from the **projected** state at the instant of entry, so a permanent
+ * that was an artifact (or a Zombie) when it entered still counts even after it leaves the
+ * battlefield, loses the type, or changes controllers (CR 603.10 last-known style — the entry
+ * event is what matters, not current state). [entityId] lets a triggered ability exclude the
+ * permanent that caused it to trigger ("each *other* Zombie", and simultaneous entries per the
+ * 2024-04-12 ruling).
  */
 @Serializable
 data class EnteredPermanentRecord(
     val entityId: EntityId,
+    val cardTypes: Set<com.wingedsheep.sdk.core.CardType> = emptySet(),
     val subtypes: Set<String> = emptySet()
-)
+) {
+    val isLand: Boolean get() = com.wingedsheep.sdk.core.CardType.LAND in cardTypes
+}
 
 /**
- * Tracks every permanent that entered the battlefield under this player's control during the
- * current turn, with the subtypes each had at entry. Populated by `PermanentEntryTracker.record`
- * (exactly once per ETB) and cleared at end of turn by [CleanupPhaseManager].
+ * The single per-player log of every permanent that entered the battlefield under this player's
+ * control during the current turn, one [EnteredPermanentRecord] per entry. Populated by
+ * `PermanentEntryTracker.record` (exactly once per ETB) and cleared at end of turn by
+ * [CleanupPhaseManager].
  *
- * Backs `DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity)`
- * — "for each [other] [subtype] that entered the battlefield under your control this turn"
- * (Geralf, the Fleshwright). Counts entries even if the permanent has since left or changed type.
+ * One entry per *entry event*, not per permanent: a permanent that leaves and re-enters is a new
+ * object (CR 400.7) and is logged twice.
+ *
+ * Every "an X entered the battlefield under your control this turn" reader derives from this log
+ * rather than keeping its own counter:
+ *  - [countNonland] → `TurnTracker.NONLAND_PERMANENTS_ENTERED`, the Celebration ability word's
+ *    "two or more nonland permanents entered the battlefield under your control this turn" (WOE).
+ *  - [countOfType] → `TurnTracker.LANDS_ENTERED_UNDER_CONTROL` ("for each land that entered the
+ *    battlefield under your control this turn", Bioengineered Future) and the
+ *    `PermanentTypeEnteredBattlefieldThisTurn` condition (Mechan Shieldmate's "as long as an
+ *    artifact entered the battlefield under your control this turn").
+ *  - [entries] directly → `DynamicAmount.SubtypeEnteredUnderControlThisTurn` ("each other Zombie
+ *    that entered the battlefield under your control this turn", Geralf, the Fleshwright).
  */
 @Serializable
 data class PermanentsEnteredUnderControlThisTurnComponent(
     val entries: List<EnteredPermanentRecord> = emptyList()
-) : Component
+) : Component {
+    /** Number of logged entries that were **not** lands at the moment they entered. */
+    fun countNonland(): Int = entries.count { !it.isLand }
+
+    /** Number of logged entries that had [cardType] at the moment they entered. */
+    fun countOfType(cardType: com.wingedsheep.sdk.core.CardType): Int =
+        entries.count { cardType in it.cardTypes }
+}
 
 /**
  * Marker component indicating that this player has put a counter on a creature this turn.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkalPakalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkalPakalScenarioTest.kt
@@ -2,7 +2,8 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.SelectCardsDecision
-import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
+import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.lci.cards.AkalPakal
@@ -48,7 +49,9 @@ class AkalPakalScenarioTest : FunSpec({
         d.replaceState(
             d.state.updateEntity(you) { container ->
                 container.with(
-                    PermanentTypesEnteredBattlefieldThisTurnComponent(setOf(CardType.ARTIFACT))
+                    PermanentsEnteredUnderControlThisTurnComponent(
+                        listOf(EnteredPermanentRecord(you, setOf(CardType.ARTIFACT)))
+                    )
                 )
             }
         )
@@ -87,7 +90,7 @@ class AkalPakalScenarioTest : FunSpec({
 
         d.putPermanentOnBattlefield(you, "Akal Pakal, First Among Equals")
 
-        // No PermanentTypesEnteredBattlefieldThisTurnComponent set — the intervening-if condition
+        // No permanent-entry log set — the intervening-if condition
         // fails at trigger time, so the ability must not be placed on the stack (Rule 603.4).
         d.passPriorityUntil(Step.END)
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BioengineeredFutureScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BioengineeredFutureScenarioTest.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
-import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.ManaCost
@@ -26,7 +26,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  *    that entered the battlefield under your control this turn."
  *
  * Covers both the new per-player land-ETB tracker
- * ([LandsEnteredUnderControlThisTurnComponent], TurnTracker.LANDS_ENTERED_UNDER_CONTROL) and
+ * ([PermanentsEnteredUnderControlThisTurnComponent], TurnTracker.LANDS_ENTERED_UNDER_CONTROL) and
  * the third-party ETB replacement that scales with it. The Lander-token half is shared with
  * Biotech Specialist / Kav Landseeker / etc. and tested in those.
  */
@@ -38,7 +38,8 @@ class BioengineeredFutureScenarioTest : ScenarioTestBase() {
 
     private fun landsEntered(game: TestGame, playerId: EntityId): Int =
         game.state.getEntity(playerId)
-            ?.get<LandsEnteredUnderControlThisTurnComponent>()?.count ?: 0
+            ?.get<PermanentsEnteredUnderControlThisTurnComponent>()
+            ?.countOfType(com.wingedsheep.sdk.core.CardType.LAND) ?: 0
 
     private fun forestInHand(game: TestGame, playerId: EntityId): EntityId =
         game.state.getHand(playerId).first {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CelebrationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CelebrationScenarioTest.kt
@@ -1,0 +1,457 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the **Celebration** ability word (Wilds of Eldraine).
+ *
+ * Celebration is an ability word (CR 207.2c) — italic flavor with no rules meaning — so the whole
+ * mechanic is one condition: "two or more nonland permanents entered the battlefield under your
+ * control this turn", modelled as
+ * `Compare(TurnTracking(You, NONLAND_PERMANENTS_ENTERED), GTE, Fixed(2))` behind
+ * `Conditions.Celebration`, over the per-player
+ * [PermanentsEnteredUnderControlThisTurnComponent] entry log.
+ *
+ * Each test below pins a clause of the WOE release-notes rulings:
+ *  - "Celebration abilities only care if **two or more** … They won't get more powerful if more
+ *    than two permanents entered." — threshold, no scaling.
+ *  - "The permanents that entered **don't need to remain on the battlefield or under your
+ *    control**. Celebration abilities are checking for past events, not the current game state."
+ *  - "**nonland** permanents" — lands (including land creatures) never count; tokens do.
+ *  - Both shipped shapes: the intervening-'if' trigger (CR 603.4, Pests of Honor) and the
+ *    "as long as" conditional static (Armory Mice).
+ *
+ * A permanent that leaves and re-enters is a new object (CR 400.7), so its second entry is a
+ * second entry event and counts again.
+ */
+class CelebrationScenarioTest : ScenarioTestBase() {
+
+    private fun nonlandEntries(game: TestGame, playerId: EntityId): Int =
+        game.state.getEntity(playerId)
+            ?.get<PermanentsEnteredUnderControlThisTurnComponent>()
+            ?.countNonland() ?: 0
+
+    private fun toughnessOf(game: TestGame, entityId: EntityId): Int =
+        game.state.projectedState.getToughness(entityId)!!
+
+    private fun plusOneCounters(game: TestGame, entityId: EntityId): Int =
+        game.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun cardInHand(game: TestGame, playerId: EntityId, name: String): EntityId =
+        game.state.getHand(playerId).first {
+            game.state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+
+    /** Overwrite the entry log wholesale — the cheapest way to pin a snapshot shape. */
+    private fun setEntryLog(game: TestGame, playerId: EntityId, vararg types: Set<CardType>) {
+        game.state = game.state.updateEntity(playerId) { container ->
+            container.with(
+                PermanentsEnteredUnderControlThisTurnComponent(
+                    types.mapIndexed { i, t -> EnteredPermanentRecord(EntityId.of("entry-$i"), t) }
+                )
+            )
+        }
+    }
+
+    init {
+        // A one-mana vanilla creature, so a test can cast several in a turn without mana or
+        // colour-identity noise.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Beast",
+                manaCost = ManaCost.parse("{G}"),
+                subtypes = setOf(Subtype.BEAST),
+                power = 1,
+                toughness = 1
+            )
+        )
+
+        context("Celebration — the entry count itself") {
+
+            test("only nonland permanents count; lands never do") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player = game.player1Id
+                game.execute(PlayLand(player, cardInHand(game, player, "Forest"))).error shouldBe null
+                withClue("a land ETB must not feed the nonland count") {
+                    nonlandEntries(game, player) shouldBe 0
+                }
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                nonlandEntries(game, player) shouldBe 1
+            }
+
+            test("a permanent that is both a land and a creature does not count") {
+                // "Nonland permanent" is a type test, not a "not only a land" test: a Dryad
+                // Arbor-style land creature is a land, so Celebration ignores it. Pinned against
+                // the snapshot the tracker records, since the entry is what's classified.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                setEntryLog(
+                    game, game.player1Id,
+                    setOf(CardType.LAND, CardType.CREATURE),
+                    setOf(CardType.LAND, CardType.CREATURE),
+                )
+                nonlandEntries(game, game.player1Id) shouldBe 0
+            }
+
+            test("tokens count — one Raise the Alarm turns Celebration on by itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mice = game.findPermanent("Armory Mice")!!
+                toughnessOf(game, mice) shouldBe 1
+
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                withClue("two 1/1 Soldier tokens are two nonland permanents entering") {
+                    nonlandEntries(game, game.player1Id) shouldBe 2
+                    toughnessOf(game, mice) shouldBe 3
+                }
+            }
+
+            test("the count is per-player — an opponent's permanents never help you") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withCardInHand(2, "Raise the Alarm")
+                    .withLandsOnBattlefield(2, "Plains", 5)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                nonlandEntries(game, game.player2Id) shouldBe 2
+                nonlandEntries(game, game.player1Id) shouldBe 0
+                withClue("Armory Mice reads its own controller's count") {
+                    toughnessOf(game, game.findPermanent("Armory Mice")!!) shouldBe 1
+                }
+            }
+
+            test("the same permanent entering twice counts twice (CR 400.7 — a new object)") {
+                // Cast a creature, bounce it, re-cast it. One card, two entry events.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Test Beast")
+                    .withCardInHand(1, "Unsummon")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player = game.player1Id
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                nonlandEntries(game, player) shouldBe 1
+
+                game.castSpell(1, "Unsummon", targetId = game.findPermanent("Test Beast")!!)
+                    .error shouldBe null
+                game.resolveStack()
+                withClue("leaving the battlefield does not un-count the first entry") {
+                    nonlandEntries(game, player) shouldBe 1
+                }
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                withClue("the re-entry is a second entry event") {
+                    nonlandEntries(game, player) shouldBe 2
+                }
+            }
+
+            test("the count is cleared at the turn boundary") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+                nonlandEntries(game, game.player1Id) shouldBe 2
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                nonlandEntries(game, game.player1Id) shouldBe 0
+            }
+        }
+
+        context("Celebration — Armory Mice (conditional static: +0/+2 as long as …)") {
+
+            test("off at zero and at one entry; on at exactly two") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withCardInHand(1, "Test Beast")
+                    .withCardsInHand(1, "Test Beast", 1)
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mice = game.findPermanent("Armory Mice")!!
+                withClue("nothing has entered yet") { toughnessOf(game, mice) shouldBe 1 }
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                withClue("one nonland permanent is below the threshold") {
+                    toughnessOf(game, mice) shouldBe 1
+                }
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                withClue("the second entry switches the static on") {
+                    toughnessOf(game, mice) shouldBe 3
+                }
+            }
+
+            test("a third entry does not stack the bonus") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mice = game.findPermanent("Armory Mice")!!
+                setEntryLog(
+                    game, game.player1Id,
+                    setOf(CardType.CREATURE),
+                    setOf(CardType.CREATURE),
+                    setOf(CardType.ARTIFACT),
+                    setOf(CardType.ENCHANTMENT),
+                )
+                withClue("Celebration is a threshold, not a count") {
+                    toughnessOf(game, mice) shouldBe 3
+                }
+            }
+
+            test("stays on after the permanents that entered have left — past events, not board state") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withCardsInHand(1, "Unsummon", 2)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mice = game.findPermanent("Armory Mice")!!
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+                toughnessOf(game, mice) shouldBe 3
+
+                // Bounce both Soldier tokens — they cease to exist entirely.
+                repeat(2) {
+                    val soldier = game.findPermanent("Soldier Token")!!
+                    game.castSpell(1, "Unsummon", targetId = soldier).error shouldBe null
+                    game.resolveStack()
+                }
+                game.findPermanent("Soldier Token") shouldBe null
+
+                withClue("the entries already happened; Celebration doesn't re-read the board") {
+                    toughnessOf(game, mice) shouldBe 3
+                }
+            }
+
+            test("turns off again on the next turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Armory Mice")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mice = game.findPermanent("Armory Mice")!!
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+                toughnessOf(game, mice) shouldBe 3
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                withClue("the tracker resets, so the static drops off") {
+                    toughnessOf(game, mice) shouldBe 1
+                }
+            }
+
+            test("the celebrating permanent's own entry counts toward its condition") {
+                // Armory Mice is itself a nonland permanent: cast it as the second entry of the
+                // turn and it comes down already buffed.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Test Beast")
+                    .withCardInHand(1, "Armory Mice")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                game.castSpell(1, "Armory Mice").error shouldBe null
+                game.resolveStack()
+
+                nonlandEntries(game, game.player1Id) shouldBe 2
+                toughnessOf(game, game.findPermanent("Armory Mice")!!) shouldBe 3
+            }
+        }
+
+        context("Celebration — Pests of Honor (intervening-'if' trigger, CR 603.4)") {
+
+            test("does not trigger when fewer than two nonland permanents entered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pests of Honor")
+                    .withCardInHand(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                nonlandEntries(game, game.player1Id) shouldBe 1
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("the intervening-'if' fails at trigger time, so nothing goes on the stack") {
+                    plusOneCounters(game, game.findPermanent("Pests of Honor")!!) shouldBe 0
+                }
+            }
+
+            test("triggers at the beginning of combat once two entered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pests of Honor")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+                nonlandEntries(game, game.player1Id) shouldBe 2
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                plusOneCounters(game, game.findPermanent("Pests of Honor")!!) shouldBe 1
+            }
+
+            test("lands entering do not turn the trigger on") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pests of Honor")
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player = game.player1Id
+                game.state = game.state.updateEntity(player) { container ->
+                    val drops = container
+                        .get<com.wingedsheep.engine.state.components.player.LandDropsComponent>()!!
+                    container.with(drops.copy(remaining = 2))
+                }
+                game.execute(PlayLand(player, cardInHand(game, player, "Forest"))).error shouldBe null
+                game.execute(PlayLand(player, cardInHand(game, player, "Plains"))).error shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                plusOneCounters(game, game.findPermanent("Pests of Honor")!!) shouldBe 0
+            }
+
+            test("triggers again on a later turn once that turn's own entries qualify") {
+                // The counter from turn 1 stays, but the tracker resets: turn 2 needs its own
+                // two entries before the trigger fires a second time.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pests of Honor")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withCardsInHand(1, "Test Beast", 2)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pests = game.findPermanent("Pests of Honor")!!
+
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+                plusOneCounters(game, pests) shouldBe 1
+
+                // Round through the opponent's main phase back to our own.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.state.activePlayerId shouldBe game.player1Id
+                nonlandEntries(game, game.player1Id) shouldBe 0
+
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+                game.castSpell(1, "Test Beast").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("a second, independent Celebration turn adds a second counter") {
+                    plusOneCounters(game, pests) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Celebration is an ability word (CR 207.2c) — italic flavor with no rules meaning — so the whole mechanic is **one condition**: *"two or more nonland permanents entered the battlefield under your control this turn."*

## SDK

- `TurnTracker.NONLAND_PERMANENTS_ENTERED` — the complement of the existing `LANDS_ENTERED_UNDER_CONTROL` over the same per-player entry log.
- `Conditions.Celebration` (threshold 2) and the general `Conditions.NonlandPermanentsEnteredThisTurn(atLeast, player)`. Both compose `Compare(TurnTracking(player, NONLAND_PERMANENTS_ENTERED), GTE, Fixed(n))` — a tracker threshold, not a new condition class. Dual-mode, which is exactly what the mechanic needs: the printed cards use it both as an intervening-'if' `triggerCondition` (CR 603.4) and as a `ConditionalStaticAbility` gate.
- `DynamicAmounts.nonlandPermanentsEnteredUnderControlThisTurn(player)` for the raw count.

## Engine — one entry log instead of three parallel trackers

`PermanentsEnteredUnderControlThisTurnComponent` gains the entering permanent's card types and becomes the single source of truth for "an X entered the battlefield under your control this turn". This **deletes** `LandsEnteredUnderControlThisTurnComponent` and `PermanentTypesEnteredBattlefieldThisTurnComponent` — the land count, the nonland count, and the `PermanentTypeEnteredBattlefieldThisTurn` condition now all derive from the log.

`PermanentEntryTracker.record` now appends one entry per call rather than deduplicating on entity id: a permanent that leaves and re-enters is a new object (CR 400.7), so its second entry is a second event. That also fixes a latent undercount in the subtype-entry path (Geralf, the Fleshwright) for blinked permanents.

## Cards — end-to-end proof of both shapes

- **Armory Mice** (WOE) — conditional static `+0/+2`.
- **Pests of Honor** (WOE) — begin-combat intervening-'if' `+1/+1` counter.

The other nine WOE Celebration cards are left for `add-card` follow-up; several of them (Goddric, Bespoke Battlegarb, Raging Battle Mouse) carry unrelated capability needs of their own.

## Tests

`CelebrationScenarioTest` (15 tests) pins every clause of the WOE release-notes rulings:

- nonland-only — a permanent that is both a land and a creature does not count
- tokens count (one Raise the Alarm turns Celebration on by itself)
- per-player scoping — an opponent's entries never help you
- threshold, not a count — a third entry adds nothing
- past events, not board state — stays on after the entered permanents are bounced
- turn-boundary reset, and re-arming on a later turn
- the same permanent entering twice counts twice (CR 400.7)
- both card shapes: the conditional static and the intervening-'if' trigger

## mtgish tooling

Bridge + emitter entry for `NumberPermanentsEnteredTheBattlefieldUnderPlayersControlThisTurn`, rendering `Conditions.Celebration` for the bare nonland-permanent + `You` shape and declining to SCAFFOLD otherwise. Promotes five WOE Celebration cards from BLOCKED to AUTOGEN.

## Notes

- No client work: the mechanic adds no keyword, decision, or client-visible state — it only feeds P/T and triggers the UI already renders.
- `docs/card-sdk-language-reference.md` updated (condition + tracker entries).
- WOE card snapshot golden re-blessed (additive only — the two new cards).
- `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)