### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HauntTheNetwork.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HauntTheNetwork.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Haunt the Network — Aetherdrift #207
+ * {3}{U}{B} · Sorcery
+ *
+ * Choose target opponent. Create two 1/1 colorless Thopter artifact creature tokens with flying.
+ * Then the chosen player loses X life and you gain X life, where X is the number of artifacts you
+ * control.
+ *
+ * Order matters and the oracle text spells it out: the tokens are created *first*, and they are
+ * artifact creatures, so they count themselves toward X. On an otherwise empty board this drains
+ * for 2, not 0. [Effects.Composite] executes its steps in sequence against the updated state, so
+ * the [DynamicAmount.Count] over battlefield artifacts sees the two new Thopters.
+ *
+ * The drain is modelled as separate life-loss and life-gain steps rather than
+ * [Effects.DrainLife]: the card gains a flat X, not "life equal to the life lost this way", so the
+ * gain is unaffected by anything that changed how much life the opponent actually lost.
+ */
+val HauntTheNetwork = card("Haunt the Network") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Sorcery"
+    oracleText = "Choose target opponent. Create two 1/1 colorless Thopter artifact creature " +
+        "tokens with flying. Then the chosen player loses X life and you gain X life, where X is " +
+        "the number of artifacts you control."
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        val artifactsYouControl = DynamicAmount.Count(
+            Player.You,
+            Zone.BATTLEFIELD,
+            GameObjectFilter.Artifact
+        )
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                creatureTypes = setOf("Thopter"),
+                keywords = setOf(Keyword.FLYING),
+                count = 2,
+                artifactToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677",
+            ),
+            Effects.LoseLife(artifactsYouControl, opponent),
+            Effects.GainLife(artifactsYouControl),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Jeff Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg?1783907857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MidnightMangler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MidnightMangler.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Midnight Mangler — Aetherdrift #50
+ * {1}{U} · Artifact — Vehicle · 3/3
+ *
+ * During turns other than yours, this Vehicle is an artifact creature.
+ * Crew 2
+ *
+ * A free blocker that switches itself on: the animation is a Layer 4 type-adding static
+ * ([GrantCardType]) gated by [Conditions.IsNotYourTurn], not a triggered ability. Because
+ * [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] is re-evaluated on every projection, the
+ * Vehicle becomes a creature the instant the turn passes to an opponent and stops being one when
+ * your turn begins again — including mid-turn control changes, since the condition is read against
+ * the ability's current controller.
+ *
+ * The card is already an Artifact, so adding CREATURE is the whole type change; the printed 3/3
+ * needs no help. Crew 2 still works on your own turn for attacking.
+ */
+val MidnightMangler = card("Midnight Mangler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 3
+    oracleText = "During turns other than yours, this Vehicle is an artifact creature.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+
+    staticAbility {
+        condition = Conditions.IsNotYourTurn
+        ability = GrantCardType("CREATURE", GroupFilter.source())
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Villarrte"
+        flavorText = "\"Is someone asleep at the wheel, or are the wheels driving themselves?!\"\n" +
+            "—Vnwxt, Grand Prix host"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg?1783907906"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PrideOfTheRoad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PrideOfTheRoad.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Pride of the Road — Aetherdrift #24
+ * {3}{W} · Creature — Zombie Cat Warrior · 2/5
+ *
+ * Vigilance
+ * Start your engines!
+ * Max speed — At the beginning of combat on your turn, target creature or Vehicle you control gains
+ * double strike until end of turn.
+ *
+ * "Max speed — [ability]" is "as long as you have max speed, this object has [ability]"
+ * (CR 702.178a), so the [maxSpeed] block gates the triggered ability with a `triggerCondition`
+ * (CR 603.4): checked when the trigger would fire *and* again on resolution. Dropping below speed 4
+ * between the two — which can't normally happen, speed only rises — would correctly do nothing.
+ *
+ * The target is a plain creature-or-Vehicle-you-control permanent target, so an un-crewed Vehicle is
+ * legal (Vehicles are targetable whether or not they're currently creatures) and keeps the double
+ * strike if it's crewed later the same turn.
+ */
+val PrideOfTheRoad = card("Pride of the Road") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Zombie Cat Warrior"
+    power = 2
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — At the beginning of combat on your turn, target creature or Vehicle you " +
+        "control gains double strike until end of turn."
+
+    keywords(Keyword.VIGILANCE)
+    startYourEngines()
+
+    maxSpeed {
+        triggeredAbility {
+            trigger = Triggers.BeginCombat
+            val t = target(
+                "creature or Vehicle you control",
+                TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle.youControl()))
+            )
+            effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+            description = "At the beginning of combat on your turn, target creature or Vehicle " +
+                "you control gains double strike until end of turn."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "Alfonso Santano"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg?1783907916"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ScroungingSkyray.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ScroungingSkyray.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Scrounging Skyray — Aetherdrift #60
+ * {1}{U} · Creature — Fish Pirate · 1/2
+ *
+ * Flying
+ * Whenever you discard one or more cards, put that many +1/+1 counters on this creature.
+ * Cycling {2}
+ *
+ * Batch-worded discard payoff (CR 603.2c), so it uses [Triggers.YouDiscardOneOrMore] — one trigger
+ * per discard *event*, however many cards it contained — and reads the batch size back through
+ * [ContextPropertyKey.TRIGGER_DISCARD_COUNT] ("that many"). Discarding three cards to one effect
+ * puts three counters on; three sequential single discards fire three triggers for one each. Same
+ * shape as Magmakin Artillerist's damage rider.
+ *
+ * Cycling *this* card never triggers its own ability: cycling discards it from hand, and the
+ * battlefield-only trigger doesn't function from hand. Cycling anything else while this is on the
+ * battlefield does fire it for 1.
+ */
+val ScroungingSkyray = card("Scrounging Skyray") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish Pirate"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever you discard one or more cards, put that many +1/+1 counters on this creature.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscardOneOrMore
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DISCARD_COUNT),
+            EffectTarget.Self,
+        )
+        description = "Whenever you discard one or more cards, put that many +1/+1 counters on " +
+            "this creature."
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Ron Spears"
+        flavorText = "\"Oi, you ain't gonna believe what these kelpheads just threw away!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg?1783907904"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThunderingBroodwagon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThunderingBroodwagon.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Thundering Broodwagon — Aetherdrift #225
+ * {2}{B}{B}{G}{G} · Artifact — Vehicle · 6/5
+ *
+ * Menace, reach
+ * When this Vehicle enters, destroy target nonland permanent an opponent controls with mana value
+ * 4 or less.
+ * Crew 3
+ * Cycling {2}
+ *
+ * A Vehicle carries its keywords in every zone but only *matters* while it's a creature — menace
+ * and reach sit on the card as printed keywords and the combat rules read them off projected state
+ * once it's crewed, so nothing special is needed here.
+ *
+ * The ETB is the plain destroy shape over [TargetFilter.NonlandPermanentOpponentControls] narrowed
+ * by `manaValueAtMost(4)`. Mana value is read off the *card*, so an animated land is still a land
+ * (not a legal target) and a face-down 2/2 has mana value 0.
+ *
+ * Cycling it never fires the ETB: cycling discards the card from hand, so the Vehicle never enters.
+ */
+val ThunderingBroodwagon = card("Thundering Broodwagon") {
+    manaCost = "{2}{B}{B}{G}{G}"
+    colorIdentity = "BG"
+    typeLine = "Artifact — Vehicle"
+    power = 6
+    toughness = 5
+    oracleText = "Menace, reach\n" +
+        "When this Vehicle enters, destroy target nonland permanent an opponent controls with " +
+        "mana value 4 or less.\n" +
+        "Crew 3\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.MENACE, Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "nonland permanent an opponent controls with mana value 4 or less",
+            TargetPermanent(filter = TargetFilter.NonlandPermanentOpponentControls.manaValueAtMost(4))
+        )
+        effect = Effects.Destroy(permanent)
+        description = "When this Vehicle enters, destroy target nonland permanent an opponent " +
+            "controls with mana value 4 or less."
+    }
+
+    keywordAbility(KeywordAbility.crew(3))
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Bartek Fedyczak"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg?1783907851"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -3869,6 +3869,77 @@
     ]
 }
 
