### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AatchikEmeraldRadian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AatchikEmeraldRadian.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aatchik, Emerald Radian
+ * {3}{B}{B}{G}
+ * Legendary Creature — Insect Druid
+ * 3/3
+ * When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature
+ * card in your graveyard.
+ * Whenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1
+ * life.
+ *
+ * The token count is one `Count` over the graveyard with a single artifact-or-creature predicate,
+ * so an artifact creature card is counted once rather than twice (Scryfall ruling below).
+ */
+val AatchikEmeraldRadian = card("Aatchik, Emerald Radian") {
+    manaCost = "{3}{B}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Insect Druid"
+    oracleText = "When Aatchik enters, create a 1/1 green Insect creature token for each artifact " +
+        "and/or creature card in your graveyard.\n" +
+        "Whenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent " +
+        "loses 1 life."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            count = DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.CreatureOrArtifact),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Insect"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg?1783907678"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.INSECT),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "187"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg?1783907862"
+        ruling(
+            "2025-02-07",
+            "If a card in your graveyard is an artifact creature card, count it only once when " +
+                "determining how many Insect tokens to create for Aatchik's first ability."
+        )
+        ruling(
+            "2025-02-07",
+            "If Aatchik is dealt lethal damage at the same time as another Insect you control, " +
+                "Aatchik's last ability will still trigger, causing each opponent to lose 1 life, " +
+                "but Aatchik won't get a +1/+1 counter in time to save it."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AmonkhetRaceway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AmonkhetRaceway.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Amonkhet Raceway
+ * Land
+ *
+ * Start your engines!
+ * {T}: Add {C}.
+ * Max speed — {T}: Target creature gains haste until end of turn.
+ */
+val AmonkhetRaceway = card("Amonkhet Raceway") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{T}: Add {C}.\n" +
+        "Max speed — {T}: Target creature gains haste until end of turn."
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Tap
+            val creature = target("target creature", Targets.Creature)
+            effect = Effects.GrantKeyword(Keyword.HASTE, creature)
+            // The auto-rendered label reads "{T}: target gains haste until end of turn" — the bound
+            // variable name lands mid-sentence. `maxSpeed { }` prepends "Max speed — " to whichever
+            // of the two the ability carries, so the override only needs the cost and the effect.
+            description = "{T}: Target creature gains haste until end of turn"
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "248"
+        artist = "Brian Valeza"
+        flavorText = "Stage 2: The sands and waters of Amonkhet."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg?1783907845"
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AvishkarRaceway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AvishkarRaceway.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Avishkar Raceway
+ * Land
+ *
+ * Start your engines!
+ * {T}: Add {C}.
+ * Max speed — {3}, {T}, Discard a card: Draw a card.
+ */
+val AvishkarRaceway = card("Avishkar Raceway") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{T}: Add {C}.\n" +
+        "Max speed — {3}, {T}, Discard a card: Draw a card."
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.DiscardCard)
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Julian Kok Joon Wen"
+        flavorText = "Stage 1: The winding streets of Ghirapur."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg?1783907845"
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HauntedHellride.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HauntedHellride.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Haunted Hellride
+ * {1}{U}{B}
+ * Artifact — Vehicle
+ * 3/3
+ * Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of
+ * turn. Untap it.
+ * Crew 1
+ *
+ * The attack trigger is the once-per-combat group trigger ([Triggers.YouAttack]), not an "attacks"
+ * trigger on this permanent — it fires whenever you declare any attacker, even when this Vehicle
+ * isn't among them (or isn't a creature at all). "Untap it" refers back to the same target, so all
+ * three parts share one target requirement.
+ */
+val HauntedHellride = card("Haunted Hellride") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch " +
+        "until end of turn. Untap it.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, creature),
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, creature),
+            Effects.Untap(creature)
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg?1783907857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MuragandaRaceway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MuragandaRaceway.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Muraganda Raceway
+ * Land
+ *
+ * Start your engines!
+ * {T}: Add {C}.
+ * Max speed — {T}: Add {C}{C}.
+ */
+val MuragandaRaceway = card("Muraganda Raceway") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{T}: Add {C}.\n" +
+        "Max speed — {T}: Add {C}{C}."
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddColorlessMana(2)
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Brian Valeza"
+        flavorText = "Stage 3: The steaming jungles of Muraganda under falling skies."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg?1783907840"
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -1,3 +1,96 @@
+// Aatchik, Emerald Radian
+{
+    "name": "Aatchik, Emerald Radian",
+    "manaCost": "{3}{B}{B}{G}",
+    "typeLine": "Legendary Creature — Insect Druid",
+    "oracleText": "When Aatchik enters, create a 1/1 green Insect creature token for each artifact and/or creature card in your graveyard.\nWhenever another Insect you control dies, put a +1/+1 counter on Aatchik. Each opponent loses 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature|artifact"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Insect"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d3d855d-93a1-4ec4-af19-e544f271ae10.jpg?1783907678"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Insect ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "RARE",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbdaa29b-85ff-4a06-b27e-fcdbdfd4a3fe.jpg?1783907862",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If a card in your graveyard is an artifact creature card, count it only once when determining how many Insect tokens to create for Aatchik's first ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If Aatchik is dealt lethal damage at the same time as another Insect you control, Aatchik's last ability will still trigger, causing each opponent to lose 1 life, but Aatchik won't get a +1/+1 counter in time to save it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Aetherjacket
 {
     "name": "Aetherjacket",
@@ -232,6 +325,85 @@
     ]
 }
 
