### PR TITLE
Add five Wilds of Eldraine cards with IsEnchanted predicate support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2886,6 +2886,18 @@ work for abilities-on-stack (which carry no `CardComponent`).
   your Ring-bearer" use the existing `Conditions.SourceIsRingBearer`.
 - `IsFaceDown` — currently face-down.
 - `HasCounter(type)` — has at least one counter of `type`.
+- `IsEquipped` (filter builder `equipped()`) — has at least one Equipment attached.
+- `IsEnchanted` (filter builder `enchanted()`) — has at least one **Aura** attached, i.e. the MTG
+  adjective "enchanted" (CR 303.4). The Aura mirror of `IsEquipped`, and strictly narrower than
+  `SourceIsModified` / `IsModified`: Equipment attached or counters on the permanent do *not* make it
+  enchanted. Control of the Aura is irrelevant — an opponent's Aura still enchants your creature — so
+  "enchanted creatures you control" is two predicates that bind to different objects:
+  `GameObjectFilter.Creature.youControl().enchanted()` (A Tale for the Ages' +2/+2 anthem, Lord
+  Skitter's Blessing's `Conditions.YouControlAtLeast(1, …)` draw-step gate). Role tokens are Auras
+  (CR 113.2c), which makes this the Wilds of Eldraine Roles payoff predicate. Resolves in both
+  `PredicateEvaluator` (targets/conditions) and `AffectsFilterResolver` (layer-7c group projection).
+- `IsModified` — has an Equipment attached, an Aura attached, **or** any counter (the MTG "modified"
+  definition). For the source-relative form use `Conditions.SourceIsModified`.
 - `AttachedToCardType(cardType)` — Aura/Equipment whose `AttachedToComponent` points to a
   permanent that currently has the given top-level [`CardType`] in its **projected** type
   set. Used by filters like "Aura attached to a land" (Pyramids) or "Equipment attached

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -924,6 +924,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must have at least one Aura attached — "enchanted creature" as a group adjective. Compose with
+     * [youControl] for "enchanted creatures you control" (A Tale for the Ages); the Aura's own
+     * controller is irrelevant. See [StatePredicate.IsEnchanted].
+     */
+    fun enchanted() = copy(
+        statePredicates = statePredicates + StatePredicate.IsEnchanted
+    )
+
+    /**
      * Must be marked as a "warped card in exile" (CR 702.185b) — i.e., the
      * engine wrote a `WarpExiledComponent` when the warped permanent left the
      * battlefield at end of turn. Use this when filtering candidates in the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -371,7 +371,7 @@ sealed interface StatePredicate {
     }
 
     // =============================================================================
-    // Equipment (Entity)
+    // Equipment / Auras (Entity)
     // =============================================================================
 
     /** Has at least one Equipment attached */
