### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LivingLectern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LivingLectern.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Living Lectern
+ * {1}{U}
+ * Artifact Creature — Construct
+ * 0/4
+ *
+ * {1}, Sacrifice this creature: Draw a card. Create a Sorcerer Role token attached to up to one
+ * other target creature you control. Activate only as a sorcery.
+ *
+ * "Up to one other target" is `optional = true` on [TargetFilter.OtherCreatureYouControl] — the
+ * "other" is the `excludeSelf` flag on that filter, and it is load-bearing even though the Lectern
+ * sacrifices itself: targets are chosen (CR 601.2c) *before* costs are paid (CR 601.2h), so the
+ * Lectern is still on the battlefield and would otherwise be a legal choice for its own Role.
+ *
+ * The draw and the Role are one effect sequence, not two independent ones, and that is exactly the
+ * asymmetry the WOE rulings call out: activating with **no** target still draws, but choosing a
+ * target that has become illegal by resolution means the whole ability doesn't resolve (CR 608.2b) —
+ * no Role *and* no card. Modelling this as `Draw.then(CreateRoleToken)` behind a single optional
+ * target requirement gets both halves for free rather than special-casing the fizzle.
+ */
+val LivingLectern = card("Living Lectern") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Construct"
+    power = 0
+    toughness = 4
+    oracleText = "{1}, Sacrifice this creature: Draw a card. Create a Sorcerer Role token attached " +
+        "to up to one other target creature you control. Activate only as a sorcery. (If you " +
+        "control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 " +
+        "and has \"Whenever this creature attacks, scry 1.\")"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        val host = target(
+            "up to one other target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.OtherCreatureYouControl),
+        )
+        effect = Effects.DrawCards(1).then(Effects.CreateRoleToken("Sorcerer Role", host))
+        description = "Draw a card. Create a Sorcerer Role token attached to up to one other " +
+            "target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg?1783915118"
+
+        ruling(
+            "2023-09-01",
+            "You can activate Living Lectern's ability without a target just to draw a card. However, " +
+                "if you do choose a target, and that target is illegal at the time the ability tries " +
+                "to resolve, the ability won't resolve and none of its effects will happen. You won't " +
+                "draw a card."
+        )
+        ruling(
+            "2023-09-01",
+            "If you don't choose a target creature, the Sorcerer Role token won't be created."
+        )
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the " +
+                "enchant creature ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TempestHart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TempestHart.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.SpellCastEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tempest Hart // Scan the Clouds
+ * {3}{G}
+ * Creature — Elemental Elk
+ * 3/4
+ *
+ * Trample
+ * Whenever you cast a spell with mana value 5 or greater, put a +1/+1 counter on this creature.
+ *
+ * Adventure: Scan the Clouds — {1}{U}, Instant — Adventure
+ * Draw two cards, then discard two cards.
+ *
+ * The cast trigger is the usual "cast a big spell" payoff shape: a [SpellCastEvent] whose
+ * `spellFilter` carries the mana-value threshold, so the check happens against the spell *on the
+ * stack*. That matters for {X} spells — per the WOE ruling, the value chosen for X counts toward
+ * mana value, and the spell already has its X locked in by the time the trigger sees it.
+ * `TriggerBinding.ANY` because the trigger cares about the spell, not about which permanent the
+ * event names; the payoff points back at the Hart via [EffectTarget.Self].
+ *
+ * The Adventure is a plain loot: draw then discard, in that order — the discard sees the two freshly
+ * drawn cards, and with a hand of fewer than two cards afterwards you simply discard what you have.
+ */
+val TempestHart = card("Tempest Hart") {
+    manaCost = "{3}{G}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elemental Elk"
+    power = 3
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Whenever you cast a spell with mana value 5 or greater, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = SpellCastEvent(
+                spellFilter = GameObjectFilter.Any.manaValueAtLeast(5),
+                player = Player.You,
+            ),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    adventure("Scan the Clouds") {
+        manaCost = "{1}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Draw two cards, then discard two cards. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.DrawCards(2).then(Effects.Discard(2))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Aldo Domínguez"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1783915060"
+
+        ruling(
+            "2023-09-01",
+            "If a spell has {X} in its mana cost, use the value chosen for that X to determine the " +
+                "mana value of that spell."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThreadbindClique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThreadbindClique.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Threadbind Clique // Rip the Seams
+ * {3}{U}
+ * Creature — Faerie
+ * 3/3
+ *
+ * Flying
+ *
+ * Adventure: Rip the Seams — {2}{W}, Instant — Adventure
+ * Destroy target tapped creature.
+ *
+ * "Tapped" is a state predicate on the target requirement ([TargetFilter.TappedCreature]), not a
+ * check inside the effect, so the restriction is enforced twice: once when targets are chosen and
+ * again on resolution (CR 608.2b). A creature that untaps in response — Hylda's Crown of Winter
+ * pointed the other way, a flash blink — stops being a legal target and the Adventure is countered
+ * for having no legal targets, which is the whole reason this is a two-mana removal spell.
+ *
+ * The two faces are in different colors, so the card's color identity spans both (CR 903.4 — every
+ * mana symbol on the card counts): the creature is mono-blue but the Adventure's {W} makes the
+ * *card* {U}{W}, which is what `colorIdentity` records.
+ */
+val ThreadbindClique = card("Threadbind Clique") {
+    manaCost = "{3}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Faerie"
+    power = 3
+    toughness = 3
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    adventure("Rip the Seams") {
+        manaCost = "{2}{W}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Destroy target tapped creature. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val victim = target(
+                "target tapped creature",
+                TargetCreature(filter = TargetFilter.TappedCreature),
+            )
+            effect = Effects.Destroy(victim)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Michal Ivan"
+        flavorText = "Giggles of delight may be the last thing you hear."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1783915061"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwistedSewerWitch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwistedSewerWitch.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Twisted Sewer-Witch
+ * {3}{B}{B}
+ * Creature — Human Warlock
+ * 3/4
+ *
+ * When this creature enters, create a 1/1 black Rat creature token with "This creature can't block."
+ * Then for each Rat you control, create a Wicked Role token attached to that Rat.
+ *
+ * Two sequenced steps, not one: [woeRatToken] first, *then* the iteration. Because an
+ * `IterationSpace.Group` is snapshotted when the `ForEach` starts executing — after the `.then()`
+ * boundary — the Rat that was just created is already on the battlefield and is included, which is
+ * how the card is meant to read ("for each Rat you control" is evaluated at that point, not before
+ * the token entered).
+ *
+ * Nothing here targets, so the Roles land on Rats with hexproof or shroud too, and the ability can't
+ * fizzle. The Rats themselves are the iteration entities, so the body attaches to
+ * [EffectTarget.Self] — under a `Group` space that resolves to the current entity rather than to the
+ * Witch. [Effects.CreateRoleToken] already implements the Role state-based action (CR 303.7a /
+ * 704.5y) that bins an older Role you control on the same creature, so landing this on Rats that
+ * already carry a Monster or Cursed Role replaces rather than stacks.
+ */
+val TwistedSewerWitch = card("Twisted Sewer-Witch") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, create a 1/1 black Rat creature token with " +
+        "\"This creature can't block.\" Then for each Rat you control, create a Wicked Role token " +
+        "attached to that Rat. (If you control another Role on it, put that one into the graveyard. " +
+        "Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent " +
+        "loses 1 life.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = woeRatToken().then(
+            Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Rat").youControl()),
+                effect = Effects.CreateRoleToken("Wicked Role", EffectTarget.Self),
+            )
+        )
+        description = "When this creature enters, create a 1/1 black Rat creature token with " +
+            "\"This creature can't block.\" Then for each Rat you control, create a Wicked Role " +
+            "token attached to that Rat."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "114"
+        artist = "Scott Murphy"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg?1783915101"
+
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the " +
+                "enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each " +
+                "of those Roles except the one with the most recent timestamp is put into its owner's " +
+                "graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "A permanent can have multiple Roles attached to it if each one is controlled by a " +
+                "different player."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoodlandAcolyte.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoodlandAcolyte.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Woodland Acolyte // Mend the Wilds
+ * {2}{W}
+ * Creature — Human Cleric
+ * 2/2
+ *
+ * When this creature enters, draw a card.
+ *
+ * Adventure: Mend the Wilds — {G}, Instant — Adventure
+ * Put target permanent card from your graveyard on top of your library.
+ *
+ * The Adventure targets in the graveyard, so the requirement carries `zone = Zone.GRAVEYARD` and
+ * `ownedByYou()` — ownership, not control, is what "your graveyard" means (CR 404.1). Targeting is
+ * mandatory: with no permanent card in your graveyard there's no legal target and the spell can't be
+ * cast at all, which also means it never exiles itself and the creature half stays uncastable from
+ * exile.
+ *
+ * "Permanent card" is [GameObjectFilter.Permanent] — artifact, creature, enchantment, land,
+ * planeswalker, battle. Note the adventurer-card ruling that cuts the other way here: a card with an
+ * Adventure sitting in a graveyard is a *permanent* card (its alternative instant/sorcery
+ * characteristics are ignored outside the stack), so Mend the Wilds can return another adventurer.
+ */
+val WoodlandAcolyte = card("Woodland Acolyte") {
+    manaCost = "{2}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    adventure("Mend the Wilds") {
+        manaCost = "{G}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Put target permanent card from your graveyard on top of your library. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val card = target(
+                "target permanent card from your graveyard",
+                TargetObject(
+                    filter = TargetFilter(
+                        baseFilter = GameObjectFilter.Permanent.ownedByYou(),
+                        zone = Zone.GRAVEYARD,
+                    ),
+                ),
+            )
+            effect = Effects.Move(
+                target = card,
+                destination = Zone.LIBRARY,
+                placement = ZonePlacement.Top,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Steve Prescott"
+        flavorText = "He left knighthood behind to heal the scars of the invasion."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1783915061"
+
+        ruling(
+            "2023-09-01",
+            "An adventurer card is a permanent card in every zone except the stack, as well as while " +
+                "on the stack if not cast as an Adventure. Ignore its alternative characteristics in " +
+                "those cases."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -4602,6 +4602,93 @@
     ]
 }
 
+// Living Lectern
+{
+    "name": "Living Lectern",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{1}, Sacrifice this creature: Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control. Activate only as a sorcery. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has \"Whenever this creature attacks, scry 1.\")",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "CreateRoleToken",
+                            "roleName": "Sorcerer Role",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "up to one other target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Draw a card. Create a Sorcerer Role token attached to up to one other target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/169afcaf-7ebf-4590-9e51-2a1a5eb3ac76.jpg?1783915118",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You can activate Living Lectern's ability without a target just to draw a card. However, if you do choose a target, and that target is illegal at the time the ability tries to resolve, the ability won't resolve and none of its effects will happen. You won't draw a card."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a target creature, the Sorcerer Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Lord Skitter's Butcher
 {
     "name": "Lord Skitter's Butcher",
@@ -8585,6 +8672,120 @@
     ]
 }
 
+// Tempest Hart
+{
+    "name": "Tempest Hart",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elemental Elk",
+    "oracleText": "Trample\nWhenever you cast a spell with mana value 5 or greater, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtLeast",
+                                "min": 5
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Aldo Domínguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/559bacc8-facc-4d93-90b5-8ac21d3246f5.jpg?1783915060",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a spell has {X} in its mana cost, use the value chosen for that X to determine the mana value of that spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Scan the Clouds",
+            "manaCost": "{1}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Draw two cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 2 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Territorial Witchstalker
 {
     "name": "Territorial Witchstalker",
@@ -8641,6 +8842,61 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Threadbind Clique
+{
+    "name": "Threadbind Clique",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Michal Ivan",
+        "flavorText": "Giggles of delight may be the last thing you hear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd6ed252-c262-4062-97ba-75c50d6b5579.jpg?1783915061"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Rip the Seams",
+            "manaCost": "{2}{W}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Destroy target tapped creature. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target tapped creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature tapped"
+                        },
+                        "id": "target tapped creature"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -9143,6 +9399,87 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Twisted Sewer-Witch
+{
+    "name": "Twisted Sewer-Witch",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "When this creature enters, create a 1/1 black Rat creature token with \"This creature can't block.\" Then for each Rat you control, create a Wicked Role token attached to that Rat. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Rat"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                            "staticAbilities": [
+                                "CantBlock"
+                            ]
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Rat ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "CreateRoleToken",
+                                "roleName": "Wicked Role",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create a 1/1 black Rat creature token with \"This creature can't block.\" Then for each Rat you control, create a Wicked Role token attached to that Rat."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Murphy",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6e3ddf7-582d-4923-be30-8428e52237e4.jpg?1783915101",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "A permanent can have multiple Roles attached to it if each one is controlled by a different player."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -9947,5 +10284,83 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Woodland Acolyte
+{
+    "name": "Woodland Acolyte",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "He left knighthood behind to heal the scars of the invasion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9f10623-4783-4773-b9c8-a5a2bcfdb5d9.jpg?1783915061",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "An adventurer card is a permanent card in every zone except the stack, as well as while on the stack if not cast as an Adventure. Ignore its alternative characteristics in those cases."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Mend the Wilds",
+            "manaCost": "{G}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Put target permanent card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent card from your graveyard"
+                    },
+                    "destination": "Library",
+                    "placement": "Top"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target permanent card from your graveyard"
+                    }
+                ]
+            }
+        }
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch9ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch9ScenarioTest.kt
@@ -1,0 +1,292 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the ninth batch of Wilds of Eldraine cards. All five cards in the batch are
+ * composed from existing primitives, so the snapshot and lint nets already pin their *shape* — what
+ * this covers is the handful of places where a plausible-looking model could still resolve wrong:
+ *
+ *  - **Twisted Sewer-Witch** — the Rat it creates has to be inside the "for each Rat you control"
+ *    snapshot. The card hinges on the `ForEach` group being sampled *after* the token step, and
+ *    nothing in the definition itself would catch that ordering being inverted.
+ *  - **Living Lectern** — both sides of its "up to one other target": with a target chosen, and
+ *    declined (which per the WOE ruling must still draw, and must be activatable even when you
+ *    control no other creature at all).
+ *  - **Rip the Seams** — "tapped" is a *targeting* restriction, so an untapped creature has to be
+ *    rejected at cast time rather than quietly destroyed on resolution.
+ *  - **Tempest Hart** — mana value 5 is a boundary, so both sides of it are checked.
+ */
+class WoeCardsBatch9ScenarioTest : ScenarioTestBase() {
+
+    private val lecternAbilityId by lazy {
+        cardRegistry.requireCard("Living Lectern").activatedAbilities[0].id
+    }
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun rolesAttachedTo(game: TestGame, roleName: String, host: EntityId): Int =
+        game.findAllPermanents(roleName).count { role ->
+            game.state.getEntity(role)?.get<AttachedToComponent>()?.targetId == host
+        }
+
+    init {
+        context("Twisted Sewer-Witch — a Wicked Role on every Rat you control") {
+            test("the Rat created by the same trigger is inside the 'for each Rat' snapshot") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twisted Sewer-Witch")
+                    // A Rat already on the battlefield, so the count spans pre-existing and new.
+                    .withCardOnBattlefield(1, "Voracious Vermin")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vermin = game.findPermanent("Voracious Vermin")!!
+
+                game.castSpell(1, "Twisted Sewer-Witch").error shouldBe null
+                game.resolveStack()
+
+                val witch = game.findPermanent("Twisted Sewer-Witch")!!
+                val ratTokens = game.findAllPermanents("Rat Token")
+
+                withClue("the Witch's ETB created one Rat token") {
+                    ratTokens.size shouldBe 1
+                }
+
+                withClue("every Rat you control got a Wicked Role — the new token included") {
+                    rolesAttachedTo(game, "Wicked Role", ratTokens.single()) shouldBe 1
+                    rolesAttachedTo(game, "Wicked Role", vermin) shouldBe 1
+                    game.findAllPermanents("Wicked Role").size shouldBe 2
+                }
+
+                withClue("the Witch is a Human Warlock, not a Rat, so it gets no Role") {
+                    rolesAttachedTo(game, "Wicked Role", witch) shouldBe 0
+                }
+
+                withClue("Wicked Role grants +1/+1 — the 1/1 Rat token projects as 2/2") {
+                    game.state.projectedState.getPower(ratTokens.single()) shouldBe 2
+                    game.state.projectedState.getToughness(ratTokens.single()) shouldBe 2
+                }
+            }
+        }
+
+        context("Living Lectern — 'up to one other target creature you control'") {
+            test("with a target chosen: draw a card and attach a Sorcerer Role to it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Living Lectern")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lectern = game.findPermanent("Living Lectern")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = lectern,
+                        abilityId = lecternAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.handSize(1) shouldBe handBefore + 1
+                withClue("the Lectern sacrificed itself as part of the cost") {
+                    game.isOnBattlefield("Living Lectern") shouldBe false
+                }
+                rolesAttachedTo(game, "Sorcerer Role", bears) shouldBe 1
+                withClue("Sorcerer Role grants +1/+1 to the 2/2 Bears") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                }
+            }
+
+            test("declining the target still draws — even with no other creature to target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Deliberately your only creature, so there is no legal "other" target at all.
+                    .withCardOnBattlefield(1, "Living Lectern")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lectern = game.findPermanent("Living Lectern")!!
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = lectern,
+                        abilityId = lecternAbilityId,
+                        targets = emptyList(),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("'up to one' declined — the draw is not gated on the Role") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("no target chosen means no Sorcerer Role is created") {
+                    game.findPermanent("Sorcerer Role") shouldBe null
+                }
+            }
+        }
+
+        context("Rip the Seams — 'target tapped creature' is a targeting restriction") {
+            test("a tapped creature is destroyed, and the card exiles itself (CR 715.3d)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Threadbind Clique")
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val clique = game.findCardsInHand(1, "Threadbind Clique").single()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // faceIndex = 0 is the Adventure face (CR 715).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = clique,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        faceIndex = 0,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                game.isInExile(1, "Threadbind Clique") shouldBe true
+            }
+
+            test("an untapped creature is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Threadbind Clique")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val clique = game.findCardsInHand(1, "Threadbind Clique").single()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = clique,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        faceIndex = 0,
+                    )
+                ).error shouldNotBe null
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+        }
+
+        context("Tempest Hart — the mana value 5 threshold") {
+            test("a mana value 6 spell adds a counter, a mana value 2 spell does not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Tempest Hart")
+                    .withCardInHand(1, "Craw Wurm")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hart = game.findPermanent("Tempest Hart")!!
+                plusOneCounters(game, hart) shouldBe 0
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                withClue("Grizzly Bears is mana value 2 — below the threshold") {
+                    plusOneCounters(game, hart) shouldBe 0
+                }
+
+                game.castSpell(1, "Craw Wurm").error shouldBe null
+                game.resolveStack()
+                withClue("Craw Wurm is mana value 6 — at or above 5") {
+                    plusOneCounters(game, hart) shouldBe 1
+                }
+                withClue("3/4 base plus the counter") {
+                    game.state.projectedState.getPower(hart) shouldBe 4
+                    game.state.projectedState.getToughness(hart) shouldBe 5
+                }
+            }
+        }
+
+        context("Mend the Wilds — returning a permanent card from your graveyard") {
+            test("the targeted permanent card goes on top of your library and is drawn next") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Woodland Acolyte")
+                    .withCardInGraveyard(1, "Craw Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val acolyte = game.findCardsInHand(1, "Woodland Acolyte").single()
+                val wurm = game.findCardsInGraveyard(1, "Craw Wurm").single()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = acolyte,
+                        targets = listOf(ChosenTarget.Card(wurm, game.player1Id, Zone.GRAVEYARD)),
+                        faceIndex = 0,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Wurm left the graveyard for the top of the library") {
+                    game.isInGraveyard(1, "Craw Wurm") shouldBe false
+                    game.findCardsInLibrary(1, "Craw Wurm").size shouldBe 1
+                    game.state.getLibrary(game.player1Id).first() shouldBe wurm
+                }
+                withClue("the Adventure exiled itself, so the creature is castable later") {
+                    game.isInExile(1, "Woodland Acolyte") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more Wilds of Eldraine cards — three Adventure cards and two Role-token cards. All are composed from existing SDK primitives; no new engine vocabulary, so `docs/card-sdk-language-reference.md` is unchanged.

## Cards

| Card | Cost | What it does |
|---|---|---|
| **Threadbind Clique // Rip the Seams** (239) | `{3}{U}` // `{2}{W}` | 3/3 flier; the Adventure destroys a target **tapped** creature |
| **Tempest Hart // Scan the Clouds** (238) | `{3}{G}` // `{1}{U}` | Trample + a mana-value-5-or-greater cast trigger; the Adventure draws two then discards two |
| **Woodland Acolyte // Mend the Wilds** (241) | `{2}{W}` // `{G}` | ETB draw; the Adventure puts a target permanent card from your graveyard on top of your library |
| **Twisted Sewer-Witch** (114) | `{3}{B}{B}` | Creates a Rat, then a Wicked Role on each Rat you control |
| **Living Lectern** (59) | `{1}{U}` | `{1}`, Sacrifice: draw a card + a Sorcerer Role on up to one *other* target creature you control |

## Modelling notes

- **"Target tapped creature"** is a targeting restriction (`TargetFilter.TappedCreature`), not a check inside the effect — so it is enforced when targets are chosen *and* rechecked on resolution (CR 608.2b). A creature that untaps in response makes the Adventure fizzle.
- **Twisted Sewer-Witch** sequences the token step and the iteration with `.then()`. `IterationSpace.Group` is snapshotted when the `ForEach` starts executing — after that boundary — so the Rat just created is included in "for each Rat you control", which is how the card reads. Nothing else in the definition would catch that ordering being inverted, so it has a test.
- **Living Lectern** uses `optional = true` over `TargetFilter.OtherCreatureYouControl`. The `excludeSelf` is load-bearing even though the Lectern sacrifices itself: targets are chosen (CR 601.2c) before costs are paid (CR 601.2h). Modelling it as `Draw.then(CreateRoleToken)` behind one optional requirement gets both ruling-mandated behaviors for free — declining still draws, but a chosen-then-illegal target fizzles the whole ability including the draw.
- **Color identity** spans both faces on the Adventure cards (`UW`, `GU`, `GW`), matching the existing WOE Adventure convention.

## Verification

- `just build` — green.
- `WoeCardsBatch9ScenarioTest` — 7 tests, all passing. Covers the Sewer-Witch ForEach ordering, both branches of Living Lectern's optional target (including that the ability is activatable with no other creature on board, per the WOE ruling), the tapped-target restriction accepting tapped and rejecting untapped, both sides of the mana-value-5 boundary, and Mend the Wilds' graveyard→library-top move with self-exile.
- WOE card snapshot re-blessed; the diff adds only these five cards and removes nothing.
- `just check-card-printing` clean for all five — WOE is each card's only printing, so all are canonical there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)