+// Amonkhet Raceway
+{
+    "name": "Amonkhet Raceway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed — {T}: Target creature gains haste until end of turn.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — {T}: Target creature gains haste until end of turn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "flavorText": "Stage 2: The sands and waters of Amonkhet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f312807-ea2a-4385-8774-4e23b4a5d4a6.jpg?1783907845",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Apocalypse Runner
 {
     "name": "Apocalypse Runner",
@@ -378,6 +550,90 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Avishkar Raceway
+{
+    "name": "Avishkar Raceway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed — {3}, {T}, Discard a card: Draw a card.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — {3}, {T}, Discard a card: Draw a card"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Julian Kok Joon Wen",
+        "flavorText": "Stage 1: The winding streets of Ghirapur.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08a6b378-c7fa-4226-a310-4ee7e550b4d6.jpg?1783907845",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Beastrider Vanguard
@@ -4378,6 +4634,90 @@
     ]
 }
 
+// Haunted Hellride
+{
+    "name": "Haunted Hellride",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever you attack, target creature you control gets +1/+0 and gains deathtouch until end of turn. Untap it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DEATHTOUCH",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            },
+                            "tap": false
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Olivier Bernard",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2ce0d37-d5d7-49dd-885e-9998bb8abede.jpg?1783907857"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Hazard of the Dunes
 {
     "name": "Hazard of the Dunes",
@@ -5839,6 +6179,77 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Muraganda Raceway
+{
+    "name": "Muraganda Raceway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{T}: Add {C}.\nMax speed — {T}: Add {C}{C}.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "isManaAbility": true,
+                "descriptionOverride": "Max speed — {T}: Add {C}{C}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "flavorText": "Stage 3: The steaming jungles of Muraganda under falling skies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/5041ae16-29ff-4ad5-8a37-4736e9409294.jpg?1783907840",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Mutant Surveyor


### PR DESCRIPTION
Five more Aetherdrift cards, taking DFT from 169/276 to 174/276. All compose existing SDK vocabulary — no new effects, triggers, keywords, or engine behavior — so the card snapshot and structural lint nets are the coverage and no scenario test was added.

## Cards

| Card | Notes |
|---|---|
| **Amonkhet Raceway** (U, #248) | `startYourEngines()` + max-speed `{T}: Target creature gains haste until end of turn`. |
| **Avishkar Raceway** (C, #249) | Max-speed `{3}, {T}, Discard a card: Draw a card` via `Costs.Composite` over the mana / tap / discard atoms. |
| **Muraganda Raceway** (R, #257) | Max-speed `{T}: Add {C}{C}`. |
| **Haunted Hellride** (U, #208) | `{1}{U}{B}` 3/3 Vehicle, Crew 1, attack trigger. |
| **Aatchik, Emerald Radian** (R, #187) | `{3}{B}{B}{G}` 3/3 legend — ETB Insect tokens + an "another Insect dies" trigger. |

This completes the three-card DFT "Raceway" land cycle.

## Implementation notes

- **Muraganda's max-speed ability is flagged `manaAbility`** so the mana solver can reach it, mirroring the already-shipped Endrider Catalyzer. The land ends up with two `{T}` mana abilities competing for the same tap, which is the same shape as the DFT Verge lands.
- **Amonkhet Raceway overrides `description`.** The auto-rendered label came out as `{T}: target gains haste until end of turn` — the bound variable name lands mid-sentence. `maxSpeed { }` prepends `Max speed — ` to whichever of `descriptionOverride`/`description` the ability carries, so the override only supplies the cost and the effect. That string is the action-menu button text.
- **Haunted Hellride uses `Triggers.YouAttack`**, the once-per-combat group trigger, not an "attacks" trigger on the permanent — it fires whenever you declare any attacker, even when this Vehicle isn't among them or isn't a creature at all. "Untap it" refers back to the same target, so all three parts (`ModifyStats`, `GrantKeyword`, `Untap`) share one target requirement rather than each taking their own.
- **Aatchik's token count is one `DynamicAmount.Count` over the graveyard** with a single `CreatureOrArtifact` predicate, so an artifact creature card is counted once rather than twice — the 2025-02-07 Scryfall ruling, which is recorded in `metadata { }`. The dies trigger is `Triggers.leavesBattlefield(… to = GRAVEYARD, binding = TriggerBinding.OTHER)` for "another".

## Cards deliberately not taken

**Reckless Velocitaur** and **Canyon Vaulter** were on the shortlist but need "Whenever this creature saddles a Mount or crews a Vehicle" — a trigger on the *contributor*, not on the Mount/Vehicle. `CrewVehicleHandler`/`SaddleMountHandler` emit no event for that today, and the effect has to bind the crewed/saddled permanent as its target. That's a new SDK primitive, so it belongs in an `add-feature` change rather than here.

## Verification

- `just build` — green (full gate: compile, `FacadeBoundaryTest`, card linter, snapshot, rules-engine suite).
- `just rebless-cards` — DFT golden diff is purely additive, 411 lines, only these five cards.
- `just check-card-printing` — ok for all five (all are DFT-original; canonical is the earliest real printing).
- Scryfall re-verified field by field: name, mana cost, type line, P/T, rarity, collector number, artist, flavor text, and `image_uris.normal` (each URL curl'd for HTTP 200, query parameter included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)