### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RestlessBivouac.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RestlessBivouac.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Restless Bivouac
+ * Land
+ *
+ * This land enters tapped.
+ * {T}: Add {R} or {W}.
+ * {1}{R}{W}: This land becomes a 2/2 red and white Ox creature until end of turn. It's still a land.
+ * Whenever this land attacks, put a +1/+1 counter on target creature you control.
+ *
+ * The Wilds of Eldraine half of the "Restless" creature-land cycle (the Lost Caverns of Ixalan half
+ * is [com.wingedsheep.mtg.sets.definitions.lci.cards.RestlessAnchorage] and friends). As with the
+ * rest of the cycle the attack trigger is an *intrinsic* triggered ability of the land, not one
+ * granted by the animate ability: a land can only attack while it's a creature, so in practice the
+ * trigger is live only after {1}{R}{W} resolves, but per the second Scryfall ruling it also fires if
+ * something else animates the land.
+ *
+ * The +1/+1 counter may go on any creature you control — including the Bivouac itself, which is a
+ * creature at that point. Counters are not part of the until-end-of-turn animation, so they simply
+ * sit on the land once it stops being a creature and count again the next time it animates.
+ */
+val RestlessBivouac = card("Restless Bivouac") {
+    typeLine = "Land"
+    colorIdentity = "RW"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R} or {W}.\n" +
+        "{1}{R}{W}: This land becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\n" +
+        "Whenever this land attacks, put a +1/+1 counter on target creature you control."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}{W}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 2,
+            toughness = 2,
+            creatureTypes = setOf("Ox"),
+            colors = setOf(Color.RED.name, Color.WHITE.name),
+            duration = Duration.EndOfTurn,
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "Whenever this land attacks, put a +1/+1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg?1783915056"
+
+        ruling(
+            "2023-09-01",
+            "Counters on Restless Bivouac remain on it when it stops being a creature. If it becomes " +
+                "a creature later, they'll apply to it."
+        )
+        ruling(
+            "2023-09-01",
+            "If this becomes a creature because of an effect other than its own ability, its last " +
+                "ability will still trigger whenever it attacks."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RestlessFortress.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RestlessFortress.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Restless Fortress
+ * Land
+ *
+ * This land enters tapped.
+ * {T}: Add {W} or {B}.
+ * {2}{W}{B}: This land becomes a 1/4 white and black Nightmare creature until end of turn. It's
+ *   still a land.
+ * Whenever this land attacks, defending player loses 2 life and you gain 2 life.
+ *
+ * The white-black member of the Wilds of Eldraine "Restless" creature-land cycle (see
+ * [RestlessBivouac]). The attack trigger is an intrinsic triggered ability of the land, not one
+ * granted by the animate ability.
+ *
+ * The drain is two independent fixed amounts rather than a linked life-transfer: the printed text is
+ * "loses 2 life and you gain 2 life", so you gain 2 even if the defending player's life loss is
+ * prevented or replaced. [Player.DefendingPlayer] resolves per CR 802.2a through this land's own
+ * attack assignment, so attacking a planeswalker drains that planeswalker's controller.
+ */
+val RestlessFortress = card("Restless Fortress") {
+    typeLine = "Land"
+    colorIdentity = "WB"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W} or {B}.\n" +
+        "{2}{W}{B}: This land becomes a 1/4 white and black Nightmare creature until end of turn. " +
+        "It's still a land.\n" +
+        "Whenever this land attacks, defending player loses 2 life and you gain 2 life."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}{B}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 1,
+            toughness = 4,
+            creatureTypes = setOf("Nightmare"),
+            colors = setOf(Color.WHITE.name, Color.BLACK.name),
+            duration = Duration.EndOfTurn,
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            Effects.LoseLife(2, EffectTarget.PlayerRef(Player.DefendingPlayer)),
+            Effects.GainLife(2, EffectTarget.Controller),
+        )
+        description = "Whenever this land attacks, defending player loses 2 life and you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg?1783915055"
+
+        ruling(
+            "2023-09-01",
+            "If this becomes a creature because of an effect other than its own ability, its last " +
+                "ability will still trigger whenever it attacks."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ReturnFromTheWilds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ReturnFromTheWilds.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.woe.cards
 
-import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.card
@@ -44,16 +43,7 @@ val ReturnFromTheWilds = card("Return from the Wilds") {
                     entersTapped = true
                 )
             )
