### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/CrystalGrotto.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/CrystalGrotto.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Crystal Grotto
+ * Land
+ *
+ * When this land enters, scry 1.
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ *
+ * Canonical definition lives here in Dominaria United, the card's earliest real printing; Wilds of
+ * Eldraine contributes only a [com.wingedsheep.sdk.model.Printing] row
+ * (`definitions/woe/cards/CrystalGrottoReprint.kt`).
+ *
+ * Both mana abilities are the same permanent's, and the {C} one is free — so the {1} filter ability
+ * can be paid by first tapping the Grotto itself only if another source supplies the {1}; the
+ * Grotto cannot fund its own filter, since {T} is part of both costs. Nothing special is needed to
+ * model that: the shared {T} makes it fall out of ordinary cost payment.
+ */
+val CrystalGrotto = card("Crystal Grotto") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "When this land enters, scry 1.\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg?1783921264"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CrystalGrottoReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CrystalGrottoReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crystal Grotto reprint in Wilds of Eldraine. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the card's earliest printing, Dominaria
+ * United (`definitions/dmu/cards/CrystalGrotto.kt`); this file contributes only WOE's presentation
+ * data.
+ */
+val CrystalGrottoReprint = Printing(
+    oracleId = "f15fb0cc-8e96-4f03-94d0-b51410415afd",
+    name = "Crystal Grotto",
+    setCode = "WOE",
+    collectorNumber = "254",
+    scryfallId = "6f6f9d3d-600d-43f3-a915-612e5d53aaa1",
+    artist = "Andreas Zafiratos",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f6f9d3d-600d-43f3-a915-612e5d53aaa1.jpg?1783915057",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DiminisherWitch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DiminisherWitch.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Diminisher Witch
+ * {2}{U}
+ * Creature — Human Warlock
+ * 3/2
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * When this creature enters, if it was bargained, create a Cursed Role token attached to target
+ * creature an opponent controls. (If you control another Role on it, put that one into the
+ * graveyard. Enchanted creature is 1/1.)
+ *
+ * The permanent-spell shape of bargain: the "if it was bargained" clause is an intervening-'if'
+ * (CR 603.4) on [Conditions.WasBargained], so an unbargained cast never puts the ability on the
+ * stack at all — and therefore never asks for a target. Same wiring as Agatha's Champion and
+ * Troublemaker Ouphe.
+ *
+ * The Cursed Role sets base P/T to 1/1 ([Effects.CreateRoleToken] carries the Role's statics and the
+ * one-Role-per-creature state-based action, CR 704.5s), which is why the target is an *opponent's*
+ * creature here rather than Spiteful Hexmage's own.
+ */
+val DiminisherWitch = card("Diminisher Witch") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "When this creature enters, if it was bargained, create a Cursed Role token attached to " +
+        "target creature an opponent controls. (If you control another Role on it, put that one " +
+        "into the graveyard. Enchanted creature is 1/1.)"
+
+    bargain()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasBargained
+        val cursed = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.CreateRoleToken("Cursed Role", cursed)
+        description = "When this creature enters, if it was bargained, create a Cursed Role token " +
+            "attached to target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Fariba Khamseh"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg?1783915121"
+
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and " +
+                "the enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, " +
+                "each of those Roles except the one with the most recent timestamp is put into its " +
+                "owner's graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "You can bargain a permanent spell even if you won't be able to choose targets for an " +
+                "enters-the-battlefield ability of that permanent once the spell resolves."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KellansLightblades.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KellansLightblades.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kellan's Lightblades
+ * {1}{W}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Kellan's Lightblades deals 3 damage to target attacking or blocking creature. If this spell was
+ * bargained, destroy that creature instead.
+ *
+ * The spell-rider shape of bargain (CR 702.166c): the fact is read off the spell while it is still
+ * on the stack, so the payoff is gated on [Conditions.WasBargained] at resolution.
+ *
+ * Unlike Candy Grapple's additive "-5/-5 instead", the word "instead" here swaps the whole effect —
+ * a bargained Lightblades deals **no** damage at all, it destroys. So this is a true either/or
+ * branch ([ConditionalEffect] with an `elseEffect`) rather than a base effect plus a rider. The
+ * distinction is observable: no damage means no lifelink, no damage-triggered abilities, and no
+ * marked damage for "damage dealt to it this turn" counts.
+ *
+ * One target requirement shared by both branches, so the creature is chosen once at announcement
+ * regardless of which branch resolves — and the restriction ("attacking or blocking") is checked at
+ * announcement and again on resolution, so a creature that stops attacking before this resolves
+ * makes the spell fizzle.
+ */
+val KellansLightblades = card("Kellan's Lightblades") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Kellan's Lightblades deals 3 damage to target attacking or blocking creature. If this " +
+        "spell was bargained, destroy that creature instead."
+
+    bargain()
+
+    spell {
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature),
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.WasBargained,
+            effect = Effects.Destroy(creature),
+            elseEffect = Effects.DealDamage(3, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Fajareka Setiawan"
+        flavorText = "Kellan struck out on pure instinct, and his conjured blades cleaved through " +
+            "the icy guardians as though they were nothing but air."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg?1783915131"
+
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/NightOfTheSweetsRevenge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/NightOfTheSweetsRevenge.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Night of the Sweets' Revenge
+ * {3}{G}
+ * Enchantment
+ *
+ * When this enchantment enters, create a Food token.
+ * Foods you control have "{T}: Add {G}."
+ * {5}{G}{G}, Sacrifice this enchantment: Creatures you control get +X/+X until end of turn, where X
+ * is the number of Foods you control. Activate only as a sorcery.
+ *
+ * Three abilities, each on an existing primitive:
+ *
+ * 1. The ETB is the shared predefined Food token behind [Effects.CreateFood].
+ * 2. "Foods you control have …" is a [GrantActivatedAbility] over a battlefield-scoped
+ *    [GroupFilter] — the same lord-style ability grant as Citanul Hierophants, filtered to the Food
+ *    artifact subtype rather than creatures. The granted ability is flagged
+ *    `isManaAbility`/[TimingRule.ManaAbility] so it never uses the stack and is available while
+ *    paying costs, including the {5}{G}{G} of this card's own last ability.
+ * 3. The finisher is a [Effects.ForEachInGroup] over creatures you control, each getting a
+ *    dynamically-sized until-end-of-turn buff. Per the Scryfall ruling, X is locked in as the
+ *    ability *resolves*: the amount is evaluated once at resolution and baked into the
+ *    layer-7c modification, so later Food changes don't move it, and creatures that arrive after
+ *    resolution are never in the iterated group.
+ *
+ * A subtlety worth noting: sacrificing the enchantment is part of the *cost*, so the granted
+ * "{T}: Add {G}" is gone by the time the buff resolves — but the Foods that were tapped for it are
+ * still on the battlefield and still counted by X. Tapping a Food does not sacrifice it.
+ */
+val NightOfTheSweetsRevenge = card("Night of the Sweets' Revenge") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create a Food token. (It's an artifact with " +
+        "\"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "Foods you control have \"{T}: Add {G}.\"\n" +
+        "{5}{G}{G}, Sacrifice this enchantment: Creatures you control get +X/+X until end of turn, " +
+        "where X is the number of Foods you control. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Tap,
+                effect = Effects.AddMana(Color.GREEN),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            ),
+            filter = GroupFilter(GameObjectFilter.Artifact.withSubtype("Food").youControl()),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}{G}{G}"), Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Artifact.withSubtype("Food"),
+                ).count(),
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Artifact.withSubtype("Food"),
+                ).count(),
+                EffectTarget.Self,
+            ),
+        )
+        description = "Creatures you control get +X/+X until end of turn, where X is the number of " +
+            "Foods you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Leonardo Santanna"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg?1783915080"
+
+        ruling(
+            "2023-09-01",
+            "The value of X is determined only as Night of the Sweets' Revenge's last ability " +
+                "resolves. It won't change later in the turn if the number of Foods you control changes."
+        )
+        ruling(
+            "2023-09-01",
+            "Night of the Sweets' Revenge's last ability affects only creatures you control at the " +
+                "time it resolves. Creatures you begin to control later in the turn won't be affected."
+        )
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ShatterTheOath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ShatterTheOath.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Shatter the Oath
+ * {3}{B}{B}
+ * Sorcery
+ *
+ * Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target
+ * creature you control. (If you control another Role on it, put that one into the graveyard.
+ * Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1
+ * life.)
+ *
+ * Two independent target requirements, same shape as Cut In: a mandatory "target creature or
+ * enchantment" that is destroyed, and an optional ("up to one") creature you control that gains the
+ * Wicked Role. Per the Scryfall ruling, declining the second target — or having it become illegal —
+ * only costs the Role token; the destruction still happens, because each target is checked
+ * independently and the spell resolves as long as at least one target is still legal (CR 608.2b).
+ *
+ * The Wicked Role's own "when this token is put into a graveyard, each opponent loses 1 life"
+ * trigger lives on the predefined token, so nothing about the drain needs restating here.
+ */
+val ShatterTheOath = card("Shatter the Oath") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature or enchantment. Create a Wicked Role token attached to " +
+        "up to one target creature you control. (If you control another Role on it, put that one " +
+        "into the graveyard. Enchanted creature gets +1/+1. When this token is put into a " +
+        "graveyard, each opponent loses 1 life.)"
+
+    spell {
+        val doomed = target("target creature or enchantment", Targets.CreatureOrEnchantment)
+        val roleTarget = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.Composite(
+            Effects.Destroy(doomed),
+            Effects.CreateRoleToken("Wicked Role", roleTarget),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg?1783915102"
+
+        ruling(
+            "2023-09-01",
+            "If you don't choose a second target for Shatter the Oath or that target is illegal as " +
+                "the spell resolves, the Wicked Role token won't be created."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, " +
+                "each of those Roles except the one with the most recent timestamp is put into its " +
+                "owner's graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "A permanent can have multiple Roles attached to it if each one is controlled by a " +
+                "different player."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -193,6 +193,69 @@
     ]
 }
 
+// Crystal Grotto
+{
+    "name": "Crystal Grotto",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "When this land enters, scry 1.\n{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg?1783921264"
+    },
+    "colorIdentityOverride": []
+}
+
 // Garna, Bloodfist of Keld
 {
     "name": "Garna, Bloodfist of Keld",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1841,6 +1841,89 @@
     ]
 }
 
