### PR TITLE
Add five Wilds of Eldraine cards with per-Food sacrifice trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1566,7 +1566,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     `MayPayXForEffect` (see "Optional & gated" below).
   - The multi-player APNAP `AnyPlayerMayPayEffect` stays a **standalone effect**, not a gate — a
     single `decisionMaker` can't express its turn-order loop (see below).
-- `MayEffect(effect, descriptionOverride?, sourceRequiredZone?, inlineOnTrigger?, hint?, decisionMaker?, otherwise?)`
+- `MayEffect(effect, descriptionOverride?, sourceRequiredZone?, inlineOnTrigger?, hint?, decisionMaker?, otherwise?, feasibility?)`
   — "You may [effect]." Facade preserved for existing cards; it now **lowers to
   `GatedEffect(Gate.MayDecide(...), then = effect, otherwise = otherwise, decisionMaker = decisionMaker)`**
   (compiled form is `Gated`, no distinct `May` type or executor). The may-vs-target trigger reorder —
@@ -1578,6 +1578,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     as `target("target opponent", Targets.Opponent)` for "**target opponent may …**"). Only the
     yes/no prompt is delegated; the `then`/`otherwise` effects still resolve from the controller's
     perspective unless they themselves target a specific player.
+  - **`feasibility` suppresses an unanswerable prompt** — a `FeasibilityCheck`
+    (`ControlsPermanentMatching(filter, count?)` / `HasCardsInZone(zone, filter?, count?)`, both scoped to
+    the decision-maker) evaluated at resolution. Unmet ⇒ the yes/no is skipped and `otherwise` runs
+    directly, the no-target analogue of a targeted "may" with no legal targets. Reach for it on
+    **recurring** triggers whose action needs a resource the player may not have — Provisions Merchant
+    ("whenever this creature attacks, you may sacrifice a Food") would otherwise ask every combat. Only
+    for preconditions the engine can decide; never to pre-empt a genuine choice.
   - **`otherwise` is the "if that player doesn't" branch** — runs iff the chooser declines. Combine
     with a delegated `decisionMaker` for "target opponent may [then]; if that player doesn't,
     [otherwise]" (Palantír of Orthanc: "target opponent may have you draw a card; if that player
@@ -3718,8 +3725,9 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   matching permanent is sacrificed and when the source permanent is itself sacrificed. The triggering entity is
   bound to the just-sacrificed permanent, so a payoff reading "that <permanent>" (its mana value / a token copy
   of it) resolves against its last-known information in the graveyard. This is exactly the wording "whenever you