-            mode(
-                "Create a 1/1 white Human creature token",
-                Effects.CreateToken(
-                    power = 1,
-                    toughness = 1,
-                    colors = setOf(Color.WHITE),
-                    creatureTypes = setOf("Human"),
-                    imageUri = "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1783914992"
-                )
-            )
+            mode("Create a 1/1 white Human creature token", woeHumanToken())
             mode("Create a Food token", Effects.CreateFood())
         }
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StrokeOfMidnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StrokeOfMidnight.kt
@@ -4,7 +4,6 @@
 
 package com.wingedsheep.mtg.sets.definitions.woe.cards
 
-import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
@@ -29,13 +28,7 @@ val StrokeOfMidnight = card("Stroke of Midnight") {
         val t = target("target", TargetPermanent(filter = TargetFilter.NonlandPermanent))
         effect = Effects.Composite(
             Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
-            Effects.CreateToken(
-                power = 1,
-                toughness = 1,
-                colors = setOf(Color.WHITE),
-                creatureTypes = setOf("Human"),
-                controller = EffectTarget.TargetController
-            )
+            woeHumanToken(controller = EffectTarget.TargetController)
         )
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheHuntsmansRedemption.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheHuntsmansRedemption.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * The Huntsman's Redemption
+ * {2}{G}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Create a 3/3 green Beast creature token.
+ * II — You may sacrifice a creature. If you do, search your library for a creature or basic land
+ *   card, reveal it, put it into your hand, then shuffle.
+ * III — Up to two target creatures each get +2/+2 and gain trample until end of turn.
+ *
+ * Chapter II is the "you may X. If you do, Y" idiom (cf. Witherbloom Charm): a [MayEffect] for the
+ * "you may", wrapping an [IfYouDoEffect] whose action is a gather → choose-one → sacrifice pipeline
+ * over the creatures you control, gating the tutor on the sacrifice actually happening. The
+ * [FeasibilityCheck] suppresses the yes/no prompt entirely when you control no creature — the
+ * chapter triggers on its own every turn, so an unanswerable prompt would be pure noise. The Beast
+ * token from chapter I is the natural thing to feed it. Note the choose step is *not* a target: the
+ * creature is picked as the chapter ability resolves, so nothing is locked in when it triggers.
+ *
+ * The tutor's "creature or basic land card" is a plain filter union, and `reveal = true` mirrors the
+ * printed "reveal it" (the search is not optional, so declining to find simply shuffles).
+ *
+ * Chapter III fans an optional two-target requirement out with [ForEachTargetEffect] so each chosen
+ * creature gets its own +2/+2 and its own trample grant — "up to two", so zero or one target is
+ * legal and the chapter still resolves.
+ */
+val TheHuntsmansRedemption = card("The Huntsman's Redemption") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Create a 3/3 green Beast creature token.\n" +
+        "II — You may sacrifice a creature. If you do, search your library for a creature or basic " +
+        "land card, reveal it, put it into your hand, then shuffle.\n" +
+        "III — Up to two target creatures each get +2/+2 and gain trample until end of turn."
+
+    sagaChapter(1) {
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Beast"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg?1783914991",
+        )
+    }
+
+    sagaChapter(2) {
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Effects.Pipeline {
+                    val creatures = gather(GameObjectFilter.Creature, player = Player.You)
+                    val chosen = chooseExactly(
+                        1,
+                        from = creatures,
+                        useTargetingUI = true,
+                        prompt = "Choose a creature to sacrifice",
+                    )
+                    sacrifice(chosen)
+                },
+                ifYouDo = Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.Creature or GameObjectFilter.BasicLand,
+                    count = 1,
+                    destination = SearchDestination.HAND,
+                    reveal = true,
+                ),
+            ),
+            descriptionOverride = "You may sacrifice a creature. If you do, search your library for a " +
+                "creature or basic land card, reveal it, put it into your hand, then shuffle.",
+            feasibility = FeasibilityCheck.ControlsPermanentMatching(GameObjectFilter.Creature.youControl()),
+        )
+    }
+
+    sagaChapter(3) {
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0), Duration.EndOfTurn),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.ContextTarget(0), Duration.EndOfTurn),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg?1783915080"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheWitchsVanity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheWitchsVanity.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * The Witch's Vanity
+ * {1}{B}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Destroy target creature an opponent controls with mana value 2 or less.
+ * II — Create a Food token.
+ * III — Create a Wicked Role token attached to target creature you control.
+ *
+ * All three chapters sit on existing primitives. Chapter I is a plain destroy over a
+ * `Creature.opponentControls().manaValueAtMost(2)` target — mana value is read from the card, so a
+ * token (mana value 0) or an animated land is a legal target, while a creature pumped past 2 mana
+ * value by a cost-changing effect is not.
+ *
+ * Chapter III mints the shared Wicked Role Aura token
+ * ([com.wingedsheep.mtg.sets.tokens.PredefinedTokens.WickedRole]) attached to a creature you
+ * control. Per the Role rulings, if that creature already carries another Role you control, the
+ * older one is put into its owner's graveyard as a state-based action — which is itself what
+ * triggers Wicked Visitor and friends. Both targeting chapters fizzle entirely if their target is
+ * gone by resolution, so no Role token is created.
+ */
+val TheWitchsVanity = card("The Witch's Vanity") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Destroy target creature an opponent controls with mana value 2 or less.\n" +
+        "II — Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "III — Create a Wicked Role token attached to target creature you control."
+
+    sagaChapter(1) {
+        val creature = target(
+            "target creature an opponent controls with mana value 2 or less",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.opponentControls().manaValueAtMost(2)),
+            ),
+        )
+        effect = Effects.Destroy(creature)
+    }
+
+    sagaChapter(2) {
+        effect = Effects.CreateFood()
+    }
+
+    sagaChapter(3) {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateRoleToken("Wicked Role", creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Alix Branwyn"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg?1783915098"
+
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the " +
+                "enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, each " +
+                "of those Roles except the one with the most recent timestamp is put into its owner's " +
+                "graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "Some spells and abilities that create Role tokens require targets. If each target chosen " +
+                "is an illegal target as that spell or ability tries to resolve, it won't resolve. The " +
+                "Role token won't be created."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WelcomeToSweettooth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WelcomeToSweettooth.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Welcome to Sweettooth
+ * {1}{G}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Create a 1/1 white Human creature token.
+ * II — Create a Food token.
+ * III — Put X +1/+1 counters on target creature you control, where X is one plus the number of
+ *   Foods you control.
+ *
+ * Chapters I and II are the shared WOE Human token ([woeHumanToken]) and the predefined Food token.
+ *
+ * Chapter III's X is "one plus the number of Foods you control": a [DynamicAmount.Add] over a
+ * battlefield count of Food *artifacts* — not just Food tokens, per the Scryfall ruling, which is
+ * exactly what the `Artifact.withSubtype("Food")` filter matches. X is evaluated as the chapter
+ * ability resolves, and the Food token minted by chapter II two turns earlier is still counted if
+ * it's around. The chapter targets, so the whole ability does nothing if the chosen creature has
+ * left or become an illegal target by resolution.
+ */
+val WelcomeToSweettooth = card("Welcome to Sweettooth") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Create a 1/1 white Human creature token.\n" +
+        "II — Create a Food token.\n" +
+        "III — Put X +1/+1 counters on target creature you control, where X is one plus the number " +
+        "of Foods you control."
+
+    sagaChapter(1) {
+        effect = woeHumanToken()
+    }
+
+    sagaChapter(2) {
+        effect = Effects.CreateFood()
+    }
+
+    sagaChapter(3) {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.Add(
+                DynamicAmount.Fixed(1),
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Artifact.withSubtype("Food"),
+                ).count(),
+            ),
+            creature,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg?1783915075"
+
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WoeTokens.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
 import com.wingedsheep.sdk.scripting.CantBlock
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -28,6 +29,27 @@ internal fun woeRatToken(count: DynamicAmount = DynamicAmount.Fixed(1)): Effect 
     creatureTypes = setOf("Rat"),
     imageUri = "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
     staticAbilities = listOf(CantBlock())
+)
+
+/**
+ * Wilds of Eldraine's Human token: a plain 1/1 white Human creature token.
+ *
+ * Another type-named token (see [woeRatToken]) shared by several WOE cards — Welcome to Sweettooth,
+ * Return from the Wilds, Stroke of Midnight. [controller] is who creates the token; `null` means the
+ * effect's controller, and Stroke of Midnight passes [EffectTarget.TargetController] for "its
+ * controller creates a 1/1 white Human creature token".
+ */
+internal fun woeHumanToken(
+    count: DynamicAmount = DynamicAmount.Fixed(1),
+    controller: EffectTarget? = null,
+): Effect = Effects.CreateToken(
+    count = count,
+    power = 1,
+    toughness = 1,
+    colors = setOf(Color.WHITE),
+    creatureTypes = setOf("Human"),
+    controller = controller,
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1783914992",
 )
 
 /**

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -7506,6 +7506,221 @@
     ]
 }
 
+// Restless Bivouac
+{
+    "name": "Restless Bivouac",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {W}.\n{1}{R}{W}: This land becomes a 2/2 red and white Ox creature until end of turn. It's still a land.\nWhenever this land attacks, put a +1/+1 counter on target creature you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "Whenever this land attacks, put a +1/+1 counter on target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "creatureTypes": [
+                        "Ox"
+                    ],
+                    "colors": [
+                        "RED",
+                        "WHITE"
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b85e0aed-bfb2-4aa8-a754-849c4d9a6a58.jpg?1783915056",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Counters on Restless Bivouac remain on it when it stops being a creature. If it becomes a creature later, they'll apply to it."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If this becomes a creature because of an effect other than its own ability, its last ability will still trigger whenever it attacks."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Restless Fortress
+{
+    "name": "Restless Fortress",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {B}.\n{2}{W}{B}: This land becomes a 1/4 white and black Nightmare creature until end of turn. It's still a land.\nWhenever this land attacks, defending player loses 2 life and you gain 2 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "DefendingPlayer"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this land attacks, defending player loses 2 life and you gain 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "creatureTypes": [
+                        "Nightmare"
+                    ],
+                    "colors": [
+                        "WHITE",
+                        "BLACK"
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/675213bb-28d7-460c-a4f3-950f5b9090af.jpg?1783915055",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If this becomes a creature because of an effect other than its own ability, its last ability will still trigger whenever it attacks."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Return Triumphant
 {
     "name": "Return Triumphant",
@@ -9366,6 +9581,7 @@
                     "creatureTypes": [
                         "Human"
                     ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1783914992",
                     "controller": "TargetController"
                 }
             ]
@@ -9991,6 +10207,263 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// The Huntsman's Redemption
+{
+    "name": "The Huntsman's Redemption",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Create a 3/3 green Beast creature token.\nII — You may sacrifice a creature. If you do, search your library for a creature or basic land card, reveal it, put it into your hand, then shuffle.\nIII — Up to two target creatures each get +2/+2 and gain trample until end of turn.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Beast"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2d33cf3-c803-4e90-9d4b-fa34136b600e.jpg?1783914991"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayDecide",
+                        "feasibility": {
+                            "type": "ControlsPermanentMatching",
+                            "filter": "creature ctrl:you"
+                        }
+                    },
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "BattlefieldMatching",
+                                            "filter": "creature",
+                                            "player": "You"
+                                        },
+                                        "storeAs": "gathered0"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "gathered0",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected1",
+                                        "prompt": "Choose a creature to sacrifice",
+                                        "useTargetingUI": true
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "selected1",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Sacrifice"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "creature|basicland"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        }
+                    },
+                    "descriptionOverride": "You may sacrifice a creature. If you do, search your library for a creature or basic land card, reveal it, put it into your hand, then shuffle."
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to two target creatures"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27003577-e276-4ad5-b3e9-8523b166ad49.jpg?1783915080"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// The Witch's Vanity
+{
+    "name": "The Witch's Vanity",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Destroy target creature an opponent controls with mana value 2 or less.\nII — Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nIII — Create a Wicked Role token attached to target creature you control.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls with mana value 2 or less"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=2 ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls with mana value 2 or less"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Alix Branwyn",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/47ca4926-b5ac-405a-8b58-f8db6df400ff.jpg?1783915098",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some spells and abilities that create Role tokens require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. The Role token won't be created."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -11259,6 +11732,89 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Welcome to Sweettooth
+{
+    "name": "Welcome to Sweettooth",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Create a 1/1 white Human creature token.\nII — Create a Food token.\nIII — Put X +1/+1 counters on target creature you control, where X is one plus the number of Foods you control.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1783914992"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "right": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact Food"
+                        }
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e629a31-2e06-4f95-9628-34670dcf68b9.jpg?1783915075",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsScenarioTest.kt
@@ -2,7 +2,9 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -26,6 +28,8 @@ import io.kotest.matchers.shouldNotBe
  *  - **Wicked Visitor** — an enchantment you control hitting the graveyard drains each opponent.
  *  - **Knight of Doves** — an enchantment you control hitting the graveyard makes a 1/1 white flying Bird.
  *  - **Gnawing Crescendo** — team +2/+0, and a turn-long delayed trigger that Rats each nontoken death.
+ *  - **Restless Bivouac** — animate for {1}{R}{W}, attack, put a +1/+1 counter on a chosen creature.
+ *  - **Restless Fortress** — animate for {2}{W}{B}, attack, drain the defending player for 2.
  */
 class WoeCardsScenarioTest : ScenarioTestBase() {
 
@@ -38,6 +42,10 @@ class WoeCardsScenarioTest : ScenarioTestBase() {
     private val tabbyDeathtouchAbility by lazy {
         cardRegistry.requireCard("Warehouse Tabby").activatedAbilities[0].id
     }
+
+    /** The animate ability of a Restless land — after the two `{T}: Add …` mana abilities. */
+    private fun animateAbility(landName: String) =
+        cardRegistry.requireCard(landName).activatedAbilities[2].id
 
     init {
         context("Hopeless Nightmare") {
@@ -512,6 +520,94 @@ class WoeCardsScenarioTest : ScenarioTestBase() {
                     val rat = game.findPermanent("Rat Token")
                     rat shouldNotBe null
                     game.state.projectedState.cantBlock(rat!!) shouldBe true
+                }
+            }
+        }
+
+        context("Restless Bivouac") {
+
+            test("animates into a 2/2 Ox and its attack trigger counters a chosen creature") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Restless Bivouac")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bivouac = game.findPermanent("Restless Bivouac")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bivouac,
+                        abilityId = animateAbility("Restless Bivouac")
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val animated = projector.project(game.state)
+                withClue("{1}{R}{W} makes it a 2/2 that is still a land") {
+                    animated.isCreature(bivouac) shouldBe true
+                    animated.getPower(bivouac) shouldBe 2
+                    animated.getToughness(bivouac) shouldBe 2
+                }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Restless Bivouac" to 2)).error shouldBe null
+
+                withClue("the attack trigger asks for a target creature you control") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                val counters = game.state.getEntity(bears)?.get<CountersComponent>()
+                withClue("Grizzly Bears should carry exactly one +1/+1 counter") {
+                    counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+        }
+
+        context("Restless Fortress") {
+
+            test("animates into a 1/4 Nightmare and its attack trigger drains the defender for 2") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Restless Fortress")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fortress = game.findPermanent("Restless Fortress")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = fortress,
+                        abilityId = animateAbility("Restless Fortress")
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val animated = projector.project(game.state)
+                withClue("{2}{W}{B} makes it a 1/4") {
+                    animated.isCreature(fortress) shouldBe true
+                    animated.getPower(fortress) shouldBe 1
+                    animated.getToughness(fortress) shouldBe 4
+                }
+
+                val ourLife = game.getLifeTotal(1)
+                val theirLife = game.getLifeTotal(2)
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Restless Fortress" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger drains before combat damage is dealt") {
+                    game.getLifeTotal(2) shouldBe theirLife - 2
+                    game.getLifeTotal(1) shouldBe ourLife + 2
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeSagasScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeSagasScenarioTest.kt
@@ -1,0 +1,225 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.TheHuntsmansRedemption
+import com.wingedsheep.mtg.sets.definitions.woe.cards.TheWitchsVanity
+import com.wingedsheep.mtg.sets.definitions.woe.cards.WelcomeToSweettooth
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Chapter-by-chapter tests for the three Wilds of Eldraine Sagas in this batch.
+ *
+ *  - **Welcome to Sweettooth** — I Human token, II Food token, III `X = 1 + Foods you control`
+ *    +1/+1 counters. The X calculation is the interesting part: it's a
+ *    [com.wingedsheep.sdk.scripting.values.DynamicAmount.Add] over a battlefield Food count, so the
+ *    Food minted by chapter II must be visible to chapter III two turns later.
+ *  - **The Witch's Vanity** — I destroys a mana-value-2-or-less creature an opponent controls,
+ *    II Food token, III Wicked Role attached to your creature.
+ *  - **The Huntsman's Redemption** — I 3/3 Beast token, II the optional "sacrifice a creature →
+ *    tutor a creature or basic land", III up-to-two creatures get +2/+2 and trample.
+ *
+ * All three are cast on turn 1, so chapter II resolves on turn 2 and chapter III on turn 3. A
+ * chapter's targeting decision surfaces at the start of that turn's precombat main, which is where
+ * [advanceToMain] hands off to a drain helper.
+ */
+class WoeSagasScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + PredefinedTokens.allTokens + listOf(
+                WelcomeToSweettooth,
+                TheWitchsVanity,
+                TheHuntsmansRedemption,
+            )
+        )
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    /**
+     * Drain the stack, answering every target request with [targets] — the Saga chapters that target
+     * would otherwise get an arbitrary auto-pick.
+     */
+    fun GameTestDriver.drainTargeting(chooser: EntityId, targets: List<EntityId>) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            val decision = state.pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> submitTargetSelection(chooser, targets)
+                decision != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    /** Advance to the given turn's precombat main phase through the real game flow. */
+    fun GameTestDriver.advanceToMain(targetTurn: Int) {
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+            guard++
+        }
+        if (guard >= 500) error("Failed to reach turn $targetTurn precombat main")
+    }
+
+    fun GameTestDriver.plusOnePlusOne(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.countPermanentsNamed(playerId: EntityId, name: String): Int =
+        getPermanents(playerId).count { getCardName(it) == name }
+
+    test("Welcome to Sweettooth: Human, then Food, then X = 1 + Foods you control counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.GREEN, 2)
+        val saga = driver.putCardInHand(controller, "Welcome to Sweettooth")
+        driver.castSpell(controller, saga)
+        driver.drain() // enters with lore 1 → chapter I
+
+        withClue("chapter I creates a 1/1 white Human token") {
+            driver.countPermanentsNamed(controller, "Human Token") shouldBe 1
+        }
+
+        driver.advanceToMain(2) // lore 2 → chapter II
+        driver.drain()
+
+        withClue("chapter II creates a Food token") {
+            driver.countPermanentsNamed(controller, "Food") shouldBe 1
+        }
+
+        // Chapter III's X counts every Food artifact we control, so add a second one by hand to
+        // prove the count is read from the battlefield rather than hard-coded.
+        driver.putPermanentOnBattlefield(controller, "Food")
+
+        val human = driver.getPermanents(controller).first { driver.getCardName(it) == "Human Token" }
+        driver.advanceToMain(3) // lore 3 → chapter III, which targets
+        driver.drainTargeting(controller, listOf(human))
+
+        withClue("X is one plus the two Foods we control, so the Human gets three +1/+1 counters") {
+            driver.plusOnePlusOne(human) shouldBe 3
+        }
+        withClue("a three-chapter Saga is sacrificed after its last chapter resolves") {
+            driver.getGraveyardCardNames(controller).contains("Welcome to Sweettooth") shouldBe true
+        }
+    }
+
+    test("The Witch's Vanity: destroy a small creature, then Food, then a Wicked Role") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.BLACK, 2)
+        val saga = driver.putCardInHand(controller, "The Witch's Vanity")
+        driver.castSpell(controller, saga)
+        driver.drainTargeting(controller, listOf(bear))
+
+        withClue("Grizzly Bears is mana value 2, so chapter I destroys it") {
+            driver.getGraveyardCardNames(opponent).contains("Grizzly Bears") shouldBe true
+        }
+
+        driver.advanceToMain(2)
+        driver.drain()
+        withClue("chapter II creates a Food token") {
+            driver.countPermanentsNamed(controller, "Food") shouldBe 1
+        }
+
+        val ours = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+        driver.advanceToMain(3)
+        driver.drainTargeting(controller, listOf(ours))
+
+        withClue("chapter III attaches a Wicked Role to our creature, making the 2/2 a 3/3") {
+            driver.findPermanent(controller, "Wicked Role") shouldNotBe null
+            driver.state.projectedState.getPower(ours) shouldBe 3
+            driver.state.projectedState.getToughness(ours) shouldBe 3
+        }
+    }
+
+    test("The Huntsman's Redemption: Beast token, sacrifice-to-tutor, then +2/+2 and trample") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.GREEN, 3)
+        val saga = driver.putCardInHand(controller, "The Huntsman's Redemption")
+        driver.castSpell(controller, saga)
+        driver.drain() // chapter I
+
+        val beast = driver.findPermanent(controller, "Beast Token")
+        withClue("chapter I creates a 3/3 green Beast token") {
+            beast shouldNotBe null
+            driver.state.projectedState.getPower(beast!!) shouldBe 3
+            driver.state.projectedState.getToughness(beast) shouldBe 3
+        }
+
+        // Chapter II: accept the optional sacrifice, feed it the Beast, and tutor a basic land.
+        val handBefore = driver.getHandSize(controller)
+        driver.advanceToMain(2)
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision != null) && guard < 60) {
+            val decision = driver.state.pendingDecision
+            when {
+                decision is YesNoDecision -> driver.submitYesNo(controller, true)
+                decision is SelectCardsDecision && decision.options.contains(beast) ->
+                    driver.submitCardSelection(controller, listOf(beast!!))
+                decision != null -> driver.autoResolveDecision()
+                else -> driver.bothPass()
+            }
+            guard++
+        }
+
+        withClue("the Beast was sacrificed to chapter II (a token, so it then ceases to exist)") {
+            driver.findPermanent(controller, "Beast Token") shouldBe null
+        }
+        withClue("sacrificing tutors a creature or basic land into hand (the deck is all Forests)") {
+            driver.getHandSize(controller) shouldBe handBefore + 1
+        }
+
+        val bear = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+        driver.advanceToMain(3) // chapter III
+        driver.drainTargeting(controller, listOf(bear))
+
+        withClue("the chosen creature gets +2/+2 and trample until end of turn") {
+            driver.state.projectedState.getPower(bear) shouldBe 4
+            driver.state.projectedState.getToughness(bear) shouldBe 4
+            driver.state.projectedState.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Five more Wilds of Eldraine cards — two creature-lands and three Sagas. Everything composes existing SDK primitives; no new effects, triggers, conditions, or engine vocabulary, so `docs/card-sdk-language-reference.md` is unchanged.

## Cards

| Card | Shape |
|---|---|
| **Restless Bivouac** (#257) | `{1}{R}{W}` animate to a 2/2 Ox; attack trigger puts a +1/+1 counter on target creature you control |
| **Restless Fortress** (#259) | `{2}{W}{B}` animate to a 1/4 Nightmare; attack trigger drains the defending player for 2 |
| **Welcome to Sweettooth** (#198) | Saga — Human token / Food token / X +1/+1 counters where X is one plus your Food count |
| **The Witch's Vanity** (#119) | Saga — destroy a MV≤2 creature an opponent controls / Food token / Wicked Role token |
| **The Huntsman's Redemption** (#176) | Saga — 3/3 Beast token / optional sacrifice→tutor / up-to-two creatures get +2/+2 and trample |

The two lands follow the LCI `Restless` cycle template; WOE is the earliest printing for all five (`just check-card-printing` clean).

## Notes worth a reviewer's eye

- **Restless Fortress' drain is not `DrainLife`.** The printed text is "defending player loses 2 life *and* you gain 2 life" — two independent fixed amounts, so you gain 2 even when the life loss is prevented or replaced. Modelled as `Composite(LoseLife(2, DefendingPlayer), GainLife(2))`, matching Agate-Blade Assassin.
- **Welcome to Sweettooth's X** is `DynamicAmount.Add(Fixed(1), battlefield Food-artifact count)`. It counts *Food artifacts*, not Food tokens, per the Scryfall ruling — the `Artifact.withSubtype("Food")` filter is what makes that right.
- **The Huntsman's Redemption chapter II** is the `MayEffect` + `IfYouDo` idiom (cf. Witherbloom Charm) over a gather → choose-one → sacrifice pipeline, gating the tutor on the sacrifice happening. A `FeasibilityCheck.ControlsPermanentMatching` suppresses the yes/no prompt when you control no creature — the chapter triggers on its own every turn, so an unanswerable prompt would be pure noise. The creature is picked at resolution, not targeted.
- **Shared Human token.** The 1/1 white Human shape moves into `WoeTokens.kt` now that it has three users (Welcome to Sweettooth, Return from the Wilds, Stroke of Midnight). That is the only reason Stroke of Midnight appears in the snapshot diff: its token was missing `imageUri` and now has it.
- Oracle text for Welcome to Sweettooth chapter II carries **no** Food reminder text, unlike The Witch's Vanity chapter II. That asymmetry is what Scryfall prints.

## Tests

- `WoeCardsScenarioTest` — two new contexts: each land animates to the right P/T, attacks, and fires its trigger (counter placed on the chosen creature; drain moves both life totals).
- `WoeSagasScenarioTest` (new) — all three Sagas chapter by chapter, including the `1 + Foods` X calculation with a second Food added by hand to prove the count is read from the battlefield, and the chapter II sacrifice-then-tutor path driven explicitly rather than auto-resolved.

`just build` green; card snapshot re-blessed and the diff is additions-only plus the Stroke of Midnight token art.

## Not in scope

`backlog/cube-draft-format.md:322` lists the whole five-land WOE `Restless` cycle behind one checkbox. This PR does two of them, so that line stays unticked — Restless Cottage, Restless Spire, and Restless Vinestalk are still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)