### PR TITLE
Add six Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GearseekerSerpentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GearseekerSerpentReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gearseeker Serpent reprint in DFT.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * `definitions/kld/cards/GearseekerSerpent.kt` — Kaladesh (2016) is the card's earliest real
+ * expansion printing. This file contributes only the DFT-specific presentation row — set,
+ * collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val GearseekerSerpentReprint = Printing(
+    oracleId = "fdbd8a95-1dc8-4df2-bab0-a93d1941a405",
+    name = "Gearseeker Serpent",
+    setCode = "DFT",
+    collectorNumber = "43",
+    scryfallId = "3dca0007-42d3-4ee2-8e88-361d80a7103c",
+    artist = "J.P. Targete",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3dca0007-42d3-4ee2-8e88-361d80a7103c.jpg?1783907909",
+    releaseDate = "2025-02-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarketbackWalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarketbackWalker.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Marketback Walker — Aetherdrift #235
+ * {X}{X} · Artifact Creature — Construct · 0/0
+ *
+ * This creature enters with X +1/+1 counters on it.
+ * {4}: Put a +1/+1 counter on this creature.
+ * When this creature dies, draw a card for each +1/+1 counter on it.
+ *
+ * The cost prints **two** {X} symbols: the caster announces one value for X (CR 601.2b) and pays
+ * it twice, which `ManaCost.xCount` already drives through the solver and the payment path. The
+ * counters use the announced X once — [DynamicAmount.XValue] — so a 4/4 costs eight mana.
+ *
+ * The dies trigger reads [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the
+ * live entity: by the time it resolves the Walker is a graveyard card with no counters, so the
+ * count must come from last-known information (CR 603.10 / 608.2g). A Walker that dies with zero
+ * counters — cast for X=0, which state-based actions kill immediately as a 0/0 — still triggers
+ * and simply draws nothing.
+ */
+val MarketbackWalker = card("Marketback Walker") {
+    manaCost = "{X}{X}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with X +1/+1 counters on it.\n" +
+        "{4}: Put a +1/+1 counter on this creature.\n" +
+        "When this creature dies, draw a card for each +1/+1 counter on it."
+
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "{4}: Put a +1/+1 counter on this creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT)
+        )
+        description = "When this creature dies, draw a card for each +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "235"
+        artist = "Svetlin Velinov"
+        flavorText = "Many of the inventions built to fight the Phyrexians have since been " +
+            "repurposed for civilian use."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg?1783907848"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ScrapCompactor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ScrapCompactor.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Scrap Compactor — Aetherdrift #242
+ * {1} · Artifact
+ *
+ * {3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.
+ * {6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle.
+ *
+ * Two independent activated abilities sharing one body — sacrificing the Compactor is part of
+ * each cost, so at most one of them ever resolves. Both are modelled as separate
+ * `activatedAbility` blocks rather than a modal choice: the printed card is two abilities, and
+ * the action menu should show both prices side by side.
+ *
+ * "It deals 3 damage" — the Compactor is the damage source even though it is already in the
+ * graveyard when the ability resolves (CR 608.2g / last-known information); the default
+ * `damageSource` on [Effects.DealDamage] is the ability's source, which is exactly that.
+ * The second mode reaches Vehicles too ([GameObjectFilter.CreatureOrVehicle]), which a Vehicle
+ * matches by subtype whether or not it is currently crewed.
+ */
+val ScrapCompactor = card("Scrap Compactor") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.\n" +
+        "{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target creature", TargetCreature())
+        effect = Effects.DealDamage(3, t)
+        description = "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target(
+            "target creature or Vehicle",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle))
+        )
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+        description = "{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Viko Menezes"
+        flavorText = "From the screaming of Duskmourn's possessed metal came the happy cries of freed souls."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg?1783907846"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpectralInterference.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpectralInterference.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Spectral Interference — Aetherdrift #63
+ * {1}{U} · Instant
+ *
+ * Counter target artifact or creature spell unless its controller pays {4}.
+ *
+ * Same soft-counter shape as [SpellPierce], narrowed to the artifact/creature half of the stack
+ * ([GameObjectFilter.CreatureOrArtifact] restricted to [Zone.STACK] — an artifact creature spell
+ * matches on either half). The tax is a fixed {4}, so [Effects.CounterUnlessPays] rather than the
+ * dynamic variant.
+ */
+val SpectralInterference = card("Spectral Interference") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target artifact or creature spell unless its controller pays {4}."
+
+    spell {
+        target = TargetSpell(
+            filter = TargetFilter(GameObjectFilter.CreatureOrArtifact, zone = Zone.STACK)
+        )
+        effect = Effects.CounterUnlessPays("{4}")
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Steve Ellis"
+        flavorText = "\"So many fears. Let's make them all come true.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg?1783907903"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VoyagerQuickwelder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VoyagerQuickwelder.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Voyager Quickwelder — Aetherdrift #37
+ * {2}{W} · Artifact Creature — Robot Artificer · 2/4
+ *
+ * Artifact spells you cast cost {1} less to cast.
+ *
+ * A plain generic-cost reduction on the caster's own artifact spells
+ * ([SpellCostTarget.YouCast] + [CostModification.ReduceGeneric]). Generic-only, so it never
+ * shaves a colored pip, and — like every cost static — it reduces the Quickwelder's *own*
+ * successors, not itself: the ability only functions while it's on the battlefield.
+ */
+val VoyagerQuickwelder = card("Voyager Quickwelder") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Robot Artificer"
+    power = 2
+    toughness = 4
+    oracleText = "Artifact spells you cast cost {1} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Artifact),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Kenn Yap"
+        flavorText = "The Guidelight Voyagers had been stranded on Avishkar with no way to get home. " +
+            "They considered every last unit essential, down to the glitchiest grunt."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg?1783907912"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WreckRemover.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WreckRemover.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Wreck Remover — Aetherdrift #247
+ * {4} · Artifact Creature — Construct · 3/4
+ *
+ * Whenever this creature enters or attacks, exile up to one target card from a graveyard.
+ * You gain 1 life.
+ * Cycling {2}
+ *
+ * "Enters or attacks" is one printed ability with two trigger conditions; the SDK has no combined
+ * trigger spec, so it is expressed as two `triggeredAbility` blocks with identical effects — the
+ * established shape here (Sentinel of the Nameless City). Only one of the two can ever fire from
+ * a single event, so the split never double-triggers.
+ *
+ * The graveyard target is **up to one** (`optional = true`), and it may sit in *any* graveyard
+ * ([TargetFilter.CardInGraveyard] is not owner-scoped). The life gain is not conditional on the
+ * exile: with no target chosen, or with the chosen card gone by resolution, the controller still
+ * gains 1 — so the gain is a sibling in the [Effects.Composite], not a rider on the move.
+ */
+val WreckRemover = card("Wreck Remover") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever this creature enters or attacks, exile up to one target card from a " +
+        "graveyard. You gain 1 life.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "up to one target card in a graveyard",
+            TargetObject(optional = true, filter = TargetFilter.CardInGraveyard)
+        )
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.EXILE),
+            Effects.GainLife(1)
+        )
+        description = "Whenever this creature enters or attacks, exile up to one target card from " +
+            "a graveyard. You gain 1 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target(
+            "up to one target card in a graveyard",
+            TargetObject(optional = true, filter = TargetFilter.CardInGraveyard)
+        )
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.EXILE),
+            Effects.GainLife(1)
+        )
+        description = "Whenever this creature enters or attacks, exile up to one target card from " +
+            "a graveyard. You gain 1 life."
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Villarrte"
+        flavorText = "\"Don't get too cocky. We're all junk to the cleanup crew.\"\n—Far Fortune"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg?1783907845"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearseekerSerpentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearseekerSerpentReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gearseeker Serpent reprint in J22.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * `definitions/kld/cards/GearseekerSerpent.kt` — Kaladesh (2016) is the card's earliest real
+ * expansion printing. This file contributes only the J22-specific presentation row.
+ */
+val GearseekerSerpentReprint = Printing(
+    oracleId = "fdbd8a95-1dc8-4df2-bab0-a93d1941a405",
+    name = "Gearseeker Serpent",
+    setCode = "J22",
+    collectorNumber = "302",
+    scryfallId = "8d3ff91c-3d6c-45ed-bc58-28b17e8a213d",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d3ff91c-3d6c-45ed-bc58-28b17e8a213d.jpg?1783919058",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/GearseekerSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/GearseekerSerpent.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gearseeker Serpent — Kaladesh #48 (canonical; reprinted in Aetherdrift #43)
+ * {5}{U}{U} · Creature — Serpent · 5/6
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * {5}{U}: This creature can't be blocked this turn.
+ *
+ * Affinity is the stock [KeywordAbility.Affinity] cost reduction over [CardType.ARTIFACT] — it
+ * shaves generic mana only, so the cost floors at {U}{U} no matter how many artifacts are out.
+ *
+ * The evasion ability grants [AbilityFlag.CANT_BE_BLOCKED] to the Serpent itself for the turn.
+ * It is *not* an unblock: activating it after blockers are declared leaves the Serpent blocked
+ * (per the Scryfall ruling below) — the flag only matters while blockers are being declared.
+ */
+val GearseekerSerpent = card("Gearseeker Serpent") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    power = 5
+    toughness = 6
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you " +
+        "control.)\n" +
+        "{5}{U}: This creature can't be blocked this turn."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{U}")
+        effect = GrantKeywordEffect(AbilityFlag.CANT_BE_BLOCKED.name, EffectTarget.Self)
+        description = "{5}{U}: This creature can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Filip Burburan"
+        flavorText = "Its collection is vast, yet each ship has a special place in its heart."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg?1783937221"
+        ruling("2025-02-07", "This card's first ability can't reduce the total cost to cast the spell below {U}{U}.")
+        ruling("2025-02-07", "Once this creature has been blocked, activating its last ability won't cause it to become unblocked.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -3431,6 +3431,71 @@
     ]
 }
 
