### PR TITLE
Add five more Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArchonsGlory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArchonsGlory.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Archon's Glory
+ * {W}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Target creature gets +2/+2 until end of turn. If this spell was bargained, that creature also
+ * gains flying and lifelink until end of turn.
+ *
+ * The spell-rider shape of bargain (CR 702.166c), the same one [CandyGrapple] uses: the bargained
+ * fact is stamped on the spell as it's cast, so the payoff is a [ConditionalEffect] gated on
+ * [Conditions.WasBargained] and read while the spell is still resolving.
+ *
+ * "Also" rather than "instead" here, so the two halves simply stack: the +2/+2 always applies and
+ * the bargained branch adds two layer 6 keyword grants on top of it. All three share the one
+ * target requirement, so the creature is chosen once at announcement — and if it's an illegal
+ * target by resolution the whole spell fizzles, bargained or not.
+ */
+val ArchonsGlory = card("Archon's Glory") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Target creature gets +2/+2 until end of turn. If this spell was bargained, that creature " +
+        "also gains flying and lifelink until end of turn."
+
+    bargain()
+
+    spell {
+        val creature = target("target creature", TargetCreature())
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 2, toughness = 2, target = creature),
+            ConditionalEffect(
+                condition = Conditions.WasBargained,
+                effect = Effects.Composite(
+                    Effects.GrantKeyword(Keyword.FLYING, creature),
+                    Effects.GrantKeyword(Keyword.LIFELINK, creature),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "A winged dawn dispels the terrors of night."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg?1783915136"
+
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HighFaeNegotiator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HighFaeNegotiator.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * High Fae Negotiator
+ * {3}{B}{B}
+ * Creature — Faerie Warlock
+ * 3/5
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Flying
+ * When this creature enters, if it was bargained, each opponent loses 3 life and you gain 3 life.
+ *
+ * The permanent shape of bargain (CR 702.166b), same as [TroublemakerOuphe]: the bargained fact is
+ * stamped on the spell and rides the permanent it becomes, so the enters trigger can still read
+ * it. Modelled as an intervening-'if' clause (CR 603.4) on [Conditions.WasBargained] — an
+ * unbargained cast never puts the ability on the stack at all.
+ *
+ * The drain is *not* [Effects.DrainLife]: the life gain is a flat 3, not "life equal to the life
+ * lost this way", so with two or more opponents the Negotiator still gains exactly 3. That's a
+ * [Effects.LoseLife] over [Player.EachOpponent] composed with a fixed [Effects.GainLife], the same
+ * shape Sinister Monolith uses.
+ */
+val HighFaeNegotiator = card("High Fae Negotiator") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Warlock"
+    power = 3
+    toughness = 5
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Flying\n" +
+        "When this creature enters, if it was bargained, each opponent loses 3 life and you gain " +
+        "3 life."
+
+    bargain()
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasBargained
+        effect = Effects.Composite(
+            Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(3),
+        )
+        description = "When this creature enters, if it was bargained, each opponent loses 3 life " +
+            "and you gain 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Anna Christenson"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg?1783915107"
+
+        ruling(
+            "2023-09-01",
+            "You can bargain a permanent spell even if you won't be able to choose targets for an " +
+                "enters-the-battlefield ability of that permanent once the spell resolves."
+        )
+        ruling(
+            "2023-09-01",
+            "If a card or token enters the battlefield as a copy of a permanent that's already on the " +
+                "battlefield, the new permanent isn't bargained, even if the original was."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/NevaStalkedByNightmares.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/NevaStalkedByNightmares.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Neva, Stalked by Nightmares
+ * {2}{W}{B}
+ * Legendary Creature — Human Noble
+ * 2/2
+ *
+ * Menace
+ * When Neva enters, return target creature or enchantment card from your graveyard to your hand.
+ * Whenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1
+ * counter on Neva, then scry 1.
+ *
+ * Two triggers with nothing in common but the card they're printed on:
+ *
+ * 1. The enters trigger is a plain regrowth over the union filter
+ *    [GameObjectFilter.CreatureOrEnchantment], scoped to cards you own in [Zone.GRAVEYARD]. It's a
+ *    mandatory target — with an empty (or creature-and-enchantment-free) graveyard the ability
+ *    simply never goes on the stack, per CR 603.3d.
+ *
+ * 2. The enchantment-death trigger uses the generic `leavesBattlefield` factory with an
+ *    [TriggerBinding.ANY] binding, exactly as [WarehouseTabby] does, so it catches *every* route
+ *    to the graveyard — destroyed, sacrificed, or a Role token replaced by another Role. Enchantment
+ *    tokens do reach the graveyard before ceasing to exist, so Roles falling off count (WOE ruling).
+ *
+ * The counter and the scry are ordered, not simultaneous ("then"): [Effects.Composite] runs them in
+ * sequence. If Neva has already left the battlefield the counter finds nothing to land on and the
+ * scry still happens — which is also why an Aura attached to Neva when Neva itself leaves doesn't
+ * trigger this ability at all unless the same effect destroyed both.
+ */
+val NevaStalkedByNightmares = card("Neva, Stalked by Nightmares") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\n" +
+        "When Neva enters, return target creature or enchantment card from your graveyard to your " +
+        "hand.\n" +
+        "Whenever an enchantment you control is put into a graveyard from the battlefield, put a " +
+        "+1/+1 counter on Neva, then scry 1."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "target creature or enchantment card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.CreatureOrEnchantment.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.ReturnToHand(card)
+        description = "When Neva enters, return target creature or enchantment card from your " +
+            "graveyard to your hand."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Patterns.Library.scry(1),
+        )
+        description = "Whenever an enchantment you control is put into a graveyard from the " +
+            "battlefield, put a +1/+1 counter on Neva, then scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Tyler Jacobson"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg?1783915070"
+
+        ruling(
+            "2023-09-01",
+            "Enchantment tokens (such as Roles) that are sacrificed, destroyed, or would otherwise go " +
+                "to the graveyard are put into their owner's graveyard before ceasing to exist. If you " +
+                "controlled the token, Neva's ability will trigger."
+        )
+        ruling(
+            "2023-09-01",
+            "If Neva leaves the battlefield while it has an Aura you control attached to it or at the " +
+                "same time as another creature with an Aura you control attached to it, its ability " +
+                "won't trigger for those enchantments unless they were destroyed by the same effect " +
+                "that caused Neva to leave the battlefield."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TotentanzSwarmPiper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TotentanzSwarmPiper.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Totentanz, Swarm Piper
+ * {1}{B}{R}
+ * Legendary Creature — Human Warlock Bard
+ * 2/3
+ *
+ * Whenever Totentanz or another nontoken creature you control dies, create a 1/1 black Rat
+ * creature token with "This token can't block."
+ * {1}{B}: Target attacking Rat you control gains deathtouch until end of turn.
+ *
+ * "Totentanz or another nontoken creature you control" is one per-creature death trigger over
+ * nontoken creatures you control, bound [TriggerBinding.ANY] so Totentanz's own death counts —
+ * the same shape [VengefulBloodwitch] uses for "this creature or another creature you control
+ * dies". Per-creature (not once-per-event) is what the WOE ruling calls for: when Totentanz dies
+ * alongside other nontoken creatures you control, the ability triggers for each of them, so a
+ * board wipe makes a Rat for every one.
+ *
+ * The Rats it makes are tokens, so they never feed the trigger themselves — sacrificing the swarm
+ * doesn't snowball. The Rat itself is WOE's shared type-named token via [woeRatToken].
+ *
+ * The deathtouch grant targets an *attacking* Rat, so it's only castable once blockers matter;
+ * [TargetFilter] carries the attacking + Rat + you-control restriction so the engine rejects an
+ * illegal choice at announcement rather than fizzling on resolution.
+ */
+val TotentanzSwarmPiper = card("Totentanz, Swarm Piper") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Warlock Bard"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever Totentanz or another nontoken creature you control dies, create a 1/1 " +
+        "black Rat creature token with \"This token can't block.\"\n" +
+        "{1}{B}: Target attacking Rat you control gains deathtouch until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = woeRatToken()
+        description = "Whenever Totentanz or another nontoken creature you control dies, create a " +
+            "1/1 black Rat creature token with \"This token can't block.\""
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        val rat = target(
+            "target attacking Rat you control",
+            TargetCreature(
+                filter = TargetFilter.Creature.withSubtype(Subtype.RAT).youControl().attacking()
+            ),
+        )
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, rat)
+        description = "{1}{B}: Target attacking Rat you control gains deathtouch until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Matt Stewart"
+        flavorText = "Among the rats, he found the acceptance the human world never gave him."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg?1783915068"
+
+        ruling(
+            "2023-09-01",
+            "If Totentanz, Swarm Piper dies at the same time as one or more other nontoken creatures " +
+                "you control, Totentanz's ability triggers for each of them."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TuinvaleGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TuinvaleGuide.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Tuinvale Guide
+ * {3}{W}
+ * Creature — Faerie Scout
+ * 2/3
+ *
+ * Flying
+ * Celebration — This creature gets +1/+0 and has lifelink as long as two or more nonland
+ * permanents entered the battlefield under your control this turn.
+ *
+ * The static half of the Celebration ability word (CR 207.2c — italic flavor, no rules meaning),
+ * combining what [ArmoryMice] and [GallantPieWielder] each do on their own: one printed ability
+ * that touches layer 7c (the +1/+0) *and* layer 6 (lifelink), so it's a [CompositeStaticAbility]
+ * rather than two independent statics. Removing the ability removes both halves together, and the
+ * shared [Conditions.Celebration] gate is evaluated once per projection — so the bonus and the
+ * keyword appear and vanish in lockstep with the turn's second nonland permanent.
+ *
+ * Per the WOE rulings, Celebration is a pure past-events check: the two permanents don't have to
+ * still be on the battlefield or still be yours, and a third one adds nothing.
+ */
+val TuinvaleGuide = card("Tuinvale Guide") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Faerie Scout"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Celebration — This creature gets +1/+0 and has lifelink as long as two or more nonland " +
+        "permanents entered the battlefield under your control this turn."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CompositeStaticAbility(
+                listOf(
+                    ModifyStats(powerBonus = 1, toughnessBonus = 0, filter = Filters.Self),
+                    GrantKeyword(Keyword.LIFELINK, Filters.Self),
+                )
+            ),
+            condition = Conditions.Celebration,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "\"Weary traveler, follow me. The night is a cage, and my light is the key.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg?1783915125"
+
+        ruling(
+            "2023-09-01",
+            "The permanents that entered the battlefield don't need to remain on the battlefield or " +
+                "under your control. Celebration abilities are checking for past events, not the " +
+                "current game state."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,113 @@
     ]
 }
 
+// Archon's Glory
+{
+    "name": "Archon's Glory",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTarget creature gets +2/+2 until end of turn. If this spell was bargained, that creature also gains flying and lifelink until end of turn.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "BARGAINED"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "FLYING",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "LIFELINK",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "A winged dawn dispels the terrors of night.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e71768e7-4ef7-4fb2-838b-eb3a7f662d38.jpg?1783915136",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Armory Mice
 {
     "name": "Armory Mice",
@@ -3279,6 +3386,95 @@
     ]
 }
 
+// High Fae Negotiator
+{
+    "name": "High Fae Negotiator",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Faerie Warlock",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying\nWhen this creature enters, if it was bargained, each opponent loses 3 life and you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                },
+                "descriptionOverride": "When this creature enters, if it was bargained, each opponent loses 3 life and you gain 3 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Christenson",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0fc77e7-154d-4433-93b3-1a1dee34791b.jpg?1783915107",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You can bargain a permanent spell even if you won't be able to choose targets for an enters-the-battlefield ability of that permanent once the spell resolves."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a card or token enters the battlefield as a copy of a permanent that's already on the battlefield, the new permanent isn't bargained, even if the original was."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hollow Scavenger
 {
     "name": "Hollow Scavenger",
@@ -4605,6 +4801,95 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Neva, Stalked by Nightmares
+{
+    "name": "Neva, Stalked by Nightmares",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Menace\nWhen Neva enters, return target creature or enchantment card from your graveyard to your hand.\nWhenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Neva, then scry 1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or enchantment card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|enchantment own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature or enchantment card in your graveyard"
+                },
+                "descriptionOverride": "When Neva enters, return target creature or enchantment card from your graveyard to your hand."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Scry",
+                            "count": 1
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever an enchantment you control is put into a graveyard from the battlefield, put a +1/+1 counter on Neva, then scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Jacobson",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6f925ab-ade7-4da8-a791-185e098d18f2.jpg?1783915070",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Enchantment tokens (such as Roles) that are sacrificed, destroyed, or would otherwise go to the graveyard are put into their owner's graveyard before ceasing to exist. If you controlled the token, Neva's ability will trigger."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If Neva leaves the battlefield while it has an Aura you control attached to it or at the same time as another creature with an Aura you control attached to it, its ability won't trigger for those enchantments unless they were destroyed by the same effect that caused Neva to leave the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 
@@ -7759,6 +8044,95 @@
     ]
 }
 
+// Totentanz, Swarm Piper
+{
+    "name": "Totentanz, Swarm Piper",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Legendary Creature — Human Warlock Bard",
+    "oracleText": "Whenever Totentanz or another nontoken creature you control dies, create a 1/1 black Rat creature token with \"This token can't block.\"\n{1}{B}: Target attacking Rat you control gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                },
+                "descriptionOverride": "Whenever Totentanz or another nontoken creature you control dies, create a 1/1 black Rat creature token with \"This token can't block.\""
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking Rat you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Rat attacking ctrl:you"
+                        },
+                        "id": "target attacking Rat you control"
+                    }
+                ],
+                "descriptionOverride": "{1}{B}: Target attacking Rat you control gains deathtouch until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "flavorText": "Among the rats, he found the acceptance the human world never gave him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1422d6db-fe5b-4a89-951a-fbd7985a29fc.jpg?1783915068",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If Totentanz, Swarm Piper dies at the same time as one or more other nontoken creatures you control, Totentanz's ability triggers for each of them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Tough Cookie
 {
     "name": "Tough Cookie",
@@ -7945,6 +8319,78 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Tuinvale Guide
+{
+    "name": "Tuinvale Guide",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Faerie Scout",
+    "oracleText": "Flying\nCelebration — This creature gets +1/+0 and has lifelink as long as two or more nonland permanents entered the battlefield under your control this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CompositeStaticAbility",
+                    "abilities": [
+                        {
+                            "type": "ModifyStats",
+                            "powerBonus": 1,
+                            "toughnessBonus": 0,
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        }
+                    ]
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "\"Weary traveler, follow me. The night is a cage, and my light is the key.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01334fed-781e-4864-83fd-d37f787a778b.jpg?1783915125",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The permanents that entered the battlefield don't need to remain on the battlefield or under your control. Celebration abilities are checking for past events, not the current game state."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Five more Wilds of Eldraine cards, all composed from existing SDK primitives — no new effects, triggers, conditions, or keywords, so no engine change and no new scenario tests.

| Card | Cost | Shape |
|---|---|---|
| Tuinvale Guide | `{3}{W}` | Flying + the static half of Celebration |
| Archon's Glory | `{W}` | Bargain spell rider |
| High Fae Negotiator | `{3}{B}{B}` | Bargain permanent, enters drain |
| Totentanz, Swarm Piper | `{1}{B}{R}` | Nontoken dies trigger + targeted deathtouch grant |
| Neva, Stalked by Nightmares | `{2}{W}{B}` | Enters regrowth + enchantment-to-graveyard trigger |

### Modelling notes

**Tuinvale Guide** — "gets +1/+0 and has lifelink" is one printed ability spanning layer 7c and layer 6, so it's a `CompositeStaticAbility` under a single `Conditions.Celebration` gate rather than two independent statics: removing the ability removes both halves together, and the two are evaluated in lockstep.

**Archon's Glory** — the spell-rider shape of bargain (CR 702.166c), same as Candy Grapple. "Also" rather than "instead", so the bargained branch simply stacks two keyword grants on top of the unconditional +2/+2. All three share the one target requirement, so the creature is chosen once at announcement and the whole spell fizzles together on an illegal target.

**High Fae Negotiator** — the permanent shape of bargain (CR 702.166b): the flag rides the resolved permanent and the enters trigger reads it as an intervening-'if' (CR 603.4), so an unbargained cast never puts the ability on the stack. The life gain is a flat 3, *not* "life equal to the life lost this way" — so it's `LoseLife(EachOpponent) + GainLife(3)`, not `DrainLife`, and it still gains exactly 3 against multiple opponents.

**Totentanz, Swarm Piper** — "Totentanz or another nontoken creature you control dies" is one per-creature death trigger over nontoken creatures you control, bound `ANY` so Totentanz's own death counts. Per-creature rather than once-per-event is what the ruling requires: dying alongside other nontoken creatures triggers for each of them, so a board wipe makes a Rat per creature. The Rats are tokens and never feed the trigger themselves. The `{1}{B}` grant's `TargetFilter` carries attacking + Rat + you-control, so illegal picks are rejected at announcement rather than fizzling on resolution.

**Neva, Stalked by Nightmares** — the enters trigger is a mandatory-target regrowth over the `CreatureOrEnchantment` union filter scoped to cards you own in the graveyard, so with nothing legal it never goes on the stack (CR 603.3d). The second trigger reuses the `ANY`-bound enchantment-to-graveyard shape from Warehouse Tabby, catching destroyed / sacrificed / replaced Roles alike. Counter and scry are ordered ("then"), not simultaneous.

### Rulings recorded

Celebration as a past-events check; bargain's one-permanent limit and copy semantics; Totentanz triggering per creature on a wipe; Neva firing for Role tokens but not for Auras that leave the battlefield alongside her.

### Verification

- `just build` green (compile + `mtg-sets` suite, including `CardLintTest` and `FacadeBoundaryTest`).
- `just rebless-cards` — `WOE.json` gains these five and nothing else; zero removed lines.
- `just check-card-printing` ok for all five; each is a WOE-only printing, so WOE is canonical.
- Every field (mana cost, type line, P/T, rarity, collector number, artist, image URI, oracle text) re-checked against Scryfall; all image URIs return HTTP 200.

No new decision types, keywords, or icons, so no client change and no E2E test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)