### PR TITLE
Add five more Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AgonasaurRex.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AgonasaurRex.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Agonasaur Rex — Aetherdrift #151
+ * {3}{G}{G} · Creature — Dinosaur · 8/8
+ *
+ * Trample
+ * Cycling {2}{G}
+ * When you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It
+ * gains trample and indestructible until end of turn.
+ *
+ * The cycle payoff is a separate ability from cycling itself (CR 702.29 rulings): it's legal to
+ * cycle with no creature or Vehicle on the battlefield, because the target is "up to one"
+ * (`optional = true`) and countering one ability leaves the other to resolve. The trample and
+ * indestructible grants ride the same chosen target and take [Effects.GrantKeyword]'s default
+ * end-of-turn duration; the counters, being counters, stay.
+ */
+val AgonasaurRex = card("Agonasaur Rex") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 8
+    toughness = 8
+    oracleText = "Trample\n" +
+        "Cycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. " +
+        "It gains trample and indestructible until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    keywordAbility(KeywordAbility.cycling("{2}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target(
+            "up to one target creature or Vehicle",
+            TargetPermanent(optional = true, filter = TargetFilter(GameObjectFilter.CreatureOrVehicle))
+        )
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t),
+        )
+        description = "When you cycle this card, put two +1/+1 counters on up to one target " +
+            "creature or Vehicle. It gains trample and indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Lucas Graciano"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg?1783907875"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalThrillseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalThrillseeker.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Gastal Thrillseeker — Aetherdrift #205
+ * {B}{R} · Creature — Lizard Berserker · 2/3
+ *
+ * Start your engines!
+ * When this creature enters, it deals 1 damage to target opponent and you gain 1 life.
+ * Max speed — This creature has deathtouch and haste.
+ *
+ * The ETB is a nice self-contained speed enabler: the damage is dealt *by this creature*
+ * (`damageSource = Self`, so lifelink/damage-replacement riders on it apply), and an opponent losing
+ * life during your turn is what advances your speed — so casting it on your own turn immediately
+ * ticks you from 1 to 2. `startYourEngines()` is keyword-only by design; raising speed to 1 is a
+ * state-based action, not a trigger.
+ *
+ * The max-speed half is the plain keyword-grant shape: two gated [com.wingedsheep.sdk.scripting.GrantKeyword]
+ * statics that appear and disappear with your speed, re-evaluated every projection.
+ */
+val GastalThrillseeker = card("Gastal Thrillseeker") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Lizard Berserker"
+    power = 2
+    toughness = 3
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "When this creature enters, it deals 1 damage to target opponent and you gain 1 life.\n" +
+        "Max speed — This creature has deathtouch and haste."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Effects.DealDamage(1, opponent, damageSource = EffectTarget.Self),
+            Effects.GainLife(1),
+        )
+        description = "When this creature enters, it deals 1 damage to target opponent and you gain 1 life."
+    }
+
+    maxSpeed {
+        keywords(Keyword.DEATHTOUCH, Keyword.HASTE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg?1783907857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MaraudingMako.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MaraudingMako.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Marauding Mako — Aetherdrift #138
+ * {R} · Creature — Shark Pirate · 1/1
+ *
+ * Whenever you discard one or more cards, put that many +1/+1 counters on this creature.
+ * Cycling {2}
+ *
+ * The payoff is batch-worded (CR 603.2c), so it uses [Triggers.YouDiscardOneOrMore] — one trigger
+ * per discard *event* however many cards it held — and reads the batch size back through
+ * [ContextPropertyKey.TRIGGER_DISCARD_COUNT] for "that many". Same shape as its set-mate Magmakin
+ * Artillerist: discarding three cards to one effect adds 3 counters, three separate discards add 1
+ * each.
+ *
+ * Cycling this card never feeds its own trigger — cycling discards it *from hand*, and the
+ * battlefield-only discard trigger doesn't function from hand. Cycling anything else while the
+ * Mako is on the battlefield does add a counter.
+ */
+val MaraudingMako = card("Marauding Mako") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Shark Pirate"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever you discard one or more cards, put that many +1/+1 counters on this " +
+        "creature.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscardOneOrMore
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DISCARD_COUNT),
+            target = EffectTarget.Self,
+        )
+        description = "Whenever you discard one or more cards, put that many +1/+1 counters on " +
+            "this creature."
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Alix Branwyn"
+        flavorText = "\"What a bunch of junk. I'll take the lot.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg?1783907879"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TuneUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TuneUp.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Tune Up — Aetherdrift #33
+ * {3}{W} · Sorcery
+ *
+ * Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes
+ * an artifact creature.
+ *
+ * Two ordered steps on the same chosen target: [Effects.Move] to the battlefield, then a
+ * [ConditionalEffect] that re-reads that target *as a permanent* — [Conditions.TargetMatchesFilter]
+ * on the Vehicle subtype — and adds the Creature card type. The animation has no stated duration,
+ * so it's [com.wingedsheep.sdk.scripting.Duration.Permanent] (the default of [Effects.AddCardType]):
+ * the Vehicle stays a creature for as long as it stays on the battlefield, unlike crew's
+ * until-end-of-turn animation.
+ *
+ * Checking after the move rather than before matters for the type line the client renders — the
+ * returned Vehicle becomes `Artifact Creature — Vehicle`. A non-Vehicle artifact just comes back
+ * unchanged; if the targeted card has left the graveyard by resolution the spell fizzles on its
+ * only target.
+ */
+val TuneUp = card("Tune Up") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target artifact card from your graveyard to the battlefield. If it's a " +
+        "Vehicle, it becomes an artifact creature."
+
+    spell {
+        val artifact = target(
+            "target artifact card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.Move(artifact, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD).then(
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Permanent.withSubtype(Subtype.VEHICLE)
+                ),
+                effect = Effects.AddCardType("Creature", artifact),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Chris Rallis"
+        flavorText = "\"For most people? The odds would be insurmountable,\" Daretti said.\n" +
+            "\"But we're not most people,\" Pia replied."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg?1783907912"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/UnstoppablePlan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/UnstoppablePlan.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unstoppable Plan — Aetherdrift #72
+ * {2}{U} · Enchantment
+ *
+ * At the beginning of your end step, untap all nonland permanents you control.
+ *
+ * A group untap, not a targeted one: [Effects.ForEachInGroup] over
+ * [GroupFilter.AllNonlandPermanents]`.youControl()` rebinds [EffectTarget.Self] to each iterated
+ * permanent, so nothing is targeted and no shroud/protection check applies. The enchantment itself
+ * is in the group (it's a nonland permanent you control) — untapping an untapped permanent is a
+ * no-op, which is exactly what the rules say happens.
+ */
+val UnstoppablePlan = card("Unstoppable Plan") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your end step, untap all nonland permanents you control."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllNonlandPermanents.youControl(),
+            Effects.Untap(EffectTarget.Self)
+        )
+        description = "At the beginning of your end step, untap all nonland permanents you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "72"
+        artist = "Borja Pindado"
+        flavorText = "Jace knew that if he just had time to explain his plan, he would find " +
+            "support. Unfortunately, time was in short supply."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg?1783907901"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -61,6 +61,83 @@
     "colorIdentityOverride": []
 }
 
