### PR TITLE
Put the landing screen's account pills back in the top-right corner

### DIFF
--- a/web-client/src/components/auth/AuthWidget.module.css
+++ b/web-client/src/components/auth/AuthWidget.module.css
@@ -1,16 +1,18 @@
 /**
- * Landing-screen account widget. Lives at the top of the fixed top-right side-panel stack (above the
- * Public Lobbies / Live Games panels), right-aligned so it never overlaps them. Frosted pills
- * matching the app's other overlay controls, kept visually distinct from the navigation row.
+ * Landing-screen account widget: the right-hand half of the landing top bar (`.landingTopBar` in
+ * `GameUI.module.css`), opposite the fullscreen and help controls. Frosted pills matching the app's
+ * other overlay controls, kept visually distinct from the navigation row.
  */
-/* Wraps because the signed-in state is now four or five pills and the rail it sits in is 320px. */
+/* Sized by its content and right-aligned, so the pills hug the top-right corner however many of
+   them there are — four signed in, five as an admin. Wraps rather than overflowing when the
+   viewport is too narrow to seat the row beside the fullscreen/help cluster. */
 .widget {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   align-items: stretch;
   gap: var(--space-2);
-  width: 100%;
+  min-width: 0;
 }
 
 /* Shared frosted-pill base for every control in the widget. */