+// Marketback Walker
+{
+    "name": "Marketback Walker",
+    "manaCost": "{X}{X}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "This creature enters with X +1/+1 counters on it.\n{4}: Put a +1/+1 counter on this creature.\nWhen this creature dies, draw a card for each +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, draw a card for each +1/+1 counter on it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{4}: Put a +1/+1 counter on this creature."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Many of the inventions built to fight the Phyrexians have since been repurposed for civilian use.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2152030-6007-493f-a616-545723a00249.jpg?1783907848"
+    },
+    "colorIdentityOverride": []
+}
+
 // Maximum Overdrive
 {
     "name": "Maximum Overdrive",
@@ -4959,6 +5024,99 @@
     ]
 }
 
+// Scrap Compactor
+{
+    "name": "Scrap Compactor",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.\n{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}, Sacrifice this artifact: It deals 3 damage to target creature."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|Vehicle"
+                        },
+                        "id": "target creature or Vehicle"
+                    }
+                ],
+                "descriptionOverride": "{6}, {T}, Sacrifice this artifact: Destroy target creature or Vehicle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Viko Menezes",
+        "flavorText": "From the screaming of Duskmourn's possessed metal came the happy cries of freed souls.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg?1783907846"
+    },
+    "colorIdentityOverride": []
+}
+
 // Shefet Archfiend
 {
     "name": "Shefet Archfiend",
@@ -5195,6 +5353,41 @@
         "artist": "Elizabeth Peiró",
         "flavorText": "Garima was delighted to finally test out her design. The amazing views were a bonus.",
         "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Spectral Interference
+{
+    "name": "Spectral Interference",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target artifact or creature spell unless its controller pays {4}.",
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "condition": {
+                "type": "CounterCondition.UnlessPaysMana",
+                "cost": "{4}"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|artifact",
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Steve Ellis",
+        "flavorText": "\"So many fears. Let's make them all come true.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/860cb8af-a5f6-47e7-a34b-7b9f11ddc8c6.jpg?1783907903"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -6263,6 +6456,42 @@
     ]
 }
 
+// Voyager Quickwelder
+{
+    "name": "Voyager Quickwelder",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact Creature — Robot Artificer",
+    "oracleText": "Artifact spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "artifact"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Kenn Yap",
+        "flavorText": "The Guidelight Voyagers had been stranded on Avishkar with no way to get home. They considered every last unit essential, down to the glitchiest grunt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6dcdc8c-fba1-4ea1-bf93-65072d10f0da.jpg?1783907912"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Walking Sarcophagus
 {
     "name": "Walking Sarcophagus",
@@ -6439,6 +6668,106 @@
         "GREEN",
         "BLUE"
     ]
+}
+
+// Wreck Remover
+{
+    "name": "Wreck Remover",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Whenever this creature enters or attacks, exile up to one target card from a graveyard. You gain 1 life.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target card in a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target card in a graveyard"
+                },
+                "descriptionOverride": "Whenever this creature enters or attacks, exile up to one target card from a graveyard. You gain 1 life."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target card in a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target card in a graveyard"
+                },
+                "descriptionOverride": "Whenever this creature enters or attacks, exile up to one target card from a graveyard. You gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Villarrte",
+        "flavorText": "\"Don't get too cocky. We're all junk to the cleanup crew.\"\n—Far Fortune",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3151960-cc0c-47b5-b476-295d7a17ae14.jpg?1783907845"
+    },
+    "colorIdentityOverride": []
 }
 
 // Wreckage Wickerfolk

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -311,6 +311,66 @@
     ]
 }
 
