### PR TITLE
Add six Aetherdrift cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1869,6 +1869,12 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   so the count is readable downstream as `DynamicAmount.VariableReference("${storeAs}_count")` — e.g.
   Miasma Demon wires this as the `ReflexiveTriggerEffect` action and reads `discarded_count` as the
   reflexive targets' `dynamicMaxCount` ("up to that many target creatures").
+- `discardUpToThenDraw(max, draw?, storeAs?, prompt?)` — "discard up to N cards, then draw that many
+  cards" (Tersa Lightshatter, Sokka, Bold Boomeranger, Greasewrench Goblin). Loot backwards: the
+  selection is `SelectionMode.ChooseUpTo(max)` so declining entirely is legal and then nothing is drawn,
+  and the draw defaults to `DynamicAmount.VariableReference("${storeAs}_count")` — the number *actually*
+  discarded, not `max`. `max` takes an `Int` or a `DynamicAmount` ("discard up to X cards"); pass `draw`
+  to decouple the payoff from the discard ("discard up to two cards, then draw three").
 - `discardRandom(count, target)` — random discards.
 - `discardHand(target)` — discard entire hand.
 - `eachOpponentDiscards(count, controllerDrawsPerDiscard?)` — Mind Twist-style.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -473,6 +473,58 @@ object HandPatterns {
     )
 
     /**
+     * Fixed-ceiling [discardUpToThenDraw] — "discard up to [max] cards, then draw that many cards",
+     * the wording Tersa Lightshatter, Sokka, Bold Boomeranger and Greasewrench Goblin all print
+     * verbatim. Only the prompt differs from the [DynamicAmount] overload, which can name the number.
+     */
+    fun discardUpToThenDraw(
+        max: Int,
+        draw: DynamicAmount? = null,
+        storeAs: String = "discarded",
+        prompt: String = "Discard up to $max card${if (max != 1) "s" else ""}",
+    ): CompositeEffect = discardUpToThenDraw(DynamicAmount.Fixed(max), draw, storeAs, prompt)
+
+    /**
+     * "Discard up to [max] cards, then draw that many cards" — loot run backwards.
+     *
+     * The bound matters twice: the selection is *up to* [max], so declining entirely is legal and
+     * then nothing is drawn, and the number drawn is the number **actually** discarded rather than
+     * [max] — read off the pipeline collection's `${storeAs}_count`, so a player holding one card
+     * discards one and draws one. Same Gather → Select → Move spine as [discardAnyNumber], with the
+     * ceiling applied at the select step.
+     *
+     * Both halves are [DynamicAmount]s. [max] takes a resolution-time ceiling ("discard up to X
+     * cards" off a cast X, or a count of permanents). [draw] defaults to `null`, meaning the printed
+     * "that many"; pass one to decouple the draw from the discard — a cost-shaped discard whose
+     * payoff is a flat or separately-scaled draw ("discard up to two cards, then draw three").
+     */
+    fun discardUpToThenDraw(
+        max: DynamicAmount,
+        draw: DynamicAmount? = null,
+        storeAs: String = "discarded",
+        prompt: String = "Choose cards to discard",
+    ): CompositeEffect = CompositeEffect(
+        listOf(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You),
+                storeAs = "${storeAs}_candidates"
+            ),
+            SelectFromCollectionEffect(
+                from = "${storeAs}_candidates",
+                selection = SelectionMode.ChooseUpTo(max),
+                storeSelected = storeAs,
+                prompt = prompt
+            ),
+            MoveCollectionEffect(
+                from = storeAs,
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                moveType = MoveType.Discard
+            ),
+            DrawCardsEffect(draw ?: DynamicAmount.VariableReference("${storeAs}_count"))
+        )
+    )
+
+    /**
      * Read the Runes-style "draw X, then for each card drawn discard a card unless
      * you sacrifice a permanent" pipeline. Loops X times via [RepeatDynamicTimesEffect]
      * (iteration count = the X paid for the spell); each iteration presents a

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GreasewrenchGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GreasewrenchGoblin.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Greasewrench Goblin — Aetherdrift #132
+ * {R} · Creature — Goblin Artificer · 2/1
+ *
+ * Exhaust — {2}{R}: Discard up to two cards, then draw that many cards. Put a +1/+1 counter on
+ * this creature.
+ *
+ * `isExhaust = true` carries both halves of CR 702.177: the "Exhaust — " prefix and the
+ * [com.wingedsheep.sdk.scripting.ActivationRestriction.Once] that makes it once per *object* — so a
+ * Goblin that leaves and returns may exhaust again.
+ *
+ * The discard is genuinely optional (Scryfall ruling 2025-02-07: "You may activate this creature's
+ * exhaust ability without discarding cards if you just want to put a +1/+1 counter on it"), and the
+ * counter is a sibling of the loot rather than a rider on it — it lands even when zero cards are
+ * discarded and zero drawn.
+ */
+val GreasewrenchGoblin = card("Greasewrench Goblin") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Artificer"
+    power = 2
+    toughness = 1
+    oracleText = "Exhaust — {2}{R}: Discard up to two cards, then draw that many cards. Put a " +
+        "+1/+1 counter on this creature. (Activate each exhaust ability only once.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        isExhaust = true
+        // The printed text goes on the *effect*, not the ability: `description` here would be a
+        // `descriptionOverride` that swallows the auto-rendered "Exhaust — {2}{R}: " prefix, leaving
+        // the action button with no cost and no exhaust marker.
+        effect = Effects.Composite(
+            effects = listOf(
+                Patterns.Hand.discardUpToThenDraw(2),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            ),
+            descriptionOverride = "Discard up to two cards, then draw that many cards. " +
+                "Put a +1/+1 counter on this creature."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "132"
+        artist = "Alexandre Honoré"
+        flavorText = "Killswitch finally had the right wrench for the job. Now she needed to remember what the job was."
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg?1783907881"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LoxodonSurveyor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LoxodonSurveyor.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Surveyor — Aetherdrift #167
+ * {2}{G} · Creature — Elephant Scout · 3/3
+ *
+ * Start your engines!
+ * Max speed — {3}, Exile this card from your graveyard: Draw a card.
+ *
+ * The Surveyor cycle's graveyard ability is the one max-speed shape that functions outside the
+ * battlefield, and the rules say the gate follows it there (Scryfall ruling 2025-02-07: "If the
+ * granted ability functions in a zone other than the battlefield, the max speed ability does too").
+ * That falls out of the vocabulary: `maxSpeed { }` gates activated abilities with
+ * `ActivationRestriction.OnlyIfCondition`, and `GraveyardAbilityEnumerator` runs the same
+ * restriction check as the battlefield enumerator, resolving `Player.You` to the player who would
+ * activate — the card's owner while it sits in their graveyard.
+ */
+val LoxodonSurveyor = card("Loxodon Surveyor") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant Scout"
+    power = 3
+    toughness = 3
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — {3}, Exile this card from your graveyard: Draw a card."
+
+    startYourEngines()
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(Costs.Mana("{3}"), Costs.ExileSelf)
+            effect = Effects.DrawCards(1)
+            activateFromZone = Zone.GRAVEYARD
+            description = "{3}, Exile this card from your graveyard: Draw a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "J.P. Targete"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg?1783907870"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/NestingBot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/NestingBot.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Nesting Bot — Aetherdrift #22
+ * {W} · Artifact Creature — Robot · 1/1
+ *
+ * Start your engines!
+ * When this creature dies, create a 1/1 colorless Servo artifact creature token.
+ * Max speed — This creature gets +1/+0.
+ *
+ * The dies trigger is unconditional — it is *not* under the max-speed gate, so the Servo arrives
+ * whatever the controller's speed is. Only the +1/+0 is gated, as a [ModifyStats] static that the
+ * projection re-evaluates every pass; speed dropping is impossible today, but the gate is read
+ * rather than latched either way.
+ */
+val NestingBot = card("Nesting Bot") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Robot"
+    power = 1
+    toughness = 1
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "When this creature dies, create a 1/1 colorless Servo artifact creature token.\n" +
+        "Max speed — This creature gets +1/+0."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Servo"),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg?1783907678"
+        )
+        description = "When this creature dies, create a 1/1 colorless Servo artifact creature token."
+    }
+
+    maxSpeed {
+        staticAbility { ability = ModifyStats(1, 0, GroupFilter.source()) }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "22"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg?1783907917"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StallOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StallOut.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stall Out — Aetherdrift #66
+ * {1}{U} · Sorcery
+ *
+ * Tap target creature or Vehicle, then put three stun counters on it.
+ * Cycling {2}
+ *
+ * Tap and counters are one composite on a single target, in printed order: an already-tapped
+ * creature still receives all three stun counters, and the counters land on an uncrewed Vehicle
+ * just as well (a Vehicle matches [GameObjectFilter.CreatureOrVehicle] by subtype whether or not it
+ * is currently a creature — and tapping it is what the card is for).
+ */
+val StallOut = card("Stall Out") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Tap target creature or Vehicle, then put three stun counters on it. (If a " +
+        "permanent with a stun counter would become untapped, remove one from it instead.)\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target(
+            "target creature or Vehicle",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle))
+        )
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            Effects.AddCounters(Counters.STUN, 3, t)
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Inkognit"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg?1783907902"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StartingColumn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StartingColumn.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Starting Column — Aetherdrift #244
+ * {3} · Artifact
+ *
+ * Start your engines!
+ * {T}: Add one mana of any color.
+ * Max speed — {T}, Sacrifice this artifact: Draw two cards, then discard a card.
+ *
+ * Two abilities that compete for the same tap: the mana ability is always available, and at max
+ * speed the Column can instead cash itself in. The second is not a mana ability (it draws), so it
+ * uses the stack and can be responded to, which is why only the first carries `manaAbility = true`.
+ */
+val StartingColumn = card("Starting Column") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{T}: Add one mana of any color.\n" +
+        "Max speed — {T}, Sacrifice this artifact: Draw two cards, then discard a card."
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        description = "{T}: Add one mana of any color."
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+            effect = Patterns.Hand.loot(draw = 2, discard = 1)
+            description = "{T}, Sacrifice this artifact: Draw two cards, then discard a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "244"
+        artist = "Jakub Kasper"
+        flavorText = "Ten teams. Ten dreams. One winner."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg?1783907846"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StreakingOilgorger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/StreakingOilgorger.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Streaking Oilgorger — Aetherdrift #107
+ * {4}{B} · Creature — Vampire · 3/3
+ *
+ * Flying, haste
+ * Start your engines!
+ * Max speed — This creature has lifelink.
+ */
+val StreakingOilgorger = card("Streaking Oilgorger") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, haste\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — This creature has lifelink."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+    startYourEngines()
+    maxSpeed { keywords(Keyword.LIFELINK) }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Campbell White"
+        flavorText = "\"They feed on OIL? Where were they during the Phyrexian Invasion?!\"\n—Chandra Nalaar"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg?1783907889"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TersaLightshatter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/TersaLightshatter.kt
@@ -3,13 +3,13 @@ package com.wingedsheep.mtg.sets.definitions.tdm.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
@@ -43,30 +43,10 @@ val TersaLightshatter = card("Tersa Lightshatter") {
 
     keywords(Keyword.HASTE)
 
-    // ETB loot: discard up to two, then draw that many. The draw count reads the actual number
-    // discarded via the pipeline collection's `_count` (declining discards draws zero).
+    // ETB loot run backwards: discard up to two, then draw that many (declining discards draws zero).
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Composite(
-            listOf(
-                GatherCardsEffect(
-                    source = CardSource.FromZone(Zone.HAND, Player.You),
-                    storeAs = "hand"
-                ),
-                SelectFromCollectionEffect(
-                    from = "hand",
-                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
-                    storeSelected = "discarded",
-                    prompt = "Discard up to two cards"
-                ),
-                MoveCollectionEffect(
-                    from = "discarded",
-                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
-                    moveType = MoveType.Discard
-                ),
-                DrawCardsEffect(DynamicAmount.VariableReference("discarded_count"))
-            )
-        )
+        effect = Patterns.Hand.discardUpToThenDraw(2)
         description = "When Tersa Lightshatter enters, discard up to two cards, then draw that many cards."
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SokkaBoldBoomeranger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SokkaBoldBoomeranger.kt
@@ -2,23 +2,13 @@ package com.wingedsheep.mtg.sets.definitions.tla.cards
 
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Subtype
-import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.CardDestination
-import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
-import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.MoveType
-import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.SelectionMode
-import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Sokka, Bold Boomeranger — Avatar: The Last Airbender #240
@@ -37,30 +27,10 @@ val SokkaBoldBoomeranger = card("Sokka, Bold Boomeranger") {
     oracleText = "When Sokka enters, discard up to two cards, then draw that many cards.\n" +
         "Whenever you cast an artifact or Lesson spell, put a +1/+1 counter on Sokka."
 
-    // ETB loot: discard up to two, then draw that many. The draw count reads the actual number
-    // discarded via the pipeline collection's `_count` (declining discards draws zero).
+    // ETB loot run backwards: discard up to two, then draw that many (declining discards draws zero).
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = Effects.Composite(
-            listOf(
-                GatherCardsEffect(
-                    source = CardSource.FromZone(Zone.HAND, Player.You),
-                    storeAs = "hand"
-                ),
-                SelectFromCollectionEffect(
-                    from = "hand",
-                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
-                    storeSelected = "discarded",
-                    prompt = "Discard up to two cards"
-                ),
-                MoveCollectionEffect(
-                    from = "discarded",
-                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
-                    moveType = MoveType.Discard
-                ),
-                DrawCardsEffect(DynamicAmount.VariableReference("discarded_count"))
-            )
-        )
+        effect = Patterns.Hand.discardUpToThenDraw(2)
         description = "When Sokka enters, discard up to two cards, then draw that many cards."
     }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2680,6 +2680,100 @@
     ]
 }
 