+// Haunt the Network
+{
+    "name": "Haunt the Network",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose target opponent. Create two 1/1 colorless Thopter artifact creature tokens with flying. Then the chosen player loses X life and you gain X life, where X is the number of artifacts you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677",
+                    "artifactToken": true
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/478d236c-9778-435a-ac21-bd0017a17d5b.jpg?1783907857"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Hazard of the Dunes
 {
     "name": "Hazard of the Dunes",
@@ -4833,6 +4904,49 @@
     ]
 }
 
+// Midnight Mangler
+{
+    "name": "Midnight Mangler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantCardType",
+                    "cardType": "CREATURE"
+                },
+                "condition": "IsNotYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Villarrte",
+        "flavorText": "\"Is someone asleep at the wheel, or are the wheels driving themselves?!\"\n—Vnwxt, Grand Prix host",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/237568e3-7331-4bbb-a091-a766723134fc.jpg?1783907906"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Migrating Ketradon
 {
     "name": "Migrating Ketradon",
@@ -5684,6 +5798,69 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Pride of the Road
+{
+    "name": "Pride of the Road",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Zombie Cat Warrior",
+    "oracleText": "Vigilance\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — At the beginning of combat on your turn, target creature or Vehicle you control gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature or Vehicle you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|Vehicle ctrl:you"
+                    },
+                    "id": "creature or Vehicle you control"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Max speed — At the beginning of combat on your turn, target creature or Vehicle you control gains double strike until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "Alfonso Santano",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/4172222f-d871-4354-9a02-7af0001d8956.jpg?1783907916"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -6591,6 +6768,59 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/2/12ccd555-60d4-49a1-b022-1e119344172a.jpg?1783907846"
     },
     "colorIdentityOverride": []