+// Diminisher Witch
+{
+    "name": "Diminisher Witch",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen this creature enters, if it was bargained, create a Cursed Role token attached to target creature an opponent controls. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Cursed Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                },
+                "descriptionOverride": "When this creature enters, if it was bargained, create a Cursed Role token attached to target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/646d604f-b187-4122-bd4b-67634654b6f1.jpg?1783915121",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You can bargain a permanent spell even if you won't be able to choose targets for an enters-the-battlefield ability of that permanent once the spell resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dream Spoilers
 {
     "name": "Dream Spoilers",
@@ -4245,6 +4328,105 @@
     ]
 }
 
+// Kellan's Lightblades
+{
+    "name": "Kellan's Lightblades",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nKellan's Lightblades deals 3 damage to target attacking or blocking creature. If this spell was bargained, destroy that creature instead.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                }
+            },
+            "then": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target attacking or blocking creature"
+                },
+                "destination": "Graveyard",
+                "byDestruction": true
+            },
+            "otherwise": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target attacking or blocking creature"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target attacking or blocking creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "Kellan struck out on pure instinct, and his conjured blades cleaved through the icy guardians as though they were nothing but air.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cc727a6-f875-49b1-b7a4-67f22fbc3d50.jpg?1783915131",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kindled Heroism
 {
     "name": "Kindled Heroism",
@@ -5235,6 +5417,113 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Night of the Sweets' Revenge
+{
+    "name": "Night of the Sweets' Revenge",
+    "manaCost": "{3}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nFoods you control have \"{T}: Add {G}.\"\n{5}{G}{G}, Sacrifice this enchantment: Creatures you control get +X/+X until end of turn, where X is the number of Foods you control. Activate only as a sorcery.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{G}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact Food"
+                        },
+                        "toughnessModifier": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact Food"
+                        },
+                        "target": "Self"
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Creatures you control get +X/+X until end of turn, where X is the number of Foods you control."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "GREEN"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "artifact Food ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Santanna",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27f53bed-7075-4303-aa9e-fcca0a266e19.jpg?1783915080",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The value of X is determined only as Night of the Sweets' Revenge's last ability resolves. It won't change later in the turn if the number of Foods you control changes."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Night of the Sweets' Revenge's last ability affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't be affected."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -6820,6 +7109,77 @@
         "artist": "Nicholas Gregory",
         "flavorText": "Too much sugar is bad for your health.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/6/c62d0ae9-5a82-40bf-b8bb-9c2e2d55d458.jpg?1783915103"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Shatter the Oath