+// Greasewrench Goblin
+{
+    "name": "Greasewrench Goblin",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Artificer",
+    "oracleText": "Exhaust — {2}{R}: Discard up to two cards, then draw that many cards. Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "discarded_candidates"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "discarded_candidates",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Discard up to 2 cards"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                },
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "VariableReference",
+                                        "variableName": "discarded_count"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ],
+                    "descriptionOverride": "Discard up to two cards, then draw that many cards. Put a +1/+1 counter on this creature."
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "rarity": "UNCOMMON",
+        "artist": "Alexandre Honoré",
+        "flavorText": "Killswitch finally had the right wrench for the job. Now she needed to remember what the job was.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8f0b123-fdb0-4f3e-ba78-fa155c227e20.jpg?1783907881"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Greenbelt Guardian
 {
     "name": "Greenbelt Guardian",
@@ -3431,6 +3525,73 @@
     ]
 }
 
+// Loxodon Surveyor
+{
+    "name": "Loxodon Surveyor",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elephant Scout",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — {3}, Exile this card from your graveyard: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "Max speed — {3}, Exile this card from your graveyard: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "J.P. Targete",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd1cecb1-6776-4495-be56-b7dde65453f1.jpg?1783907870"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Marketback Walker
 {
     "name": "Marketback Walker",
@@ -3713,6 +3874,78 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Nesting Bot
+{
+    "name": "Nesting Bot",
+    "manaCost": "{W}",
+    "typeLine": "Artifact Creature — Robot",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature dies, create a 1/1 colorless Servo artifact creature token.\nMax speed — This creature gets +1/+0.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Servo"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/0/10de413b-3307-4bc7-bb21-f177543d7e21.jpg?1783907678",
+                    "artifactToken": true
+                },
+                "descriptionOverride": "When this creature dies, create a 1/1 colorless Servo artifact creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "UNCOMMON",
+        "artist": "Racrufi",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/7829c0ae-f72f-4195-ad43-775d7218565c.jpg?1783907917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -5512,6 +5745,60 @@
     ]
 }
 
