### PR TITLE
Add five Aetherdrift cards with max-speed cost-reduction support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7750,6 +7750,11 @@ Card authors rarely reference these directly; they are created/updated by the ma
     `ConditionalStaticAbility`, activated via `ActivationRestriction.OnlyIfCondition`, triggered via
     `triggerCondition` (CR 603.4). No new ability type; activated/triggered labels get the printed
     "Max speed — " prefix. Several abilities may share one block (Tsagan, Raider Warlord).
+    A `staticAbility { ability = ModifySpellCost(…) }` is the one exception to the wrapper: cost
+    calculation scans the raw static list for `is ModifySpellCost` and never unwraps a conditional, so
+    the gate is folded into the modifier's own `CostGating.OnlyIf` slot instead (Racers' Scoreboard,
+    "Max speed — Spells you cast cost {1} less to cast"). Authoring is unchanged — declare it in the
+    block and the builder picks the right seam.
   - Raising speed is `Effects.IncreaseSpeed(amount, target)`. The inherent CR 702.179d trigger
     ("Whenever one or more opponents lose life during your turn, if your speed is less than 4, your
     speed increases by 1. This ability triggers only once each turn.") is synthesized per player by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
@@ -4,7 +4,9 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
@@ -48,6 +50,7 @@ fun CardBuilder.startYourEngines() {
  * | Declared as | Gate |
  * |---|---|
  * | `staticAbility { }` | [ConditionalStaticAbility] — re-evaluated every projection, so the ability appears and disappears with your speed |
+ * | `staticAbility { ability = ModifySpellCost(…) }` | [CostGating.OnlyIf] folded into the modifier itself — cost calculation never reads the layer system, so a wrapper would hide it (Racers' Scoreboard's "Max speed — Spells you cast cost {1} less to cast") |
  * | `activatedAbility { }` | [ActivationRestriction.OnlyIfCondition] — the ability isn't a legal action below max speed |
  * | `triggeredAbility { }` | `triggerCondition` (CR 603.4) — checked when the trigger would fire and again on resolution |
  * | `keywords(…)` | sugar for a gated [GrantKeyword] on the source, covering the common "Max speed — This creature has double strike" shape |
@@ -132,13 +135,27 @@ class MaxSpeedBuilder {
     }
 
     internal fun gatedStaticAbilities(): List<StaticAbility> = statics.map { ability ->
-        // A `staticAbility { condition = … }` block already wrapped itself; fold the max-speed gate
-        // into that wrapper's condition instead of nesting two ConditionalStaticAbility layers, so
-        // the projected description and the layer system see one conditional ability.
-        if (ability is ConditionalStaticAbility) {
-            ability.copy(condition = ability.condition and MAX_SPEED_GATE)
-        } else {
-            ConditionalStaticAbility(ability, MAX_SPEED_GATE)
+        when (ability) {
+            // A cost modifier never reaches the layer system: `CostCalculator` scans the raw
+            // static-ability list for `is ModifySpellCost`, so a ConditionalStaticAbility wrapper
+            // would hide it and the reduction would silently never apply. ModifySpellCost carries
+            // its own condition slot for exactly this — fold the gate into it.
+            is ModifySpellCost -> ability.copy(
+                gating = when (val existing = ability.gating) {
+                    CostGating.None -> CostGating.OnlyIf(MAX_SPEED_GATE)
+                    is CostGating.OnlyIf -> CostGating.OnlyIf(existing.condition and MAX_SPEED_GATE)
+                    // NthOfTypePerTurn holds a count, not a condition, so the two gates can't be
+                    // merged into one slot. No card needs both; refuse rather than drop one.
+                    else -> throw IllegalArgumentException(
+                        "Max speed cannot gate a ModifySpellCost that already uses ${existing::class.simpleName} gating"
+                    )
+                }
+            )
+            // A `staticAbility { condition = … }` block already wrapped itself; fold the max-speed
+            // gate into that wrapper's condition instead of nesting two ConditionalStaticAbility
+            // layers, so the projected description and the layer system see one conditional ability.
+            is ConditionalStaticAbility -> ability.copy(condition = ability.condition and MAX_SPEED_GATE)
+            else -> ConditionalStaticAbility(ability, MAX_SPEED_GATE)
         }
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/EmbalmedAscendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/EmbalmedAscendant.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Embalmed Ascendant — Aetherdrift #201
+ * {1}{W}{B} · Creature — Zombie · 1/2
+ *
+ * Start your engines!
+ * When this creature enters, create a 2/2 black Zombie creature token.
+ * Max speed — Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.
+ *
+ * The max-speed half is gated as a `triggerCondition` (CR 603.4), so it is checked both when a
+ * creature dies and again on resolution — dropping below max speed in between correctly stops the
+ * drain. [Triggers.YourCreatureDies] is an ANY binding over creatures you control, which includes
+ * this creature itself: when it dies alongside another creature, both deaths see the ability.
+ *
+ * "Each opponent loses 1 life and you gain 1 life" is a two-part drain rather than life *lost* being
+ * mirrored into life gained — you gain exactly 1 no matter how many opponents there are.
+ */
+val EmbalmedAscendant = card("Embalmed Ascendant") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Zombie"
+    oracleText = "Start your engines!\n" +
+        "When this creature enters, create a 2/2 black Zombie creature token.\n" +
+        "Max speed — Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life."
+    power = 1
+    toughness = 2
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie")
+        )
+    }
+
+    maxSpeed {
+        triggeredAbility {
+            trigger = Triggers.YourCreatureDies
+            effect = Effects.Composite(
+                Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                Effects.GainLife(1)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg?1783907858"
+        ruling(
+            "2025-02-07",
+            "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something " +
+                "that happens as a state-based action as soon as you control a permanent with the " +
+                "ability. Notably, this includes gaining control of a permanent with the ability that " +
+                "another player controls."
+        )
+        ruling(
+            "2025-02-07",
+            "“Max speed — [ability]” means “As long as you have max speed, this object has " +
+                "[ability].” If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+        ruling("2025-02-07", "A player “has max speed” if their speed is 4.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GuardianSunmare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GuardianSunmare.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Guardian Sunmare — Aetherdrift #15
+ * {3}{W}{W} · Creature — Horse Mount · 5/5
+ *
+ * Ward {2}
+ * Whenever this creature attacks while saddled, search your library for a nonland permanent card
+ * with mana value 3 or less, put it onto the battlefield, then shuffle.
+ * Saddle 4
+ *
+ * "Attacks while saddled" is [Triggers.Attacks] plus [Conditions.SourceIsSaddled] as the
+ * `triggerCondition` — the saddled state is read when the trigger would fire, i.e. as attackers are
+ * declared, which is exactly the ruling ("will trigger only if that creature was saddled when it was
+ * declared as an attacker"). Saddled lasts until end of turn and nothing removes it mid-turn, so the
+ * CR 603.4 re-check on resolution can't diverge from the fire-time read.
+ *
+ * The tutor is the standard search pattern with a [SearchDestination.BATTLEFIELD] landing zone; a
+ * player may always fail to find, which is what the pattern's "choose up to one" selection models.
+ */
+val GuardianSunmare = card("Guardian Sunmare") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Horse Mount"
+    oracleText = "Ward {2}\n" +
+        "Whenever this creature attacks while saddled, search your library for a nonland permanent " +
+        "card with mana value 3 or less, put it onto the battlefield, then shuffle.\n" +
+        "Saddle 4 (Tap any number of other creatures you control with total power 4 or more: This " +
+        "Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+    power = 5
+    toughness = 5
+
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.NonlandPermanent.manaValueAtMost(3),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    keywordAbility(KeywordAbility.saddle(4))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Christina Kraus"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg?1783907919"
+        ruling(
+            "2025-02-07",
+            "“Saddled” isn't an ability that a creature has. It's just something true about " +
+                "that creature. It won't stop being saddled until the turn ends or it leaves the battlefield."
+        )
+        ruling(
+            "2025-02-07",
+            "An ability that triggers when a creature “attacks while saddled” will trigger " +
+                "only if that creature was saddled when it was declared as an attacker."
+        )
+        ruling("2025-02-07", "Creatures with saddle can attack or block as normal even if they aren't saddled.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KickoffCelebrations.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KickoffCelebrations.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kickoff Celebrations — Aetherdrift #135
+ * {1}{R} · Enchantment
+ *
+ * Start your engines!
+ * When this enchantment enters, you may discard a card. If you do, draw two cards.
+ * Max speed — Sacrifice this enchantment: Creatures and Vehicles you control gain haste until end
+ * of turn.
+ *
+ * The ETB is the standard "you may X. If you do, Y" nesting: [MayEffect] is the optional outer
+ * wrapper (declining does nothing at all), [IfYouDoEffect] gates the draw on the discard actually
+ * happening — so saying yes with an empty hand discards nothing and draws nothing.
+ *
+ * "Creatures and Vehicles you control" is one union filter rather than two grants, and it is
+ * deliberately not narrowed to creatures: an uncrewed Vehicle is a noncreature artifact that still
+ * picks up haste here, so crewing it later this turn gives a permanent that can attack immediately.
+ */
+val KickoffCelebrations = card("Kickoff Celebrations") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Start your engines!\n" +
+        "When this enchantment enters, you may discard a card. If you do, draw two cards.\n" +
+        "Max speed — Sacrifice this enchantment: Creatures and Vehicles you control gain haste " +
+        "until end of turn."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(2)
+            )
+        )
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.SacrificeSelf
+            effect = Effects.ForEachInGroup(
+                GroupFilter(
+                    (GameObjectFilter.Creature or GameObjectFilter.Any.withSubtype("Vehicle")).youControl()
+                ),
+                Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+            )
+            description = "Creatures and Vehicles you control gain haste until end of turn."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg?1783907880"
+        ruling(
+            "2025-02-07",
+            "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something " +
+                "that happens as a state-based action as soon as you control a permanent with the " +
+                "ability. Notably, this includes gaining control of a permanent with the ability that " +
+                "another player controls."
+        )
+        ruling(
+            "2025-02-07",
+            "Your speed doesn't change until a spell or ability says so, such as the inherent " +
+                "triggered ability that cares about opponents losing life during your turn. Notably, " +
+                "losing control of permanents with start your engines! doesn't affect your speed."
+        )
+        ruling("2025-02-07", "A player “has max speed” if their speed is 4.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MindspringMerfolk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MindspringMerfolk.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mindspring Merfolk — Aetherdrift #51
+ * {U} · Creature — Merfolk Wizard · 1/1
+ *
+ * Exhaust — {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control.
+ *
+ * `isExhaust = true` is the whole of CR 702.177 — the builder adds the once-per-object activation
+ * restriction and the "Exhaust — " prefix, so this is an ordinary activated ability with an X in its
+ * cost. X is chosen on activation and reaches the draw through [DynamicAmount.XValue].
+ *
+ * The counters go on **each** Merfolk you control, this creature included — it is itself a Merfolk,
+ * and tapping it to pay the cost doesn't remove it from the battlefield — so the group filter keeps
+ * the default `excludeSelf = false`. Ordering matters and matches the text: the draw happens first,
+ * so a Merfolk drawn by this ability is not on the battlefield in time to get a counter.
+ */
+val MindspringMerfolk = card("Mindspring Merfolk") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    oracleText = "Exhaust — {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk " +
+        "creature you control. (Activate each exhaust ability only once.)"
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{U}{U}"), Costs.Tap)
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.DrawCards(DynamicAmount.XValue),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.withSubtype("Merfolk").youControl()),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Andreia Ugrai"
+        flavorText = "The Invasion roused the reclusive jalpari from the depths. Since then, they " +
+            "had fully integrated into Avishkari society."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg?1783907907"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RacersScoreboard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RacersScoreboard.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Racers' Scoreboard — Aetherdrift #239
+ * {4} · Artifact
+ *
+ * Start your engines!
+ * When this artifact enters, draw two cards, then discard a card.
+ * Max speed — Spells you cast cost {1} less to cast.
+ *
+ * The cost reduction is a [ModifySpellCost] over every spell its controller casts. Declaring it
+ * inside [maxSpeed] folds [com.wingedsheep.sdk.dsl.Conditions.YouHaveMaxSpeed] into the modifier's
+ * own `gating` slot rather than wrapping it in a conditional static ability — cost calculation reads
+ * the raw static list and never unwraps a conditional, so a wrapper would make the reduction
+ * silently never apply.
+ *
+ * "Draw two cards, then discard a card" is sequential, not a single rummage: the discard sees the two
+ * freshly drawn cards, so a hand that was empty still has three cards to choose from.
+ */
+val RacersScoreboard = card("Racers' Scoreboard") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Start your engines!\n" +
+        "When this artifact enters, draw two cards, then discard a card.\n" +
+        "Max speed — Spells you cast cost {1} less to cast."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            Effects.Discard(1)
+        )
+    }
+
+    maxSpeed {
+        staticAbility {
+            ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+                modification = CostModification.ReduceGeneric(1)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Konstantin Porubov"
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1783907847"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2576,6 +2576,111 @@
     ]
 }
 
+// Embalmed Ascendant
+{
+    "name": "Embalmed Ascendant",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Start your engines!\nWhen this creature enters, create a 2/2 black Zombie creature token.\nMax speed — Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Max speed — a creature you control would die, each opponent loses 1 life. You gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cf181ae-daa7-42f9-b667-5e679d80cf34.jpg?1783907858",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something that happens as a state-based action as soon as you control a permanent with the ability. Notably, this includes gaining control of a permanent with the ability that another player controls."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "“Max speed — [ability]” means “As long as you have max speed, this object has [ability].” If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player “has max speed” if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Endrider Catalyzer
 {
     "name": "Endrider Catalyzer",
@@ -3941,6 +4046,112 @@
     ]
 }
 
+// Guardian Sunmare
+{
+    "name": "Guardian Sunmare",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Horse Mount",
+    "oracleText": "Ward {2}\nWhenever this creature attacks while saddled, search your library for a nonland permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.\nSaddle 4 (Tap any number of other creatures you control with total power 4 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "WARD",
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        },
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "nonland permanent mv<=3"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Christina Kraus",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c274595-94e2-4587-9cef-b38639d6429a.jpg?1783907919",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "“Saddled” isn't an ability that a creature has. It's just something true about that creature. It won't stop being saddled until the turn ends or it leaves the battlefield."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "An ability that triggers when a creature “attacks while saddled” will trigger only if that creature was saddled when it was declared as an attacker."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Creatures with saddle can attack or block as normal even if they aren't saddled."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Guidelight Matrix
 {
     "name": "Guidelight Matrix",
@@ -4663,6 +4874,138 @@
     ]
 }
 
+// Kickoff Celebrations
+{
+    "name": "Kickoff Celebrations",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Start your engines!\nWhen this enchantment enters, you may discard a card. If you do, draw two cards.\nMax speed — Sacrifice this enchantment: Creatures and Vehicles you control gain haste until end of turn.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature|Vehicle ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — Creatures and Vehicles you control gain haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Evyn Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e5590e1-0ac0-4bdd-815b-136bf24ced03.jpg?1783907880",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something that happens as a state-based action as soon as you control a permanent with the ability. Notably, this includes gaining control of a permanent with the ability that another player controls."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Your speed doesn't change until a spell or ability says so, such as the inherent triggered ability that cares about opponents losing life during your turn. Notably, losing control of permanents with start your engines! doesn't affect your speed."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player “has max speed” if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Leonin Surveyor
 {
     "name": "Leonin Surveyor",
@@ -5340,6 +5683,86 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Mindspring Merfolk
+{
+    "name": "Mindspring Merfolk",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Exhaust — {X}{U}{U}, {T}: Draw X cards. Put a +1/+1 counter on each Merfolk creature you control. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": "XValue"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Merfolk ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Andreia Ugrai",
+        "flavorText": "The Invasion roused the reclusive jalpari from the depths. Since then, they had fully integrated into Avishkari society.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6250b8b-1943-445f-ada9-30b41eb6d29b.jpg?1783907907",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -6423,6 +6846,108 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Racers' Scoreboard
+{
+    "name": "Racers' Scoreboard",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "Start your engines!\nWhen this artifact enters, draw two cards, then discard a card.\nMax speed — Spells you cast cost {1} less to cast.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {}
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": "Speed",
+                        "operator": "EQ",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Konstantin Porubov",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1783907847"
+    },
+    "colorIdentityOverride": []
 }
 
 // Regal Imperiosaur

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftSpeedCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftSpeedCardsScenarioTest.kt
@@ -1,11 +1,13 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.mechanics.speed.SpeedService
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Speed
 import com.wingedsheep.sdk.core.Step
@@ -14,7 +16,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 
 /**
- * The four Aetherdrift speed cards added with the mechanic, exercised as printed — one per
+ * The Aetherdrift speed cards added with the mechanic, exercised as printed — one per
  * "Max speed — [Ability]" payload kind, so each gate the `maxSpeed { }` block installs is proven on
  * real content rather than only on the inline test cards in [SpeedMechanicScenarioTest]:
  *
@@ -24,6 +26,7 @@ import io.kotest.matchers.shouldBe
  * | Walking Sarcophagus | static P/T buff | `ConditionalStaticAbility` |
  * | Endrider Catalyzer | activated mana ability | `ActivationRestriction.OnlyIfCondition` |
  * | Risen Necroregent | end-step trigger | `triggerCondition` |
+ * | Racers' Scoreboard | spell cost reduction | `CostGating.OnlyIf` |
  *
  * Each also carries "Start your engines!", so every test doubles as a check that the CR 704.5z
  * state-based action starts speed from a real card's printed keyword.
@@ -141,6 +144,70 @@ class AetherdriftSpeedCardsScenarioTest : ScenarioTestBase() {
                 atMax.resolveStack()
                 withClue("At max speed the end step makes one 2/2 Zombie") {
                     atMax.zombieTokens() shouldBe 1
+                }
+            }
+        }
+
+        context("Racers' Scoreboard") {
+
+            // A cost reduction never reaches the layer system: CostCalculator scans the raw static
+            // list for `is ModifySpellCost`, so the max-speed gate has to live in the modifier's own
+            // CostGating.OnlyIf slot. Wrapped in a ConditionalStaticAbility it would be invisible
+            // here and the reduction would apply at every speed.
+            test("its reduction applies only at max speed") {
+                val game = speedGame("Racers' Scoreboard")
+                val calculator = EngineServices(cardRegistry).costCalculator
+                val bears = cardRegistry.getCard("Grizzly Bears")!!
+
+                withClue("At speed 1 Grizzly Bears still costs its printed {1}{G}") {
+                    calculator.calculateEffectiveCost(game.state, bears, game.player1Id)
+                        .toString() shouldBe ManaCost.parse("{1}{G}").toString()
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                withClue("At max speed the generic pip is shaved off") {
+                    calculator.calculateEffectiveCost(game.state, bears, game.player1Id)
+                        .toString() shouldBe ManaCost.parse("{G}").toString()
+                }
+            }
+
+            test("the reduction is scoped to its controller's spells") {
+                val game = speedGame("Racers' Scoreboard")
+                val calculator = EngineServices(cardRegistry).costCalculator
+                val bears = cardRegistry.getCard("Grizzly Bears")!!
+
+                // "Spells you cast" reads the source's controller, so raising the *opponent's* speed
+                // must not discount their spells off a Scoreboard player 1 controls.
+                game.state = SpeedService.set(game.state, game.player2Id, Speed.MAX, "test").first
+
+                withClue("The opponent having max speed doesn't discount their spells") {
+                    calculator.calculateEffectiveCost(game.state, bears, game.player2Id)
+                        .toString() shouldBe ManaCost.parse("{1}{G}").toString()
+                }
+            }
+
+            test("it can actually be cast down to a cheaper real cast at max speed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Racers' Scoreboard")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val blocked = game.castSpell(1, "Grizzly Bears")
+                withClue("One Forest can't pay {1}{G} at speed 1") {
+                    (blocked.error != null).shouldBeTrue()
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val allowed = game.castSpell(1, "Grizzly Bears")
+                withClue("At max speed the cost is {G}, which one Forest covers: ${allowed.error}") {
+                    allowed.error shouldBe null
                 }
             }
         }


### PR DESCRIPTION
Implements five unimplemented Aetherdrift cards, plus the one SDK gap they turned up.

## Cards

All five are canonical in DFT (verified earliest real printing via `just check-card-printing`).

| Card | Cost | Shape |
|---|---|---|
| Mindspring Merfolk | `{U}` | Exhaust `{X}{U}{U}`, `{T}`: draw X, +1/+1 counter on each Merfolk you control |
| Guardian Sunmare | `{3}{W}{W}` | Ward `{2}`, Saddle 4, attacks-while-saddled → tutor a nonland permanent MV ≤ 3 to the battlefield |
| Kickoff Celebrations | `{1}{R}` | Start your engines!, may-discard → draw two; max speed — sacrifice for group haste |
| Racers' Scoreboard | `{4}` | Start your engines!, draw two then discard; max speed — spells you cast cost `{1}` less |
| Embalmed Ascendant | `{1}{W}{B}` | Start your engines!, 2/2 Zombie token; max speed — creature-dies drain |

Every card composes existing primitives — no new effects, triggers, or conditions.

## SDK fix: max-speed-gated cost reduction was silently inert

Racers' Scoreboard is the first card to put a `ModifySpellCost` inside a `maxSpeed { }` block, which exposed a fail-open gap.

`CostCalculator.scanBattlefieldModifySpellCost` walks the raw static-ability list looking for `is ModifySpellCost`. It never unwraps a `ConditionalStaticAbility` — cost calculation doesn't go through the layer system at all. So the wrapper `MaxSpeedBuilder` applies to statics made the modifier invisible: the reduction would never have applied, at any speed, with nothing failing loudly.

`MaxSpeedBuilder.gatedStaticAbilities()` now folds the max-speed gate into the modifier's own `CostGating.OnlyIf` slot, which `CostCalculator` already evaluates against the caster. That is the same principle the block already follows everywhere else — gate each ability kind with the vocabulary it already has, rather than adding a new one. Authoring is unchanged; the builder picks the right seam.

A `ModifySpellCost` that already carries `NthOfTypePerTurn` gating can't merge two gates into one slot, so that combination throws rather than dropping one silently. No card needs it.

## Verification

- `just build` — green across all modules
- Three new cases in `AetherdriftSpeedCardsScenarioTest` covering the new gate: reduction absent below max speed, present at max speed, scoped to the source's controller (an opponent at max speed gets no discount), and a real cast that only goes through on one fewer land at max speed
- Snapshot re-blessed: `DFT.json` only, 525 insertions and no deletions, so no existing card shifted
- Every field re-checked against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, oracle text, color identity); all five `image_uris.normal` confirmed HTTP 200
- `docs/card-sdk-language-reference.md` updated in the same change, per the repo rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)