+// Gearseeker Serpent
+{
+    "name": "Gearseeker Serpent",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Creature — Serpent",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{5}{U}: This creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{5}{U}: This creature can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Filip Burburan",
+        "flavorText": "Its collection is vast, yet each ship has a special place in its heart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d32d8327-6ec2-4d43-b254-b04407612715.jpg?1783937221",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "This card's first ability can't reduce the total cost to cast the spell below {U}{U}."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Once this creature has been blocked, activating its last ability won't cause it to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Workshop Assistant
 {
     "name": "Workshop Assistant",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarketbackWalkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarketbackWalkerScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Marketback Walker (DFT #235).
+ *
+ * {X}{X} Artifact Creature — Construct 0/0
+ * "This creature enters with X +1/+1 counters on it.
+ *  {4}: Put a +1/+1 counter on this creature.
+ *  When this creature dies, draw a card for each +1/+1 counter on it."
+ *
+ * The point of interest is the **doubled** {X}: the caster announces one X (CR 601.2b) and pays it
+ * once per {X} symbol, so X=3 costs six mana while still yielding only three counters. That path —
+ * `ManaCost.xCount` on a *card's* mana cost rather than an activated ability's — is what these
+ * tests pin down, alongside the dies trigger reading counters via last-known information.
+ */
+class MarketbackWalkerScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("X=3 costs six mana and enters as a 3/3 with three +1/+1 counters") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val walker = driver.putCardInHand(player, "Marketback Walker")
+        // {X}{X} with X=3 → 3 + 3 = 6 generic mana.
+        driver.giveMana(player, Color.RED, 6)
+
+        driver.castXSpell(player, walker, xValue = 3).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(walker) shouldBe true
+
+        // Base 0/0 plus X counters — the announced X is used once, not twice.
+        plusOneCounters(driver, walker) shouldBe 3
+        val projected = projector.project(driver.state)
+        projected.getPower(walker) shouldBe 3
+        projected.getToughness(walker) shouldBe 3
+    }
+
+    test("X=3 cannot be paid with only five mana — both {X} symbols are charged") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val walker = driver.putCardInHand(player, "Marketback Walker")
+        driver.giveMana(player, Color.RED, 5)
+
+        driver.submitExpectFailure(
+            CastSpell(
+                playerId = player,
+                cardId = walker,
+                xValue = 3,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+
+        // Still in hand, nothing spent on a half-paid cast.
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(walker) shouldBe true
+    }
+
+    test("X=0 makes a 0/0 that dies immediately to state-based actions and draws nothing") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val walker = driver.putCardInHand(player, "Marketback Walker")
+        driver.giveMana(player, Color.RED, 1)
+
+        val handBefore = driver.getHand(player).size
+
+        driver.castXSpell(player, walker, xValue = 0).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 0/0 with no counters — SBAs bin it the moment it lands (CR 704.5f).
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(walker) shouldBe true
+
+        // The dies trigger still fires; it just draws zero cards. Net hand change is
+        // -1 (the Walker left) and +0 drawn.
+        driver.bothPass()
+        driver.getHand(player).size shouldBe handBefore - 1
+    }
+
+    test("dies trigger draws one card per +1/+1 counter, counting the {4}-ability counter") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val walker = driver.putCardInHand(player, "Marketback Walker")
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        // 4 to cast at X=2, then 4 more for the activated ability, then {R} for the Bolt.
+        driver.giveMana(player, Color.RED, 9)
+
+        driver.castXSpell(player, walker, xValue = 2).isSuccess shouldBe true
+        driver.bothPass()
+        plusOneCounters(driver, walker) shouldBe 2
+
+        // {4}: Put a +1/+1 counter on this creature → 3/3 with three counters.
+        val addCounter = driver.cardRegistry.requireCard("Marketback Walker").activatedAbilities[0].id
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = walker,
+                abilityId = addCounter,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        plusOneCounters(driver, walker) shouldBe 3
+
+        val handBefore = driver.getHand(player).size
+
+        // 3 damage to a 3/3 is lethal.
+        driver.castSpell(player, bolt, targets = listOf(walker)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(walker) shouldBe true
+
+        // Dies trigger resolves: three counters → three cards. The Walker is already a graveyard
+        // card with no counters by then, so the count comes from last-known information.
+        driver.bothPass()
+        driver.getHand(player).size shouldBe handBefore - 1 + 3
+    }
+})