@@ -379,6 +379,23 @@ sealed interface StatePredicate {
     @Serializable
     data object IsEquipped : Entity {
         override val description: String = "equipped"
+    }
+
+    /**
+     * Has at least one Aura attached — the MTG adjective "enchanted" (CR 303.4: an Aura *enchants*
+     * the permanent it's attached to). The Aura mirror of [IsEquipped], and deliberately narrower
+     * than [IsModified]: an Equipment attached or a counter on the permanent does not make it
+     * enchanted. Control of the Aura is irrelevant — an opponent's Aura still enchants your
+     * creature, which is why "enchanted creatures you control" (A Tale for the Ages) scopes control
+     * on the *creature* via a separate controller predicate rather than on the attachment.
+     *
+     * Role tokens are Auras (CR 113.2c), so this is also the Wilds of Eldraine Roles payoff
+     * ("if you control an enchanted creature" — Lord Skitter's Blessing).
+     */
+    @SerialName("IsEnchanted")
+    @Serializable
+    data object IsEnchanted : Entity {
+        override val description: String = "enchanted"
     }
 
     /** Has an Equipment attached, an Aura attached, or any counter (MTG "modified" definition) */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ATaleForTheAges.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ATaleForTheAges.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * A Tale for the Ages
+ * {1}{W}
+ * Enchantment
+ *
+ * Enchanted creatures you control get +2/+2.
+ *
+ * A plain layer-7c group static (an anthem in the [GloriousAnthem][com.wingedsheep.mtg.sets.definitions.usg.cards.GloriousAnthem]
+ * mould), the only novelty being the group itself: "enchanted" is
+ * [StatePredicate.IsEnchanted][com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted],
+ * i.e. *has an Aura attached*, added alongside the pre-existing `IsEquipped`.
+ *
+ * The two adjectives in "enchanted creatures you control" bind to different objects and so are two
+ * separate predicates: `youControl()` constrains the *creature's* controller, `enchanted()` only asks
+ * that some Aura be attached to it. An opponent's Aura on your creature still turns the buff on
+ * (CR 303.4 — an Aura enchants what it's attached to regardless of who controls the Aura), and your
+ * Aura on their creature does not. Role tokens are Auras (CR 113.2c), so in practice this is the
+ * Wilds of Eldraine Roles payoff — and note it is *not* `IsModified`: Equipment and counters don't
+ * enchant anything.
+ *
+ * The buff is unconditional and self-independent (this enchantment is not itself an Aura), so no
+ * `ConditionalStaticAbility` and no dependency wrinkle: it re-evaluates continuously as Auras come
+ * and go, which is exactly what projected state gives us for free.
+ */
+val ATaleForTheAges = card("A Tale for the Ages") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Enchanted creatures you control get +2/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().enchanted()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Julie Dillon"
+        flavorText = "With every retelling of Agatha's demise, Kellan got taller and Ruby got " +
+            "stronger. But the core story stayed the same, and people remembered what happens to " +
+            "those who prey on the weak."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg?1783915126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HowlingGalefang.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HowlingGalefang.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Howling Galefang
+ * {2}{G}{G}
+ * Creature — Beast
+ * 4/4
+ *
+ * Vigilance
+ * This creature has haste as long as you own a card in exile that has an Adventure.
+ *
+ * A [ConditionalStaticAbility] self-grant in the [KavuRunner][com.wingedsheep.mtg.sets.definitions.inv.cards.KavuRunner]
+ * mould; the only interesting part is the condition.
+ *
+ * "A card in exile that has an Adventure" is [CardPredicate.HasAdventure] — a property of the *card*
+ * (its layout), not of how it got there. Per the WOE ruling this deliberately does not care whether the
+ * card was cast as an Adventure: a card exiled by any means at all turns haste on, which is why the
+ * condition is a plain zone existence check rather than anything reading the adventure-exile marker.
+ *
+ * "You own" maps to `Exists(Player.You, Zone.EXILE, …)` because exile is keyed per player in this
+ * engine and a card sits in its owner's exile zone, so the player scoping already means ownership
+ * rather than control — the right reading here, since exiled cards have no controller.
+ */
+val HowlingGalefang = card("Howling Galefang") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "This creature has haste as long as you own a card in exile that has an Adventure."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, Filters.Self),
+            condition = Exists(
+                Player.You,
+                Zone.EXILE,
+                GameObjectFilter(cardPredicates = listOf(CardPredicate.HasAdventure)),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "\"I have to hand it to you, Yorvo. Since your pet showed up, not a single " +
+            "smallfolk has even made it to the door of my vault.\"\n—Beluna Grandsquall"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg?1783915080"
+
+        ruling(
+            "2023-09-01",
+            "Howling Galefang will have haste as long as any card you own in exile has an Adventure. " +
+                "It doesn't matter if that card was cast as an Adventure or not."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LordSkittersBlessing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LordSkittersBlessing.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Lord Skitter's Blessing
+ * {1}{B}
+ * Enchantment
+ *
+ * When this enchantment enters, create a Wicked Role token attached to target creature you control.
+ * At the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you
+ * draw an additional card.
+ *
+ * Two independent triggered abilities, no statics.
+ *
+ * The enters ability reuses [Effects.CreateRoleToken] — the shared Role machinery that already backs
+ * [CharmingScoundrel] and [NotDeadAfterAll], so the +1/+1 and the "each opponent loses 1 life" death
+ * trigger come with the token rather than being restated here. Per the WOE Role rulings the target is
+ * required: with no legal creature the enters ability is removed from the stack and no Role is created,
+ * and the state-based Role-uniqueness action (one Role per permanent per controller, oldest ones
+ * binned) is likewise the token's business, not this card's.
+ *
+ * The draw-step ability is an intervening-'if' clause (CR 603.4), so the check runs twice — once as
+ * the step begins, once again on resolution — and "an enchanted creature" is exactly
+ * [StatePredicate.IsEnchanted][com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted]
+ * scoped to creatures you control. Usually that creature is the Role this card just made, but any
+ * Aura will do, including an opponent's Aura on your creature (CR 303.4).
+ *
+ * "You draw an additional card" is modelled as a plain extra draw on the trigger, which is the whole
+ * of its meaning here: the ability resolves during the draw step alongside the turn-based draw rather
+ * than replacing or modifying it, so a second `DrawCards(1)` is not an approximation. Life loss is
+ * ordered before the draw to match the printed order — it matters when the loss is lethal.
+ */
+val LordSkittersBlessing = card("Lord Skitter's Blessing") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create a Wicked Role token attached to target " +
+        "creature you control. (Enchanted creature gets +1/+1. When this token is put into a " +
+        "graveyard, each opponent loses 1 life.)\n" +
+        "At the beginning of your draw step, if you control an enchanted creature, you lose 1 life " +
+        "and you draw an additional card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.CreateRoleToken("Wicked Role", creature)
+        description = "When this enchantment enters, create a Wicked Role token attached to target " +
+            "creature you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourDrawStep
+        triggerCondition = Conditions.YouControlAtLeast(
+            1,
+            GameObjectFilter.Creature.youControl().enchanted(),
+        )
+        effect = Effects.LoseLife(1, EffectTarget.Controller)
+            .then(Effects.DrawCards(1))
+        description = "At the beginning of your draw step, if you control an enchanted creature, " +
+            "you lose 1 life and you draw an additional card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "Joseph Weston"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg?1783915106"
+
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and " +
+                "the enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, " +
+                "each of those Roles except the one with the most recent timestamp is put into its " +
+                "owner's graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "A permanent can have multiple Roles attached to it if each one is controlled by a " +
+                "different player."
+        )
+        ruling(
+            "2023-09-01",
+            "Some spells and abilities that create Role tokens require targets. If each target " +
+                "chosen is an illegal target as that spell or ability tries to resolve, it won't " +
+                "resolve. The Role token won't be created."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StonesplitterBolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StonesplitterBolt.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Stonesplitter Bolt
+ * {X}{R}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Stonesplitter Bolt deals X damage to target creature or planeswalker. If this spell was bargained,
+ * it deals twice X damage to that permanent instead.
+ *
+ * The spell-rider shape of bargain (CR 702.166c), read off the spell while it's still on the stack —
+ * so the payoff gates on [Conditions.WasBargained], as in [CandyGrapple].
+ *
+ * Unlike Candy Grapple, though, the "instead" is **not** composed as a base hit plus a second top-up
+ * hit. Damage is not a layer-7c modification that silently merges: two instances of X damage and one
+ * instance of 2X are distinguishable in the rules — damage-prevention shields absorb per instance,
+ * damage-doubling and redirection replacement effects apply per instance, and "whenever a source deals
+ * damage" triggers would fire twice. So the conditional lives in the *amount* instead, via
+ * [DynamicAmount.Conditional], leaving exactly one [Effects.DealDamage] on either branch.
+ * `Multiply(XValue, 2)` is "twice X" rather than a hardcoded doubling of the final number, so it
+ * stays correct when X is 0.
+ *
+ * One target requirement, chosen at announcement regardless of branch — the printed text says
+ * "that permanent", not a second target.
+ */
+val StonesplitterBolt = card("Stonesplitter Bolt") {
+    manaCost = "{X}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Stonesplitter Bolt deals X damage to target creature or planeswalker. If this spell was " +
+        "bargained, it deals twice X damage to that permanent instead."
+
+    bargain()
+
+    spell {
+        val victim = target("target creature or planeswalker", TargetCreatureOrPlaneswalker())
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.Conditional(
+                condition = Conditions.WasBargained,
+                ifTrue = DynamicAmount.Multiply(DynamicAmount.XValue, 2),
+                ifFalse = DynamicAmount.XValue,
+            ),
+            target = victim,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Alexandr Leskinen"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg?1783915088"
+
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TenaciousTomeseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TenaciousTomeseeker.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Tenacious Tomeseeker
+ * {2}{U}
+ * Creature — Human Knight
+ * 3/2
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * When this creature enters, if it was bargained, return target instant or sorcery card from your
+ * graveyard to your hand.
+ *
+ * The permanent shape of bargain (CR 702.166b), same as [AgathasChampion] and [HighFaeNegotiator]:
+ * the bargained fact is stamped on the spell as it's cast and rides the permanent it becomes, so the
+ * enters trigger can still read it. [Conditions.WasBargained] is the intervening-'if' clause
+ * (CR 603.4), so an unbargained cast never puts the ability on the stack — and per the WOE ruling you
+ * may bargain the spell even when your graveyard holds nothing to return.
+ *
+ * `InstantOrSorceryInGraveyard.ownedByYou()` is the "from your graveyard" scoping. This also gets the
+ * Adventure ruling right for free: an adventurer card in a graveyard is a creature card, not an
+ * instant or sorcery card, and `GameObjectFilter.InstantOrSorcery` matches on the front face's types —
+ * the deliberately separate `InstantSorceryOrAdventure` filter is what cards that *do* count
+ * adventurers (Frantic Firebolt) reach for.
+ */
+val TenaciousTomeseeker = card("Tenacious Tomeseeker") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 2
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "When this creature enters, if it was bargained, return target instant or sorcery card from " +
+        "your graveyard to your hand."
+
+    bargain()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasBargained
+        val spellCard = target(
+            "target instant or sorcery card from your graveyard",
+            TargetObject(filter = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou()),
+        )
+        effect = Effects.ReturnToHand(spellCard)
+        description = "When this creature enters, if it was bargained, return target instant or " +
+            "sorcery card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Kai Carpenter"
+        flavorText = "\"An intact volume of Tales of the Fae? The king will be pleased.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg?1783915113"
+
+        ruling(
+            "2023-09-01",
+            "Adventurer cards aren't instant or sorcery cards while they're in your graveyard. You " +
+                "can't use Tenacious Tomeseeker's ability to return an adventurer card from your " +
+                "graveyard to your hand."
+        )
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "You can bargain a permanent spell even if you won't be able to choose targets for an " +
+                "enters-the-battlefield ability of that permanent once the spell resolves."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1,3 +1,41 @@
+// A Tale for the Ages
+{
+    "name": "A Tale for the Ages",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Enchanted creatures you control get +2/+2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsEnchanted"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "RARE",
+        "artist": "Julie Dillon",
+        "flavorText": "With every retelling of Agatha's demise, Kellan got taller and Ruby got stronger. But the core story stayed the same, and people remembered what happens to those who prey on the weak.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca0c8d3b-ce30-4da5-a6a8-9bdcb3c757f9.jpg?1783915126"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Agatha's Champion
 {
     "name": "Agatha's Champion",
@@ -4067,6 +4105,62 @@
     ]
 }
 
+// Howling Galefang
+{
+    "name": "Howling Galefang",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Vigilance\nThis creature has haste as long as you own a card in exile that has an Adventure.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Exile",
+                    "filter": {
+                        "cardPredicates": [
+                            "HasAdventure"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Néstor Ossandón Leal",
+        "flavorText": "\"I have to hand it to you, Yorvo. Since your pet showed up, not a single smallfolk has even made it to the door of my vault.\"\n—Beluna Grandsquall",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86311523-d0eb-4db3-b586-8349de9c2d37.jpg?1783915080",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Howling Galefang will have haste as long as any card you own in exile has an Adventure. It doesn't matter if that card was cast as an Adventure or not."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Imodane's Recruiter
 {
     "name": "Imodane's Recruiter",
@@ -4686,6 +4780,118 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Lord Skitter's Blessing
+{
+    "name": "Lord Skitter's Blessing",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create a Wicked Role token attached to target creature you control. (Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)\nAt the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "When this enchantment enters, create a Wicked Role token attached to target creature you control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "DRAW"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "IsEnchanted"
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "At the beginning of your draw step, if you control an enchanted creature, you lose 1 life and you draw an additional card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "Joseph Weston",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84f343a9-883f-4532-ae66-be6470d67d38.jpg?1783915106",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "A permanent can have multiple Roles attached to it if each one is controlled by a different player."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some spells and abilities that create Role tokens require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. The Role token won't be created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -8161,6 +8367,79 @@
     ]
 }
 
+// Stonesplitter Bolt
+{
+    "name": "Stonesplitter Bolt",
+    "manaCost": "{X}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nStonesplitter Bolt deals X damage to target creature or planeswalker. If this spell was bargained, it deals twice X damage to that permanent instead.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                },
+                "ifTrue": {
+                    "type": "Multiply",
+                    "amount": "XValue",
+                    "multiplier": 2
+                },
+                "ifFalse": "XValue"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature or planeswalker"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Alexandr Leskinen",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb22f79c-3075-439d-a072-ceaabe35d76f.jpg?1783915088",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Stormkeld Prowler
 {
     "name": "Stormkeld Prowler",
@@ -8783,6 +9062,92 @@
                 }
             }
         }
+    ]
+}
+
+// Tenacious Tomeseeker
+{
+    "name": "Tenacious Tomeseeker",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nWhen this creature enters, if it was bargained, return target instant or sorcery card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target instant or sorcery card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target instant or sorcery card from your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                },
+                "descriptionOverride": "When this creature enters, if it was bargained, return target instant or sorcery card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Kai Carpenter",
+        "flavorText": "\"An intact volume of Tales of the Fae? The king will be pleased.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c40be735-0780-459b-8dd2-a298575beaab.jpg?1783915113",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Adventurer cards aren't instant or sorcery cards while they're in your graveyard. You can't use Tenacious Tomeseeker's ability to return an adventurer card from your graveyard to your hand."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You can bargain a permanent spell even if you won't be able to choose targets for an enters-the-battlefield ability of that permanent once the spell resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -478,6 +478,7 @@ class BeginningPhaseManager(
         StatePredicate.HasLeastPowerAmongAllCreatures,
         StatePredicate.HasLeastPower,
         StatePredicate.IsEquipped,
+        StatePredicate.IsEnchanted,
         StatePredicate.IsModified,
         StatePredicate.IsSaddled,
         StatePredicate.HasLockedDoor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1809,6 +1809,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPowerAmongAllCreatures,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPower,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsSaddled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.CrewedOrSaddledSourceThisTurn,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1160,6 +1160,16 @@ class PredicateEvaluator {
                 }
             }
 
+            // Aura state — "enchanted". Mirrors IsEquipped over the Aura subtype instead of
+            // Equipment, so a permanent carrying only Equipment (or only counters) is not enchanted.
+            StatePredicate.IsEnchanted -> {
+                val attachments = container.get<AttachmentsComponent>()
+                if (attachments == null || attachments.attachedIds.isEmpty()) return false
+                attachments.attachedIds.any { attachId ->
+                    state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isAura == true
+                }
+            }
+
             StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
 
             // Attached-to-type — entity has an AttachedToComponent and the referenced

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -478,6 +478,16 @@ internal class AffectsFilterResolver {
                 state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isEquipment == true
             }
         }
+        // "Enchanted creatures you control get +2/+2" (A Tale for the Ages) is a layer-7c group
+        // static, so this has to resolve during projection: read the base attachment index and the
+        // attached card's printed type line — an Aura's own Aura-ness is never granted or removed by
+        // a continuous effect, so no projected lookup is needed for the attachment itself.
+        StatePredicate.IsEnchanted -> {
+            val attachments = container.get<AttachmentsComponent>()
+            attachments != null && attachments.attachedIds.any { attachId ->
+                state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isAura == true
+            }
+        }
         StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
         // A general "attached to <filter>" host constraint whose nested filter may carry a controller
         // predicate ("a creature you control"). Group-static projection has no ability controller to

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch10ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch10ScenarioTest.kt
@@ -1,0 +1,446 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the tenth batch of Wilds of Eldraine cards.
+ *
+ * The batch adds one piece of SDK vocabulary —
+ * [StatePredicate.IsEnchanted][com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted],
+ * "has an Aura attached" — so the bulk of this file pins that predicate down from both of its two
+ * users and from both of the engine paths it resolves on:
+ *
+ *  - **A Tale for the Ages** exercises it in layer-7c *group projection* (`AffectsFilterResolver`).
+ *    The traps a plausible implementation falls into are all encoded here: an Equipment-only creature
+ *    must **not** be buffed (the predicate is not `IsModified`), an opponent's creature must not be
+ *    buffed even while carrying your own Aura, and your creature carrying an *opponent's* Aura must
+ *    be (CR 303.4 — the Aura's controller is irrelevant). The buff also has to appear and disappear
+ *    as Auras arrive and leave, which is what makes it a projection concern rather than a one-shot.
+ *  - **Lord Skitter's Blessing** exercises it as a *trigger gate* (`PredicateEvaluator`), which is a
+ *    separate code path. Its intervening-'if' (CR 603.4) must suppress the whole ability — no life
+ *    loss, no extra card — when nothing you control is enchanted.
+ *
+ * The remaining three cards are pure compositions, but each has one place a plausible model resolves
+ * wrong, so they get a check apiece: **Stonesplitter Bolt**'s "twice X" (both branches, and X = 0),
+ * **Tenacious Tomeseeker**'s bargain-gated enters trigger, and **Howling Galefang**'s conditional
+ * haste.
+ */
+class WoeCardsBatch10ScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? = game.state.projectedState.getToughness(id)
+
+    private fun auraOn(game: TestGame, auraName: String, host: EntityId): EntityId? =
+        game.findPermanents(auraName).firstOrNull { aura ->
+            game.state.getEntity(aura)?.get<AttachedToComponent>()?.targetId == host
+        }
+
+    init {
+        context("A Tale for the Ages — 'enchanted creatures you control get +2/+2'") {
+            test("buffs your enchanted creature, and leaves your unenchanted one alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Redtooth Genealogist")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val elf = game.findPermanent("Redtooth Genealogist").shouldNotBeNull()
+
+                withClue("the enchanted 2/2 Bears projects as 4/4") {
+                    power(game, bears) shouldBe 4
+                    toughness(game, bears) shouldBe 4
+                }
+                withClue("the unenchanted 2/3 Genealogist is untouched") {
+                    power(game, elf) shouldBe 2
+                    toughness(game, elf) shouldBe 3
+                }
+            }
+
+            test("an Equipment attached is not 'enchanted' — the predicate is not IsModified") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Whispersilk Cloak", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("Whispersilk Cloak is Equipment, not an Aura — the Bears stays 2/2") {
+                    power(game, bears) shouldBe 2
+                    toughness(game, bears) shouldBe 2
+                }
+            }
+
+            test("your creature enchanted by an opponent's Aura still gets the buff (CR 303.4)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Player 2 owns and controls the Pacifism; player 1 controls the creature.
+                    .withCardAttachedTo(2, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("'enchanted' asks only that an Aura be attached, whoever controls it") {
+                    power(game, bears) shouldBe 4
+                    toughness(game, bears) shouldBe 4
+                }
+            }
+
+            test("an opponent's enchanted creature is not buffed — 'you control' scopes the creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    // Player 1's own Aura, on player 2's creature.
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("the creature is the opponent's, so the anthem does not see it") {
+                    power(game, bears) shouldBe 2
+                    toughness(game, bears) shouldBe 2
+                }
+            }
+
+            test("the buff falls away when the Aura leaves — it is projected, not applied once") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                power(game, bears) shouldBe 4
+
+                // Destroy the Aura by bouncing it off: kill the host with X=4 damage, which takes
+                // the Aura to the graveyard with it (CR 704.5m) and removes the anthem's subject.
+                game.castXSpell(1, "Stonesplitter Bolt", xValue = 4, targetId = bears)
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("a 4/4 enchanted Bears dies to 4 damage, and its Aura follows it") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Pacifism") shouldBe true
+                }
+            }
+        }
+
+        context("Lord Skitter's Blessing") {
+            test("the enters trigger attaches a Wicked Role to the targeted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lord Skitter's Blessing")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castSpell(1, "Lord Skitter's Blessing").error shouldBe null
+                game.resolveStack()
+
+                // The Role's target belongs to the *enters* trigger, so it is chosen when that
+                // trigger goes on the stack — after the enchantment itself has resolved.
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a Wicked Role token is attached to the Bears") {
+                    auraOn(game, "Wicked Role", bears).shouldNotBeNull()
+                }
+                withClue("Wicked Role grants +1/+1 — the 2/2 Bears projects as 3/3") {
+                    power(game, bears) shouldBe 3
+                    toughness(game, bears) shouldBe 3
+                }
+            }
+
+            test("the draw step fires when you control an enchanted creature: -1 life, +1 card") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lord Skitter's Blessing")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    // Not turn 1 — the starting player skips their first draw step (CR 103.7a),
+                    // which would hide the turn-based draw this test counts against.
+                    .withTurnNumber(3)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                repeat(10) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(10) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("you lose 1 life") { game.getLifeTotal(1) shouldBe 19 }
+                withClue("the turn-based draw plus the additional card — two cards this draw step") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+            }
+
+            test("with nothing enchanted the intervening 'if' suppresses the whole ability") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lord Skitter's Blessing")
+                    // A creature, but no Aura on it.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                repeat(10) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(10) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+
+                withClue("no life lost — the ability never went on the stack") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+                withClue("only the turn-based draw") { game.handSize(1) shouldBe handBefore + 1 }
+            }
+        }
+
+        context("Stonesplitter Bolt — X damage, twice X if bargained") {
+            test("unbargained deals exactly X") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                // X = 1 into a 2/2: survives. Were the amount doubled without bargain, it would die.
+                game.castXSpell(1, "Stonesplitter Bolt", xValue = 1, targetId = bears)
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("1 damage does not kill a 2/2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("bargained deals twice X — the same X that survived unbargained now kills") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                // Sacrifice the enchantment to bargain; X = 1 becomes 2 damage, lethal to the 2/2.
+                game.castSpellBargained(
+                    1,
+                    "Stonesplitter Bolt",
+                    sacrificeName = "A Tale for the Ages",
+                    targetId = bears,
+                    xValue = 1,
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the enchantment paid the bargain cost") {
+                    game.isInGraveyard(1, "A Tale for the Ages") shouldBe true
+                }
+                withClue("twice X = 2 damage kills the 2/2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("X = 0 bargained is still 0 damage — 'twice X', not a flat doubling") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lions = game.findPermanent("Savannah Lions").shouldNotBeNull()
+
+                game.castSpellBargained(
+                    1,
+                    "Stonesplitter Bolt",
+                    sacrificeName = "A Tale for the Ages",
+                    targetId = lions,
+                    xValue = 0,
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("twice 0 is 0 — the 2/1 lives") {
+                    game.isOnBattlefield("Savannah Lions") shouldBe true
+                }
+            }
+        }
+
+        context("Tenacious Tomeseeker — bargain-gated graveyard return") {
+            test("bargained, it returns the targeted instant from your graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Tenacious Tomeseeker")
+                    .withCardOnBattlefield(1, "A Tale for the Ages")
+                    .withCardInGraveyard(1, "Candy Grapple")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellBargained(
+                    1,
+                    "Tenacious Tomeseeker",
+                    sacrificeName = "A Tale for the Ages",
+                ).error shouldBe null
+                game.resolveStack()
+
+                // The graveyard target belongs to the enters trigger, chosen once that trigger is
+                // put on the stack — i.e. only on the bargained branch (CR 702.166d).
+                val grapple = game.findCardsInGraveyard(1, "Candy Grapple").single()
+                game.selectTargets(listOf(grapple)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the bargained enters trigger returned the instant to hand") {
+                    game.isInHand(1, "Candy Grapple") shouldBe true
+                    game.isInGraveyard(1, "Candy Grapple") shouldBe false
+                }
+            }
+
+            test("unbargained, the enters trigger never goes on the stack (CR 603.4)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Tenacious Tomeseeker")
+                    .withCardInGraveyard(1, "Candy Grapple")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Tenacious Tomeseeker").error shouldBe null
+                game.resolveStack()
+
+                withClue("the creature resolved") {
+                    game.isOnBattlefield("Tenacious Tomeseeker") shouldBe true
+                }
+                withClue("no bargain, so nothing came back and no decision was raised") {
+                    game.isInGraveyard(1, "Candy Grapple") shouldBe true
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+
+        context("Howling Galefang — haste while you own an Adventure card in exile") {
+            test("no Adventure card in exile: vigilance only, no haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Howling Galefang")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fang = game.findPermanent("Howling Galefang").shouldNotBeNull()
+                val projected = game.state.projectedState
+
+                projected.hasKeyword(fang, Keyword.VIGILANCE) shouldBe true
+                withClue("nothing in exile, so the conditional grant is off") {
+                    projected.hasKeyword(fang, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("an Adventure card you own in exile turns haste on, however it got there") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Besotted Knight // Betroth the Beast — an Adventure card. Per the WOE ruling
+                    // it does not matter that it was not cast as an Adventure.
+                    .withCardInExile(1, "Besotted Knight")
+                    .withCardOnBattlefield(1, "Howling Galefang")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fang = game.findPermanent("Howling Galefang").shouldNotBeNull()
+
+                withClue("a card with an Adventure sits in your exile zone") {
+                    game.state.projectedState.hasKeyword(fang, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("an Adventure card in an opponent's exile does not grant it — 'you own'") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInExile(2, "Besotted Knight")
+                    .withCardOnBattlefield(1, "Howling Galefang")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fang = game.findPermanent("Howling Galefang").shouldNotBeNull()
+
+                withClue("the exiled Adventure is the opponent's, so no haste") {
+                    game.state.projectedState.hasKeyword(fang, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("a non-Adventure card in your exile does not grant haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInExile(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Howling Galefang")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fang = game.findPermanent("Howling Galefang").shouldNotBeNull()
+
+                withClue("Grizzly Bears has no Adventure") {
+                    game.state.projectedState.hasKeyword(fang, Keyword.HASTE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -1425,12 +1425,15 @@ abstract class ScenarioTestBase : FunSpec() {
          * @param spellName The name of the spell to cast, from that player's hand
          * @param sacrificeName The permanent that player controls to sacrifice for bargain
          * @param targetId Optional single target for the spell
+         * @param xValue The value chosen for `{X}` on a bargained X spell (Stonesplitter Bolt);
+         *   leave `null` for spells with no `{X}` in their cost
          */
         fun castSpellBargained(
             playerNumber: Int,
             spellName: String,
             sacrificeName: String,
             targetId: EntityId? = null,
+            xValue: Int? = null,
         ): ExecutionResult {
             val playerId = if (playerNumber == 1) player1Id else player2Id
             val cardId = state.getHand(playerId).find { entityId ->
@@ -1448,6 +1451,7 @@ abstract class ScenarioTestBase : FunSpec() {
                     playerId = playerId,
                     cardId = cardId,
                     targets = targetId?.let { listOf(ChosenTarget.Permanent(it)) } ?: emptyList(),
+                    xValue = xValue,
                     declaredCostSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.BARGAINED,
                     additionalCostPayment = com.wingedsheep.sdk.scripting.AdditionalCostPayment(
                         sacrificedPermanents = listOf(sacrificeId)


### PR DESCRIPTION
Five more Wilds of Eldraine cards, one per colour. All five are canonical in WOE (`just check-card-printing` clean on each), and every mechanical field was re-verified against Scryfall field by field — name, mana cost, type line, oracle text, P/T, rarity, collector number, artist, image URI.

| Card | Cost | Text |
|---|---|---|
| A Tale for the Ages | `{1}{W}` | Enchanted creatures you control get +2/+2. |
| Lord Skitter's Blessing | `{1}{B}` | ETB: Wicked Role on target creature you control. At the beginning of your draw step, if you control an enchanted creature, you lose 1 life and draw an additional card. |
| Tenacious Tomeseeker | `{2}{U}` | 3/2. Bargain. ETB, if bargained: return target instant or sorcery from your graveyard to your hand. |
| Stonesplitter Bolt | `{X}{R}` | Bargain. X damage to target creature or planeswalker; twice X if bargained. |
| Howling Galefang | `{2}{G}{G}` | 4/4. Vigilance. Haste as long as you own a card in exile that has an Adventure. |

## New SDK vocabulary

Four cards are pure compositions. White and black needed one addition:

**`StatePredicate.IsEnchanted`** (filter builder `enchanted()`) — "has an Aura attached", the MTG adjective *enchanted* (CR 303.4). It mirrors the pre-existing `IsEquipped` over the Aura subtype, and is deliberately narrower than `IsModified`: Equipment attached, or counters on the permanent, do **not** make it enchanted.

Two design points worth a reviewer's eye:

- **Control of the Aura is irrelevant.** An Aura enchants whatever it's attached to regardless of who controls the Aura, so "enchanted creatures you control" is two predicates binding to *different* objects — `youControl()` on the creature, `enchanted()` on the attachment relation. Both directions are tested.
- **Role tokens are Auras** (CR 113.2c), so this is the Wilds of Eldraine Roles payoff predicate, which is why it arrives with two users rather than one: A Tale for the Ages exercises the layer-7c projection path (`AffectsFilterResolver`), Lord Skitter's Blessing the target/condition path (`PredicateEvaluator`). Those are separate branches, so both needed a user and a test.

It also lands in the two exhaustive predicate lists (`TriggerMatcher`, `BeginningPhaseManager`), and the SDK reference is updated in the same change — including back-filling the `IsEquipped` and `IsModified` entries that were missing from that section.

## Notes on the three compositions

- **Stonesplitter Bolt** models "twice X" as a `DynamicAmount.Conditional` on the *amount*, not as a base hit plus a bargained top-up hit. Candy Grapple can compose `-3/-3` + `-2/-2` because those merge invisibly in layer 7c, but damage does not: two instances of X and one instance of 2X are rules-distinguishable — prevention shields absorb per instance, doubling and redirection replacements apply per instance, and "whenever a source deals damage" triggers would fire twice. One `DealDamage` on either branch, and `Multiply(XValue, 2)` keeps X=0 correct (tested).
- **Tenacious Tomeseeker** gets its Adventure ruling for free: an adventurer card in a graveyard is a creature card, and `InstantOrSorcery` matches front-face types, so the deliberately separate `InstantSorceryOrAdventure` filter remains the one for cards that *do* count adventurers.
- **Howling Galefang**'s condition is a plain exile-zone existence check on `CardPredicate.HasAdventure`, which matches the ruling that it does not matter whether the card was ever cast as an Adventure. "You own" maps to `Player.You` because exile is keyed per player.

## Testing

`WoeCardsBatch10ScenarioTest` — 17 tests, all passing. Beyond the happy paths it pins the traps a plausible-but-wrong implementation falls into:

- Equipment-only creature is **not** buffed (the predicate is not `IsModified`)
- your creature carrying an **opponent's** Aura **is** buffed
- an opponent's creature carrying **your** Aura is **not**
- the buff falls away when the Aura leaves — it's projected, not applied once
- Lord Skitter's intervening-'if' suppresses the whole ability (no life loss, no extra card) when nothing is enchanted
- both bargain branches on both bargain cards, plus X=0 on Stonesplitter Bolt
- Howling Galefang: no exile, your Adventure, opponent's Adventure, non-Adventure card

Gates: `just build`, `just test`, and `just check` all green; the WOE snapshot golden was re-blessed and only these five cards moved.

One test-fixture change: `castSpellBargained` gains an `xValue` parameter, needed to cast a bargained X spell.

## Player experience

No new UI. Every decision shape already routes: the two enters triggers raise a `ChooseTargetsDecision` handled by battlefield selection and `GraveyardTargetingUI` respectively (both established by existing cards), bargain declaration and the X prompt are pre-existing cast-time flows, and `HASTE`/`VIGILANCE` are already known to the client. The two statics raise no decisions at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)