+// Stall Out
+{
+    "name": "Stall Out",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Tap target creature or Vehicle, then put three stun counters on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle"
+                    }
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "stun",
+                    "count": 3,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|Vehicle"
+                },
+                "id": "target creature or Vehicle"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Inkognit",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ea0e0d3-833f-4353-b648-57b0b657cc1c.jpg?1783907902"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Stampeding Scurryfoot
 {
     "name": "Stampeding Scurryfoot",
@@ -5571,6 +5858,108 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Starting Column
+{
+    "name": "Starting Column",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add one mana of any color.\nMax speed — {T}, Sacrifice this artifact: Draw two cards, then discard a card.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — {T}, Sacrifice this artifact: Draw two cards, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "artist": "Jakub Kasper",
+        "flavorText": "Ten teams. Ten dreams. One winner.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0530b343-98c2-440a-b32e-d1566d318c3b.jpg?1783907846"
+    },
+    "colorIdentityOverride": []
 }
 
 // Stock Up
@@ -5637,6 +6026,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Streaking Oilgorger
+{
+    "name": "Streaking Oilgorger",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Flying, haste\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — This creature has lifelink.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE",
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Campbell White",
+        "flavorText": "\"They feed on OIL? Where were they during the Phyrexian Invasion?!\"\n—Chandra Nalaar",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6ff120a2-e2bb-42a2-bcb7-a48eb7a6d9b2.jpg?1783907889"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -16753,11 +16753,11 @@
                                 "type": "FromZone",
                                 "zone": "Hand"
                             },