### PR DESCRIPTION
Implements five cards canonical to Aetherdrift plus one DFT reprint whose canonical printing belongs in an earlier set.

## Cards

| Card | Cost | What it needed |
|---|---|---|
| **Spectral Interference** (DFT #63) | `{1}{U}` | `CounterUnlessPays("{4}")` over `CreatureOrArtifact` restricted to the stack |
| **Voyager Quickwelder** (DFT #37) | `{2}{W}` | `ModifySpellCost` / `ReduceGeneric(1)` on `YouCast(Artifact)` |
| **Scrap Compactor** (DFT #242) | `{1}` | Two sacrifice-priced activated abilities; the second reaches Vehicles via `CreatureOrVehicle` |
| **Wreck Remover** (DFT #247) | `{4}` | Enters/attacks graveyard exile (up-to-one) with unconditional 1 life, plus cycling `{2}` |
| **Marketback Walker** (DFT #235) | `{X}{X}` | Enters with X `+1/+1` counters; dies-draw off last-known counters |
| **Gearseeker Serpent** | `{5}{U}{U}` | Affinity for artifacts + `CANT_BE_BLOCKED` grant |

All six compose existing SDK primitives — no new effects, triggers, or keywords, so no SDK reference changes.

## Canonical placement

Gearseeker Serpent's earliest real printing is **Kaladesh (2016)**, not Aetherdrift, so the `CardDefinition` lands in `definitions/kld/cards/` and both scaffolded reprint sets get presentation-only `Printing` rows (DFT #43, J22 #302). `just check-card-printing` is clean for all six.

## Testing

Only Marketback Walker sits on a lightly-trodden path: a doubled `{X}` on a *card's* mana cost, where the announced X is paid once per symbol (`ManaCost.xCount`) but yields counters only once. The prior precedent in the repo was an activated-ability cost, not a card cost, so `MarketbackWalkerScenarioTest` pins it down:

- X=3 enters as a 3/3 with three counters and costs six mana
- X=3 is **rejected** with only five mana — both `{X}` symbols are charged
- X=0 is a 0/0 that state-based actions bin immediately, drawing nothing
- the dies trigger draws one card per counter (including one added by `{4}`), reading the count from last-known information after the Walker is already in the graveyard

`just build` is green. Card snapshots reblessed for DFT and KLD — **insertions only**, no existing card tree moved.

## Skipped deliberately

Several other unimplemented DFT cards (Dynamite Diver, Cloudspire Captain, Deathless Pilot, Marauding Mako) need engine capability that doesn't exist yet — "saddles/crews as though its power were 2 greater", and a trigger context key for the number of cards discarded in a batch. Those are `add-feature` work, not card authoring, so they were left out rather than approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)