+{
+    "name": "Shatter the Oath",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature or enchantment. Create a Wicked Role token attached to up to one target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|enchantment"
+                },
+                "id": "target creature or enchantment"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "up to one target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc79f0f7-0a09-4a74-b2b9-cc1ce608d89f.jpg?1783915102",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a second target for Shatter the Oath or that target is illegal as the spell resolves, the Wicked Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "A permanent can have multiple Roles attached to it if each one is controlled by a different player."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"


### PR DESCRIPTION
Five more Wilds of Eldraine cards, one per colour plus a land. All compose existing SDK primitives — no new engine vocabulary, no new UX mechanic.

## Cards

| Card | Cost | Notes |
|---|---|---|
| **Kellan's Lightblades** (WOE 18) | `{1}{W}` Instant | Bargain. 3 damage to target attacking or blocking creature; **destroy instead** if bargained. |
| **Diminisher Witch** (WOE 46) | `{2}{U}` 3/2 | Bargain. ETB, if bargained: Cursed Role token on target creature an opponent controls. |
| **Shatter the Oath** (WOE 106) | `{3}{B}{B}` Sorcery | Destroy target creature or enchantment; Wicked Role token on up to one target creature you control. |
| **Night of the Sweets' Revenge** (WOE 178) | `{3}{G}` Enchantment | ETB Food; Foods you control have `{T}: Add {G}`; sac for a Food-counting team pump. |
| **Crystal Grotto** | Land | ETB scry 1; `{T}: Add {C}`; `{1}, {T}`: any colour. |