+// Agonasaur Rex
+{
+    "name": "Agonasaur Rex",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample\nCycling {2}{G} ({2}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or Vehicle"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or Vehicle"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or Vehicle"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|Vehicle"
+                    },
+                    "id": "up to one target creature or Vehicle"
+                },
+                "descriptionOverride": "When you cycle this card, put two +1/+1 counters on up to one target creature or Vehicle. It gains trample and indestructible until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Lucas Graciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b11ec26-9e07-45e1-bcaa-5d44d1231586.jpg?1783907875"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Air Response Unit
 {
     "name": "Air Response Unit",
@@ -2721,6 +2798,114 @@
     ]
 }
 
+// Gastal Thrillseeker
+{
+    "name": "Gastal Thrillseeker",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Lizard Berserker",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this creature enters, it deals 1 damage to target opponent and you gain 1 life.\nMax speed — This creature has deathtouch and haste.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            },
+                            "damageSource": "Self"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, it deals 1 damage to target opponent and you gain 1 life."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Olivier Bernard",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8e5205d-d734-4292-a3c8-70cf5f131289.jpg?1783907857"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Gilded Ghoda
 {
     "name": "Gilded Ghoda",
@@ -4105,6 +4290,56 @@
         "collectorNumber": "137",
         "artist": "Madeline Boni",
         "imageUri": "https://cards.scryfall.io/normal/front/2/a/2ac26341-a100-424d-be84-33fbbf1b4078.jpg?1783907878"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Marauding Mako
+{
+    "name": "Marauding Mako",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Shark Pirate",
+    "oracleText": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "batch": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DISCARD_COUNT"
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Alix Branwyn",
+        "flavorText": "\"What a bunch of junk. I'll take the lot.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9efbfd67-e0f5-43e0-9fff-1eb4a2bed0d8.jpg?1783907879"
     },
     "colorIdentityOverride": [
         "RED"
@@ -7345,6 +7580,72 @@
     ]
 }
 
+// Tune Up
+{
+    "name": "Tune Up",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact card in your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "permanent Vehicle"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCardType",
+                        "cardType": "Creature",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact card in your graveyard"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target artifact card in your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rallis",
+        "flavorText": "\"For most people? The odds would be insurmountable,\" Daretti said.\n\"But we're not most people,\" Pia replied.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8bddc5f-8f25-4313-b5bb-e5eae2923878.jpg?1783907912"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Tyrox, Saurid Tyrant
 {
     "name": "Tyrox, Saurid Tyrant",
@@ -7363,6 +7664,51 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Unstoppable Plan
+{
+    "name": "Unstoppable Plan",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your end step, untap all nonland permanents you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "nonland permanent ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, untap all nonland permanents you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "RARE",
+        "artist": "Borja Pindado",
+        "flavorText": "Jace knew that if he just had time to explain his plan, he would find support. Unfortunately, time was in short supply.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aaeb5981-7e6a-4ffd-bb02-4757b2e92f08.jpg?1783907901"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgonasaurRexScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgonasaurRexScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Agonasaur Rex — Cycling {2}{G} plus "When you cycle this card, put two +1/+1 counters on up to one
+ * target creature or Vehicle. It gains trample and indestructible until end of turn."
+ *
+ * Cycling and the cycle trigger are separate abilities (CR 702.29 rulings), so the third case pins
+ * the consequence: with nothing to target you may still cycle, and the draw happens anyway. The
+ * first two cases prove the payload reaches a creature and a Vehicle alike, and that the keyword
+ * grants are end-of-turn while the counters stay.
+ */
+class AgonasaurRexScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cycling puts two counters on a target creature and grants trample and indestructible") {
+            val game = rexGame(extraPermanent = "Grizzly Bears")
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            val cycle = game.cycleCard(1, "Agonasaur Rex")
+            withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            if (game.hasPendingDecision()) game.selectTargets(listOf(bears))
+            game.resolveStack()
+
+            val projected = game.state.projectedState
+            withClue("Two +1/+1 counters — a 2/2 becomes a 4/4") {
+                game.counters(bears) shouldBe 2
+                projected.getPower(bears) shouldBe 4
+                projected.getToughness(bears) shouldBe 4
+            }
+            withClue("Both keywords are granted") {
+                projected.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                projected.hasKeyword(bears, Keyword.INDESTRUCTIBLE) shouldBe true
+            }
+            withClue("The Rex itself is in the graveyard — cycling discarded it") {
+                game.isInGraveyard(1, "Agonasaur Rex") shouldBe true
+            }
+
+            // Into the opponent's upkeep, i.e. past this turn's cleanup step.
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            withClue("The grants were until end of turn; the counters are permanent") {
+                game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe false
+                game.state.projectedState.hasKeyword(bears, Keyword.INDESTRUCTIBLE) shouldBe false
+                game.counters(bears) shouldBe 2
+            }
+        }
+
+        test("a Vehicle is a legal target even while it isn't a creature") {
+            val game = rexGame(extraPermanent = "Air Response Unit")
+            val vehicle = game.findPermanent("Air Response Unit")!!
+
+            val cycle = game.cycleCard(1, "Agonasaur Rex")
+            withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            if (game.hasPendingDecision()) game.selectTargets(listOf(vehicle))
+            game.resolveStack()
+
+            withClue("\"creature or Vehicle\" matches an uncrewed Vehicle by subtype") {
+                game.counters(vehicle) shouldBe 2
+                game.state.projectedState.hasKeyword(vehicle, Keyword.INDESTRUCTIBLE) shouldBe true
+            }
+        }
+
+        test("cycling with nothing to target still draws — the two abilities are independent") {
+            val game = rexGame(extraPermanent = null)
+            val handBefore = game.handSize(1)
+
+            val cycle = game.cycleCard(1, "Agonasaur Rex")
+            withClue("Cycling should succeed with no creature or Vehicle in play: ${cycle.error}") {
+                cycle.error shouldBe null
+            }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            if (game.hasPendingDecision()) game.skipTargets()
+            game.resolveStack()
+
+            withClue("Cycling drew a card, replacing the discarded Rex") {
+                game.handSize(1) shouldBe handBefore
+                game.isInGraveyard(1, "Agonasaur Rex") shouldBe true
+            }
+        }
+    }
+
+    /** The Rex in hand, three Forests to cycle it, and optionally one permanent to target. */
+    private fun rexGame(extraPermanent: String?): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Agonasaur Rex")
+            .withLandsOnBattlefield(1, "Forest", 3)
+        if (extraPermanent != null) {
+            builder.withCardOnBattlefield(1, extraPermanent, summoningSickness = false)
+        }
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    private fun TestGame.counters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GastalThrillseekerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GastalThrillseekerScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gastal Thrillseeker — "Start your engines!", an ETB that drains an opponent for 1, and
+ * "Max speed — This creature has deathtouch and haste."
+ *
+ * The ETB is the card's own speed enabler, so the first case checks the whole chain in one go:
+ * entering starts speed at 1 (CR 704.5z state-based action), and the opponent losing life *during
+ * your turn* then ticks the inherent speed trigger to 2. The second case pins the max-speed gate —
+ * the two keywords must be absent below speed 4 and present at it.
+ */
+class GastalThrillseekerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("its ETB drains for 1, gains 1, and advances your own speed past the start") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Gastal Thrillseeker")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val card = game.findCardsInHand(1, "Gastal Thrillseeker").single()
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = card,
+                    targets = listOf(ChosenTarget.Player(game.player2Id))
+                )
+            )
+            withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("1 damage to the targeted opponent, 1 life to you") {
+                game.getLifeTotal(2) shouldBe 19
+                game.getLifeTotal(1) shouldBe 21
+            }
+            withClue(
+                "Start your engines! set speed to 1, then the opponent losing life on your turn " +
+                    "ticked the inherent trigger to 2"
+            ) {
+                game.state.speed(game.player1Id) shouldBe 2
+            }
+            withClue("Each player's speed is tracked separately — the opponent has none") {
+                game.state.speed(game.player2Id) shouldBe Speed.NONE
+            }
+        }
+
+        test("deathtouch and haste only apply at max speed") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Gastal Thrillseeker", summoningSickness = false)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lizard = game.findPermanent("Gastal Thrillseeker")!!
+
+            withClue("Both keywords sit behind the max-speed gate") {
+                game.state.projectedState.hasKeyword(lizard, Keyword.DEATHTOUCH) shouldBe false
+                game.state.projectedState.hasKeyword(lizard, Keyword.HASTE) shouldBe false
+            }
+
+            game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+            withClue("At speed 4 the gated statics apply") {
+                game.state.projectedState.hasKeyword(lizard, Keyword.DEATHTOUCH) shouldBe true
+                game.state.projectedState.hasKeyword(lizard, Keyword.HASTE) shouldBe true
+            }
+        }
+    }
+
+    /** Both libraries stocked so nobody decks out on the forced draws. */
+    private fun ScenarioBuilder.stocked(): ScenarioBuilder = apply {
+        repeat(8) {
+            withCardInLibrary(1, "Grizzly Bears")
+            withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaraudingMakoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaraudingMakoScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Marauding Mako — "Whenever you discard one or more cards, put that many +1/+1 counters on this
+ * creature." plus Cycling {2}.
+ *
+ * Batch semantics (CR 603.2c): one trigger per discard *event*, sized by that event. These cases pin
+ * the two-card case (one counter per card of a single event) and the "cycling this card doesn't feed
+ * its own trigger" edge, since the discard ability only functions on the battlefield.
+ */
+class MaraudingMakoScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("a two-card discard event adds two +1/+1 counters") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Marauding Mako", summoningSickness = false)
+                .withCardInHand(1, "Faithless Looting")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val mako = game.findPermanent("Marauding Mako")!!
+
+            // Faithless Looting: draw two, then discard two — a single discard event.
+            val cast = game.castSpell(1, "Faithless Looting")
+            withClue("Faithless Looting cast should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+            if (game.hasPendingDecision()) {
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears").take(2))
+            }
+            game.resolveStack()
+
+            withClue("\"That many\" reads the size of the one discard event: 2") {
+                game.counters(mako) shouldBe 2
+                game.state.projectedState.getPower(mako) shouldBe 3
+                game.state.projectedState.getToughness(mako) shouldBe 3
+            }
+        }
+
+        test("cycling another card is a one-card discard event") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Marauding Mako", summoningSickness = false)
+                .withCardInHand(1, "Agonasaur Rex")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val mako = game.findPermanent("Marauding Mako")!!
+
+            val cycle = game.cycleCard(1, "Agonasaur Rex")
+            withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            // The Rex's own cycle trigger targets "up to one" — decline it, we only care about the Mako.
+            if (game.hasPendingDecision()) game.skipTargets()
+            game.resolveStack()
+
+            withClue("One card discarded → one counter") { game.counters(mako) shouldBe 1 }
+        }
+
+        test("cycling the Mako itself doesn't trigger it — the ability only works on the battlefield") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Marauding Mako")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.handSize(1)
+            val cycle = game.cycleCard(1, "Marauding Mako")
+            withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("It went to the graveyard and replaced itself with a draw") {
+                game.isInGraveyard(1, "Marauding Mako") shouldBe true
+                game.handSize(1) shouldBe handBefore
+            }
+        }
+    }
+
+    private fun TestGame.counters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Both libraries stocked so nobody decks out on the draws these cases force. */
+    private fun ScenarioBuilder.stocked(): ScenarioBuilder = apply {
+        repeat(8) {
+            withCardInLibrary(1, "Grizzly Bears")
+            withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TuneUpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TuneUpScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tune Up — "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle,
+ * it becomes an artifact creature."
+ *
+ * The interesting part is the *order*: the conditional re-reads the chosen target after it has
+ * already moved, so these cases prove the target still resolves once it's a battlefield permanent
+ * and that the animation is permanent (no until-end-of-turn expiry) rather than crew's temporary one.
+ * The non-Vehicle case proves the condition actually gates — a plain artifact must come back inert.
+ */
+class TuneUpScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("a returned Vehicle becomes an artifact creature") {
+            val game = tuneUpGame("Air Response Unit")
+
+            val cast = game.castSpellTargetingGraveyardCard(1, "Tune Up", 1, "Air Response Unit")
+            withClue("Tune Up cast should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val vehicle = game.findPermanent("Air Response Unit")!!
+            val projected = game.state.projectedState
+
+            withClue("It left the graveyard for the battlefield") {
+                game.isInGraveyard(1, "Air Response Unit") shouldBe false
+                game.isOnBattlefield("Air Response Unit") shouldBe true
+            }
+            withClue("It is a Vehicle, so it gains the Creature card type — and keeps Artifact") {
+                projected.isCreature(vehicle) shouldBe true
+                projected.hasType(vehicle, "ARTIFACT") shouldBe true
+            }
+
+            // No stated duration, so the animation survives the turn boundary (unlike crew).
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            withClue("\"It becomes an artifact creature\" has no duration — it stays a creature") {
+                game.state.projectedState.isCreature(vehicle) shouldBe true
+            }
+        }
+
+        test("a returned non-Vehicle artifact comes back unanimated") {
+            val game = tuneUpGame("Starting Column")
+
+            val cast = game.castSpellTargetingGraveyardCard(1, "Tune Up", 1, "Starting Column")
+            withClue("Tune Up cast should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val column = game.findPermanent("Starting Column")!!
+            withClue("It returned to the battlefield") { game.isOnBattlefield("Starting Column") shouldBe true }
+            withClue("Not a Vehicle, so the conditional half does nothing") {
+                game.state.projectedState.isCreature(column) shouldBe false
+            }
+        }
+    }
+
+    /** Tune Up in hand, [artifactInGraveyard] in the graveyard, and enough Plains to cast it. */
+    private fun tuneUpGame(artifactInGraveyard: String): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Tune Up")
+            .withCardInGraveyard(1, artifactInGraveyard)
+            .withLandsOnBattlefield(1, "Plains", 4)
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnstoppablePlanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnstoppablePlanScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unstoppable Plan — "At the beginning of your end step, untap all nonland permanents you control."
+ *
+ * The three ways a group untap can go wrong, one per assertion: it must reach *every* nonland
+ * permanent you control (not only creatures), it must skip lands, and it must not touch permanents
+ * an opponent controls.
+ */
+class UnstoppablePlanScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("untaps your nonland permanents at your end step, sparing lands and the opponent's") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Unstoppable Plan")
+                .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                .withCardOnBattlefield(1, "Air Response Unit", tapped = true)
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardOnBattlefield(2, "Centaur Courser", tapped = true)
+                .stocked()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val myBears = game.findPermanent("Grizzly Bears")!!
+            val theirCourser = game.findPermanent("Centaur Courser")!!
+            val vehicle = game.findPermanent("Air Response Unit")!!
+            val island = game.findPermanent("Island")!!
+            game.state = game.state.updateEntity(island) { it.with(TappedComponent) }
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            withClue("A tapped creature you control untaps") {
+                game.state.getEntity(myBears)?.has<TappedComponent>() shouldBe false
+            }
+            withClue("So does a noncreature nonland permanent — a tapped Vehicle") {
+                game.state.getEntity(vehicle)?.has<TappedComponent>() shouldBe false
+            }
+            withClue("Lands are excluded: \"all nonland permanents\"") {
+                game.state.getEntity(island)?.has<TappedComponent>() shouldBe true
+            }
+            withClue("And it is \"you control\", so the opponent's creature stays tapped") {
+                game.state.getEntity(theirCourser)?.has<TappedComponent>() shouldBe true
+            }
+        }
+    }
+
+    /** Both libraries stocked so nobody decks out while passing to the end step. */
+    private fun ScenarioBuilder.stocked(): ScenarioBuilder = apply {
+        repeat(8) {
+            withCardInLibrary(1, "Grizzly Bears")
+            withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+}


### PR DESCRIPTION
Five more Aetherdrift (DFT) cards, spread across colors and mechanics. Every one composes existing SDK vocabulary — **no new effect, trigger, condition, or keyword types**, so `docs/card-sdk-language-reference.md` needs no update.

| Card | Cost | What it exercises |
|---|---|---|
| Unstoppable Plan | `{2}{U}` | `ForEachInGroup` group untap over nonland permanents you control |
| Marauding Mako | `{R}` | batch discard payoff via `TRIGGER_DISCARD_COUNT` (CR 603.2c) + cycling `{2}` |
| Tune Up | `{3}{W}` | reanimate a graveyard artifact, then conditionally animate it if it's a Vehicle |
| Gastal Thrillseeker | `{B}{R}` | start your engines! + a max-speed deathtouch/haste gate |
| Agonasaur Rex | `{3}{G}{G}` | cycling `{2}{G}` with an "up to one target creature or Vehicle" cycle trigger |

## Notes on the two non-obvious ones

**Tune Up** — "Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature." The conditional re-reads the *same chosen target* after it has already moved, so `Conditions.TargetMatchesFilter` evaluates against the battlefield permanent. The animation has **no stated duration**, so it's permanent — deliberately unlike crew's until-end-of-turn animation, and the test asserts it survives the turn boundary.

**Agonasaur Rex** — cycling and the cycle trigger are separate abilities (CR 702.29 rulings), so it's legal to cycle with nothing to target; the draw still happens. Modelled with `optional = true` on the target, and covered by a test.

## Verification

- `just build` — green (full JVM suite).
- 11 new scenario assertions across 5 test classes, all passing. Beyond the happy paths they pin the edges that would otherwise fail silently: lands and opponents excluded from the group untap, cycling the Mako not feeding its own battlefield-only trigger, a non-Vehicle artifact returning inert, the max-speed gate opening *and* closing, and Agonasaur Rex's keyword grants expiring at end of turn while its counters stay.
- `just check-card-printing` — all five canonical in DFT, their earliest real printing.
- Card snapshot golden re-blessed: `DFT.json` gains only these five trees, zero deletions.
- Every field re-verified against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, flavor, oracle text) and all five `imageUri` values return HTTP 200.

## UX

No new decision types or client work. Each card reuses a routed flow already shipped by set-mates: graveyard-card targeting (Salvation Engine, Broodheart Engine), "up to one target" battlefield targeting with a skip (Explosive Getaway), opponent targeting, and the existing cycling special action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)