### PR TITLE
Add six Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalRaider.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gastal Raider — Aetherdrift #86
+ * {2}{B} · Creature — Vampire Rogue · 2/1
+ *
+ * Start your engines!
+ * When this creature enters, target opponent reveals their hand. You choose an instant or sorcery
+ * card from it. That player discards that card.
+ * Max speed — This creature gets +1/+1 and has menace.
+ *
+ * The gather is filtered to instants and sorceries so the choice is legal by construction: an
+ * opponent holding none simply reveals and discards nothing, which is the printed outcome — the
+ * card says "you choose an instant or sorcery card from it", not "a card". The discard is a real
+ * discard ([MoveType.Discard]), so "whenever a player discards" triggers see it.
+ *
+ * The reveal and the discard both resolve against the *chosen* opponent
+ * ([Player.ContextPlayer] 0), which matters in multiplayer — this is a targeted trigger, not an
+ * each-opponent one.
+ */
+val GastalRaider = card("Gastal Raider") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "Start your engines!\n" +
+        "When this creature enters, target opponent reveals their hand. You choose an instant or " +
+        "sorcery card from it. That player discards that card.\n" +
+        "Max speed — This creature gets +1/+1 and has menace."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            RevealHandEffect(opponent),
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    Zone.HAND,
+                    Player.ContextPlayer(0),
+                    GameObjectFilter.InstantOrSorcery
+                ),
+                storeAs = "revealedInstantsAndSorceries"
+            ),
+            SelectFromCollectionEffect(
+                from = "revealedInstantsAndSorceries",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "toDiscard",
+                prompt = "Choose an instant or sorcery card to discard"
+            ),
+            MoveCollectionEffect(
+                from = "toDiscard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard
+            )
+        )
+        description = "When this creature enters, target opponent reveals their hand. You choose " +
+            "an instant or sorcery card from it. That player discards that card."
+    }
+
+    maxSpeed {
+        staticAbility { ability = ModifyStats(1, 1, GroupFilter.source()) }
+        keywords(Keyword.MENACE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "Win or lose, she will sate her hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg?1783907897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GoblinSurveyor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GoblinSurveyor.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Surveyor — Aetherdrift #131
+ * {2}{R} · Creature — Goblin Scout · 3/2
+ *
+ * Trample
+ * Start your engines!
+ * Max speed — {3}, Exile this card from your graveyard: Draw a card.
+ *
+ * The red member of the Surveyor cycle; see Loxodon Surveyor for why the max-speed gate follows
+ * the ability into the graveyard (Scryfall ruling 2025-02-07: "If the granted ability functions in
+ * a zone other than the battlefield, the max speed ability does too").
+ */
+val GoblinSurveyor = card("Goblin Surveyor") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Scout"
+    power = 3
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — {3}, Exile this card from your graveyard: Draw a card."
+
+    keywords(Keyword.TRAMPLE)
+    startYourEngines()
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(Costs.Mana("{3}"), Costs.ExileSelf)
+            effect = Effects.DrawCards(1)
+            activateFromZone = Zone.GRAVEYARD
+            description = "{3}, Exile this card from your graveyard: Draw a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg?1783907881"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlersHeavy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlersHeavy.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Howler's Heavy — Aetherdrift #46
+ * {3}{U} · Creature — Seal Pirate · 3/4
+ *
+ * Cycling {1}{U}
+ * When you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 until end
+ * of turn.
+ *
+ * The cycling trigger ([Triggers.YouCycleThis]) fires from the graveyard after the cycling ability
+ * has already resolved, and it targets on the way to the stack — so it can be responded to, and it
+ * simply fizzles if the chosen permanent leaves before resolution.
+ *
+ * A Vehicle matches [GameObjectFilter.CreatureOrVehicle] by subtype whether or not it is currently
+ * crewed, which is what the printed "creature or Vehicle" wants: -3/-0 applied to an uncrewed
+ * Vehicle still shrinks it once it is crewed later this turn.
+ */
+val HowlersHeavy = card("Howler's Heavy") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Seal Pirate"
+    power = 3
+    toughness = 4
+    oracleText = "Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 " +
+        "until end of turn."
+
+    keywordAbility(KeywordAbility.cycling("{1}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val victim = target(
+            "target creature or Vehicle an opponent controls",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle.opponentControls()))
+        )
+        effect = Effects.ModifyStats(-3, 0, victim)
+        description = "When you cycle this card, target creature or Vehicle an opponent controls " +
+            "gets -3/-0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Borja Pindado"
+        flavorText = "\"It takes a thick skin to ride among the Keelhaulers.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg?1783907909"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PointTheWay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PointTheWay.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Point the Way — Aetherdrift #175
+ * {G} · Enchantment
+ *
+ * Start your engines!
+ * {3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, where X is
+ * your speed. Put those cards onto the battlefield tapped, then shuffle.
+ *
+ * The activated ability is *not* max-speed gated — it is available at any speed and just finds
+ * fewer lands, so X is a [DynamicAmounts.speed] read at resolution rather than a gate.
+ *
+ * Sacrificing the enchantment is a cost, so it is gone by the time X is read. That costs nothing:
+ * start your engines! only raises a player with *no* speed to 1 as a state-based action, and
+ * "losing control of permanents with start your engines! doesn't affect your speed"
+ * (Scryfall ruling 2025-02-07). A player who has reached max speed still finds four lands.
+ *
+ * "Up to X" is honest — [Patterns.Library.searchLibrary] selects with `ChooseUpTo`, so finding
+ * fewer than X (or none) is legal, and X = 0 leaves a search that finds nothing but still fires
+ * "whenever a player searches their library" triggers (CR 701.23b).
+ */
+val PointTheWay = card("Point the Way") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, " +
+        "where X is your speed. Put those cards onto the battlefield tapped, then shuffle."
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{G}"), Costs.SacrificeSelf)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = DynamicAmounts.speed(),
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true
+        )
+        description = "{3}{G}, Sacrifice this enchantment: Search your library for up to X basic " +
+            "land cards, where X is your speed. Put those cards onto the battlefield tapped, then " +
+            "shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg?1783907867"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SwiftwingAssailant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SwiftwingAssailant.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Swiftwing Assailant — Aetherdrift #32
+ * {3}{W} · Creature — Bird Warrior · 3/3
+ *
+ * Flying
+ * Start your engines!
+ * Max speed — This creature gets +0/+1 and has vigilance.
+ *
+ * One printed max-speed ability, two gated statics: the `maxSpeed { }` block conjoins
+ * "your speed is 4" onto each, and both are re-read every projection pass rather than latched
+ * at any point in time.
+ */
+val SwiftwingAssailant = card("Swiftwing Assailant") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — This creature gets +0/+1 and has vigilance."
+
+    keywords(Keyword.FLYING)
+    startYourEngines()
+
+    maxSpeed {
+        staticAbility { ability = ModifyStats(0, 1, GroupFilter.source()) }
+        keywords(Keyword.VIGILANCE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Pig Hands"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg?1783907913"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TripUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TripUp.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Trip Up — Aetherdrift #71
+ * {3}{U} · Instant
+ *
+ * Target nonland permanent's owner puts it on their choice of the top or bottom of their library.
+ * Cycling {2}
+ *
+ * The top-or-bottom choice belongs to the permanent's *owner*, not to Trip Up's controller —
+ * [Effects.PutOnTopOrBottomOfLibrary] pauses for exactly that player. Tokens are legal targets and
+ * simply cease to exist once they leave the battlefield.
+ */
+val TripUp = card("Trip Up") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target nonland permanent's owner puts it on their choice of the top or bottom of " +
+        "their library.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.PutOnTopOrBottomOfLibrary(permanent)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Josiah \"Jo\" Cameron"
+        flavorText = "\"That net was made to hold skywhales. Good luck getting to the next checkpoint!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg?1783907901"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2543,6 +2543,142 @@
     ]
 }
 
+// Gastal Raider
+{
+    "name": "Gastal Raider",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Rogue",
+    "oracleText": "Start your engines!\nWhen this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\nMax speed — This creature gets +1/+1 and has menace.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RevealHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "filter": "instant|sorcery"
+                            },
+                            "storeAs": "revealedInstantsAndSorceries"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "revealedInstantsAndSorceries",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toDiscard",
+                            "prompt": "Choose an instant or sorcery card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toDiscard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "MENACE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "Win or lose, she will sate her hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e4877b5-4ce5-466a-810f-6501f2a0f217.jpg?1783907897"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gilded Ghoda
 {
     "name": "Gilded Ghoda",
@@ -2677,6 +2813,74 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Goblin Surveyor
+{
+    "name": "Goblin Surveyor",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Scout",
+    "oracleText": "Trample\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — {3}, Exile this card from your graveyard: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "Max speed — {3}, Exile this card from your graveyard: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1efffe9-00f8-4177-a9e6-4ad62887d32f.jpg?1783907881"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3092,6 +3296,64 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Howler's Heavy
+{
+    "name": "Howler's Heavy",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Seal Pirate",
+    "oracleText": "Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|Vehicle ctrl:opponent"
+                    },
+                    "id": "target creature or Vehicle an opponent controls"
+                },
+                "descriptionOverride": "When you cycle this card, target creature or Vehicle an opponent controls gets -3/-0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Borja Pindado",
+        "flavorText": "\"It takes a thick skin to ride among the Keelhaulers.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bbd7758-59c7-4ae1-9af8-c3580f4aa958.jpg?1783907909"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4342,6 +4604,81 @@
         "artist": "Brian Valeza",
         "flavorText": "Like most goblins, Rocketeers value nothing more than a good old-fashioned near-death experience.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/3/a311d4b3-ab2a-43c2-8480-6c5daac41178.jpg?1782687824"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Point the Way
+{
+    "name": "Point the Way",
+    "manaCost": "{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, where X is your speed. Put those cards onto the battlefield tapped, then shuffle.",
+    "keywords": [
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": "Speed"
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "descriptionOverride": "{3}{G}, Sacrifice this enchantment: Search your library for up to X basic land cards, where X is your speed. Put those cards onto the battlefield tapped, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fd4c73d-0e9a-4ffe-8062-f2f4d0e601fe.jpg?1783907867"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -6166,6 +6503,76 @@
     ]
 }
 
+// Swiftwing Assailant
+{
+    "name": "Swiftwing Assailant",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Bird Warrior",
+    "oracleText": "Flying\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — This creature gets +0/+1 and has vigilance.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 0,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Pig Hands",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72db9bb9-d930-40e5-b144-01ebfd377996.jpg?1783907913"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Syphon Fuel
 {
     "name": "Syphon Fuel",
@@ -6544,6 +6951,47 @@
         "artist": "Mark Poole",
         "flavorText": "\"Remember: You can take the wheel if you want, but I choose the music.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/6/7/6727169f-c33a-4ca5-889d-a63bcfc5a3f0.jpg?1782687907"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Trip Up
+{
+    "name": "Trip Up",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target nonland permanent's owner puts it on their choice of the top or bottom of their library.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "PutOnLibraryPositionOfChoice",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Josiah \"Jo\" Cameron",
+        "flavorText": "\"That net was made to hold skywhales. Good luck getting to the next checkpoint!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/273061f3-7aa7-4cb0-afd6-616252b88948.jpg?1783907901"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftRoadCrewScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftRoadCrewScenarioTest.kt
@@ -1,0 +1,251 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Three Aetherdrift cards whose behaviour the snapshot can't prove:
+ *
+ * | Card | Under test |
+ * |---|---|
+ * | Point the Way | a library search whose "up to X" ceiling is a *dynamic* amount — the controller's speed |
+ * | Gastal Raider | a targeted reveal-and-discard filtered to instants and sorceries, including the empty case |
+ * | Howler's Heavy | the "when you cycle this card" trigger targeting from the graveyard |
+ *
+ * Swiftwing Assailant and Goblin Surveyor are deliberately absent: both are the plain
+ * `maxSpeed { }` shapes already pinned down by Nesting Bot (gated statics) and Loxodon Surveyor
+ * (a gated graveyard ability) in [AetherdriftDriftersScenarioTest].
+ */
+class AetherdriftRoadCrewScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Point the Way") {
+
+            test("at starting speed the search ceiling is one basic land, and it enters tapped") {
+                val game = pointTheWayGame()
+                withClue("Start your engines! sets an unset speed to 1 as a state-based action") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+
+                game.activatePointTheWay()
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("X is the controller's speed, so exactly one Island may be found") {
+                    decision.maxSelections shouldBe 1
+                }
+
+                game.selectCards(decision.options.take(1))
+                game.resolveStack()
+
+                val islands = game.findAllPermanents("Island")
+                withClue("One Island fetched onto the battlefield") { islands.size shouldBe 1 }
+                withClue("Put onto the battlefield tapped") {
+                    game.state.getEntity(islands.single())!!.get<TappedComponent>().shouldNotBeNull()
+                }
+                withClue("The enchantment was sacrificed as a cost") {
+                    game.isInGraveyard(1, "Point the Way") shouldBe true
+                }
+            }
+
+            test("at max speed the ceiling rises to four, and finding fewer is still legal") {
+                val game = pointTheWayGame()
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                game.activatePointTheWay()
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("Speed 4 means 'up to four basic land cards'") {
+                    decision.maxSelections shouldBe 4
+                }
+                withClue("'Up to' — the search may find nothing at all") {
+                    decision.minSelections shouldBe 0
+                }
+
+                game.selectCards(decision.options.take(2))
+                game.resolveStack()
+
+                withClue("Only the two chosen Islands arrive, both tapped") {
+                    val islands = game.findAllPermanents("Island")
+                    islands.size shouldBe 2
+                    islands.all { game.state.getEntity(it)?.get<TappedComponent>() != null } shouldBe true
+                }
+            }
+        }
+
+        context("Gastal Raider") {
+
+            test("you pick from the opponent's instants and sorceries only, and they discard it") {
+                val game = raiderGame(opponentHand = listOf("Lightning Strike", "Duress", "Grizzly Bears"))
+
+                game.castRaider()
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("The Bears are neither instant nor sorcery, so they aren't offered") {
+                    decision.options.map { game.cardName(it) }.sortedBy { it } shouldBe
+                        listOf("Duress", "Lightning Strike")
+                }
+
+                val duress = decision.options.single { game.cardName(it) == "Duress" }
+                game.selectCards(listOf(duress))
+                game.resolveStack()
+
+                withClue("Only the card *you* chose leaves the targeted opponent's hand") {
+                    game.isInGraveyard(2, "Duress") shouldBe true
+                    game.isInHand(2, "Lightning Strike") shouldBe true
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("a single matching card is taken without a pointless prompt") {
+                val game = raiderGame(opponentHand = listOf("Lightning Strike", "Grizzly Bears"))
+
+                game.castRaider()
+                withClue("One eligible card and one required pick — there is nothing to decide") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("It is still a real discard, just an unprompted one") {
+                    game.isInGraveyard(2, "Lightning Strike") shouldBe true
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("an opponent holding no instant or sorcery reveals and discards nothing") {
+                val game = raiderGame(opponentHand = listOf("Grizzly Bears", "Hill Giant"))
+
+                game.castRaider()
+                withClue("Nothing matches the filter, so there is no choice to make") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("The trigger resolves as a no-op rather than forcing an illegal discard") {
+                    game.handSize(2) shouldBe 2
+                    game.graveyardSize(2) shouldBe 0
+                }
+                withClue("The Raider itself still resolved onto the battlefield") {
+                    game.isOnBattlefield("Gastal Raider") shouldBe true
+                }
+            }
+        }
+
+        context("Howler's Heavy") {
+
+            test("cycling it shrinks a targeted opposing creature by three power") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Howler's Heavy")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val cycle = game.cycleCard(1, "Howler's Heavy")
+                withClue("Cycling failed: ${cycle.error}") { cycle.error shouldBe null }
+                game.autoPayIfAsked()
+
+                // The trigger targets on the way to the stack, from the graveyard.
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(giant))
+                game.resolveStack()
+
+                withClue("3/3 becomes 0/3 — power only") {
+                    game.state.projectedState.getPower(giant) shouldBe 0
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                }
+                withClue("Cycling still discarded the card and drew a replacement") {
+                    game.isInGraveyard(1, "Howler's Heavy") shouldBe true
+                }
+            }
+        }
+    }
+
+    /**
+     * Player 1's precombat main with Point the Way out, four Forests for the {3}{G} activation and
+     * six Islands in the library to find. Built in the upkeep step so the CR 704.5z
+     * start-your-engines state-based action has a step change to run on.
+     */
+    private fun pointTheWayGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Point the Way")
+            .withLandsOnBattlefield(1, "Forest", 4)
+        repeat(6) { builder.withCardInLibrary(1, "Island") }
+        repeat(6) { builder.withCardInLibrary(2, "Grizzly Bears") }
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+
+    /** Activate "{3}{G}, Sacrifice this enchantment: …" and resolve up to the search decision. */
+    private fun TestGame.activatePointTheWay() {
+        val abilityId = cardRegistry.getCard("Point the Way")!!.script.activatedAbilities.single().id
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = findPermanent("Point the Way")!!,
+                abilityId = abilityId
+            )
+        )
+        withClue("Activation failed: ${result.error}") { result.error shouldBe null }
+        autoPayIfAsked()
+        resolveStack()
+    }
+
+    /** Player 1 holds Gastal Raider with the mana to cast it; player 2 holds [opponentHand]. */
+    private fun raiderGame(opponentHand: List<String>): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Gastal Raider")
+            .withLandsOnBattlefield(1, "Swamp", 3)
+        opponentHand.forEach { builder.withCardInHand(2, it) }
+        stockLibraries(builder)
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+        return game
+    }
+
+    /** Cast the Raider, let it resolve, and put its targeted enters trigger onto the stack. */
+    private fun TestGame.castRaider() {
+        val cast = castSpell(1, "Gastal Raider")
+        withClue("Cast failed: ${cast.error}") { cast.error shouldBe null }
+        autoPayIfAsked()
+        resolveStack()
+        if (getPendingDecision() is ChooseTargetsDecision) selectTargets(listOf(player2Id))
+        resolveStack()
+    }
+
+    private fun stockLibraries(builder: ScenarioBuilder) {
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+
+    private fun TestGame.cardName(id: EntityId): String? =
+        state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Submit auto-pay if the engine paused for a mana-source decision. */
+    private fun TestGame.autoPayIfAsked() {
+        if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+    }
+}


### PR DESCRIPTION
Six more Aetherdrift cards, one per colour plus a second blue. All are DFT-exclusive (single expansion printing), so each gets a full `card(...)` in `dft/cards` and nothing needed relocating — `just check-card-printing` is clean for all six.

**No new SDK vocabulary.** Every card composes existing facades, and the DFT snapshot diff is insertions only (zero deletions).

| Card | # | Shape |
|---|---|---|
| Swiftwing Assailant | W, 32 | Flying; one printed max-speed ability that is two gated statics (+0/+1 and vigilance) |
| Trip Up | U, 71 | `Effects.PutOnTopOrBottomOfLibrary` on any nonland permanent; cycling {2} |
| Howler's Heavy | U, 46 | Cycling {1}{U} + `Triggers.YouCycleThis` targeting a creature or Vehicle an opponent controls for -3/-0 |
| Gastal Raider | B, 86 | Start your engines!; targeted reveal-and-discard filtered to instants and sorceries; max-speed +1/+1 and menace |
| Goblin Surveyor | R, 131 | Trample + the Surveyor cycle's max-speed graveyard ability |
| Point the Way | G, 175 | {3}{G}, sacrifice: search for up to X basic lands tapped, X = your speed |

### Notes worth reading

**Trip Up** — the top-or-bottom choice belongs to the permanent's *owner*, not to Trip Up's controller. `PutOnTopOrBottomContinuation` already pauses for exactly that player.

**Point the Way** is the first library search whose "up to X" ceiling is a `DynamicAmount`. Sacrificing the enchantment is a cost, so it is gone by the time X is read — that costs nothing, because losing a permanent with start your engines! doesn't reduce speed (Scryfall ruling 2025-02-07). A player at max speed still finds four.

**Gastal Raider** filters the *gather* to instants and sorceries rather than the selection, which makes the choice legal by construction and gives the right behaviour at both edges rather than by accident.

### Tests

`AetherdriftRoadCrewScenarioTest` (6 tests) pins the three cards the snapshot can't prove:

- Point the Way at starting speed offers max 1; at max speed, max 4 with min 0 ("up to"), and the found lands enter tapped.
- Gastal Raider with two eligible cards prompts and discards only the chosen one; with exactly one, it is taken without a pointless prompt; with none, the trigger is a clean no-op rather than an error, and the Raider still resolves.
- Howler's Heavy cycles, targets from the graveyard, and turns a 3/3 Hill Giant into a 0/3.

Swiftwing Assailant and Goblin Surveyor are deliberately untested here — both are the plain `maxSpeed { }` shapes already covered by Nesting Bot (gated statics) and Loxodon Surveyor (a gated graveyard ability).

### Verification

- `just build` — green
- `just check` — green
- `just test-class AetherdriftRoadCrewScenarioTest` — 6/6 pass
- Every field re-verified against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, oracle text, flavour text, image URI); all six image URIs return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)