-                            "storeAs": "hand"
+                            "storeAs": "discarded_candidates"
                         },
                         {
                             "type": "SelectFromCollection",
-                            "from": "hand",
+                            "from": "discarded_candidates",
                             "selection": {
                                 "type": "ChooseUpTo",
                                 "count": {
@@ -16766,7 +16766,7 @@
                                 }
                             },
                             "storeSelected": "discarded",
-                            "prompt": "Discard up to two cards"
+                            "prompt": "Discard up to 2 cards"
                         },
                         {
                             "type": "MoveCollection",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -17118,11 +17118,11 @@
                                 "type": "FromZone",
                                 "zone": "Hand"
                             },
-                            "storeAs": "hand"
+                            "storeAs": "discarded_candidates"
                         },
                         {
                             "type": "SelectFromCollection",
-                            "from": "hand",
+                            "from": "discarded_candidates",
                             "selection": {
                                 "type": "ChooseUpTo",
                                 "count": {
@@ -17131,7 +17131,7 @@
                                 }
                             },
                             "storeSelected": "discarded",
-                            "prompt": "Discard up to two cards"
+                            "prompt": "Discard up to 2 cards"
                         },
                         {
                             "type": "MoveCollection",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftDriftersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftDriftersScenarioTest.kt
@@ -1,0 +1,297 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Four Aetherdrift cards whose behaviour isn't already covered by the mechanic-level suites:
+ *
+ * | Card | Under test |
+ * |---|---|
+ * | Greasewrench Goblin | `Patterns.Hand.discardUpToThenDraw` — the draw counts what was *actually* discarded, and the exhaust fires once |
+ * | Loxodon Surveyor | a max-speed gate on an ability that functions from the **graveyard** |
+ * | Nesting Bot | an ungated dies trigger under a gated P/T buff |
+ * | Stall Out | tap-then-stun on one target |
+ */
+class AetherdriftDriftersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Greasewrench Goblin") {
+
+            test("discarding two draws two, and the +1/+1 counter lands alongside") {
+                val game = goblinGame(handCards = 2)
+                val goblin = game.findPermanent("Greasewrench Goblin")!!
+                val handBefore = game.handSize(1)
+
+                game.activateExhaust(goblin)
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears").take(2))
+                game.resolveStack()
+
+                withClue("Two discarded, two drawn — hand size is unchanged") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("Both chosen cards are in the graveyard") {
+                    game.graveyardSize(1) shouldBe 2
+                }
+                withClue("The counter is a sibling of the loot, not a rider on it") {
+                    game.plusOneCounters(goblin) shouldBe 1
+                }
+            }
+
+            test("declining the discard draws nothing but still adds the counter") {
+                val game = goblinGame(handCards = 2)
+                val goblin = game.findPermanent("Greasewrench Goblin")!!
+                val handBefore = game.handSize(1)
+                val libraryBefore = game.librarySize(1)
+
+                game.activateExhaust(goblin)
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Ruling 2025-02-07: activating without discarding is legal, and draws zero") {
+                    game.handSize(1) shouldBe handBefore
+                    game.librarySize(1) shouldBe libraryBefore
+                    game.graveyardSize(1) shouldBe 0
+                }
+                withClue("The counter still lands") { game.plusOneCounters(goblin) shouldBe 1 }
+            }
+
+            test("discarding one card draws exactly one, not the ceiling of two") {
+                val game = goblinGame(handCards = 1)
+                val goblin = game.findPermanent("Greasewrench Goblin")!!
+                val libraryBefore = game.librarySize(1)
+
+                game.activateExhaust(goblin)
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears").take(1))
+                game.resolveStack()
+
+                withClue("The draw reads discarded_count, so one discard means one draw") {
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                    game.graveyardSize(1) shouldBe 1
+                }
+            }
+
+            test("the exhaust ability can only be activated once") {
+                val game = goblinGame(handCards = 0, lands = 6)
+                val goblin = game.findPermanent("Greasewrench Goblin")!!
+
+                // Empty hand: the gather yields nothing, so there is no discard prompt to answer.
+                game.activateExhaust(goblin)
+                withClue("Nothing to discard, so no selection decision is raised") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.resolveStack()
+
+                val second = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = goblin,
+                        abilityId = exhaustAbilityId()
+                    )
+                )
+                withClue("CR 702.177a: activate each exhaust ability only once") {
+                    (second.error != null).shouldBeTrue()
+                }
+            }
+        }
+
+        context("Loxodon Surveyor") {
+
+            test("its graveyard ability is gated on max speed and exiles the card to draw") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Loxodon Surveyor")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val surveyor = game.findCardsInGraveyard(1, "Loxodon Surveyor").single()
+                val abilityId = cardRegistry.getCard("Loxodon Surveyor")!!
+                    .script.activatedAbilities.single().id
+
+                val blocked = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = surveyor, abilityId = abilityId)
+                )
+                withClue("Below max speed the graveyard ability isn't there to activate") {
+                    (blocked.error != null).shouldBeTrue()
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+                val libraryBefore = game.librarySize(1)
+
+                val allowed = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = surveyor, abilityId = abilityId)
+                )
+                withClue("At max speed the gate opens in the graveyard too: ${allowed.error}") {
+                    allowed.error shouldBe null
+                }
+                game.autoPayIfAsked()
+                game.resolveStack()
+
+                withClue("Exiled as a cost, and one card drawn") {
+                    game.isInExile(1, "Loxodon Surveyor") shouldBe true
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                }
+            }
+        }
+
+        context("Nesting Bot") {
+
+            test("leaves a Servo behind when it dies below max speed") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nesting Bot", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Strike")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val bot = game.findPermanent("Nesting Bot")!!
+                withClue("Speed 1: the +1/+0 gate is shut, so it's still a 1/1") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                    game.state.projectedState.getPower(bot) shouldBe 1
+                }
+
+                // Three damage to the 1/1 kills it for real, so the dies trigger actually fires
+                // (the moveToGraveyard test helper skips dies triggers by design).
+                val bolt = game.castSpell(1, "Lightning Strike", bot)
+                withClue("Lightning Strike cast failed: ${bolt.error}") { bolt.error shouldBe null }
+                game.autoPayIfAsked()
+                game.resolveStack()
+
+                withClue("The dies trigger is ungated, so the Servo arrives at speed 1") {
+                    game.isOnBattlefield("Nesting Bot") shouldBe false
+                    game.servoTokens() shouldBe 1
+                }
+            }
+
+            test("gets +1/+0 at max speed") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Nesting Bot", summoningSickness = false)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                val bot = game.findPermanent("Nesting Bot")!!
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                withClue("1/1 becomes 2/1") {
+                    game.state.projectedState.getPower(bot) shouldBe 2
+                    game.state.projectedState.getToughness(bot) shouldBe 1
+                }
+            }
+        }
+
+        context("Stall Out") {
+
+            test("taps the target and puts three stun counters on it") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Stall Out")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Stall Out", bear)
+                withClue("Cast failed: ${cast.error}") { cast.error shouldBe null }
+                game.autoPayIfAsked()
+                game.resolveStack()
+
+                withClue("Tapped, and holding three stun counters") {
+                    game.state.getEntity(bear)!!.get<TappedComponent>().shouldNotBeNull()
+                    game.state.getEntity(bear)?.get<CountersComponent>()
+                        ?.getCount(CounterType.STUN) shouldBe 3
+                }
+            }
+        }
+    }
+
+    /**
+     * Player 1's precombat main phase with Greasewrench Goblin out, [handCards] discardable cards in
+     * hand and enough red mana for the exhaust. Built in the upkeep step so the CR 704.5z
+     * start-your-engines state-based action has a step change to run on.
+     */
+    private fun goblinGame(handCards: Int, lands: Int = 3): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Greasewrench Goblin", summoningSickness = false)
+            .withLandsOnBattlefield(1, "Mountain", lands)
+        if (handCards > 0) builder.withCardsInHand(1, "Grizzly Bears", handCards)
+        stockLibraries(builder)
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+
+    /** Both libraries stocked so nobody decks out and draws always have something to take. */
+    private fun stockLibraries(builder: ScenarioBuilder) {
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+
+    private fun exhaustAbilityId() =
+        cardRegistry.getCard("Greasewrench Goblin")!!
+            .script.activatedAbilities.single { it.isExhaust }.id
+
+    /** Activate the exhaust ability, pay for it, and resolve up to the discard decision. */
+    private fun TestGame.activateExhaust(sourceId: EntityId) {
+        val result = execute(
+            ActivateAbility(playerId = player1Id, sourceId = sourceId, abilityId = exhaustAbilityId())
+        )
+        withClue("Exhaust activation failed: ${result.error}") { result.error shouldBe null }
+        autoPayIfAsked()
+        resolveStack()
+    }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Servo artifact creature tokens on the battlefield. */
+    private fun TestGame.servoTokens(): Int =
+        state.getBattlefield().count { id ->
+            val container = state.getEntity(id) ?: return@count false
+            container.has<TokenComponent>() &&
+                container.get<CardComponent>()?.typeLine?.subtypes?.any { it.value == "Servo" } == true
+        }
+
+    /** Submit auto-pay if the engine paused for a mana-source decision. */
+    private fun TestGame.autoPayIfAsked() {
+        if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+    }
+}