+}
+
+// Scrounging Skyray
+{
+    "name": "Scrounging Skyray",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Fish Pirate",
+    "oracleText": "Flying\nWhenever you discard one or more cards, put that many +1/+1 counters on this creature.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "batch": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DISCARD_COUNT"
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you discard one or more cards, put that many +1/+1 counters on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spears",
+        "flavorText": "\"Oi, you ain't gonna believe what these kelpheads just threw away!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d60bece3-6f63-4d9e-bca0-cef2d38f1472.jpg?1783907904"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Shefet Archfiend
@@ -7780,6 +8010,72 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Thundering Broodwagon
+{
+    "name": "Thundering Broodwagon",
+    "manaCost": "{2}{B}{B}{G}{G}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Menace, reach\nWhen this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less.\nCrew 3\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "MENACE",
+        "REACH",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        },
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "nonland permanent an opponent controls with mana value 4 or less"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent mv<=4 ctrl:opponent"
+                    },
+                    "id": "nonland permanent an opponent controls with mana value 4 or less"
+                },
+                "descriptionOverride": "When this Vehicle enters, destroy target nonland permanent an opponent controls with mana value 4 or less."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Bartek Fedyczak",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d1576d4-15a3-4e91-84ef-e71e258185e7.jpg?1783907851"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Five more Aetherdrift (DFT) cards. All of them compose existing SDK vocabulary — no new effects, triggers, statics, or keywords — so the snapshot and lint nets are the coverage.

## Cards

| Card | # | Cost | Shape |
|---|---|---|---|
| **Thundering Broodwagon** | 225 | `{2}{B}{B}{G}{G}` | Menace, reach Vehicle 6/5. ETB destroys a target nonland permanent an opponent controls with mana value 4 or less. Crew 3, cycling `{2}`. |
| **Scrounging Skyray** | 60 | `{1}{U}` | Flying 1/2. Batch-worded discard payoff → that many +1/+1 counters. Cycling `{2}`. |
| **Haunt the Network** | 207 | `{3}{U}{B}` | Sorcery. Target opponent, two 1/1 flying Thopter artifact tokens, then drain X = artifacts you control. |
| **Midnight Mangler** | 50 | `{1}{U}` | Vehicle 3/3 that is an artifact creature during turns other than yours. Crew 2. |
| **Pride of the Road** | 24 | `{3}{W}` | Vigilance 2/5. Start your engines! Max speed — begin-combat trigger grants double strike to a target creature or Vehicle you control. |

## Implementation notes

- **Scrounging Skyray** uses `Triggers.YouDiscardOneOrMore` (batch, CR 603.2c) and reads "that many" back through `ContextPropertyKey.TRIGGER_DISCARD_COUNT` — the same shape as Magmakin Artillerist. Discarding three cards to one effect puts three counters on; three sequential single discards fire three triggers for one each. Cycling the Skyray itself never triggers it (the ability doesn't function from hand).
- **Haunt the Network** creates the tokens *before* computing X, matching the oracle wording — the two Thopters are artifacts, so they count themselves and this drains for at least 2. Modelled as separate `LoseLife` + `GainLife` steps rather than `Effects.DrainLife`, because the card gains a flat X, not "life equal to the life lost this way".
- **Midnight Mangler**'s animation is a Layer 4 `GrantCardType("CREATURE")` static gated on `Conditions.IsNotYourTurn` — no trigger. `ConditionalStaticAbility` is re-evaluated every projection, so it switches on the instant the turn passes and off when yours begins, and the condition reads against the ability's current controller so mid-turn control changes behave.
- **Pride of the Road**'s max-speed half goes through the existing `maxSpeed { }` builder, which gates the triggered ability with a `triggerCondition` (CR 603.4) rather than inventing a new ability type.
- **Thundering Broodwagon** reuses `TargetFilter.NonlandPermanentOpponentControls.manaValueAtMost(4)`; mana value is read off the card, so an animated land isn't a legal target.

## Verification

- `just build` — green (compile + `mtg-sets` suite incl. `CardLintTest`, `FacadeBoundaryTest`).
- `just rebless-cards` — `DFT.json` re-blessed; the diff adds **only** these five card trees, nothing else moved.
- `just check-card-printing` — all five report `ok`; DFT is each card's only real printing, so the canonical definitions belong here.
- Every `imageUri` (including the Thopter token) verified HTTP 200; all mechanical fields re-checked field-by-field against Scryfall with `&set=dft`.
- No new SDK vocabulary, so no scenario tests, no e2e, and no cross-layer tracing were required. No `backlog/sets/` file lists these cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)