### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ChargingHooligan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ChargingHooligan.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Charging Hooligan
+ * {3}{R}
+ * Creature — Human Peasant
+ * 3/3
+ *
+ * Whenever this creature attacks, it gets +1/+0 until end of turn for each attacking creature.
+ * If a Rat is attacking, this creature gains trample until end of turn.
+ *
+ * Both halves are one attack trigger, and both read the board when the ability *resolves*, not
+ * when attackers are declared — per the 2023-09-01 ruling the attacker count is taken at
+ * resolution and includes Charging Hooligan itself. A blocker killing an attacker in between is
+ * impossible (blockers aren't declared yet), but a removal spell cast in response does shrink the
+ * bonus, so the count has to stay a resolution-time [DynamicAmount] rather than a baked-in number.
+ *
+ * The count and the Rat check both scope to [Player.Each] rather than "you control": attacking
+ * creatures normally all belong to the attacking player, but a control-change effect resolving
+ * mid-combat can leave an attacking Rat under someone else's control, and the printed text asks
+ * only whether *a Rat* is attacking.
+ */
+val ChargingHooligan = card("Charging Hooligan") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Peasant"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature attacks, it gets +1/+0 until end of turn for each " +
+        "attacking creature. If a Rat is attacking, this creature gains trample until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            Effects.ModifyStats(
+                power = DynamicAmounts.battlefield(
+                    Player.Each,
+                    GameObjectFilter.Creature.attacking()
+                ).count(),
+                toughness = DynamicAmount.Fixed(0),
+                target = EffectTarget.Self
+            ),
+            ConditionalEffect(
+                condition = Conditions.CompareAmounts(
+                    DynamicAmounts.battlefield(
+                        Player.Each,
+                        GameObjectFilter.Creature.withSubtype(Subtype.RAT).attacking()
+                    ).count(),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(1)
+                ),
+                effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        )
+        description = "Whenever this creature attacks, it gets +1/+0 until end of turn for each " +
+            "attacking creature. If a Rat is attacking, this creature gains trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "318"
+        artist = "Tomas Duchek"
+        flavorText = "\"Soon the rats are gonna run this town, so I'm gonna run with them!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg?1783915039"
+
+        ruling(
+            "2023-09-01",
+            "Count the number of attacking creatures when Charging Hooligan's ability resolves, " +
+                "including Charging Hooligan itself, to determine the increase to its power."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/OldFlitterfang.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/OldFlitterfang.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Old Flitterfang
+ * {4}{B}
+ * Legendary Creature — Rat Faerie
+ * 3/4
+ *
+ * Flying
+ * At the beginning of each end step, if a creature died this turn, create a Food token.
+ * {2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn.
+ *
+ * The Food trigger is an intervening-if (CR 603.4), which is exactly what the 2023-09-01 ruling
+ * describes: the "a creature died this turn" check happens *as the end step begins*, and if nothing
+ * died the ability never triggers at all — so [Conditions.CreatureDiedThisTurn] goes on
+ * `triggerCondition`, not into a [com.wingedsheep.sdk.scripting.effects.ConditionalEffect] wrapper
+ * around the effect. [Conditions.CreatureDiedThisTurn] is the global variant (any player's
+ * creature), matching the unqualified "a creature".
+ *
+ * [Triggers.EachEndStep] rather than `YourEndStep`: it fires in every player's end step, so Old
+ * Flitterfang converts an opponent's removal spell into a Food on their own turn.
+ *
+ * The pump's sacrifice is a *cost*, so it's paid on activation and can't be undone by removal in
+ * response; [Costs.SacrificeAnother] over [GameObjectFilter.CreatureOrArtifact] enforces the printed
+ * "another" (Old Flitterfang can't eat itself) while letting the Food tokens the trigger makes feed
+ * it — Food is an artifact.
+ */
+val OldFlitterfang = card("Old Flitterfang") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Rat Faerie"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "At the beginning of each end step, if a creature died this turn, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        triggerCondition = Conditions.CreatureDiedThisTurn
+        effect = Effects.CreateFood()
+        description = "At the beginning of each end step, if a creature died this turn, create a Food token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.CreatureOrArtifact)
+        )
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets " +
+            "+2/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "316"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg?1783915039"
+
+        ruling(
+            "2023-09-01",
+            "Old Flitterfang's triggered ability will check as the end step starts to see if a " +
+                "creature died this turn. If none did, the ability won't trigger at all."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+        )
+        ruling(
+            "2024-11-08",
+            "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a " +
+                "Food token to activate its own ability and also to activate Maraleaf Rider's ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpecterOfMortality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpecterOfMortality.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Specter of Mortality
+ * {3}{B}{B}
+ * Creature — Specter
+ * 3/3
+ *
+ * Flying
+ * When this creature enters, you may exile one or more creature cards from your graveyard. When you
+ * do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this
+ * way.
+ *
+ * A Gather → Select → Move pipeline: gather the creature cards in your graveyard, let the controller
+ * take any number of them (0 is the "may" decline — a `chooseAnyNumber` with an empty selection),
+ * exile the picks, then shrink the board by however many actually moved.
+ *
+ * Two details the pipeline shape buys:
+ *  - `moveTracked` is what X reads, not the selection. "The number of cards exiled this way" counts
+ *    cards that really left the graveyard, so a card that somehow moved away between selection and
+ *    resolution doesn't inflate the debuff.
+ *  - The `ifNotEmpty` gate is the "When you do" clause. Declining exiles nothing and must apply no
+ *    -0/-0 modification at all, rather than stacking an inert floating effect on every creature.
+ *
+ * `excludeSelf` on the [GroupFilter] is the printed "each **other** creature": the Specter that just
+ * entered spares itself, and everything else — including your own creatures — shrinks.
+ */
+val SpecterOfMortality = card("Specter of Mortality") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Specter"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, you may exile one or more creature cards from your graveyard. " +
+        "When you do, each other creature gets -X/-X until end of turn, where X is the number of " +
+        "cards exiled this way."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Pipeline(
+            descriptionOverride = "You may exile one or more creature cards from your graveyard. " +
+                "When you do, each other creature gets -X/-X until end of turn, where X is the " +
+                "number of cards exiled this way."
+        ) {
+            val graveyardCreatures = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature
+                )
+            )
+            val chosen = chooseAnyNumber(
+                from = graveyardCreatures,
+                prompt = "Exile any number of creature cards from your graveyard",
+                selectedLabel = "Exile",
+                remainderLabel = "Leave in graveyard"
+            )
+            val exiled = moveTracked(
+                from = chosen,
+                destination = CardDestination.ToZone(Zone.EXILE),
+                name = "exiledCreatures"
+            )
+            ifNotEmpty(exiled) {
+                val exiledCount = DynamicAmount.VariableReference("exiledCreatures_count")
+                run(
+                    Patterns.Group.modifyStatsForAll(
+                        power = DynamicAmount.Multiply(exiledCount, -1),
+                        toughness = DynamicAmount.Multiply(exiledCount, -1),
+                        filter = GroupFilter(GameObjectFilter.Creature, excludeSelf = true)
+                    )
+                )
+            }
+        }
+        description = "When this creature enters, you may exile one or more creature cards from " +
+            "your graveyard. When you do, each other creature gets -X/-X until end of turn, where " +
+            "X is the number of cards exiled this way."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "107"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg?1783915102"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwistedFealty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwistedFealty.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Twisted Fealty
+ * {2}{R}
+ * Sorcery
+ *
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until
+ * end of turn.
+ * Create a Wicked Role token attached to up to one target creature.
+ *
+ * Two independent targets. The first is the borrowed creature and is required; the second is the
+ * Role recipient and is "up to one" ([TargetCreature] with `optional = true`), so the spell is
+ * castable with no second target and — per the 2023-09-01 ruling — simply skips the Role when the
+ * second target is absent or has become illegal. Both are chosen at cast time, and the Role
+ * recipient is any creature, not just the stolen one, so the two clauses stay separate effects
+ * rather than one composed "steal and enchant".
+ *
+ * Effect order follows the printed order (gain control, then untap, then haste) rather than
+ * Threaten's untap-first wording — with the control change first, the untap and the haste grant
+ * both land on a creature already under your control.
+ */
+val TwistedFealty = card("Twisted Fealty") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of target creature until end of turn. Untap that creature. It gains " +
+        "haste until end of turn.\n" +
+        "Create a Wicked Role token attached to up to one target creature. (If you control another " +
+        "Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this " +
+        "token is put into a graveyard, each opponent loses 1 life.)"
+
+    spell {
+        val stolen = target("target creature", Targets.Creature)
+        val roleHost = target("up to one target creature", TargetCreature(optional = true))
+        effect = Effects.Composite(
+            Effects.GainControl(stolen, Duration.EndOfTurn),
+            Effects.Untap(stolen),
+            Effects.GrantKeyword(Keyword.HASTE, stolen),
+            Effects.CreateRoleToken("Wicked Role", roleHost)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "154"
+        artist = "Mila Pesic"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg?1783915087"
+
+        ruling(
+            "2023-09-01",
+            "If you don't choose a second target for Twisted Fealty or that target is illegal as " +
+                "the spell resolves, the Wicked Role token won't be created."
+        )
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and " +
+                "the enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, " +
+                "each of those Roles except the one with the most recent timestamp is put into its " +
+                "owner's graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "A permanent can have multiple Roles attached to it if each one is controlled by a " +
+                "different player."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WildwoodMentor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WildwoodMentor.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Wildwood Mentor
+ * {2}{G}
+ * Creature — Treefolk
+ * 1/1
+ *
+ * Whenever a token you control enters, put a +1/+1 counter on this creature.
+ * Whenever this creature attacks, another target attacking creature gets +X/+X until end of turn,
+ * where X is this creature's power.
+ *
+ * The first ability is per-token, not once per batch — "a token you control enters" with
+ * [TriggerBinding.ANY] over `GameObjectFilter.Any.youControl().token()`, so a single effect making
+ * three tokens adds three counters. Any token counts, not just creature tokens (Food, Treasure and
+ * Role tokens all feed it).
+ *
+ * The attack trigger's +X/+X reads Wildwood Mentor's power *as the ability resolves* via
+ * [EntityReference.Source] — which is after the counter triggers from the same combat have already
+ * resolved, and after any pump in response. It resolves to a fixed +X/+X modification at that
+ * moment, so it does not re-scale if the Mentor grows or dies later in the turn. `.other()` on the
+ * target filter is the printed "another": the Mentor can't pump itself, and with no other attacker
+ * the trigger simply has no legal target.
+ */
+val WildwoodMentor = card("Wildwood Mentor") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a token you control enters, put a +1/+1 counter on this creature.\n" +
+        "Whenever this creature attacks, another target attacking creature gets +X/+X until end " +
+        "of turn, where X is this creature's power."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any.youControl().token(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever a token you control enters, put a +1/+1 counter on this creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val ally = target(
+            "another target attacking creature",
+            TargetCreature(filter = TargetFilter.Creature.attacking().other())
+        )
+        val sourcePower = DynamicAmount.EntityProperty(
+            EntityReference.Source,
+            EntityNumericProperty.Power
+        )
+        effect = Effects.ModifyStats(power = sourcePower, toughness = sourcePower, target = ally)
+        description = "Whenever this creature attacks, another target attacking creature gets " +
+            "+X/+X until end of turn, where X is this creature's power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "322"
+        artist = "Piotr Foksowicz"
+        flavorText = "\"Not bad. If only you had branches.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg?1783915037"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1311,6 +1311,85 @@
     "colorIdentityOverride": []
 }
 
+// Charging Hooligan
+{
+    "name": "Charging Hooligan",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "Whenever this creature attacks, it gets +1/+0 until end of turn for each attacking creature. If a Rat is attacking, this creature gains trample until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "AggregateBattlefield",
+                                "player": "Each",
+                                "filter": "creature attacking"
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "Each",
+                                        "filter": "creature Rat attacking"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, it gets +1/+0 until end of turn for each attacking creature. If a Rat is attacking, this creature gains trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "318",
+        "rarity": "UNCOMMON",
+        "artist": "Tomas Duchek",
+        "flavorText": "\"Soon the rats are gonna run this town, so I'm gonna run with them!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fddc6f47-202d-4764-abc1-ee453a8917c2.jpg?1783915039",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Count the number of attacking creatures when Charging Hooligan's ability resolves, including Charging Hooligan itself, to determine the increase to its power."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Charmed Clothier
 {
     "name": "Charmed Clothier",
@@ -6396,6 +6475,101 @@
     ]
 }
 
+// Old Flitterfang
+{
+    "name": "Old Flitterfang",
+    "manaCost": "{4}{B}",
+    "typeLine": "Legendary Creature — Rat Faerie",
+    "oracleText": "Flying\nAt the beginning of each end step, if a creature died this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "triggerCondition": "CreatureDiedThisTurn",
+                "descriptionOverride": "At the beginning of each end step, if a creature died this turn, create a Food token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{2}{B}, Sacrifice another creature or artifact: Old Flitterfang gets +2/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "316",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67c77d6f-de14-423c-bf55-0fb289171004.jpg?1783915039",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Old Flitterfang's triggered ability will check as the end step starts to see if a creature died this turn. If none did, the ability won't trigger at all."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food token to activate its own ability and also to activate Maraleaf Rider's ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pests of Honor
 {
     "name": "Pests of Honor",
@@ -8445,6 +8619,109 @@
     ]
 }
 
+// Specter of Mortality
+{
+    "name": "Specter of Mortality",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Specter",
+    "oracleText": "Flying\nWhen this creature enters, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "selected1",
+                            "prompt": "Exile any number of creature cards from your graveyard",
+                            "selectedLabel": "Exile",
+                            "remainderLabel": "Leave in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "storeMovedAs": "exiledCreatures"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "exiledCreatures",
+                            "ifNotEmpty": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "VariableReference",
+                                            "variableName": "exiledCreatures_count"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Multiply",
+                                        "amount": {
+                                            "type": "VariableReference",
+                                            "variableName": "exiledCreatures_count"
+                                        },
+                                        "multiplier": -1
+                                    },
+                                    "target": "Self"
+                                }
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way."
+                },
+                "descriptionOverride": "When this creature enters, you may exile one or more creature cards from your graveyard. When you do, each other creature gets -X/-X until end of turn, where X is the number of cards exiled this way."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e4c00b5-f6d6-4fbd-828f-ad30321f2cd9.jpg?1783915102"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spell Stutter
 {
     "name": "Spell Stutter",
@@ -10274,6 +10551,97 @@
     ]
 }
 