--- a/web-client/src/components/auth/AuthWidget.tsx
+++ b/web-client/src/components/auth/AuthWidget.tsx
@@ -1,6 +1,7 @@
 /**
  * Account presence widget for the landing screen — deliberately separate from the navigation
- * buttons so the sign-in state reads as a distinct, persistent affordance. Anchored top-right.
+ * buttons so the sign-in state reads as a distinct, persistent affordance. It occupies the
+ * top-right of the landing top bar, opposite the fullscreen and help controls.
  *
  *  - signed in  → "Signed in as <name>" (opens the profile), Friends, Stats, and Log out
  *  - anonymous  → a single Log in button that opens the magic-link modal

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -66,7 +66,45 @@
 }
 
 /*
- * Landing layout: the glass card and the side rail (auth widget, public lobbies, live games).
+ * Landing top bar: the viewport controls (fullscreen, help) at the left, the account widget at the
+ * right, as one flow row above everything else.
+ *
+ * The account pills belong in the corner — that is where you look for who you are signed in as — but
+ * they are the widest thing on the screen's top edge (five of them on an admin account), and a
+ * `position: fixed` corner has no way to know where the glass card's edge is. That is the collision
+ * `.landingLayout` below was built to make inexpressible, so the row is in flow too:
+ * `space-between` seats both clusters without either being able to reach the card.
+ */
+.landingTopBar {
+  flex: none;
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.landingTopBarControls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Under ~720px the two clusters can't share a line without shrinking each other — the pills start
+   breaking their own labels over two rows. Each takes a full line instead, account below controls,
+   still right-aligned. */
+@media (max-width: 720px) {
+  .landingTopBar {
+    flex-wrap: wrap;
+  }
+
+  .landingTopBar > * {
+    flex: 1 0 100%;
+  }
+}
+
+/*
+ * Landing layout: the glass card and the side rail (public lobbies, live games).
  *
  * The rail used to be `position: fixed` in the top-right corner while the card was centred in the
  * *viewport*, so the two were laid out in ignorance of each other. They only missed on a wide
@@ -2750,7 +2788,9 @@
 /* =========================================================================
  * Fullscreen Button
  * ========================================================================= */
-/* Fixed top-left cluster: fullscreen toggle, and on the home screen the help entry. */
+/* Fixed top-left cluster: the lobby screen's fullscreen toggle. The landing screen's equivalent is
+   the left half of `.landingTopBar`, which is in flow because it shares its row with the account
+   pills. */
 .cornerControls {
   position: fixed;
   top: var(--space-3);

--- a/web-client/src/components/ui/HomeScreen.tsx
+++ b/web-client/src/components/ui/HomeScreen.tsx
@@ -6,8 +6,8 @@
  * - **PLAY** — the {@link PlayWizard}'s three questions, a join-code row, and a Continue chip when a
  *   lobby is still live from a previous page load.
  * - **BUILD & BROWSE** — deckbuilder, replays and set completion. The account pages (`/stats`,
- *   `/friends`, `/profile`) live on the {@link AuthWidget} in the side rail instead, next to who
- *   you are signed in as.
+ *   `/friends`, `/profile`) live on the {@link AuthWidget} in the top bar instead, next to who you
+ *   are signed in as.
  * - **LAB** — debugging and content tools, dev builds only; the tier does not render otherwise.
  *
  * What is playable is declarative (`lobby/modeMatrix.ts`) and the wizard only renders it; this file
@@ -283,7 +283,9 @@ export function HomeScreen({
 
   const showPublicLobbies = !sessionId && !lobbyState && (publicLobbies.length > 0 || publicLobbiesError || (onlinePlayers ?? 0) > 0)
   const showLiveGames = !sessionId && !lobbyState && liveGames.length > 0
-  const showSideRail = accountsEnabled || showPublicLobbies || showLiveGames
+  // Only the lobby panels; the account widget rides the top bar, so an empty server no longer
+  // reserves a 320px rail (and its mirror gutter) for a single row of sign-in pills.
+  const showSideRail = showPublicLobbies || showLiveGames
 
   const handleSpectate = (gameSessionId: string) => {
     if (status === 'connected') {
@@ -299,16 +301,20 @@ export function HomeScreen({
 
   return (
     <div className={styles.connectionOverlay} style={{ backgroundImage: `url(${randomBackground})` }}>
-      <div className={styles.cornerControls}>
-        <FullscreenButton />
-        <button
-          type="button"
-          onClick={() => navigate('/help')}
-          className={styles.fullscreenButton}
-          title="How Argentum works — modes, priority, shortcuts"
-        >
-          ? Help
-        </button>
+      {/* One flow row across the top: viewport controls left, account right. See `.landingTopBar`. */}
+      <div className={styles.landingTopBar}>
+        <div className={styles.landingTopBarControls}>
+          <FullscreenButton />
+          <button
+            type="button"
+            onClick={() => navigate('/help')}
+            className={styles.fullscreenButton}
+            title="How Argentum works — modes, priority, shortcuts"
+          >
+            ? Help
+          </button>
+        </div>
+        <AuthWidget />
       </div>
       <div className={styles.landingLayout}>
         {/* Mirrors the side rail's width so the glass card stays viewport-centred rather than
@@ -467,7 +473,6 @@ export function HomeScreen({
 
         {showSideRail && (
           <div className={styles.sidePanelStack}>
-            <AuthWidget />
             {showPublicLobbies && (
               <PublicLobbyList
                 lobbies={publicLobbies}


### PR DESCRIPTION
Laying the side rail out in flow (#1438) moved the account widget with it: signed-in state, Friends, Stats, Admin and Log out ended up level with the glass card's title rather than in the corner — which is where you look for who you are signed in as, and where they were before.

They go back to the corner without going back to `position: fixed`. The landing screen now opens with one flow row, `.landingTopBar`: fullscreen and help at the left, the account widget at the right, `space-between` between them. Fixed is what made the old rail collide with the card at 1440px, and the account row is the widest thing on that edge — five pills on an admin account — so it is the last thing that should be laid out in ignorance of the card.

Two things fall out of the move:

- **The rail is the lobby panels only.** `accountsEnabled` no longer forces it, so a server with no public lobbies and no live games stops reserving 320px of rail (and its mirror gutter) to hold a single row of pills.
- **Under 720px the clusters stack.** They can't share a line there without breaking each other's labels over two rows, so each takes a full line — controls, then the account row beneath them, still right-aligned.

## Screenshots

Signed in as an admin (five pills — the widest the row gets), 1512×900:

![signed in](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/signedin.png)

Anonymous with accounts enabled — a single Log in pill in the same corner:

![anonymous](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/anon.png)

430px wide, where the two clusters take a line each:

![mobile](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-help-polish-screenshots/mobile.png)

The screenshot branch (`lobby-help-polish-screenshots`) is throwaway and not meant to be merged.

## Verification

`npm run typecheck` and `npm run build` are clean. Captured against the running stack at 1920, 1512, 1280, 820 and 430px wide; the signed-in states were driven by setting `authStore` directly, since a real sign-in needs a magic link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)