-  sacrifice this permanent or another <filter>" (Esoteric Duplicator) as well as the plain "whenever you sacrifice
-  a <filter>" (Mayhem Devil). For the "another" exclusion use an `OTHER`-binding trigger instead.
+  sacrifice this permanent or another <filter>" (Esoteric Duplicator). For the singular "whenever you sacrifice
+  **a** <filter>" wording, which fires once per sacrificed permanent, use `YouSacrificeA`; for the "another"
+  exclusion use an `OTHER`-binding trigger instead.
   By default the ANY-binding form watches only the source *controller's* sacrifices ("whenever **you**
   sacrifice…"). For the "whenever **a player** sacrifices…" scope set
   `EventPattern.PermanentsSacrificedEvent(filter, byAnyPlayer = true)` (Zodiark, Umbral God — "Whenever a
@@ -3734,8 +3742,14 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   permanents fires it three times; `YouSacrificeOneOrMore` (batch) fires once per event. (2) *exclusion* —
   `OTHER` excludes the source sacrificing itself; a source sacrificed *alongside* other permanents still
   reacts to those others (fires once per other), but not to itself. The `perPermanent` flag is the general
-  multiplicity switch on `PermanentsSacrificedEvent` — combine it with `binding = ANY` for the "whenever you
-  sacrifice **a** permanent" wording that also counts the source itself.
+  multiplicity switch on `PermanentsSacrificedEvent`; `YouSacrificeA` is the `ANY`-binding half of it.
+- `YouSacrificeA(filter?)` — the **per-permanent** template "whenever you sacrifice **a** <filter>"
+  (Experimental Confectioner — "Whenever you sacrifice a Food, create a 1/1 black Rat…"). Built with
+  `binding = ANY` and `PermanentsSacrificedEvent(filter, perPermanent = true)`, so it sits between the other
+  two: per-permanent multiplicity like `YouSacrificeAnother` (three Foods sacrificed at once = three Rats,
+  where `YouSacrificeOneOrMore` would give one) but ANY exclusion like `YouSacrificeOneOrMore` (a source that
+  is itself a Food counts its own sacrifice). Pick by the printed article — "one or more" → batch,
+  "a" → `YouSacrificeA`, "another" → `YouSacrificeAnother`.
 - `Sacrificed` — source is sacrificed.
 - `EventPattern.ExploitedEvent(player = Player.You, requireNontokenExploited = false)` — "whenever a creature you control
   exploits a creature" (CR 702.110b; the sacrifice half of the Exploit keyword). Fires once per exploited creature; the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1752,12 +1752,30 @@ object Triggers {
     )
 
     /**
+     * Whenever you sacrifice **a** permanent matching the filter.
+     * Per-permanent trigger — fires once for EACH matching permanent sacrificed, even when several
+     * are sacrificed simultaneously (CR 603.2c). The bare-article template ([TriggerBinding.ANY])
+     * counts the source sacrificing itself, unlike [YouSacrificeAnother].
+     *
+     * Distinct from [YouSacrificeOneOrMore] (batch — one Rat for three Foods instead of three).
+     * Template: Experimental Confectioner ("Whenever you sacrifice a Food").
+     *
+     * Example: "Whenever you sacrifice a Food"
+     * → YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Food"))
+     */
+    fun YouSacrificeA(filter: GameObjectFilter = GameObjectFilter.Any): TriggerSpec = TriggerSpec(
+        event = PermanentsSacrificedEvent(filter = filter, perPermanent = true),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever you sacrifice another permanent matching the filter.
      * Per-permanent trigger — fires once for EACH matching permanent sacrificed, even when several
      * are sacrificed simultaneously (CR 603.2c). "Another" ([TriggerBinding.OTHER]) excludes the
      * source, so the source sacrificing itself doesn't fire it.
      *
-     * Distinct from [YouSacrificeOneOrMore] (batch — fires once per event batch). Template:
+     * Distinct from [YouSacrificeOneOrMore] (batch — fires once per event batch) and from
+     * [YouSacrificeA] (same per-permanent multiplicity, but counts the source). Template:
      * Mazirek, Kraul Death Priest; Savra, Queen of the Golgari; Zhao, Ruthless Admiral.
      *
      * Example: "Whenever you sacrifice another permanent"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
@@ -268,6 +268,10 @@ fun OptionalCostEffect(
  *   delegated (e.g. [EffectTarget.TargetController] for "that creature's controller may …",
  *   or [EffectTarget.PlayerRef] of `TargetOpponent` for "target opponent may …").
  * @param otherwise Effect that runs iff the chooser declines ("If that player doesn't, …").
+ * @param feasibility Precondition for the may-action being possible at all. Unmet at resolution ⇒ the
+ *   prompt is skipped and [otherwise] runs directly, so a recurring trigger ("whenever this creature
+ *   attacks, you may sacrifice a Food") stops asking an unanswerable question every combat. Only for
+ *   preconditions the *engine* can decide — never to pre-empt a genuine player choice.
  */
 @Suppress("FunctionName")
 fun MayEffect(
@@ -277,12 +281,14 @@ fun MayEffect(
     inlineOnTrigger: Boolean = false,
     hint: String? = null,
     decisionMaker: EffectTarget? = null,
-    otherwise: Effect? = null
+    otherwise: Effect? = null,
+    feasibility: FeasibilityCheck? = null
 ): GatedEffect = GatedEffect(
     gate = Gate.MayDecide(
         hint = hint,
         sourceRequiredZone = sourceRequiredZone,
-        inlineOnTrigger = inlineOnTrigger
+        inlineOnTrigger = inlineOnTrigger,
+        feasibility = feasibility
     ),
     then = effect,
     otherwise = otherwise,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ExperimentalConfectioner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ExperimentalConfectioner.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Experimental Confectioner
+ * {2}{B}
+ * Creature — Human Peasant
+ * 2/3
+ *
+ * When this creature enters, create a Food token.
+ * Whenever you sacrifice a Food, create a 1/1 black Rat creature token with "This token can't block."
+ *
+ * "Whenever you sacrifice **a** Food" is the per-permanent template, not the batch one
+ * ([Triggers.YouSacrificeA], CR 603.2c): sacrificing three Foods at once to something like Feasting
+ * Troll King's activated cost makes three Rats, not one. Per the 2024-11-08 ruling a "Food" is any
+ * Food *artifact*, so the filter keys on the subtype rather than on token-ness — Tough Cookie (an
+ * Artifact Creature — Food Golem) counts.
+ */
+val ExperimentalConfectioner = card("Experimental Confectioner") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Peasant"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, create a Food token. (It's an artifact with \"{2}, " +
+        "{T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "Whenever you sacrifice a Food, create a 1/1 black Rat creature token with \"This token " +
+        "can't block.\""
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Food"))
+        effect = woeRatToken()
+        description = "Whenever you sacrifice a Food, create a 1/1 black Rat creature token with " +
+            "\"This token can't block.\""
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "314"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg?1783915040"
+
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact " +
+                "token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food " +
+                "Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a " +
+                "creature type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FoodComa.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FoodComa.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Food Coma
+ * {3}{W}
+ * Enchantment
+ *
+ * When this enchantment enters, exile target creature an opponent controls until this enchantment
+ * leaves the battlefield. Create a Food token.
+ *
+ * The O-Ring shape (Banishing Light): [Effects.ExileUntilLeaves] on the ETB plus a companion
+ * [Triggers.LeavesBattlefield] trigger that returns the linked exile. The Food rides along in the
+ * *same* ability, so it shares the target's fate — per the 2024-11-08 Food ruling, if the exile
+ * target is illegal as the ability resolves the whole ability is countered and no Food is created.
+ * [Effects.Composite] gives that for free; a second triggered ability would not.
+ */
+val FoodComa = card("Food Coma") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, exile target creature an opponent controls until " +
+        "this enchantment leaves the battlefield. Create a Food token. (It's an artifact with " +
+        "\"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target", TargetCreature(filter = TargetFilter.CreatureOpponentControls))
+        effect = Effects.Composite(
+            Effects.ExileUntilLeaves(victim),
+            Effects.CreateFood()
+        )
+        description = "When this enchantment enters, exile target creature an opponent controls " +
+            "until this enchantment leaves the battlefield. Create a Food token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "308"
+        artist = "Iris Compiet"
+        flavorText = "\"Busy as a bumblesheep\"\n—Faerie expression meaning \"asleep\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg?1783915040"
+
+        ruling(
+            "2024-11-08",
+            "Some spells and abilities that create Food tokens may require targets. If each target " +
+                "chosen is an illegal target as that spell or ability tries to resolve, it won't " +
+                "resolve. You won't create any Food tokens."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a " +
+                "creature type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LadyOfLaughter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LadyOfLaughter.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lady of Laughter
+ * {3}{W}{W}
+ * Creature — Faerie Noble
+ * 4/5
+ *
+ * Flying
+ * Celebration — At the beginning of your end step, if two or more nonland permanents entered the
+ * battlefield under your control this turn, draw a card.
+ *
+ * The triggered half of the Celebration ability word (CR 207.2c — italic flavor, no rules meaning),
+ * the same intervening-'if' shape as [PestsOfHonor] one step later in the turn: [Conditions.Celebration]
+ * is checked both when the end step begins and again as the ability resolves (CR 603.4). Per the WOE
+ * rulings it is a pure past-events check — the two permanents needn't still be on the battlefield or
+ * still be yours, and a third adds nothing.
+ */
+val LadyOfLaughter = card("Lady of Laughter") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Faerie Noble"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Celebration — At the beginning of your end step, if two or more nonland permanents " +
+        "entered the battlefield under your control this turn, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.Celebration
+        effect = Effects.DrawCards(1)
+        description = "At the beginning of your end step, if two or more nonland permanents " +
+            "entered the battlefield under your control this turn, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "309"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg?1783915041"
+
+        ruling(
+            "2023-09-01",
+            "Celebration abilities only care if two or more nonland permanents entered the " +
+                "battlefield under your control in a turn. They won't get more powerful if more " +
+                "than two permanents entered the battlefield under your control in a turn."
+        )
+        ruling(
+            "2023-09-01",
+            "The permanents that entered the battlefield don't need to remain on the battlefield or " +
+                "under your control. Celebration abilities are checking for past events, not the " +
+                "current game state."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/OgreChitterlord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/OgreChitterlord.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Rats you control — the count gate and the pump target of [OgreChitterlord] read the same set. */
+private val ratsYouControl = GameObjectFilter.Creature.withSubtype("Rat").youControl()
+
+/**
+ * "Create two Rats. Then if you control five or more Rats, each Rat you control gets +2/+0 until end
+ * of turn."
+ *
+ * `.then` is load-bearing: the intervening "Then" means the five-Rat count and the pumped group are
+ * both evaluated *after* the two tokens have entered, so the new Rats count toward the five and get
+ * the bonus themselves ([TwistedSewerWitch] relies on the same snapshot-after-the-boundary rule).
+ * This is an inline "if", not an intervening-'if' trigger condition — it's checked once during
+ * resolution, not again when the ability would trigger.
+ *
+ * Shared by the enters and attacks halves of the printed ability, which the SDK models as two
+ * triggered abilities (the [Triggers.EntersBattlefield] / [Triggers.Attacks] pair used for every
+ * "enters or attacks" card).
+ */
+private fun ratSwarmAndRally(): Effect = woeRatToken(DynamicAmount.Fixed(2)).then(
+    ConditionalEffect(
+        condition = Conditions.YouControlAtLeast(5, ratsYouControl),
+        effect = Patterns.Group.modifyStatsForAll(
+            power = 2,
+            toughness = 0,
+            filter = GroupFilter(ratsYouControl)
+        )
+    )
+)
+
+/**
+ * Ogre Chitterlord
+ * {4}{R}{R}
+ * Creature — Ogre Warrior
+ * 6/5
+ *
+ * Menace
+ * Whenever this creature enters or attacks, create two 1/1 black Rat creature tokens with "This
+ * token can't block." Then if you control five or more Rats, each Rat you control gets +2/+0 until
+ * end of turn.
+ *
+ * The Chitterlord is an Ogre, not a Rat, so it never pumps itself — but the two Rats it just made do
+ * count toward the five and do get the +2/+0. Nothing targets, so hexproof Rats are included and the
+ * ability can't fizzle.
+ */
+val OgreChitterlord = card("Ogre Chitterlord") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 6
+    toughness = 5
+    oracleText = "Menace\n" +
+        "Whenever this creature enters or attacks, create two 1/1 black Rat creature tokens with " +
+        "\"This token can't block.\" Then if you control five or more Rats, each Rat you control " +
+        "gets +2/+0 until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ratSwarmAndRally()
+        description = "Create two 1/1 black Rat creature tokens with \"This token can't block.\" " +
+            "Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ratSwarmAndRally()
+        description = "Create two 1/1 black Rat creature tokens with \"This token can't block.\" " +
+            "Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "319"
+        artist = "Piotr Foksowicz"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg?1783915039"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ProvisionsMerchant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ProvisionsMerchant.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Provisions Merchant
+ * {2}{G}{G}
+ * Creature — Beast Peasant
+ * 3/3
+ *
+ * When this creature enters, create a Food token.
+ * Whenever this creature attacks, you may sacrifice a Food. If you do, attacking creatures get
+ * +1/+1 and gain trample until end of turn.
+ *
+ * The attack ability is the [BristlebudFarmer] shape: a [MayEffect] wrapping
+ * `Sacrifice(Food).then(payoff)`, so declining — or simply controlling no Food — skips the payoff
+ * without the ability fizzling. "If you do" (not "When you do") means the pump happens in the same
+ * resolution rather than as a reflexive trigger.
+ *
+ * The pump is over [Filters.Group.attackingCreatures] — *every* attacking creature, not just the
+ * Merchant's controller's, which is what the oracle says and what matters once a third player is in
+ * the game. The set is snapshotted as the effect resolves, so a creature that somehow starts
+ * attacking later in the combat is not retroactively included.
+ *
+ * A `feasibility` gate suppresses the prompt when the controller has no Food. Without it a 3/3 that
+ * attacks every turn would raise an unanswerable "sacrifice a Food?" question every combat.
+ */
+val ProvisionsMerchant = card("Provisions Merchant") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast Peasant"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, create a Food token. (It's an artifact with \"{2}, " +
+        "{T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "Whenever this creature attacks, you may sacrifice a Food. If you do, attacking creatures " +
+        "get +1/+1 and gain trample until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayEffect(
+            Effects.Sacrifice(
+                GameObjectFilter.Artifact.withSubtype("Food"),
+                count = 1,
+                target = EffectTarget.Controller
+            ).then(
+                Effects.Composite(
+                    Patterns.Group.modifyStatsForAll(
+                        power = 1,
+                        toughness = 1,
+                        filter = Filters.Group.attackingCreatures
+                    ),
+                    Patterns.Group.grantKeywordToAll(
+                        Keyword.TRAMPLE,
+                        Filters.Group.attackingCreatures
+                    )
+                )
+            ),
+            // The Merchant attacks every turn; without a Food the question has no answer, so don't
+            // ask it. Purely an engine-decidable precondition — it never pre-empts a real choice.
+            feasibility = FeasibilityCheck.ControlsPermanentMatching(
+                GameObjectFilter.Artifact.withSubtype("Food")
+            )
+        )
+        description = "You may sacrifice a Food. If you do, attacking creatures get +1/+1 and gain " +
+            "trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "321"
+        artist = "Raluca Marinescu"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg?1783915038"
+
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact " +
+                "token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food " +
+                "Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a " +
+                "creature type."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2524,6 +2524,77 @@
     ]
 }
 
+// Experimental Confectioner
+{
+    "name": "Experimental Confectioner",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever you sacrifice a Food, create a 1/1 black Rat creature token with \"This token can't block.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Food",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                },
+                "descriptionOverride": "Whenever you sacrifice a Food, create a 1/1 black Rat creature token with \"This token can't block.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "314",
+        "rarity": "UNCOMMON",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/49aaf5db-9418-4b97-97da-736c674905d4.jpg?1783915040",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Faerie Dreamthief
 {
     "name": "Faerie Dreamthief",
@@ -2947,6 +3018,95 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Food Coma
+{
+    "name": "Food Coma",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, exile target creature an opponent controls until this enchantment leaves the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ExileUntilLeaves",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Food"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this enchantment enters, exile target creature an opponent controls until this enchantment leaves the battlefield. Create a Food token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "308",
+        "rarity": "UNCOMMON",
+        "artist": "Iris Compiet",
+        "flavorText": "\"Busy as a bumblesheep\"\n—Faerie expression meaning \"asleep\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61ba2aed-3514-4db9-8da0-329620b12f63.jpg?1783915040",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Some spells and abilities that create Food tokens may require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. You won't create any Food tokens."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -4632,6 +4792,73 @@
     ]
 }
 
+// Lady of Laughter
+{
+    "name": "Lady of Laughter",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Faerie Noble",
+    "oracleText": "Flying\nCelebration — At the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if two or more nonland permanents entered the battlefield under your control this turn, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "309",
+        "rarity": "RARE",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c26714f9-d42f-4bac-b185-8943d1621444.jpg?1783915041",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Celebration abilities only care if two or more nonland permanents entered the battlefield under your control in a turn. They won't get more powerful if more than two permanents entered the battlefield under your control in a turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "The permanents that entered the battlefield don't need to remain on the battlefield or under your control. Celebration abilities are checking for past events, not the current game state."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Leaping Ambush
 {
     "name": "Leaping Ambush",
@@ -6000,6 +6227,175 @@
     ]
 }
 
+// Ogre Chitterlord
+{
+    "name": "Ogre Chitterlord",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "oracleText": "Menace\nWhenever this creature enters or attacks, create two 1/1 black Rat creature tokens with \"This token can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Rat"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                            "staticAbilities": [
+                                "CantBlock"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Rat ctrl:you"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature Rat ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "Self"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Create two 1/1 black Rat creature tokens with \"This token can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Rat"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                            "staticAbilities": [
+                                "CantBlock"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Rat ctrl:you"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 5
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature Rat ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "Self"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Create two 1/1 black Rat creature tokens with \"This token can't block.\" Then if you control five or more Rats, each Rat you control gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "319",
+        "rarity": "RARE",
+        "artist": "Piotr Foksowicz",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a70b2033-eec5-4c86-9ebe-a68960a86763.jpg?1783915039"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pests of Honor
 {
     "name": "Pests of Honor",
@@ -6246,6 +6642,117 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Provisions Merchant
+{
+    "name": "Provisions Merchant",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Beast Peasant",
+    "oracleText": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever this creature attacks, you may sacrifice a Food. If you do, attacking creatures get +1/+1 and gain trample until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayDecide",
+                        "feasibility": {
+                            "type": "ControlsPermanentMatching",
+                            "filter": "artifact Food"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForceSacrifice",
+                                "filter": "artifact Food",
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature attacking"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "ModifyStats",
+                                            "powerModifier": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            },
+                                            "toughnessModifier": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            },
+                                            "target": "Self"
+                                        }
+                                    },
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature attacking"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "GrantKeyword",
+                                            "keyword": "TRAMPLE",
+                                            "target": "Self"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "You may sacrifice a Food. If you do, attacking creatures get +1/+1 and gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "321",
+        "rarity": "UNCOMMON",
+        "artist": "Raluca Marinescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a015282d-bcd4-44ab-ae26-41e4e3b23fc0.jpg?1783915038",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExperimentalConfectionerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExperimentalConfectionerScenarioTest.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Experimental Confectioner (WOE #314) — {2}{B} Creature — Human Peasant, 2/3.
+ *
+ * When this creature enters, create a Food token.
+ * Whenever you sacrifice a Food, create a 1/1 black Rat creature token with "This token can't block."
+ *
+ * These cover the new [Triggers.YouSacrificeA] vocabulary — the per-permanent "you sacrifice **a**
+ * <filter>" template with an ANY binding. Two things distinguish it from the pre-existing pair:
+ *  - vs [Triggers.YouSacrificeOneOrMore] (batch): three simultaneously-sacrificed Foods must make
+ *    three Rats, not one (CR 603.2c).
+ *  - vs [Triggers.YouSacrificeAnother] (OTHER binding): a source that is itself a Food counts its
+ *    own sacrifice. The Confectioner is a Human Peasant so it can never hit that path; a Food
+ *    artifact creature carrying the same trigger is registered below to prove it.
+ */
+class ExperimentalConfectionerScenarioTest : ScenarioTestBase() {
+
+    // {0} sorcery sacrificing every Food you control at once — one batch, N sacrifice occurrences.
+    private val cleanOutThePantry = card("Clean Out the Pantry") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Sacrifice all Foods you control."
+        spell {
+            effect = Effects.SacrificeAll(GameObjectFilter.Artifact.withSubtype("Food").youControl())
+        }
+    }
+
+    // {0} sorcery sacrificing every non-Food artifact you control — the negative control.
+    private val cleanOutTheWorkshop = card("Clean Out the Workshop") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Sacrifice all Clues you control."
+        spell {
+            effect = Effects.SacrificeAll(GameObjectFilter.Artifact.withSubtype("Clue").youControl())
+        }
+    }
+
+    // A Food artifact *creature* carrying the same trigger, so the source is inside the batch.
+    // "Whenever you sacrifice a Food" (ANY) counts itself; "another" (OTHER) would not.
+    private val toothsomeSentry = card("Toothsome Sentry") {
+        manaCost = "{0}"
+        typeLine = "Artifact Creature — Food Golem"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you sacrifice a Food, you gain 2 life."
+        triggeredAbility {
+            trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Food"))
+            effect = Effects.GainLife(2)
+        }
+    }
+
+    init {
+        cardRegistry.register(cleanOutThePantry)
+        cardRegistry.register(cleanOutTheWorkshop)
+        cardRegistry.register(toothsomeSentry)
+
+        context("Experimental Confectioner") {
+
+            test("entering the battlefield creates a Food token") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Experimental Confectioner")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Experimental Confectioner").error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Experimental Confectioner") shouldBe true
+                withClue("the enters trigger makes exactly one Food") {
+                    game.findPermanents("Food").size shouldBe 1
+                }
+                withClue("no Food has been sacrificed yet, so no Rats") {
+                    game.findPermanents("Rat Token").size shouldBe 0
+                }
+            }
+
+            test("sacrificing one Food creates one Rat") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Experimental Confectioner")
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardInHand(1, "Clean Out the Pantry")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Clean Out the Pantry").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Food is gone") {
+                    game.isOnBattlefield("Food") shouldBe false
+                }
+                game.findPermanents("Rat Token").size shouldBe 1
+            }
+
+            // CR 603.2c: "a Food" is the per-permanent template, so one batch of three sacrifices
+            // fires the ability three times. A batch trigger would produce a single Rat here.
+            test("sacrificing three Foods at once creates three Rats, not one") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Experimental Confectioner")
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withCardInHand(1, "Clean Out the Pantry")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("three Foods on the battlefield to start") {
+                    game.findPermanents("Food").size shouldBe 3
+                }
+
+                game.castSpell(1, "Clean Out the Pantry").error shouldBe null
+                game.resolveStack()
+
+                withClue("all three Foods went at once") {
+                    game.isOnBattlefield("Food") shouldBe false
+                }
+                withClue("three sacrifice occurrences = three separate triggers = three Rats") {
+                    game.findPermanents("Rat Token").size shouldBe 3
+                }
+            }
+
+            test("sacrificing a non-Food artifact creates no Rat") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Experimental Confectioner")
+                    .withCardOnBattlefield(1, "Clue", isToken = true)
+                    .withCardInHand(1, "Clean Out the Workshop")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Clean Out the Workshop").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Clue is gone") {
+                    game.isOnBattlefield("Clue") shouldBe false
+                }
+                withClue("a Clue is not a Food, so the trigger never fired") {
+                    game.findPermanents("Rat Token").size shouldBe 0
+                }
+            }
+        }
+
+        context("Triggers.YouSacrificeA binding") {
+
+            // The ANY binding is what separates YouSacrificeA from YouSacrificeAnother: a source
+            // that is itself a Food reacts to its own sacrifice.
+            test("a Food source counts its own sacrifice") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Toothsome Sentry")
+                    .withCardInHand(1, "Clean Out the Pantry")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Clean Out the Pantry").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Sentry sacrificed itself (it is a Food)") {
+                    game.isOnBattlefield("Toothsome Sentry") shouldBe false
+                }
+                withClue("'a Food' includes the source, so the trigger fired once") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProvisionsMerchantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProvisionsMerchantScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Provisions Merchant (WOE #321) — {2}{G}{G} Creature — Beast Peasant, 3/3.
+ *
+ * When this creature enters, create a Food token.
+ * Whenever this creature attacks, you may sacrifice a Food. If you do, attacking creatures get
+ * +1/+1 and gain trample until end of turn.
+ *
+ * The attack ability's UX hinges on the `feasibility` gate: with no Food the "you may sacrifice a
+ * Food" question is unanswerable, and asking it on every single attack would be noise. These tests
+ * pin both halves — the prompt appears when there is a Food to sacrifice, and is skipped when there
+ * isn't.
+ */
+class ProvisionsMerchantScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Provisions Merchant") {
+
+            test("entering the battlefield creates a Food token") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Provisions Merchant")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Provisions Merchant").error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Provisions Merchant") shouldBe true
+                game.findPermanents("Food").size shouldBe 1
+            }
+
+            test("attacking with a Food asks whether to sacrifice it") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Provisions Merchant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Provisions Merchant" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("with a Food available, the optional sacrifice is offered") {
+                    game.hasPendingDecision() shouldBe true
+                }
+            }
+
+            test("attacking with no Food does not ask an unanswerable question") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Provisions Merchant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Provisions Merchant" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("no Food to sacrifice, so the 'you may' prompt is skipped entirely") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+
+            test("sacrificing the Food pumps every attacking creature and grants trample") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Provisions Merchant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Food", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Provisions Merchant" to 2, "Grizzly Bears" to 2)
+                ).error shouldBe null
+                game.resolveStack()
+
+                // Say yes to the optional sacrifice, then pick the Food.
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                val merchant = game.findPermanent("Provisions Merchant")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("the Food was sacrificed") {
+                    game.isOnBattlefield("Food") shouldBe false
+                }
+                withClue("both attackers get +1/+1") {
+                    game.state.projectedState.getPower(merchant) shouldBe 4
+                    game.state.projectedState.getToughness(merchant) shouldBe 4
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more Wilds of Eldraine cards, all canonical in WOE (verified with `just check-card-printing`).

| # | Card | | |
|---|------|---|---|
| 308 | **Food Coma** | `{3}{W}` Enchantment | ETB exiles target creature an opponent controls until this leaves; create a Food |
| 309 | **Lady of Laughter** | `{3}{W}{W}` 4/5 Faerie Noble | Flying; Celebration — end-step draw |
| 314 | **Experimental Confectioner** | `{2}{B}` 2/3 Human Peasant | ETB Food; sacrifice a Food → 1/1 Rat that can't block |
| 319 | **Ogre Chitterlord** | `{4}{R}{R}` 6/5 Ogre Warrior | Menace; enters or attacks → two Rats, then five-Rat check pumps every Rat +2/+0 |
| 321 | **Provisions Merchant** | `{2}{G}{G}` 3/3 Beast Peasant | ETB Food; attacks → may sacrifice a Food for team +1/+1 and trample |

## SDK additions

Both fill gaps in vocabulary that already existed, rather than introducing new types.

### `Triggers.YouSacrificeA(filter)`

The per-permanent **"whenever you sacrifice *a* &lt;filter&gt;"** template — the missing third corner of the sacrifice-trigger family:

| facade | multiplicity | source counts itself |
|---|---|---|
| `YouSacrificeOneOrMore` | batch (once per event) | yes (ANY) |
| `YouSacrificeAnother` | per-permanent | no (OTHER) |
| **`YouSacrificeA`** (new) | **per-permanent** | **yes (ANY)** |

`PermanentsSacrificedEvent.perPermanent` and the `TriggerDetector` branch already supported the ANY + per-permanent combination — the detector's own comment documents it — only the facade was absent, so cards with this wording were being modelled as batch triggers. Experimental Confectioner needs the distinction: sacrificing three Foods in one batch must create three Rats, not one (CR 603.2c).

### `MayEffect(feasibility = …)`

Exposes the pre-existing `Gate.MayDecide.feasibility` field on the facade. Provisions Merchant attacks every turn, and without a feasibility gate the engine raises an unanswerable *"you may sacrifice a Food?"* prompt every single combat when the controller has no Food. A scenario test pins both directions (prompt with a Food, no prompt without).

## Notes

- **Ogre Chitterlord** uses the established two-triggered-ability pair for "enters or attacks". The `.then` boundary after token creation is load-bearing: the group is snapshotted afterwards, so the two new Rats count toward the five *and* receive the +2/+0 — same rule Twisted Sewer-Witch relies on.
- **Food Coma** keeps the exile and the Food in one `Composite` inside a single ability, so an illegal exile target counters the whole thing and no Food is created (2024-11-08 Food ruling). A second triggered ability would not give that.
- **Provisions Merchant** pumps `GroupFilter.AttackingCreatures` — *every* attacking creature, matching the oracle rather than just the controller's, which matters in multiplayer.

## Verification

- `just build`, `just test`, `just check` — all green
- `just check-card-printing` — ok for all five
- `just rebless-cards` — WOE golden diff is **507 pure insertions**, zero deletions; only these five cards moved
- New scenario tests: `ExperimentalConfectionerScenarioTest` (5), `ProvisionsMerchantScenarioTest` (4) — all pass
- Every field re-verified against Scryfall (name, mana cost, type line, P/T, rarity, collector number, artist, image URI, colour identity, oracle text); all five image URIs return HTTP 200

## Follow-up worth noting (not in this PR)

`UnluckyCabbageMerchant` (TLA) is printed "Whenever you sacrifice a Food" but modelled with the batch `YouSacrificeOneOrMore`, so it under-triggers on simultaneous sacrifices. `YouSacrificeA` is now the right facade for it — left alone here to keep this change scoped to the five new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)