### PR DESCRIPTION
Six more Aetherdrift cards, all canonical to DFT (single printing, expansion) — nothing needed relocating.

| Card | # | What it needed |
|---|---|---|
| Nesting Bot | 22 | start your engines! + an **ungated** dies trigger (Servo token) under a max-speed-gated +1/+0 |
| Stall Out | 66 | tap-then-stun on one creature-or-Vehicle target, cycling {2} |
| Streaking Oilgorger | 107 | flying/haste; max speed grants lifelink |
| Greasewrench Goblin | 132 | exhaust {2}{R}: loot backwards, plus a +1/+1 counter that lands even on zero discards |
| Loxodon Surveyor | 167 | the one max-speed shape that functions from the **graveyard** |
| Starting Column | 244 | any-color mana ability + max-speed tap-and-sacrifice for draw two/discard one |

## The two worth proving

**Loxodon Surveyor's gate has to follow the ability out of the battlefield** — "if the granted ability functions in a zone other than the battlefield, the max speed ability does too" (ruling 2025-02-07). It does, and for a reason worth recording: `GraveyardAbilityEnumerator` runs the same activation-restriction check as the battlefield enumerator, and `CastPermissionUtils` resolves `Player.You` to the player who *would* activate — the owner, while the card sits in their graveyard. The test covers both sides of the gate.