## Modelling notes

- **"Destroy that creature instead"** is a genuine either/or branch (`ConditionalEffect` with an `elseEffect`), not Candy Grapple's additive rider. The distinction is observable: a bargained Lightblades deals *no* damage, so no lifelink, no damage triggers, and no marked damage for "damage dealt to it this turn" counts.
- **Diminisher Witch's "if it was bargained"** is an intervening-'if' (CR 603.4) via `triggerCondition`, so an unbargained cast never puts the ability on the stack and therefore never prompts for a target.
- **Night of the Sweets' Revenge** grants its `{T}: Add {G}` with `isManaAbility = true` / `TimingRule.ManaAbility`. That flag is load-bearing: `ManaSolver.getStaticGrantedManaAbilities` only feeds granted abilities to the auto-payer when it is set, so without it the Foods could not help pay the card's own `{5}{G}{G}`. X is evaluated once by `ModifyStatsExecutor` and baked into the floating layer-7c effect, matching the ruling that X won't change later in the turn.
- **Crystal Grotto's canonical placement is Dominaria United**, its earliest real printing; WOE gets a `Printing` row only.

## Verification

- `just build` green.
- Card snapshot goldens re-blessed for DMU and WOE — diff confirms **only these five cards** were added, nothing else moved.
- `just check-card-printing` clean for all five.
- Every mechanical field (mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavour, image URI) re-verified field-by-field against Scryfall by script; all match exactly. All six image URIs return HTTP 200.
- No new SDK vocabulary, so no scenario test is required per the `add-card` gate; no new decision UI or keyword, so no E2E test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)