+// Twisted Fealty
+{
+    "name": "Twisted Fealty",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.\nCreate a Wicked Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this token is put into a graveyard, each opponent loses 1 life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to one target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/382d6085-79b9-48f7-8949-9f44dde2c753.jpg?1783915087",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a second target for Twisted Fealty or that target is illegal as the spell resolves, the Wicked Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "A permanent can have multiple Roles attached to it if each one is controlled by a different player."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Twisted Sewer-Witch
 {
     "name": "Twisted Sewer-Witch",
@@ -11048,6 +11416,78 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Wildwood Mentor
+{
+    "name": "Wildwood Mentor",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Treefolk",
+    "oracleText": "Whenever a token you control enters, put a +1/+1 counter on this creature.\nWhenever this creature attacks, another target attacking creature gets +X/+X until end of turn, where X is this creature's power.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "token ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a token you control enters, put a +1/+1 counter on this creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "toughnessModifier": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking",
+                        "excludeSelf": true
+                    },
+                    "id": "another target attacking creature"
+                },
+                "descriptionOverride": "Whenever this creature attacks, another target attacking creature gets +X/+X until end of turn, where X is this creature's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "322",
+        "rarity": "RARE",
+        "artist": "Piotr Foksowicz",
+        "flavorText": "\"Not bad. If only you had branches.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96c247f4-06cf-4c41-8285-d44d40f4130c.jpg?1783915037"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch11ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch11ScenarioTest.kt
@@ -1,0 +1,471 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.woe.cards.OldFlitterfang
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the eleventh batch of Wilds of Eldraine cards.
+ *
+ * Every card in this batch is composed from primitives that already existed, so these tests are not
+ * about new vocabulary — they pin down the five places where a plausible-looking composition
+ * resolves wrong:
+ *
+ *  - **Charging Hooligan** — the pump has to be counted at *resolution* over **all** attackers
+ *    including itself (2023-09-01 ruling), and the trample rider is a separate resolution-time gate
+ *    that must stay off when no Rat is attacking.
+ *  - **Wildwood Mentor** — "a token you control enters" must fire per token and must not fire for a
+ *    nontoken creature; the attack trigger's +X/+X reads the Mentor's power *after* those counters,
+ *    and must not be able to choose the Mentor itself.
+ *  - **Old Flitterfang** — the intervening 'if' has to suppress the whole ability when nothing died,
+ *    and the Food trigger has to fire in the *opponent's* end step too.
+ *  - **Specter of Mortality** — X is the size of the exiled set, applied to every creature *except*
+ *    the Specter; declining the exile must apply nothing at all.
+ *  - **Twisted Fealty** — the two targets are independent: the Role goes on whichever creature was
+ *    picked second, and the spell still resolves with no second target chosen.
+ */
+class WoeCardsBatch11ScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? = game.state.projectedState.getToughness(id)
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun auraOn(game: TestGame, auraName: String, host: EntityId): EntityId? =
+        game.findPermanents(auraName).firstOrNull { aura ->
+            game.state.getEntity(aura)?.get<AttachedToComponent>()?.targetId == host
+        }
+
+    /**
+     * Twisted Fealty has two independent targets, which the base fixture's single-target
+     * [ScenarioTestBase.TestGame.castSpell] can't express — cast it directly so the "up to one"
+     * second target can be present or absent.
+     */
+    private fun TestGame.castTwistedFealty(targets: List<EntityId>) = execute(
+        CastSpell(
+            player1Id,
+            findCardsInHand(1, "Twisted Fealty").first(),
+            targets.map { ChosenTarget.Permanent(it) }
+        )
+    )
+
+    init {
+        context("Charging Hooligan — +1/+0 per attacking creature, trample if a Rat attacks") {
+            test("attacking alongside two others is +3/+0 — the count includes the Hooligan itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Charging Hooligan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Savannah Lions", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hooligan = game.findPermanent("Charging Hooligan").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Charging Hooligan" to 2, "Grizzly Bears" to 2, "Savannah Lions" to 2)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("three attackers → +3/+0 on a 3/3") {
+                    power(game, hooligan) shouldBe 6
+                    toughness(game, hooligan) shouldBe 3
+                }
+                withClue("no Rat is attacking, so no trample") {
+                    game.state.projectedState.hasKeyword(hooligan, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+
+            test("attacking alone is only +1/+0 — the creatures left home don't count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Charging Hooligan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hooligan = game.findPermanent("Charging Hooligan").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Charging Hooligan" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("only the Hooligan attacks — it counts once, for +1/+0") {
+                    power(game, hooligan) shouldBe 4
+                }
+            }
+
+            test("an attacking Rat turns on trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Voracious Vermin is a Rat, so it satisfies "if a Rat is attacking".
+                    .withCardOnBattlefield(1, "Charging Hooligan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Voracious Vermin", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hooligan = game.findPermanent("Charging Hooligan").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Charging Hooligan" to 2, "Voracious Vermin" to 2)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("two attackers → +2/+0") { power(game, hooligan) shouldBe 5 }
+                withClue("the Rat is attacking, so trample is granted") {
+                    game.state.projectedState.hasKeyword(hooligan, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("a Rat you control that stayed home does not grant trample — it must be attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Charging Hooligan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Voracious Vermin", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hooligan = game.findPermanent("Charging Hooligan").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Charging Hooligan" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Rat is on the battlefield but not attacking") {
+                    game.state.projectedState.hasKeyword(hooligan, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+        }
+
+        context("Wildwood Mentor — counters from tokens, +X/+X on attack") {
+            test("a token entering puts a +1/+1 counter on the Mentor") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wildwood Mentor", summoningSickness = false)
+                    // Voracious Vermin's enters trigger creates one Rat *token*.
+                    .withCardInHand(1, "Voracious Vermin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mentor = game.findPermanent("Wildwood Mentor").shouldNotBeNull()
+                plusOneCounters(game, mentor) shouldBe 0
+
+                game.castSpell(1, "Voracious Vermin").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Rat token entering is one trigger; the nontoken Vermin itself is not") {
+                    plusOneCounters(game, mentor) shouldBe 1
+                }
+                withClue("the 1/1 Mentor is now 2/2") {
+                    power(game, mentor) shouldBe 2
+                    toughness(game, mentor) shouldBe 2
+                }
+            }
+
+            test("a nontoken creature entering does nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wildwood Mentor", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mentor = game.findPermanent("Wildwood Mentor").shouldNotBeNull()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is a real card, not a token") {
+                    plusOneCounters(game, mentor) shouldBe 0
+                }
+            }
+
+            test("the attack trigger pumps another attacker by the Mentor's power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wildwood Mentor", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Wildwood Mentor" to 2, "Grizzly Bears" to 2)
+                ).error shouldBe null
+
+                // Only the Bears is a legal target — "another" excludes the Mentor.
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("X = the Mentor's power (1), so the 2/2 Bears becomes 3/3") {
+                    power(game, bears) shouldBe 3
+                    toughness(game, bears) shouldBe 3
+                }
+            }
+        }
+
+        context("Old Flitterfang") {
+            test("with a creature dead this turn, the end step makes a Food token") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Old Flitterfang", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                game.castSpell(1, "Doom Blade", targetId = bears).error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("a creature died this turn, so the intervening 'if' is satisfied") {
+                    game.findPermanent("Food").shouldNotBeNull()
+                }
+            }
+
+            test("with nothing dead, the ability never triggers — no Food") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Old Flitterfang", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("nothing died, so no Food is created") {
+                    game.findPermanent("Food") shouldBe null
+                }
+            }
+
+            test("sacrificing another artifact for +2/+2 leaves Old Flitterfang itself alone") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Old Flitterfang", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val flitterfang = game.findPermanent("Old Flitterfang").shouldNotBeNull()
+                val thopter = game.findPermanent("Ornithopter").shouldNotBeNull()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = flitterfang,
+                        abilityId = OldFlitterfang.activatedAbilities[0].id
+                    )
+                ).error shouldBe null
+                // The sacrifice is a cost, so it is paid on activation: pick the Ornithopter.
+                if (game.hasPendingDecision()) {
+                    game.selectCards(listOf(thopter)).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the Ornithopter was eaten, not the Flitterfang") {
+                    game.isOnBattlefield("Ornithopter") shouldBe false
+                    game.isOnBattlefield("Old Flitterfang") shouldBe true
+                }
+                withClue("the 3/4 becomes 5/6 until end of turn") {
+                    power(game, flitterfang) shouldBe 5
+                    toughness(game, flitterfang) shouldBe 6
+                }
+            }
+        }
+
+        context("Specter of Mortality — -X/-X for each creature card exiled from your graveyard") {
+            test("exiling two creature cards shrinks every other creature by 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Specter of Mortality")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Savannah Lions")
+                    // A noncreature card in the graveyard must not be selectable.
+                    .withCardInGraveyard(1, "Pacifism")
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val thopter = game.findPermanent("Ornithopter").shouldNotBeNull()
+
+                game.castSpell(1, "Specter of Mortality").error shouldBe null
+                game.resolveStack()
+
+                val specter = game.findPermanent("Specter of Mortality").shouldNotBeNull()
+                val graveBears = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+                val graveLions = game.findCardsInGraveyard(1, "Savannah Lions").first()
+
+                game.selectCards(listOf(graveBears, graveLions)).error shouldBe null
+                game.resolveStack()
+
+                withClue("both creature cards left the graveyard for exile") {
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Savannah Lions") shouldBe true
+                }
+                withClue("X = 2, so the 3/3 Hill Giant becomes 1/1") {
+                    power(game, giant) shouldBe 1
+                    toughness(game, giant) shouldBe 1
+                }
+                withClue("'each other creature' includes your own — the 0/2 Ornithopter dies") {
+                    game.isOnBattlefield("Ornithopter") shouldBe false
+                }
+                withClue("the Specter spares itself and stays 3/3") {
+                    power(game, specter) shouldBe 3
+                    toughness(game, specter) shouldBe 3
+                }
+            }
+
+            test("declining the exile applies no modification at all") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Specter of Mortality")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castSpell(1, "Specter of Mortality").error shouldBe null
+                game.resolveStack()
+
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing was exiled, so nothing shrinks") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    power(game, giant) shouldBe 3
+                    toughness(game, giant) shouldBe 3
+                }
+            }
+        }
+
+        context("Twisted Fealty — borrow a creature, and crown a second one") {
+            test("the stolen creature is untapped, hasty and yours; the Role lands on the other target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twisted Fealty")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castTwistedFealty(listOf(giant, bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Giant changed controller for the turn and untapped with haste") {
+                    game.state.projectedState.getController(giant) shouldBe game.player1Id
+                    game.state.getEntity(giant)?.get<TappedComponent>() shouldBe null
+                    game.state.projectedState.hasKeyword(giant, Keyword.HASTE) shouldBe true
+                }
+                withClue("the Wicked Role went on the second target, not the stolen creature") {
+                    auraOn(game, "Wicked Role", bears).shouldNotBeNull()
+                    auraOn(game, "Wicked Role", giant) shouldBe null
+                }
+                withClue("Wicked Role grants +1/+1 — the 2/2 Bears projects as 3/3") {
+                    power(game, bears) shouldBe 3
+                    toughness(game, bears) shouldBe 3
+                }
+            }
+
+            test("with only the first target chosen the spell still steals, and makes no Role") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Twisted Fealty")
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castTwistedFealty(listOf(giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the steal half resolved on its own") {
+                    game.state.projectedState.getController(giant) shouldBe game.player1Id
+                    game.state.getEntity(giant)?.get<TappedComponent>() shouldBe null
+                }
+                withClue("no second target was chosen, so no Role token exists") {
+                    game.findPermanent("Wicked Role") shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five Wilds of Eldraine cards. All five are WOE-original printings, so each canonical `CardDefinition` lives in the WOE set — `just check-card-printing` is clean for all of them.

Every card composes existing SDK primitives (no new effect, trigger, condition, or keyword), so [`docs/card-sdk-language-reference.md`](docs/card-sdk-language-reference.md) is unchanged.

## Cards

| Card | Cost | Notes |
|---|---|---|
| **Charging Hooligan** | `{3}{R}` | Attack trigger; `+1/+0` per attacker counted **at resolution** over all attackers including itself (2023-09-01 ruling). The trample rider is a separate resolution-time gate on an attacking Rat, scoped to `Player.Each` so a mid-combat control change can't hide it. |
| **Wildwood Mentor** | `{2}{G}` | Per-token `entersBattlefield(Any.youControl().token(), ANY)` counter trigger — three tokens at once means three counters, and any token counts (Food, Treasure, Role). The attack trigger reads the Mentor's own power via `EntityProperty(Source, Power)`, and `.other()` on the target filter is the printed "another". |
| **Old Flitterfang** | `{4}{B}` | Intervening-'if' (CR 603.4) Food trigger on `EachEndStep` — the 2023-09-01 ruling says the check happens *as the end step begins*, so `Conditions.CreatureDiedThisTurn` goes on `triggerCondition`, not in a wrapper around the effect. Pump uses `Costs.SacrificeAnother(CreatureOrArtifact)`, so the Food it makes can feed it. |
| **Specter of Mortality** | `{3}{B}{B}` | Gather → Select → Move pipeline. X reads `moveTracked`'s output (cards that actually left the graveyard), not the raw selection; `ifNotEmpty` is the "When you do" clause, so declining applies no `-0/-0` modification at all. `excludeSelf` is the printed "each **other** creature". |
| **Twisted Fealty** | `{2}{R}` | Two independent cast-time targets. The second is `optional = true` ("up to one"), so per the 2023-09-01 ruling the spell resolves with the Role clause simply skipped. Effect order follows the printed order (gain control → untap → haste), not Threaten's untap-first wording. |

## Tests

`WoeCardsBatch11ScenarioTest` — 14 tests, all passing. These aren't new-vocabulary tests; they pin down the places a plausible-looking composition resolves wrong:

- attacker count with 3 / 1 attackers, and the trample gate on vs. off (attacking Rat vs. a Rat that stayed home)
- a token entering vs. a nontoken creature entering; the `+X/+X` reading the Mentor's power after those counters
- the intervening 'if' in both directions — Food after a death, nothing at all without one — plus "another" on the sacrifice cost
- the exiled-set size feeding `-X/-X` (killing your own `0/2` while sparing the Specter), and declining the exile
- Twisted Fealty with both targets and with only the first

## Verification

- `just build` — green (`:mtg-sets:test` incl. `FacadeBoundaryTest` + card linter, `:rules-engine:test`, `:game-server:test`)
- `just rebless-cards` — only the five new cards moved in `WOE.json`, purely additive (zero removed lines)
- All ten mechanical fields re-verified field-by-field against Scryfall (mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor text, image URI) — exact match for all five; every `image_uris.normal` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)