**"Discard up to two cards, then draw that many"** is now the third card in the corpus printing that line verbatim (Tersa Lightshatter, Sokka, Bold Boomeranger), so the inlined four-step pipeline moved behind `Patterns.Hand.discardUpToThenDraw` and both existing cards call it. Ceiling and draw are both `DynamicAmount`s — the ceiling so "discard up to X cards" is expressible, the draw so a card can decouple its payoff from the discard, defaulting to the printed "that many".

One UX trap caught in review: the Goblin's printed text lives on the **effect**, not the ability. A `description` on the `activatedAbility` is a `descriptionOverride`, and that swallows the auto-rendered `"Exhaust — {2}{R}: "` prefix — leaving an action button with no cost and no exhaust marker.

## Verification

- `AetherdriftDriftersScenarioTest` — 8 new tests, all passing: Greasewrench Goblin discarding two / discarding one (draws one, not the ceiling of two) / declining entirely (draws zero, counter still lands) / once-per-object exhaust; Loxodon Surveyor's graveyard gate both sides; Nesting Bot's dies trigger firing at speed 1 and its +1/+0 at max speed; Stall Out's tap + three stun counters.
- `TersaLightshatterScenarioTest` still green after the migration.
- `just build`, full `:mtg-sets:test` (snapshot, card lint, facade boundary, image URIs, catalog), `just check-card-printing` for all six.
- All seven image URIs (six cards + the Servo token) verified HTTP 200.
- Snapshots: DFT is insertions only; TDM/TLA move by three lines each — the shared pattern's collection names and prompt wording, no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)