### PR TITLE
Landing layout for laptops, and /help as a reading page

### DIFF
--- a/web-client/src/components/auth/AuthWidget.module.css
+++ b/web-client/src/components/auth/AuthWidget.module.css
@@ -3,8 +3,10 @@
  * Public Lobbies / Live Games panels), right-aligned so it never overlaps them. Frosted pills
  * matching the app's other overlay controls, kept visually distinct from the navigation row.
  */
+/* Wraps because the signed-in state is now four or five pills and the rail it sits in is 320px. */
 .widget {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   align-items: stretch;
   gap: var(--space-2);
@@ -15,7 +17,7 @@
 .identity,
 .login,
 .logout,
-.admin {
+.action {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -70,12 +72,14 @@
   white-space: nowrap;
 }
 
-/* Admin: matches the Log out pill's weight/casing; only renders for admin accounts. */
-.admin {
+/* Navigation pills: Friends, Stats, and Admin for admin accounts. Neutral hover — these used to
+   borrow the Log out pill's styling and so lit up red, which reads as destructive. */
+.action {
+  position: relative;
   padding: var(--space-2) var(--space-3);
 }
 
-.admin:hover {
+.action:hover {
   background-color: rgba(255, 255, 255, 0.16);
   border-color: rgba(255, 255, 255, 0.22);
   color: var(--text-primary);

--- a/web-client/src/components/auth/AuthWidget.tsx
+++ b/web-client/src/components/auth/AuthWidget.tsx
@@ -2,8 +2,12 @@
  * Account presence widget for the landing screen — deliberately separate from the navigation
  * buttons so the sign-in state reads as a distinct, persistent affordance. Anchored top-right.
  *
- *  - signed in  → "Signed in as <name>" (opens the profile) + a Log out action
+ *  - signed in  → "Signed in as <name>" (opens the profile), Friends, Stats, and Log out
  *  - anonymous  → a single Log in button that opens the magic-link modal
+ *
+ * Every account-scoped page hangs off this widget rather than off the landing card's navigation
+ * tiers: they are all "things about *your* account", and having them in both places made the card's
+ * BUILD & BROWSE row read as a grab-bag.
  *
  * Renders nothing when the server has accounts disabled, so a no-accounts deployment shows no
  * sign-in UI at all (the whole point — a login form there can only fail).
@@ -59,10 +63,9 @@ export function AuthWidget() {
           </button>
           <button
             type="button"
-            className={styles.logout}
+            className={styles.action}
             onClick={() => navigate('/friends')}
             title="Friends"
-            style={{ position: 'relative' }}
           >
             Friends
             {onlineCount > 0 && (
@@ -113,10 +116,18 @@ export function AuthWidget() {
               </span>
             )}
           </button>
+          <button
+            type="button"
+            className={styles.action}
+            onClick={() => navigate('/stats')}
+            title="Your win rate, ELO and game history"
+          >
+            Stats
+          </button>
           {user.isAdmin && (
             <button
               type="button"
-              className={styles.admin}
+              className={styles.action}
               onClick={() => navigate('/admin')}
               title="Open the admin dashboard"
             >

--- a/web-client/src/components/deckbuilder/__tests__/help-topic-claims.test.ts
+++ b/web-client/src/components/deckbuilder/__tests__/help-topic-claims.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Pins the `deck-import-export` help topic to the parser.
+ *
+ * The topic spells out every accepted line shape and section header, because there is no vendor spec
+ * to link at — this parser *is* the spec. That only stays true if the two are checked against each
+ * other, so every shape the topic promises is exercised here.
+ */
+import { describe, expect, it } from 'vitest'
+import { parseArenaDeckList } from '../parseArenaDeck'
+
+describe('help topic deck-import-export claims', () => {
+  it('plain, "x", Arena and Moxfield bulk-edit line shapes', () => {
+    const r = parseArenaDeckList([
+      '4 Lightning Bolt',
+      '4x Counterspell',
+      '1 Sol Ring (LEA) 161',
+      '1 Lightning Bolt (LEA) *F* *A* 42 #tag',
+    ].join('\n'))
+    expect(r.errors).toEqual([])
+    expect(r.entries.map((e) => [e.count, e.name])).toEqual([
+      [4, 'Lightning Bolt'], [4, 'Counterspell'], [1, 'Sol Ring'], [1, 'Lightning Bolt'],
+    ])
+    expect(r.entries[2]).toMatchObject({ setCode: 'LEA', collectorNumber: '161' })
+  })
+
+  it('SB: prefix and the section headers the topic names', () => {
+    const r = parseArenaDeckList([
+      'Deck', '4 Lightning Bolt',
+      'SB: 2 Counterspell',
+      'Commander', '1 Sol Ring',
+      'Sideboard', '1 Counterspell',
+    ].join('\n'))
+    expect(r.errors).toEqual([])
+    expect(r.entries.map((e) => e.name)).toEqual(['Lightning Bolt'])
+    expect(r.sideboard.map((e) => [e.count, e.name])).toEqual([[2, 'Counterspell'], [1, 'Counterspell']])
+    expect(r.commander.map((e) => e.name)).toEqual(['Sol Ring'])
+  })
+
+  it('the other header spellings the topic names are all recognised', () => {
+    for (const header of ['Mainboard', 'Main Deck', 'Maindeck', 'MAINBOARD']) {
+      const r = parseArenaDeckList(`${header}\n4 Lightning Bolt`)
+      expect({ header, errors: r.errors, names: r.entries.map((e) => e.name) })
+        .toEqual({ header, errors: [], names: ['Lightning Bolt'] })
+    }
+    for (const header of ['Side', 'SB']) {
+      const r = parseArenaDeckList(`4 Lightning Bolt\n${header}\n1 Counterspell`)
+      expect({ header, side: r.sideboard.map((e) => e.name) }).toEqual({ header, side: ['Counterspell'] })
+    }
+    // Companion and About are skipped, not imported.
+    const skipped = parseArenaDeckList('4 Lightning Bolt\nCompanion\n1 Sol Ring\nAbout\nName Thing')
+    expect(skipped.entries.map((e) => e.name)).toEqual(['Lightning Bolt'])
+  })
+
+  it('ignores blank lines and // or # comments', () => {
+    const r = parseArenaDeckList(['// a comment', '', '# another', '4 Lightning Bolt'].join('\n'))
+    expect(r.errors).toEqual([])
+    expect(r.entries.map((e) => e.name)).toEqual(['Lightning Bolt'])
+  })
+
+  it('reports a malformed card line instead of dropping it', () => {
+    const r = parseArenaDeckList('this is not a card line at all!!')
+    expect(r.errors.length).toBeGreaterThan(0)
+    expect(r.errors[0]).toMatchObject({ line: 1 })
+  })
+})

--- a/web-client/src/components/deckbuilder/query/__tests__/help-topic-claims.test.ts
+++ b/web-client/src/components/deckbuilder/query/__tests__/help-topic-claims.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Pins the `search-syntax` help topic to the parser.
+ *
+ * The topic lists operators by example, and a help page that documents a filter the parser rejects
+ * is worse than one that says nothing. Two of these examples were wrong when the topic was written
+ * (`banned:` isn't a filter, `is:split` reports a modelling gap) and only this caught it. Change the
+ * topic's examples, change this list.
+ */
+import { describe, expect, it } from 'vitest'
+import { parseQuery } from '../index'
+
+const CLAIMED = [
+  't:creature', 'c<=rw', 'cmc>=4', 'o:flying', 'f:standard', 'is:legendary',
+  'c:rg', 'c:azorius', 'c:colorless', 'id:r',
+  't:goblin', 't:legendary', 'kw:trample',
+  'mv>=4', 'm:{2/G}',
+  'pow>=4', 'tou<2', 'loy:3',
+  's:fdn', 'r:mythic',
+  'f:commander', 'f:pauper',
+  'is:permanent', 'is:multicolor', 'is:vanilla', 'is:dfc',
+  'lightning bolt', '-t:creature', 't:goblin or t:elf', '(t:goblin or t:elf) t:creature',
+  '"lightning bolt"',
+]
+
+describe('help topic search-syntax claims', () => {
+  for (const q of CLAIMED) {
+    it(`parses ${q}`, () => {
+      expect({ q, errors: parseQuery(q).errors.map((e) => e.message) }).toEqual({ q, errors: [] })
+    })
+  }
+  it('rejects an unimplemented Scryfall key', () => {
+    expect(parseQuery('artist:rk-post').errors.map((e) => e.message).join(' ')).toMatch(/Unknown filter/)
+  })
+  it('is:split reports the modelling gap the topic quotes', () => {
+    expect(parseQuery('is:split').errors.map((e) => e.message).join(' '))
+      .toContain('split-card layout not modelled')
+  })
+})

--- a/web-client/src/components/help/HelpDrawer.tsx
+++ b/web-client/src/components/help/HelpDrawer.tsx
@@ -73,6 +73,7 @@ export function HelpDrawer() {
             <HelpTopicView
               key={topic.id}
               topic={topic}
+              className={styles.topicSeparated}
               onNavigate={(id) => {
                 const target = topicById(id)
                 if (!target) return

--- a/web-client/src/components/help/HelpTopicView.tsx
+++ b/web-client/src/components/help/HelpTopicView.tsx
@@ -78,6 +78,24 @@ export function HelpTopicView({
           })}
         </div>
       )}
+
+      {topic.links && topic.links.length > 0 && (
+        <div className={styles.relatedRow}>
+          <span className={styles.relatedLabel}>Elsewhere</span>
+          {topic.links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.externalLink}
+            >
+              {link.label}
+              <span className={styles.externalMark} aria-hidden> ↗</span>
+            </a>
+          ))}
+        </div>
+      )}
     </article>
   )
 }

--- a/web-client/src/components/help/HelpTopicView.tsx
+++ b/web-client/src/components/help/HelpTopicView.tsx
@@ -2,6 +2,7 @@
  * Renders one {@link HelpTopic}. Shared by `/help` and the in-game drawer so the two can never
  * drift — the whole point of the single topic registry.
  */
+import type { ReactNode } from 'react'
 import { HELP_TOPICS, topicById, helpHref, type HelpTopic } from '@/help/topics'
 import { SHORTCUTS, shortcutById } from '@/help/shortcuts'
 import styles from './help.module.css'
@@ -9,22 +10,31 @@ import styles from './help.module.css'
 export function HelpTopicView({
   topic,
   onNavigate,
+  headerAction,
+  className,
 }: {
   topic: HelpTopic
   /** How a related-topic link should be followed. Omit for a plain anchor (the `/help` page). */
   onNavigate?: (topicId: string) => void
+  /** Rendered opposite the title. The `/help` page puts its copy-link button here. */
+  headerAction?: ReactNode
+  /** Extra class on the article — how `/help` gives a topic its card surface. */
+  className?: string | undefined
 }) {
   return (
-    <article id={topic.id} className={styles.topic}>
-      <h3 className={styles.topicTitle}>{topic.title}</h3>
-      <p className={styles.topicSummary}>{topic.summary}</p>
+    <article id={topic.id} className={`${styles.topic} ${className ?? ''}`}>
+      <div className={styles.topicHeader}>
+        <h3 className={styles.topicTitle}>{topic.title}</h3>
+        {headerAction}
+      </div>
+      <p className={styles.topicSummary}>{withCode(topic.summary)}</p>
 
       {topic.body?.map((block, i) => {
-        if (block.kind === 'p') return <p key={i} className={styles.topicBody}>{block.text}</p>
+        if (block.kind === 'p') return <p key={i} className={styles.topicBody}>{withCode(block.text)}</p>
         if (block.kind === 'ul') {
           return (
             <ul key={i} className={styles.topicList}>
-              {block.items.map((item, j) => <li key={j}>{item}</li>)}
+              {block.items.map((item, j) => <li key={j}>{withCode(item)}</li>)}
             </ul>
           )
         }
@@ -70,6 +80,24 @@ export function HelpTopicView({
       )}
     </article>
   )
+}
+
+/**
+ * Renders markdown-style `code` spans in a topic string.
+ *
+ * `topics.ts` is plain text and there is no markdown pipeline in the client, but query syntax and
+ * decklist lines are unreadable without the distinction — and the backticks were rendering as
+ * literal backticks. This one inline construct is the whole of the markup the topics use; anything
+ * more is a reason to reach for a real renderer rather than to extend this.
+ */
+function withCode(text: string): ReactNode {
+  const parts = text.split(/(`[^`]+`)/g)
+  if (parts.length === 1) return text
+  return parts.map((part, i) => (
+    part.length > 2 && part.startsWith('`') && part.endsWith('`')
+      ? <code key={i} className={styles.inlineCode}>{part.slice(1, -1)}</code>
+      : part
+  ))
 }
 
 export function ShortcutTable() {

--- a/web-client/src/components/help/help.module.css
+++ b/web-client/src/components/help/help.module.css
@@ -84,17 +84,30 @@
 /* =========================================================================
  * Topic rendering (page + drawer)
  * ========================================================================= */
+/* The topic's own stacking. Separating one topic from the next is the surface's call: the drawer
+   adds `.topicSeparated` rules below, the `/help` page gives each topic a card instead. */
 .topic {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-4) 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   scroll-margin-top: var(--space-6);
 }
 
-.topic:last-child {
+.topicSeparated {
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.topicSeparated:last-child {
   border-bottom: none;
+}
+
+/* Title plus whatever the surface wants beside it (the `/help` page's copy-link button). */
+.topicHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
 }
 
 .topicTitle {
@@ -127,6 +140,18 @@
   font-size: var(--font-sm);
   line-height: 1.5;
   color: var(--text-tertiary);
+}
+
+/* `code` spans inside topic prose — see `withCode` in HelpTopicView. */
+.inlineCode {
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary, #ddd);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.88em;
+  white-space: nowrap;
 }
 
 .shortcutChips {
@@ -223,10 +248,12 @@
   vertical-align: top;
 }
 
+/* Wraps rather than forcing the whole table into a horizontal scroll: the third column carries the
+   longest strings ("Any card preview — hand, battlefield, deckbuilder") and neither the 460px drawer
+   nor the reading-width `/help` column has room for them on one line. */
 .shortcutWhere {
   color: var(--text-disabled);
   font-size: var(--font-xs, 0.75rem);
-  white-space: nowrap;
 }
 
 /* =========================================================================

--- a/web-client/src/components/help/help.module.css
+++ b/web-client/src/components/help/help.module.css
@@ -217,6 +217,21 @@
   text-decoration: underline;
 }
 
+/* Off-site references — marked with ↗ so it is clear before clicking that this one leaves. */
+.externalLink {
+  color: var(--color-accent, #4fc3f7);
+  font-size: var(--font-xs, 0.75rem);
+  text-decoration: none;
+}
+
+.externalLink:hover {
+  text-decoration: underline;
+}
+
+.externalMark {
+  color: var(--text-disabled);
+}
+
 /* =========================================================================
  * Shortcut table
  * ========================================================================= */

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -32,6 +32,15 @@
 
 .contentBackdrop {
   position: relative;
+  /* Shrinkable, so the glass card gives ground to the side rail before the two can collide. The
+     max is the old fixed width: 660px of tiers plus the horizontal padding either side. Sized by
+     width rather than flex-basis because the same rule has to survive the stacked column below
+     1120px, where a basis would be read as a height. */
+  flex: 0 1 auto;
+  width: 100%;
+  max-width: var(--landing-card-w);
+  min-width: 0;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -56,12 +65,59 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
+/*
+ * Landing layout: the glass card and the side rail (auth widget, public lobbies, live games).
+ *
+ * The rail used to be `position: fixed` in the top-right corner while the card was centred in the
+ * *viewport*, so the two were laid out in ignorance of each other. They only missed on a wide
+ * monitor: at 1512px (a 14" MacBook Pro) the gap was 1px, and at 1440px the rail sat 35px *over*
+ * the card. Both are in flow now, so a collision is not expressible.
+ *
+ * Three bands, widest first:
+ *  - >= 1480px  a mirror gutter is rendered opposite the rail, so the card is back to being exactly
+ *               viewport-centred with the rail floating in the right margin.
+ *  - 1121px+    no gutter: card and rail are centred as a pair, and the card gives up width first.
+ *  - <= 1120px  stacked, rail below the card — a 500px-wide card is worse than a scroll.
+ */
 .landingLayout {
+  --landing-rail-w: 320px;
+  --landing-card-w: 756px;
   margin: auto 0;
   width: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  gap: var(--space-5);
+}
+
+/* Reserves the same width as the rail on the opposite side. Empty on purpose — its only job is to
+   keep the card centred, and it is `display: none` in the bands where that isn't affordable. */
+.landingGutter {
+  display: none;
+  flex: none;
+  width: var(--landing-rail-w);
+}
+
+@media (min-width: 1480px) {
+  .landingGutter {
+    display: block;
+  }
+}
+
+/* Below this the padding is spending width the wizard needs more than the glass does. */
+@media (max-width: 1280px) {
+  .contentBackdrop {
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
+  }
+}
+
+@media (max-width: 1120px) {
+  .landingLayout {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+  }
 }
 
 @media (max-width: 639px) {
@@ -71,7 +127,6 @@
   }
 
   .landingLayout {
-    flex-direction: column;
     gap: var(--space-3);
   }
 }
@@ -596,22 +651,22 @@
 /* =========================================================================
  * Public Tournament List
  * ========================================================================= */
+/* In flow beside the glass card (see `.landingLayout`), not pinned to the viewport corner. Capped in
+   height so a busy server's lobby list scrolls inside the rail instead of stretching the row. */
 .sidePanelStack {
-  position: fixed;
-  top: var(--space-4);
-  right: var(--space-4);
-  width: min(360px, calc(100vw - 2 * var(--space-4)));
+  flex: none;
+  width: var(--landing-rail-w);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  max-height: calc(100vh - 2 * var(--space-4));
+  max-height: calc(100vh - 2 * var(--space-6));
   overflow-y: auto;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1120px) {
   .sidePanelStack {
-    position: static;
-    width: min(480px, 100%);
+    width: min(var(--landing-card-w), 100%);
     max-height: none;
   }
 }
@@ -676,12 +731,14 @@
   box-shadow: 0 0 6px rgba(46, 204, 113, 0.7);
 }
 
+/* Sized for the 320px rail: the action button gets exactly the width its label needs and the rest
+   goes to the lobby description, which is the part that decides whether you click. */
 .publicTournamentRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3);
+  gap: var(--space-2);
+  padding: 9px var(--space-3);
   background: rgba(255, 255, 255, 0.07);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-lg);
@@ -697,8 +754,9 @@
 .publicTournamentInfo {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .publicTournamentName {
@@ -713,7 +771,8 @@
 .publicTournamentMeta,
 .publicTournamentEmpty {
   color: var(--text-tertiary);
-  font-size: 12px;
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .publicTournamentEmpty {
@@ -721,13 +780,14 @@
 }
 
 .publicTournamentJoinButton {
+  flex: 0 0 auto;
   background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
   color: var(--text-primary);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--font-sm);
+  padding: 6px var(--space-3);
+  font-size: 12px;
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
@@ -737,13 +797,14 @@
 }
 
 .spectateButton {
+  flex: 0 0 auto;
   background: linear-gradient(180deg, #6366f1 0%, #4338ca 100%);
   color: var(--text-primary);
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--font-sm);
+  padding: 6px var(--space-3);
+  font-size: 12px;
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
@@ -2858,11 +2919,13 @@
 /* =========================================================================
  * Attribution
  * ========================================================================= */
+/*
+ * In normal flow at the end of the scrolling overlay, not absolutely pinned. `.landingLayout`'s
+ * `margin: auto 0` still centres the card in whatever room is left above it, so on a roomy screen
+ * this reads as a pinned footer — but when the content is taller than the viewport the two scroll
+ * together instead of the footer sitting on top of the panel.
+ */
 .attribution {
-  position: absolute;
-  bottom: 12px;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2898,16 +2961,9 @@
   text-decoration-color: rgba(207, 231, 255, 0.9);
 }
 
-/*
- * On narrow screens the overlay scrolls and the absolutely-pinned attribution
- * floats over the content (it overlapped the public-lobby panel). Drop it back
- * into normal flow so it sits below the content as a full-width footer.
- * Placed after the base rules so these overrides win at equal specificity.
- */
+/* Full-bleed footer once the overlay's own padding is all the margin there is to spare. */
 @media (max-width: 639px) {
   .attribution {
-    position: static;
-    transform: none;
     margin: var(--space-2) auto 0;
     width: 100%;
     max-width: 100%;
@@ -3162,46 +3218,58 @@
   color: var(--text-tertiary);
 }
 
+/*
+ * The launch block: what happens, how many seats, and the button.
+ *
+ * These used to share one wrapping flex row with `align-items: flex-end`, which put a six-chip seat
+ * picker and its two-line caption beside a large primary button — the caption wrapped under the
+ * chips, the button floated at an arbitrary height, and the group read as three unrelated things
+ * that happened to be adjacent. One column, and the call to action gets the full width it is worth.
+ */
 .wizardFooter {
   display: flex;
-  align-items: flex-end;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
   gap: var(--space-3);
-  padding-top: var(--space-1, 4px);
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.025);
 }
 
 .wizardSeats {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1, 4px);
   min-width: 0;
 }
 
 .wizardSeatsRow {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-2);
 }
 
 .wizardSeatsCaption {
   margin: 0;
-  max-width: 44ch;
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.4;
   color: var(--text-disabled);
 }
 
 /* What will actually happen, stage by stage: "Open boosters → Build a deck → Standings". The one
-   thing none of the names on the tiles can tell you. Inline text on its own row, not a flex row:
-   nested flex boxes at this width broke every stage onto its own line. */
+   thing none of the names on the tiles can tell you, so it leads the launch block rather than
+   trailing the tiles as loose 10px text. Inline text on its own row, not a flex row: nested flex
+   boxes at this width broke every stage onto its own line. */
 .wizardFlow {
   margin: 0;
-  font-size: var(--font-xs, 0.75rem);
+  font-size: var(--font-sm);
   line-height: 1.6;
 }
 
 .wizardFlowStage {
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .wizardFlowArrow {
@@ -3277,6 +3345,13 @@
   gap: var(--space-3);
 }
 
+/* Four options — the Table question. Three columns leave a single tile stranded on a second row,
+   reading as an afterthought rather than as a peer of the other three; 2×2 is the same two rows with
+   no orphan, and the extra width lets the taglines fit in fewer lines. */
+.presetGridPairs {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 @media (max-width: 900px) {
   .presetGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -3284,7 +3359,8 @@
 }
 
 @media (max-width: 520px) {
-  .presetGrid {
+  .presetGrid,
+  .presetGridPairs {
     grid-template-columns: minmax(0, 1fr);
   }
 }
@@ -3422,4 +3498,35 @@
 
 .continueChipDismiss:hover {
   color: var(--text-primary);
+}
+
+/* =========================================================================
+ * Compact landing — short viewports
+ *
+ * A laptop is a wide, *short* screen: a 14" MacBook gives about 800px of viewport once the browser
+ * has taken its share. The tallest landing state — all three questions answered, four Table tiles,
+ * the seat picker and the launch block — overran that on vertical rhythm alone, so the rhythm
+ * tightens and nothing is taken away.
+ *
+ * Last in the file on purpose: every rule below overrides a single-class rule declared earlier, and
+ * at equal specificity source order is what decides.
+ * ========================================================================= */
+@media (max-height: 900px) {
+  .connectionOverlay {
+    gap: var(--space-4);
+  }
+
+  .contentBackdrop {
+    gap: var(--space-4);
+    padding-top: var(--space-4);
+    padding-bottom: var(--space-4);
+  }
+
+  .title {
+    font-size: var(--font-2xl);
+  }
+
+  .homeTiers {
+    gap: var(--space-4);
+  }
 }

--- a/web-client/src/components/ui/HomeScreen.tsx
+++ b/web-client/src/components/ui/HomeScreen.tsx
@@ -5,9 +5,10 @@
  *
  * - **PLAY** — the {@link PlayWizard}'s three questions, a join-code row, and a Continue chip when a
  *   lobby is still live from a previous page load.
- * - **BUILD & BROWSE** — deckbuilder, replays and the account pages (`/stats`, `/friends`,
- *   `/profile`), which had no home-screen entry at all before.
- * - **LAB** — debugging and content tools, explicitly captioned as not part of normal play.
+ * - **BUILD & BROWSE** — deckbuilder, replays and set completion. The account pages (`/stats`,
+ *   `/friends`, `/profile`) live on the {@link AuthWidget} in the side rail instead, next to who
+ *   you are signed in as.
+ * - **LAB** — debugging and content tools, dev builds only; the tier does not render otherwise.
  *
  * What is playable is declarative (`lobby/modeMatrix.ts`) and the wizard only renders it; this file
  * only knows how to turn a finished selection into lobby-creation messages.
@@ -282,7 +283,7 @@ export function HomeScreen({
 
   const showPublicLobbies = !sessionId && !lobbyState && (publicLobbies.length > 0 || publicLobbiesError || (onlinePlayers ?? 0) > 0)
   const showLiveGames = !sessionId && !lobbyState && liveGames.length > 0
-  const signedIn = authStatus === 'authenticated'
+  const showSideRail = accountsEnabled || showPublicLobbies || showLiveGames
 
   const handleSpectate = (gameSessionId: string) => {
     if (status === 'connected') {
@@ -310,6 +311,10 @@ export function HomeScreen({
         </button>
       </div>
       <div className={styles.landingLayout}>
+        {/* Mirrors the side rail's width so the glass card stays viewport-centred rather than
+            centred-minus-the-rail. Collapsed below 1480px, where that symmetry costs more width
+            than the card can spare — see `.landingGutter`. */}
+        {showSideRail && <div className={styles.landingGutter} aria-hidden="true" />}
         <div className={styles.contentBackdrop}>
           <h1 className={styles.title}>Argentum Engine</h1>
           <span className={styles.commitHash}>{__COMMIT_HASH__}</span>
@@ -407,7 +412,10 @@ export function HomeScreen({
                 <DeckMigrationPrompt />
               </section>
 
-              {/* ── BUILD & BROWSE ───────────────────────────────────── */}
+              {/* ── BUILD & BROWSE ───────────────────────────────────────
+                  Only what every visitor can use. Stats, Friends and Profile were here too, and
+                  they are all account-scoped and all already reachable from the AuthWidget in the
+                  side rail — two routes to the same three pages, one of which is right above. */}
               <section className={styles.homeTier}>
                 <SectionHeading label="Build & Browse" />
                 <div className={styles.secondaryButtonRow}>
@@ -417,49 +425,38 @@ export function HomeScreen({
                   <button onClick={() => setShowReplays(true)} className={styles.secondaryButton}>
                     Replays
                   </button>
-                  {signedIn && (
-                    <>
-                      <button onClick={() => navigate('/stats')} className={styles.secondaryButton}>
-                        Stats
-                      </button>
-                      <button onClick={() => navigate('/friends')} className={styles.secondaryButton}>
-                        Friends
-                      </button>
-                      <button onClick={() => navigate('/profile')} className={styles.secondaryButton}>
-                        Profile
-                      </button>
-                    </>
-                  )}
-                </div>
-              </section>
-
-              {/* ── LAB ──────────────────────────────────────────────── */}
-              <section className={styles.homeTier}>
-                <SectionHeading label="Lab" hint="advanced" />
-                <div className={styles.secondaryButtonRow}>
+                  {/* "Which cards of a set can I actually play with?" is a deckbuilding question, not
+                      a debugging one — it sat under LAB, behind an "advanced" caption that told
+                      players it wasn't for them. */}
                   <button onClick={() => navigate('/set-completion')} className={styles.secondaryButton}>
                     Set Completion
                   </button>
-                  {/* Dev-only entry points. The Scenario Builder drives `/api/dev/scenarios/*`, which
-                      only exists when the server runs with GAME_DEV_ENDPOINTS_ENABLED — so in a
-                      production build the button would lead somewhere that cannot work. The *routes*
-                      stay open either way: a replay's "share as scenario" link is a real `/scenario?s=`
-                      deep link, and gating the route would break it. */}
-                  {import.meta.env.DEV && (
-                    <>
-                      <button onClick={() => navigate('/scenario')} className={styles.secondaryButton}>
-                        Scenario Builder
-                      </button>
-                      <button onClick={() => navigate('/llm-tournament')} className={styles.secondaryButton}>
-                        LLM Tournament
-                      </button>
-                    </>
-                  )}
                 </div>
-                <p className={styles.tierCaption}>
-                  Debugging and content tools, not part of normal play.
-                </p>
               </section>
+
+              {/* ── LAB ──────────────────────────────────────────────────
+                  Dev builds only, and the whole tier goes with it. Both entry points drive
+                  `/api/dev/*`, which exists only when the server runs with GAME_DEV_ENDPOINTS_ENABLED
+                  — in a production build they lead somewhere that cannot work, and with Set
+                  Completion moved out there is nothing left in the tier to justify rendering it.
+                  The *routes* stay open either way: a replay's "share as scenario" link is a real
+                  `/scenario?s=` deep link, and gating the route would break it. */}
+              {import.meta.env.DEV && (
+                <section className={styles.homeTier}>
+                  <SectionHeading label="Lab" hint="dev builds only" />
+                  <div className={styles.secondaryButtonRow}>
+                    <button onClick={() => navigate('/scenario')} className={styles.secondaryButton}>
+                      Scenario Builder
+                    </button>
+                    <button onClick={() => navigate('/llm-tournament')} className={styles.secondaryButton}>
+                      LLM Tournament
+                    </button>
+                  </div>
+                  <p className={styles.tierCaption}>
+                    Debugging and content tools, not part of normal play.
+                  </p>
+                </section>
+              )}
             </div>
           )}
 
@@ -468,7 +465,7 @@ export function HomeScreen({
           )}
         </div>
 
-        {(accountsEnabled || showPublicLobbies || showLiveGames) && (
+        {showSideRail && (
           <div className={styles.sidePanelStack}>
             <AuthWidget />
             {showPublicLobbies && (
@@ -621,11 +618,11 @@ function LiveGameList({
 }
 
 function liveGameMeta(game: LiveGameEntry): string {
-  const lifeSummary = `${game.player1Life} / ${game.player2Life} life`
+  const lifeSummary = nbsp(`${game.player1Life} / ${game.player2Life} life`)
   if (game.kind === 'tournament') {
-    return `Tournament · Round ${game.round} · ${lifeSummary}`
+    return `Tournament · ${nbsp(`Round ${game.round}`)} · ${lifeSummary}`
   }
-  return `Quick Game · ${lifeSummary}`
+  return `${nbsp('Quick Game')} · ${lifeSummary}`
 }
 
 function publicLobbyName(entry: PublicLobbyEntry): string {
@@ -636,22 +633,34 @@ function publicLobbyName(entry: PublicLobbyEntry): string {
   return entry.hostName ? `${entry.hostName}'s Quick Game` : 'Quick Game'
 }
 
+/**
+ * Non-breaking spaces inside each fact, so the rail's narrow column only ever wraps at a `·` —
+ * "1/2" and "players" on separate lines read as two facts rather than one.
+ */
+function nbsp(text: string): string {
+  return text.replace(/ /g, ' ')
+}
+
 function publicLobbyMeta(entry: PublicLobbyEntry): string {
+  const seats = nbsp(`${entry.playerCount}/${entry.maxPlayers} players`)
   if (entry.kind === 'tournament') {
+    const series = entry.gamesPerMatch > 1 ? nbsp(`${entry.gamesPerMatch} games per matchup`) : null
     if (entry.format === 'PREMADE_DECKS') {
-      const parts = ['Premade Decks']
-      if (entry.deckFormat) parts.push(labelForFormat(entry.deckFormat))
-      parts.push(`${entry.playerCount}/${entry.maxPlayers} players`)
-      if (entry.gamesPerMatch > 1) parts.push(`${entry.gamesPerMatch} games per matchup`)
+      const parts = [nbsp('Premade Decks')]
+      if (entry.deckFormat) parts.push(nbsp(labelForFormat(entry.deckFormat)))
+      parts.push(seats)
+      if (series) parts.push(series)
       return parts.join(' · ')
     }
-    const base = `${formatTournamentFormat(entry.format)} · ${entry.boosterCount} ${entry.format === 'DRAFT' ? 'packs' : 'boosters'} · ${entry.playerCount}/${entry.maxPlayers} players`
-    return entry.gamesPerMatch > 1 ? `${base} · ${entry.gamesPerMatch} games per matchup` : base
+    const packs = nbsp(`${entry.boosterCount} ${entry.format === 'DRAFT' ? 'packs' : 'boosters'}`)
+    const parts = [nbsp(formatTournamentFormat(entry.format)), packs, seats]
+    if (series) parts.push(series)
+    return parts.join(' · ')
   }
-  const parts = ['Quick Game']
+  const parts = [nbsp('Quick Game')]
   if (entry.setCode) parts.push(entry.setCode)
-  if (entry.format) parts.push(labelForFormat(entry.format))
-  parts.push(`${entry.playerCount}/${entry.maxPlayers} players`)
+  if (entry.format) parts.push(nbsp(labelForFormat(entry.format)))
+  parts.push(seats)
   return parts.join(' · ')
 }
 

--- a/web-client/src/components/ui/PlayWizard.tsx
+++ b/web-client/src/components/ui/PlayWizard.tsx
@@ -265,18 +265,18 @@ export function PlayWizard({
 
       {complete !== null && (
         <>
-          {/* The stages, on their own full-width row rather than a repeat of the stepper: "Open
-              boosters → Build a deck → Everyone plays everyone → Standings" is the only place that
-              says how many steps this is before you commit to it. */}
-          <p className={styles.wizardFlow}>
-            {flowStages(complete).map((stage, i) => (
-              <span key={stage}>
-                {i > 0 && <span className={styles.wizardFlowArrow} aria-hidden> → </span>}
-                <span className={styles.wizardFlowStage}>{stage}</span>
-              </span>
-            ))}
-          </p>
+          {/* One block for everything that is about launching, rather than three rows loose under
+              the tiles. The stages lead it — "Open boosters → Build a deck → Everyone plays everyone
+              → Standings" is the only place that says how many steps this is before you commit. */}
           <div className={styles.wizardFooter}>
+            <p className={styles.wizardFlow}>
+              {flowStages(complete).map((stage, i) => (
+                <span key={stage}>
+                  {i > 0 && <span className={styles.wizardFlowArrow} aria-hidden> → </span>}
+                  <span className={styles.wizardFlowStage}>{stage}</span>
+                </span>
+              ))}
+            </p>
             <SeatControl
               selection={complete}
               onChange={(seats) => replaceDraft({ ...complete, seats })}
@@ -478,7 +478,7 @@ function OptionGrid<V extends string>({
   onPick: (value: V) => void
 }) {
   return (
-    <div className={styles.presetGrid}>
+    <div className={`${styles.presetGrid} ${choices.length === 4 ? styles.presetGridPairs : ''}`}>
       {choices.map((choice) => (
         // A wrapper div rather than one big button: the HelpTip is itself a button, and nesting
         // interactive elements is invalid HTML (and unreachable by keyboard).

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -18,6 +18,8 @@
  * both surfaces can render (and that a lint/test can walk).
  */
 
+import { SHORTCUTS } from './shortcuts'
+
 export type HelpSection = 'getting-started' | 'modes' | 'playing' | 'decks' | 'advanced'
 
 export type HelpBlock =
@@ -499,6 +501,17 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     ],
     related: ['cards-sealed', 'cards-draft'],
   },
+  {
+    id: 'set-completion',
+    section: 'decks',
+    title: 'Which cards are implemented',
+    summary:
+      'Set Completion, on the home screen under Build & Browse, lists every set and how much of it the engine can actually play. Useful before committing to a deck or picking a set to draft.',
+    body: [
+      { kind: 'p', text: 'The deckbuilder only ever offers implemented cards, so a deck you build there always works. This page is the other direction: it tells you what is missing from a set you had in mind.' },
+    ],
+    related: ['deckbuilder'],
+  },
 
   // ── Advanced ───────────────────────────────────────────────────────────
   {
@@ -546,8 +559,8 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     section: 'advanced',
     title: 'Lab tools',
     summary:
-      'Debugging and content tools, not part of normal play. Set Completion (which cards of a set are implemented) is always available; the Scenario Builder (start a game from a hand-authored board state) and the LLM Tournament runner only appear in dev builds, because both need server endpoints a production deployment does not expose.',
-    related: ['replays'],
+      'Debugging and content tools, not part of normal play: the Scenario Builder (start a game from a hand-authored board state) and the LLM Tournament runner. They only appear in dev builds, because both need server endpoints a production deployment does not expose.',
+    related: ['replays', 'set-completion'],
   },
 ]
 
@@ -557,6 +570,41 @@ export function topicById(id: string): HelpTopic | undefined {
 
 export function topicsInSection(section: HelpSection): readonly HelpTopic[] {
   return HELP_TOPICS.filter((t) => t.section === section)
+}
+
+export function sectionMeta(section: HelpSection) {
+  // Non-null: `HelpSection` is exactly the set of ids in HELP_SECTIONS.
+  return HELP_SECTIONS.find((s) => s.id === section)!
+}
+
+/**
+ * Everything about a topic that a reader might type into the search box, lower-cased once.
+ *
+ * Includes the section's own title and blurb (so "modes" finds the mode topics) and, for the
+ * shortcuts block, the whole shortcut table — otherwise searching "escape" or "spectate" would miss
+ * the one topic that actually documents those keys.
+ */
+function topicHaystack(topic: HelpTopic): string {
+  const meta = sectionMeta(topic.section)
+  const parts: string[] = [topic.title, topic.summary, meta.title, meta.blurb]
+  for (const block of topic.body ?? []) {
+    if (block.kind === 'p') parts.push(block.text)
+    else if (block.kind === 'ul') parts.push(...block.items)
+    else for (const s of SHORTCUTS) parts.push(s.keys, s.label, s.where)
+  }
+  return parts.join(' ').toLowerCase()
+}
+
+const HAYSTACKS = new Map(HELP_TOPICS.map((t) => [t.id, topicHaystack(t)]))
+
+/** Topics matching every whitespace-separated term in `query`, in registry order. */
+export function searchTopics(query: string): readonly HelpTopic[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (terms.length === 0) return []
+  return HELP_TOPICS.filter((t) => {
+    const haystack = HAYSTACKS.get(t.id) ?? ''
+    return terms.every((term) => haystack.includes(term))
+  })
 }
 
 /** Deep link to a topic on the help page. */

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -128,7 +128,11 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     title: 'Where your decks live',
     summary:
       'Saved decks live in this browser until you sign in, and in your account afterwards. The deckbuilder’s My Decks list is the same list every lobby deck picker reads from.',
-    related: ['deckbuilder', 'deck-sharing'],
+    body: [
+      { kind: 'p', text: 'Browser storage is per-browser and easy to lose: clearing site data or history takes your decks with it, and they do not follow you to a phone or a second computer. An account is the fix — signing in later keeps everything you already built, and you are offered a one-click migration.' },
+      { kind: 'p', text: 'A deck you want to keep without an account can also be exported as a decklist or a share link, both of which survive the browser.' },
+    ],
+    related: ['guest-vs-account', 'deckbuilder', 'deck-sharing', 'deck-import-export'],
   },
 
   // ── Game modes ─────────────────────────────────────────────────────────

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -28,6 +28,12 @@ export type HelpBlock =
   /** Renders the full `shortcuts.ts` table. */
   | { kind: 'shortcuts' }
 
+/** An off-site reference. Only for things we deliberately track rather than define ourselves. */
+export interface HelpLink {
+  label: string
+  href: string
+}
+
 export interface HelpTopic {
   id: string
   section: HelpSection
@@ -38,6 +44,8 @@ export interface HelpTopic {
   body?: readonly HelpBlock[]
   /** Other topic ids, rendered as links. */
   related?: readonly string[]
+  /** External references, rendered as outbound links below `related`. */
+  links?: readonly HelpLink[]
   /** Ids from `shortcuts.ts`, rendered as chips under the topic. */
   shortcuts?: readonly string[]
 }
@@ -476,7 +484,21 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     title: 'Search syntax',
     summary:
       'The deckbuilder search speaks a Scryfall-style query language — `t:creature`, `c<=rw`, `cmc>=4`, `o:flying`, `f:standard`, `is:legendary`. The `?` button beside the search box lists every operator with examples.',
+    body: [
+      { kind: 'p', text: 'The grammar is Scryfall’s, deliberately: bare words match names, `key:value` filters, `-` negates, `or` and parentheses group, quotes hold phrases together, and the comparison operators `:` `=` `>` `<` `>=` `<=` work wherever a value is ordered.' },
+      { kind: 'ul', items: [
+        'Colour — `c:rg`, `c:azorius`, `c<=rw`, `c:colorless`, and `id:` for colour identity.',
+        'Type and text — `t:goblin`, `t:legendary`, `o:flying` for oracle text, `kw:trample` for keywords.',
+        'Cost — `mv>=4` (`cmc` also works), `m:{2/G}` for a specific mana cost.',
+        'Stats — `pow>=4`, `tou<2`, `loy:3`.',
+        'Printing — `s:fdn` for a set, `r:mythic` for rarity.',
+        'Legality — `f:standard`, `f:commander`, `f:pauper`.',
+        'Flags — `is:legendary`, `is:permanent`, `is:multicolor`, `is:vanilla`, `is:dfc`.',
+      ] },
+      { kind: 'p', text: 'Not every filter Scryfall documents is implemented. Anything needing data the engine does not carry — prices, artists, printing dates — is rejected rather than silently ignored, and so is anything the card model does not distinguish yet: `is:split` answers “split-card layout not modelled”. A query never quietly means something other than what you typed.' },
+    ],
     related: ['deckbuilder'],
+    links: [{ label: 'Scryfall’s full syntax reference', href: 'https://scryfall.com/docs/syntax' }],
   },
   {
     id: 'deck-import-export',
@@ -484,7 +506,19 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     title: 'Import and export',
     summary:
       'Paste an Arena-style decklist (`4 Lightning Bolt`) straight into the deckbuilder or a lobby deck picker, and export the same way.',
-    related: ['deckbuilder'],
+    body: [
+      { kind: 'p', text: 'Arena, Moxfield and plain text are accepted interchangeably, so whatever your other tool exports should paste in as-is. These line shapes are recognised:' },
+      { kind: 'ul', items: [
+        '`4 Lightning Bolt` — plain.',
+        '`4x Lightning Bolt` — the Moxfield “x”.',
+        '`4 Lightning Bolt (LEA) 161` — Arena, with set code and collector number. Give these when you want a specific printing; without them you get the latest.',
+        '`1 Cardname (SET) *F* *A* 42 #tag` — Moxfield bulk edit. Foil, alter and tag markers are read and discarded.',
+        '`SB: 2 Counterspell` — the MTGO sideboard prefix.',
+      ] },
+      { kind: 'p', text: 'Section headers are case-insensitive: `Deck` / `Mainboard` / `Main Deck` / `Maindeck`, `Sideboard` / `Side` / `SB`, `Commander` / `Commanders` / `EDH`, `Companion`, and `About`. Only the main deck and commander are imported. Blank lines and lines starting with `//` or `#` are ignored.' },
+      { kind: 'p', text: 'A line that looks like a card but cannot be matched is reported rather than dropped, so an import never silently loses cards. Export writes the plain `4 Lightning Bolt` shape, which every one of the above tools reads.' },
+    ],
+    related: ['deckbuilder', 'deck-sharing'],
   },
   {
     id: 'deck-sharing',

--- a/web-client/src/pages/HelpPage.module.css
+++ b/web-client/src/pages/HelpPage.module.css
@@ -1,30 +1,88 @@
+/**
+ * `/help` page chrome. Topic *internals* are styled by `components/help/help.module.css`, which the
+ * in-game drawer shares; everything here is the page's own frame around them.
+ */
+
 .page {
   /* `#root` is locked to height:100% / overflow:hidden for the game board, so this must be its own
      scroll container. It has to be `height`, not `min-height`: with min-height the box grows to fit
      its content, so `overflow-y: auto` has nothing to scroll and #root just clips the overflow. */
   height: 100vh;
-  padding: var(--space-6) var(--space-5) var(--space-8);
-  background: var(--bg-app, #0b0c12);
-  color: var(--text-primary);
   overflow-y: auto;
+  background:
+    radial-gradient(1100px 520px at 18% -10%, rgba(79, 195, 247, 0.09), transparent 65%),
+    radial-gradient(900px 480px at 92% 0%, rgba(124, 58, 237, 0.09), transparent 60%),
+    var(--bg-app, #0b0c12);
+  color: var(--text-primary);
+
+  /*
+   * The client sets no body font anywhere — only monospace, on the handful of places that want it —
+   * so unstyled prose falls through to the UA default, which is Times. That is fine for the two
+   * lines of flavour on the landing card and wrong for pages of documentation, so this one declares
+   * its own. Scoped to the page rather than fixed globally: a global body font would reflow every
+   * screen in the app, which is not this change.
+   */
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    sans-serif;
+
+  /*
+   * The global type scale is tuned for the game board, where every pixel is board space — it puts
+   * body text at 12px on desktop and 9px on a phone. That is a reading page's job description
+   * inverted, so the tokens are re-pointed for this subtree only. Everything inside (including the
+   * shared topic styles) picks the new values up through the cascade.
+   */
+  --font-xs: 12px;
+  --font-sm: 14px;
+  --font-md: 15px;
+
+  /* What the sticky top bar occupies. Anything else that sticks, or that a deep link scrolls to,
+     has to clear it. */
+  --help-bar-h: 54px;
 }
 
-.header {
-  max-width: 1040px;
-  margin: 0 auto var(--space-6);
+/* =========================================================================
+ * Sticky top bar — back out, and search from anywhere in a long section
+ * ========================================================================= */
+.topBar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: rgba(11, 12, 18, 0.82);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.topBarInner {
+  max-width: 976px;
+  margin: 0 auto;
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  align-items: flex-start;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
+}
+
+.topBarTitle {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .backButton {
+  flex-shrink: 0;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
   cursor: pointer;
-  padding: var(--space-1) var(--space-3);
+  padding: 5px var(--space-3);
   font-size: var(--font-sm);
 }
 
@@ -33,58 +91,174 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+.searchBox {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: min(300px, 42vw);
+  padding: 5px var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.searchBox:focus-within {
+  border-color: rgba(79, 195, 247, 0.55);
+  background: rgba(79, 195, 247, 0.07);
+}
+
+.searchIcon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--text-disabled);
+}
+
+.searchBox:focus-within .searchIcon {
+  color: var(--color-accent, #4fc3f7);
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-size: var(--font-sm);
+  font-family: inherit;
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: var(--text-disabled);
+}
+
+/* Chrome's own search affordance duplicates the clear button next to it. */
+.searchInput::-webkit-search-cancel-button {
+  display: none;
+}
+
+.searchHint {
+  flex-shrink: 0;
+  padding: 0 5px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: var(--text-disabled);
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.searchClear {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.searchClear:hover {
+  color: var(--text-primary);
+}
+
+@media (max-width: 640px) {
+  .topBarTitle {
+    display: none;
+  }
+
+  .searchBox {
+    flex: 1;
+    width: auto;
+  }
+}
+
+/* =========================================================================
+ * Page body
+ * ========================================================================= */
+/* 244 nav + 32 gap + 660 content + the page's own padding. Sized so the content column *is* the
+   reading measure — see `.content`. */
+.body {
+  max-width: 976px;
+  margin: 0 auto;
+  padding: var(--space-7) var(--space-5) var(--space-8);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+  margin-bottom: var(--space-7);
+}
+
+/* Display type stays serif, the way the landing wordmark is — `ui-serif` is New York on macOS and a
+   real reading serif elsewhere, rather than the Times the page used to fall through to. */
 .title {
-  margin: var(--space-2) 0 0;
+  margin: 0;
+  font-family: ui-serif, Georgia, 'Times New Roman', serif;
   font-size: var(--font-2xl);
   font-weight: var(--font-weight-bold);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.01em;
 }
 
 .subtitle {
   margin: 0;
-  max-width: 62ch;
-  font-size: var(--font-sm);
+  max-width: 64ch;
+  font-size: var(--font-md);
   line-height: 1.6;
   color: var(--text-muted);
 }
 
 .layout {
-  max-width: 1040px;
-  margin: 0 auto;
   display: grid;
-  grid-template-columns: 250px minmax(0, 1fr);
-  gap: var(--space-6);
+  grid-template-columns: 244px minmax(0, 1fr);
+  gap: var(--space-7);
   align-items: start;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 900px) {
   .layout {
     grid-template-columns: minmax(0, 1fr);
-    gap: var(--space-4);
+    gap: var(--space-5);
   }
 }
 
+/* =========================================================================
+ * Section nav + on-this-page index
+ * ========================================================================= */
 .nav {
   position: sticky;
-  top: var(--space-5);
+  /* Clears the sticky top bar rather than the viewport edge. Bounded and scrollable because the
+     longest section's topic index is taller than a laptop viewport, and a sticky box taller than the
+     scrollport can never show its own tail. */
+  top: calc(var(--help-bar-h) + var(--space-4));
+  max-height: calc(100vh - var(--help-bar-h) - var(--space-7));
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-5);
+  /* Room for the scrollbar so it never sits on the text. */
+  padding-right: var(--space-2);
 }
 
-@media (max-width: 800px) {
-  .nav {
-    position: static;
-  }
+.navSections {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .navItem {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   text-align: left;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   border: 1px solid transparent;
   background: none;
   color: var(--text-tertiary);
@@ -96,10 +270,18 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
-.navItemActive {
+.navItemActive,
+.navItemActive:hover {
   background: rgba(79, 195, 247, 0.1);
   border-color: rgba(79, 195, 247, 0.35);
   color: var(--text-primary);
+}
+
+.navItemHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
 }
 
 .navItemTitle {
@@ -107,29 +289,251 @@
   font-weight: var(--font-weight-semibold);
 }
 
+.navItemCount {
+  flex-shrink: 0;
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-disabled);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.navItemActive .navItemCount {
+  background: rgba(79, 195, 247, 0.18);
+  color: var(--text-secondary);
+}
+
 .navItemBlurb {
-  font-size: var(--font-xs, 0.75rem);
-  line-height: 1.4;
+  font-size: var(--font-xs);
+  line-height: 1.45;
   color: var(--text-disabled);
 }
 
+.onThisPage {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  padding-left: var(--space-3);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.onThisPageLabel {
+  margin-bottom: 3px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.onThisPageLink {
+  border: none;
+  background: none;
+  padding: 1px 0;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  line-height: 1.5;
+}
+
+.onThisPageLink:hover {
+  color: var(--color-accent, #4fc3f7);
+}
+
+/* On one column the nav is a header, not a sidebar: the section blurbs and the topic index would
+   push the first topic below the fold, so both are dropped and the sections become a chip row. */
+@media (max-width: 900px) {
+  .nav {
+    position: static;
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
+    gap: var(--space-3);
+  }
+
+  .navSections {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .navItem {
+    border-color: rgba(255, 255, 255, 0.1);
+    border-radius: 999px;
+    padding: 5px var(--space-3);
+  }
+
+  .navItemBlurb,
+  .onThisPage {
+    display: none;
+  }
+}
+
+/* =========================================================================
+ * Content column
+ * ========================================================================= */
+/*
+ * Capped so a line of body text runs ~90 characters rather than the ~130 the full 1040px column
+ * produced — past that the eye starts losing its place on the return sweep. Capping the column
+ * rather than the paragraphs keeps each topic card the same width as the text inside it.
+ */
 .content {
   min-width: 0;
+  max-width: 660px;
+}
+
+.sectionIntro {
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .sectionTitle {
   margin: 0;
+  font-family: ui-serif, Georgia, 'Times New Roman', serif;
   font-size: var(--font-xl);
   font-weight: var(--font-weight-bold);
+  letter-spacing: -0.01em;
 }
 
 .sectionBlurb {
-  margin: var(--space-1) 0 0;
+  margin: var(--space-2) 0 0;
+  max-width: 70ch;
   font-size: var(--font-sm);
+  line-height: 1.6;
   color: var(--text-muted);
 }
 
 .topics {
   display: flex;
   flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Each topic gets its own surface instead of a hairline rule. Applied from the page rather than in
+   `help.module.css`, which the 460px in-game drawer shares and which wants no card at all. */
+.topicCard {
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-2xl);
+  background: rgba(255, 255, 255, 0.022);
+  /* Clears the sticky top bar when a deep link scrolls this into view. */
+  scroll-margin-top: calc(var(--help-bar-h) + var(--space-4));
+  transition: border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.topicCard:hover {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+/* Briefly ringed after a deep link or a "See also" jump, so you can see where you landed. */
+.topicCardFlagged {
+  border-color: rgba(79, 195, 247, 0.5);
+  background: rgba(79, 195, 247, 0.06);
+  box-shadow: 0 0 0 3px rgba(79, 195, 247, 0.1);
+}
+
+.resultSection {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-disabled);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.copyLink {
+  flex-shrink: 0;
+  min-width: 24px;
+  padding: 1px 6px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: none;
+  cursor: pointer;
+  color: var(--text-faint);
+  font-size: var(--font-xs);
+  font-weight: var(--font-weight-semibold);
+  transition: color var(--transition-fast), border-color var(--transition-fast), opacity 0.2s ease;
+  opacity: 0;
+}
+
+.topicCard:hover .copyLink,
+.copyLink:focus-visible,
+.copyLinkCopied {
+  opacity: 1;
+}
+
+.copyLink:hover {
+  color: var(--color-accent, #4fc3f7);
+  border-color: rgba(79, 195, 247, 0.4);
+}
+
+.copyLinkCopied,
+.copyLinkCopied:hover {
+  color: var(--color-success-light, #00cc44);
+  border-color: rgba(0, 204, 68, 0.4);
+}
+
+/* Touch devices never hover, so the affordance would be unreachable. */
+@media (hover: none) {
+  .copyLink {
+    opacity: 1;
+  }
+}
+
+/* =========================================================================
+ * Prev / next section pager
+ * ========================================================================= */
+.pager {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+.pagerLink {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+  color: var(--text-tertiary);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.pagerLinkNext {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.pagerLink:hover {
+  border-color: rgba(79, 195, 247, 0.35);
+  background: rgba(79, 195, 247, 0.07);
+  color: var(--text-primary);
+}
+
+.pagerDirection {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.pagerTitle {
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-semibold);
 }

--- a/web-client/src/pages/HelpPage.tsx
+++ b/web-client/src/pages/HelpPage.tsx
@@ -2,15 +2,30 @@
  * `/help` — the full guide. Deep-linkable as `/help/<section>#<topic-id>`, which is what every
  * inline {@link HelpTip}'s "Read more" points at.
  *
- * Content comes entirely from `src/help/topics.ts`; this file is layout only.
+ * Content comes entirely from `src/help/topics.ts`; this file is layout only. What it adds on top
+ * of rendering a section is the three things a 40-topic guide needs to be usable: a search box that
+ * spans every section, a per-section topic index, and a copy-link button on each topic — the deep
+ * links existed but there was no way to get one out of the page.
  */
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { HELP_SECTIONS, topicsInSection, topicById, type HelpSection } from '@/help/topics'
+import {
+  HELP_SECTIONS,
+  topicsInSection,
+  topicById,
+  searchTopics,
+  sectionMeta,
+  helpHref,
+  type HelpSection,
+  type HelpTopic,
+} from '@/help/topics'
 import { HelpTopicView } from '@/components/help/HelpTopicView'
 import styles from './HelpPage.module.css'
 
 const DEFAULT_SECTION: HelpSection = 'getting-started'
+
+/** How long a topic stays ringed after being jumped to, so you can see where you landed. */
+const HIGHLIGHT_MS = 2200
 
 function isSection(value: string | undefined): value is HelpSection {
   return HELP_SECTIONS.some((s) => s.id === value)
@@ -20,7 +35,36 @@ export function HelpPage() {
   const { section: sectionParam } = useParams<{ section?: string }>()
   const navigate = useNavigate()
   const section: HelpSection = isSection(sectionParam) ? sectionParam : DEFAULT_SECTION
-  const meta = HELP_SECTIONS.find((s) => s.id === section)!
+  const meta = sectionMeta(section)
+
+  const [query, setQuery] = useState('')
+  const searchRef = useRef<HTMLInputElement>(null)
+  // `#root` is overflow:hidden for the game board, so the page — not the window — is what scrolls.
+  const pageRef = useRef<HTMLDivElement>(null)
+  const [highlighted, setHighlighted] = useState<string | null>(null)
+
+  const trimmed = query.trim()
+  const results = useMemo(() => (trimmed ? searchTopics(trimmed) : null), [trimmed])
+  const sectionTopics = useMemo(() => topicsInSection(section), [section])
+  const topics = results ?? sectionTopics
+
+  const index = HELP_SECTIONS.findIndex((s) => s.id === section)
+  const previous = index > 0 ? HELP_SECTIONS[index - 1] : undefined
+  const next = index < HELP_SECTIONS.length - 1 ? HELP_SECTIONS[index + 1] : undefined
+
+  /** Ring a topic for a moment after scrolling to it, then let it fade back. */
+  const flag = useCallback((id: string) => {
+    setHighlighted(id)
+    window.setTimeout(() => setHighlighted((current) => (current === id ? null : current)), HIGHLIGHT_MS)
+  }, [])
+
+  const scrollToTopic = useCallback((id: string) => {
+    // One frame is not enough when the section changed — the topic has to be in the DOM first.
+    window.setTimeout(() => {
+      document.getElementById(id)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      flag(id)
+    }, 60)
+  }, [flag])
 
   // Honour the #topic-id fragment once the section has rendered.
   useEffect(() => {
@@ -28,60 +72,222 @@ export function HelpPage() {
     if (!id) return
     const timer = window.setTimeout(() => {
       document.getElementById(id)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      setHighlighted(id)
+      window.setTimeout(() => setHighlighted((current) => (current === id ? null : current)), HIGHLIGHT_MS)
     }, 50)
     return () => window.clearTimeout(timer)
   }, [section])
 
+  // `/` focuses search the way it does on most docs sites; Esc gives the field back.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      const typing = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA'
+      if (e.key === '/' && !typing) {
+        e.preventDefault()
+        searchRef.current?.focus()
+      } else if (e.key === 'Escape' && typing) {
+        setQuery('')
+        searchRef.current?.blur()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  /** Follow a topic link: switch section if needed, clear any search, scroll and ring it. */
+  const goToTopic = useCallback((id: string) => {
+    const target = topicById(id)
+    if (!target) return
+    setQuery('')
+    navigate(`/help/${target.section}#${id}`)
+    scrollToTopic(id)
+  }, [navigate, scrollToTopic])
+
+  const goToSection = (id: HelpSection) => {
+    setQuery('')
+    navigate(`/help/${id}`)
+    pageRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
   return (
-    <div className={styles.page}>
-      <header className={styles.header}>
-        <button type="button" className={styles.backButton} onClick={() => navigate('/')}>
-          ← Menu
-        </button>
-        <h1 className={styles.title}>Help</h1>
-        <p className={styles.subtitle}>
-          For players who know Magic and are new to Argentum. This does not teach the rules — it
-          explains what this app does with them.
-        </p>
-      </header>
-
-      <div className={styles.layout}>
-        <nav className={styles.nav} aria-label="Help sections">
-          {HELP_SECTIONS.map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              className={`${styles.navItem} ${s.id === section ? styles.navItemActive : ''}`}
-              onClick={() => navigate(`/help/${s.id}`)}
-            >
-              <span className={styles.navItemTitle}>{s.title}</span>
-              <span className={styles.navItemBlurb}>{s.blurb}</span>
-            </button>
-          ))}
-        </nav>
-
-        <main className={styles.content}>
-          <h2 className={styles.sectionTitle}>{meta.title}</h2>
-          <p className={styles.sectionBlurb}>{meta.blurb}</p>
-          <div className={styles.topics}>
-            {topicsInSection(section).map((topic) => (
-              <HelpTopicView
-                key={topic.id}
-                topic={topic}
-                onNavigate={(id) => {
-                  const target = topicById(id)
-                  if (!target) return
-                  navigate(`/help/${target.section}#${id}`)
-                  // Same-section links don't re-run the hash effect, so scroll here too.
-                  window.setTimeout(() => {
-                    document.getElementById(id)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
-                  }, 50)
-                }}
-              />
-            ))}
+    <div className={styles.page} ref={pageRef}>
+      <div className={styles.topBar}>
+        <div className={styles.topBarInner}>
+          <button type="button" className={styles.backButton} onClick={() => navigate('/')}>
+            ← Menu
+          </button>
+          <span className={styles.topBarTitle}>Argentum Help</span>
+          <div className={styles.searchBox}>
+            <svg className={styles.searchIcon} viewBox="0 0 16 16" aria-hidden="true">
+              <circle cx="7" cy="7" r="4.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M10.5 10.5 L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search the guide"
+              aria-label="Search help topics"
+              className={styles.searchInput}
+            />
+            {trimmed
+              ? (
+                <button
+                  type="button"
+                  className={styles.searchClear}
+                  onClick={() => { setQuery(''); searchRef.current?.focus() }}
+                  aria-label="Clear search"
+                >
+                  ✕
+                </button>
+                )
+              : <kbd className={styles.searchHint}>/</kbd>}
           </div>
-        </main>
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        <header className={styles.header}>
+          <h1 className={styles.title}>Help</h1>
+          <p className={styles.subtitle}>
+            For players who know Magic and are new to Argentum. This does not teach the rules — it
+            explains what this app does with them.
+          </p>
+        </header>
+
+        <div className={styles.layout}>
+          <nav className={styles.nav} aria-label="Help sections">
+            <div className={styles.navSections}>
+              {HELP_SECTIONS.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  className={`${styles.navItem} ${s.id === section && !results ? styles.navItemActive : ''}`}
+                  onClick={() => goToSection(s.id)}
+                >
+                  <span className={styles.navItemHead}>
+                    <span className={styles.navItemTitle}>{s.title}</span>
+                    <span className={styles.navItemCount}>{topicsInSection(s.id).length}</span>
+                  </span>
+                  <span className={styles.navItemBlurb}>{s.blurb}</span>
+                </button>
+              ))}
+            </div>
+
+            {/* Long sections are otherwise a wall — 14 topics under Game modes with no way to see
+                what is coming. Hidden while searching, where the result list is already the index. */}
+            {!results && sectionTopics.length > 1 && (
+              <div className={styles.onThisPage}>
+                <span className={styles.onThisPageLabel}>On this page</span>
+                {sectionTopics.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    className={styles.onThisPageLink}
+                    onClick={() => goToTopic(t.id)}
+                  >
+                    {t.title}
+                  </button>
+                ))}
+              </div>
+            )}
+          </nav>
+
+          <main className={styles.content}>
+            {results
+              ? (
+                <div className={styles.sectionIntro}>
+                  <h2 className={styles.sectionTitle}>
+                    {results.length} {results.length === 1 ? 'result' : 'results'}
+                  </h2>
+                  <p className={styles.sectionBlurb}>
+                    {results.length > 0
+                      ? <>Topics matching “{trimmed}”, across every section.</>
+                      : <>Nothing matches “{trimmed}”. Try a shorter query, or browse the sections.</>}
+                  </p>
+                </div>
+                )
+              : (
+                <div className={styles.sectionIntro}>
+                  <h2 className={styles.sectionTitle}>{meta.title}</h2>
+                  <p className={styles.sectionBlurb}>{meta.blurb}</p>
+                </div>
+                )}
+
+            <div className={styles.topics}>
+              {topics.map((topic) => (
+                <HelpTopicView
+                  key={topic.id}
+                  topic={topic}
+                  className={`${styles.topicCard} ${highlighted === topic.id ? styles.topicCardFlagged : ''}`}
+                  onNavigate={goToTopic}
+                  headerAction={
+                    <>
+                      {results && (
+                        <span className={styles.resultSection}>{sectionMeta(topic.section).title}</span>
+                      )}
+                      <CopyLinkButton topic={topic} />
+                    </>
+                  }
+                />
+              ))}
+            </div>
+
+            {!results && (previous || next) && (
+              <div className={styles.pager}>
+                {previous
+                  ? (
+                    <button type="button" className={styles.pagerLink} onClick={() => goToSection(previous.id)}>
+                      <span className={styles.pagerDirection}>← Previous</span>
+                      <span className={styles.pagerTitle}>{previous.title}</span>
+                    </button>
+                    )
+                  : <span />}
+                {next && (
+                  <button
+                    type="button"
+                    className={`${styles.pagerLink} ${styles.pagerLinkNext}`}
+                    onClick={() => goToSection(next.id)}
+                  >
+                    <span className={styles.pagerDirection}>Next →</span>
+                    <span className={styles.pagerTitle}>{next.title}</span>
+                  </button>
+                )}
+              </div>
+            )}
+          </main>
+        </div>
       </div>
     </div>
+  )
+}
+
+/** Copies the topic's deep link. The links already worked; there was no way to obtain one. */
+function CopyLinkButton({ topic }: { topic: HelpTopic }) {
+  const [copied, setCopied] = useState(false)
+  const url = new URL(helpHref(topic), window.location.origin).href
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(url).then(
+      () => {
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 1400)
+      },
+      () => { /* clipboard blocked — the anchor is still in the address bar after a click */ },
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={`${styles.copyLink} ${copied ? styles.copyLinkCopied : ''}`}
+      onClick={copy}
+      title={`Copy a link to “${topic.title}”`}
+      aria-label={`Copy a link to ${topic.title}`}
+    >
+      {copied ? 'Copied' : '#'}
+    </button>
   )
 }


### PR DESCRIPTION
On a 14" MacBook Pro the public-lobby rail sat right on top of the landing card. It was worse than it looked: the rail was `position: fixed` in the top-right corner while the glass card was centred in the **viewport**, so the two were laid out in complete ignorance of each other. Measured:

| viewport | gap between card and rail |
|---|---|
| 1920 | 205px |
| 1512 (14" MBP) | **1px** |
| 1440 (13" MBP) | **−35px — overlapping** |
| 1100 | **−205px** |

The `@media (max-width: 900px)` fallback that dropped the rail into flow was ~600px too late.

Both are in flow now, so a collision is not expressible. Three bands: at ≥1480px an empty mirror gutter opposite the rail keeps the card exactly viewport-centred; from 1121–1479px the two centre as a pair and the card gives up width first; below that they stack. The attribution footer joins normal flow at every width for the same reason — pinned absolutely, it floated over the panel whenever content outgrew the viewport.

### Landing, at 1440px

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/landing-1440-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/landing-1440-after.png) |

### Landing, at 1512px

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/landing-1512-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/landing-1512-after.png) |

## Also on the landing screen

- **Stats, Friends and Profile leave BUILD & BROWSE.** All three are account-scoped and all three already hang off the AuthWidget directly above them. Stats was the only one the widget lacked, so it gains a pill; Friends stops borrowing the Log out styling, which made it light up red on hover.
- **Set Completion moves *into* BUILD & BROWSE.** "Which cards can I actually play with?" is a deckbuilding question, and it sat under LAB behind an "advanced" caption telling players it wasn't for them. That leaves LAB holding only the two dev-only tools, so the tier now renders only in dev builds instead of showing production users a one-button section.
- **The wizard's launch step is one block.** The seat picker and its caption were sharing a wrapping flex row with the primary button, so the caption wrapped under the chips and the button floated at an arbitrary height. Four-option steps also lay out 2×2 rather than stranding a tile on its own row.
- **Spacing tightens under 900px of viewport height** — what a laptop actually has once the browser takes its share.

### The fully-answered wizard (`/play/group/sealed/bracket`)

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/wizard-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/wizard-after.png) |

(Both full-page. Note the attribution footer sitting on the LAB row in the before.)

## /help

The page was a flat wall of 12px Times at ~130 characters a line. The Times is not a choice anyone made — the client sets no body font anywhere, so unstyled prose falls through to the UA default. The page now declares its own sans, its own reading scale, and a measure of ~90 characters. Topics render as cards, display type is a deliberate serif, and the chrome does the things a 40-topic guide needs:

- a sticky bar with search across all five sections (`/` to focus, `Esc` to clear), matching on titles, summaries, body prose and the whole shortcut table
- a per-section topic index in the sidebar, scrollable and clear of the sticky bar
- prev/next section paging
- a copy-link button per topic — the deep links already worked, but nothing on the page would give you one
- a deep-linked or "See also"-jumped topic rings itself briefly so you can see where you landed

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-after.png) |

Search:

![search](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-search-after.png)

The shortcut table, which used to force a horizontal scroll:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-advanced-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-advanced-after.png) |

### Content and shared-surface fixes

- Markdown-style `` `code` `` spans in topic prose were rendering as literal backticks — on both the page and the in-game drawer. `t:creature` and `4 Lightning Bolt` now render as code.
- The shortcut table's third column wraps instead of forcing a horizontal scroll, which also fixes it inside the 460px in-game drawer.
- **"Where your decks live"** now says what browser storage costs you — clearing site data takes your decks with it, and they don't follow you to a phone — and points at signing in or exporting.
- **"Search syntax"** gets the actual grammar (bare words, `-`, `or`, parens, quotes, comparison operators) and the filter families by example, plus the caveat that unimplemented keys are *rejected* rather than ignored. `HelpTopic` gains a `links` field for off-site references, rendered as an "Elsewhere" row with an ↗; this one points at Scryfall's reference, which the query language deliberately tracks.
- **"Import and export"** gets every line shape and section header the parser accepts. No external link here — there is no vendor spec to point at, `parseArenaDeck.ts` *is* the spec, and it was documented only in a source comment no player will read.
- New topic: "Which cards are implemented", following Set Completion out of the Lab section.

![decks section](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/help-decks-after.png)

**Both new topics are pinned by tests** (`help-topic-claims.test.ts`, one beside the query parser and one beside the decklist parser). That is not decoration: writing them turned up two claims that were simply false — `banned:legacy` is not a filter, and `is:split` answers "split-card layout not modelled". A help page documenting an operator the parser rejects is worse than one that says nothing, and prose living in a `.ts` file rots silently.

`help.module.css` is shared with the in-game drawer, so the topic separator moved to an opt-in `.topicSeparated` class and the card surface is applied by the page only. Drawer verified in a live game:

- Advanced tab (wrapping shortcut table) and Decks tab (inline code) both render correctly.

## Verification

`npm run typecheck` and `npm run build` clean. Layout measured with Playwright at 1920/1512/1440/1280/1100/860/420 — card-vs-rail overlap is `false` at every width, with and without a populated rail, signed in and out. Per repo convention the e2e suite was not run; the flows above were walked manually in Chrome.

The `lobby-help-polish-screenshots` branch is throwaway — delete it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
