### PR TITLE
Correct scry/surveil (and one search) CR rule numbers

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3614,11 +3614,11 @@ Triggers.youCastSpell(
 
 ### Scry / Surveil
 
-- `WheneverYouScry` — fires once per scry resolution (CR 701.18), after the cards have
+- `WheneverYouScry` — fires once per scry resolution (CR 701.22), after the cards have
   been placed on top/bottom. Pair with `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_SCRY_COUNT)`
   for "for each card looked at" payoffs (Celeborn the Wise, Elrond Master of Healing).
   Automatically emitted by `Patterns.Library.scry(N)`; no card has to opt in.
-- `WheneverYouSurveil` — the surveil twin (CR 701.42), fired once per surveil resolution.
+- `WheneverYouSurveil` — the surveil twin (CR 701.25), fired once per surveil resolution.
   Automatically emitted by `Patterns.Library.surveil(N)`. Reads the same `TRIGGER_SCRY_COUNT`
   ("cards looked at"). Used by Golbez.
 - `WheneverYouScryOrSurveil` — the combined look-at-top trigger; fires once per scry **and**
@@ -3672,9 +3672,9 @@ Triggers.youCastSpell(
   way" can move it out of the graveyard — e.g. **Paranormal Analyst**:
   `MoveCollection(from = TRIGGER_CAPTURED_COLLECTION, destination = ToZone(HAND))`. The collection is
   empty when nothing was binned, making the payoff a safe no-op.
-- A literal "scry 0" / "surveil 0" produces no event and fires no trigger (CR 701.18b / 701.42c);
-  the trigger still fires when the library was empty and zero cards were looked at (CR 701.18d /
-  701.42d).
+- A literal "scry 0" / "surveil 0" produces no event and fires no trigger (CR 701.22b / 701.25c);
+  the trigger still fires when the library was empty and zero cards were looked at (CR 701.22d /
+  701.25d).
 
 ### Saga creatures — "Enchantment Creature — Saga" (CR 714.1a)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -508,7 +508,7 @@ object Effects {
     fun ReadTheRunes(): Effect = HandPatterns.readTheRunes()
 
     /**
-     * "Scry [count]" (CR 701.18): look at the top [count] cards of your library, put any number on
+     * "Scry [count]" (CR 701.22): look at the top [count] cards of your library, put any number on
      * the bottom and the rest on top in any order. Returns the compact `ScryEffect` macro node,
      * which the engine expands into the shared Gather → Select → Move pipeline at resolution (so the
      * card serializes as one `{"type":"Scry"}` node — see [LibraryPatterns.scry]).
@@ -525,7 +525,7 @@ object Effects {
     fun Scry(count: Int, target: EffectTarget): Effect = LibraryPatterns.scry(count, target)
 
     /**
-     * "Surveil [count]" (CR 701.42): look at the top [count] cards of your library, put any number
+     * "Surveil [count]" (CR 701.25): look at the top [count] cards of your library, put any number
      * into your graveyard and the rest on top in any order. The surveil twin of [Scry]; see
      * [LibraryPatterns.surveil].
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -293,7 +293,7 @@ object LibraryPatterns {
     )
 
     /**
-     * "Scry [count]" (CR 701.18). Returns the compact [ScryEffect] macro node; the engine expands
+     * "Scry [count]" (CR 701.22). Returns the compact [ScryEffect] macro node; the engine expands
      * it to [scryPipeline] at execution time. A card whose effect *is* scry therefore serializes as
      * a single `{"type":"Scry"}` node rather than the unrolled pipeline (see [ScryEffect]).
      */
@@ -322,7 +322,7 @@ object LibraryPatterns {
     }
 
     /**
-     * "Surveil [count]" (CR 701.42). Returns the compact [SurveilEffect] macro node; the engine
+     * "Surveil [count]" (CR 701.25). Returns the compact [SurveilEffect] macro node; the engine
      * expands it to [surveilPipeline] at execution time (see [SurveilEffect]).
      */
     fun surveil(count: Int): SurveilEffect = SurveilEffect(count)
@@ -375,12 +375,12 @@ object LibraryPatterns {
                 destination = CardDestination.ToZone(Zone.LIBRARY, player, placement = ZonePlacement.Top),
                 order = CardOrder.ControllerChooses
             ),
-            // Fire "Whenever you scry" triggers (CR 701.18) after the pipeline finishes.
+            // Fire "Whenever you scry" triggers (CR 701.22) after the pipeline finishes.
             // The event count is the actual size of the "scried" gather collection at
             // resolution time, not the literal N (handles library-smaller-than-N). Per
-            // CR 701.18d the trigger still fires when the library was empty and zero
+            // CR 701.22d the trigger still fires when the library was empty and zero
             // cards were looked at, so the tail emits unconditionally — it is only
-            // omitted for a literal "scry 0" (CR 701.18b: no scry event occurs).
+            // omitted for a literal "scry 0" (CR 701.22b: no scry event occurs).
             if (count > 0) EmitScriedEventEffect() else null
         )
     )
@@ -413,12 +413,12 @@ object LibraryPatterns {
                 destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top),
                 order = CardOrder.ControllerChooses
             ),
-            // Fire "Whenever you surveil" / "scry or surveil" triggers (CR 701.42) after the
+            // Fire "Whenever you surveil" / "scry or surveil" triggers (CR 701.25) after the
             // pipeline finishes. The event count is the actual size of the "surveiled" gather
             // collection at resolution time, not the literal N (handles library-smaller-than-N).
-            // Per CR 701.42d the trigger still fires when the library was empty and zero cards
+            // Per CR 701.25d the trigger still fires when the library was empty and zero cards
             // were looked at, so the tail emits unconditionally — it is only omitted for a literal
-            // "surveil 0" (CR 701.42c: no surveil event occurs).
+            // "surveil 0" (CR 701.25c: no surveil event occurs).
             if (count > 0) EmitSurveiledEventEffect() else null
         )
     )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1993,7 +1993,7 @@ object Triggers {
     )
 
     // =========================================================================
-    // Scry Triggers (CR 701.18)
+    // Scry Triggers (CR 701.22)
     // =========================================================================
 
     /**
@@ -2008,7 +2008,7 @@ object Triggers {
     )
 
     /**
-     * Whenever you surveil (CR 701.42). The surveil twin of [WheneverYouScry] — fires once per
+     * Whenever you surveil (CR 701.25). The surveil twin of [WheneverYouScry] — fires once per
      * surveil resolution, after the kept/graveyard moves resolve. Pair with TRIGGER_SCRY_COUNT to
      * scale by "the number of cards looked at." Used by Golbez and similar surveil payoffs.
      */
@@ -2018,7 +2018,7 @@ object Triggers {
     )
 
     /**
-     * Whenever you scry **or** surveil (CR 701.18 / 701.42) — the combined look-at-top trigger
+     * Whenever you scry **or** surveil (CR 701.22 / 701.25) — the combined look-at-top trigger
      * (Matoya, Archon Elder). Fires once per scry and once per surveil.
      */
     val WheneverYouScryOrSurveil: TriggerSpec = TriggerSpec(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -409,7 +409,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * Whenever a player scries (CR 701.18). Fires once per scry, after every card chosen
+     * Whenever a player scries (CR 701.22). Fires once per scry, after every card chosen
      * for the bottom/top has been moved. Carries the number of cards actually looked at,
      * which equals the scry N parameter unless the library had fewer cards available.
      * Read this count via [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TRIGGER_SCRY_COUNT]
@@ -424,11 +424,11 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * Whenever a player surveils (CR 701.42). Fires once per surveil, after the kept/graveyard
+     * Whenever a player surveils (CR 701.25). Fires once per surveil, after the kept/graveyard
      * moves have all resolved. Carries the number of cards actually looked at (equals the surveil
      * N parameter unless the library had fewer cards). Read this count via
      * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TRIGGER_SCRY_COUNT] ("the number of
-     * cards looked at"). A literal "surveil 0" produces no event (CR 701.42c).
+     * cards looked at"). A literal "surveil 0" produces no event (CR 701.25c).
      */
     @SerialName("SurveiledEvent")
     @Serializable
@@ -439,7 +439,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * Whenever a player scries **or** surveils (CR 701.18 / 701.42) — the combined look-at-top
+     * Whenever a player scries **or** surveils (CR 701.22 / 701.25) — the combined look-at-top
      * trigger used by "Whenever you scry or surveil, …" (Matoya, Archon Elder). Matches either a
      * scry or a surveil event from [player]; the cards-looked-at count is exposed the same way as
      * the individual triggers (TRIGGER_SCRY_COUNT).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -35,10 +35,10 @@ data class ShuffleLibraryEffect(
  *
  * The count is the size of the named gather collection (`"scried"` by default) at
  * resolution time — i.e. the cards `GatherCardsEffect` actually pulled, which equals
- * the scry N parameter unless the library held fewer (CR 701.18a). The count can be
- * zero when the library was empty; the event still fires, because CR 701.18d triggers
+ * the scry N parameter unless the library held fewer (CR 701.22a). The count can be
+ * zero when the library was empty; the event still fires, because CR 701.22d triggers
  * "whenever you scry" abilities "even if some or all of those actions were impossible."
- * Suppression of a literal "scry 0" (CR 701.18b) is handled by `scry()` omitting this
+ * Suppression of a literal "scry 0" (CR 701.22b) is handled by `scry()` omitting this
  * tail entirely, not here.
  *
  * Card authors should not use this directly; it is wired into the scry primitive.
@@ -62,9 +62,9 @@ data class EmitScriedEventEffect(
  *
  * The count is the size of the named gather collection (`"surveiled"` by default) at resolution
  * time — the cards `GatherCardsEffect` actually pulled, which equals the surveil N parameter unless
- * the library held fewer (CR 701.42a). The count can be zero when the library was empty; the event
- * still fires, because CR 701.42d triggers "whenever you surveil" abilities "even if some or all of
- * those actions were impossible." Suppression of a literal "surveil 0" (CR 701.42c) is handled by
+ * the library held fewer (CR 701.25a). The count can be zero when the library was empty; the event
+ * still fires, because CR 701.25d triggers "whenever you surveil" abilities "even if some or all of
+ * those actions were impossible." Suppression of a literal "surveil 0" (CR 701.25c) is handled by
  * `surveil()` omitting this tail entirely, not here.
  *
  * Card authors should not use this directly; it is wired into the surveil primitive.
@@ -151,7 +151,7 @@ data object EmitLibrarySearchedEventEffect : Effect {
 
 
 /**
- * "Scry [count]" (CR 701.18) as a single compact node.
+ * "Scry [count]" (CR 701.22) as a single compact node.
  *
  * This is a *macro effect*: a serializable marker that, at execution time, expands into the
  * shared Gather → Select → Move → Move → emit pipeline built by
@@ -174,7 +174,7 @@ data class ScryEffect(val count: Int) : Effect {
 }
 
 /**
- * "Surveil [count]" (CR 701.42) as a single compact node — the surveil twin of [ScryEffect].
+ * "Surveil [count]" (CR 701.25) as a single compact node — the surveil twin of [ScryEffect].
  *
  * Expands at execution time into the shared pipeline built by
  * [com.wingedsheep.sdk.dsl.LibraryPatterns.surveilPipeline]; see [ScryEffect] for the macro-effect

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/LibraryMacroEffectTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/LibraryMacroEffectTest.kt
@@ -57,7 +57,7 @@ class LibraryMacroEffectTest : FunSpec({
         surveilPipeline.effects.last().shouldBeInstanceOf<EmitSurveiledEventEffect>()
     }
 
-    test("a literal scry/surveil 0 expands without an emit-event tail (CR 701.18b / 701.42c)") {
+    test("a literal scry/surveil 0 expands without an emit-event tail (CR 701.22b / 701.25c)") {
         LibraryPatterns.scryPipeline(0).effects.none { it is EmitScriedEventEffect } shouldBe true
         LibraryPatterns.surveilPipeline(0).effects.none { it is EmitSurveiledEventEffect } shouldBe true
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MagmaticHellkite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/MagmaticHellkite.kt
@@ -43,7 +43,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *  - Gather basic lands from *the land controller's* library (after destruction the
  *    relational player reference falls back to the land's owner, which for a land equals
  *    its controller, so the correct opponent still searches).
- *  - That player selects up to one (a search may always fail to find — CR 701.18c).
+ *  - That player selects up to one (a search may always fail to find — CR 701.23b).
  *  - The chosen basic enters *their* battlefield tapped with a stun counter via
  *    [MoveCollectionEffect.addCounterType].
  *  - Then that player shuffles.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -71,7 +71,7 @@ data class TriggeredAbilityContinuation(
     val triggerModesChosenCount: Int? = null,
     /** Power of the aura/equipment's attached creature, captured at trigger time (CR 608.2h LKI). */
     val enchantedCreatureLastKnownPower: Int? = null,
-    /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
+    /** Cards looked at by the scry that fired this trigger (CR 701.22). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,
     /** Cards discarded in the batch that fired this trigger (CR 603.2c). Read via
      *  `ContextPropertyKey.TRIGGER_DISCARD_COUNT` (Magmakin Artillerist). Null for non-discard triggers. */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -308,7 +308,7 @@ data class RingTemptedEvent(
 ) : GameEvent
 
 /**
- * A player just finished a `scry N` (CR 701.18). Fires once per scry, after the
+ * A player just finished a `scry N` (CR 701.22). Fires once per scry, after the
  * top/bottom moves have all resolved. Drives "Whenever you scry" triggers; see
  * [com.wingedsheep.sdk.scripting.EventPattern.ScriedEvent].
  *
@@ -327,7 +327,7 @@ data class ScriedEvent(
 ) : GameEvent
 
 /**
- * A player just finished a `surveil N` (CR 701.42). Fires once per surveil, after the
+ * A player just finished a `surveil N` (CR 701.25). Fires once per surveil, after the
  * kept/graveyard moves have all resolved. Drives "Whenever you surveil" and "Whenever you
  * scry or surveil" triggers; see [com.wingedsheep.sdk.scripting.EventPattern.SurveiledEvent].
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitScriedEventExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitScriedEventExecutor.kt
@@ -12,15 +12,15 @@ import kotlin.reflect.KClass
 
 /**
  * Tail of the [com.wingedsheep.sdk.dsl.Patterns.Library.scry] composite: emits a
- * [ScriedEvent] so "Whenever you scry" triggers (CR 701.18) fire exactly once per
+ * [ScriedEvent] so "Whenever you scry" triggers (CR 701.22) fire exactly once per
  * scry, after the top/bottom moves have all resolved.
  *
  * The carried count is the size of the named gather collection (`"scried"` by default)
  * at resolution time — the cards `GatherCardsEffect` actually pulled, which equals
- * the scry N parameter unless the library held fewer (CR 701.18a). That count can be
- * zero when the library was empty; the event is still emitted, because CR 701.18d fires
+ * the scry N parameter unless the library held fewer (CR 701.22a). That count can be
+ * zero when the library was empty; the event is still emitted, because CR 701.22d fires
  * "whenever you scry" triggers "even if some or all of those actions were impossible."
- * A literal "scry 0" (CR 701.18b: no scry event occurs) never reaches this executor —
+ * A literal "scry 0" (CR 701.22b: no scry event occurs) never reaches this executor —
  * [com.wingedsheep.sdk.dsl.Patterns.Library.scry] omits the tail entirely for N == 0.
  */
 class EmitScriedEventExecutor : EffectExecutor<EmitScriedEventEffect> {
@@ -32,8 +32,8 @@ class EmitScriedEventExecutor : EffectExecutor<EmitScriedEventEffect> {
         effect: EmitScriedEventEffect,
         context: EffectContext
     ): EffectResult {
-        // Actual cards looked at (CR 701.18a); may be 0 if the library was empty, in
-        // which case the trigger still fires per CR 701.18d.
+        // Actual cards looked at (CR 701.22a); may be 0 if the library was empty, in
+        // which case the trigger still fires per CR 701.22d.
         val count = context.pipeline.storedCollections[effect.gatherCollection]?.size ?: 0
 
         val playerId = context.controllerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitSurveiledEventExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitSurveiledEventExecutor.kt
@@ -12,13 +12,13 @@ import kotlin.reflect.KClass
 /**
  * Tail of the [com.wingedsheep.sdk.dsl.Patterns.Library.surveil] composite: emits a
  * [SurveiledEvent] so "Whenever you surveil" / "Whenever you scry or surveil" triggers
- * (CR 701.42) fire exactly once per surveil, after the kept/graveyard moves have all resolved.
+ * (CR 701.25) fire exactly once per surveil, after the kept/graveyard moves have all resolved.
  *
  * The carried count is the size of the named gather collection (`"surveiled"` by default) at
  * resolution time — the cards `GatherCardsEffect` actually pulled, which equals the surveil N
- * parameter unless the library held fewer (CR 701.42a). That count can be zero when the library
- * was empty; the event is still emitted, because CR 701.42d fires "whenever you surveil" triggers
- * "even if some or all of those actions were impossible." A literal "surveil 0" (CR 701.42c: no
+ * parameter unless the library held fewer (CR 701.25a). That count can be zero when the library
+ * was empty; the event is still emitted, because CR 701.25d fires "whenever you surveil" triggers
+ * "even if some or all of those actions were impossible." A literal "surveil 0" (CR 701.25c: no
  * surveil event occurs) never reaches this executor —
  * [com.wingedsheep.sdk.dsl.Patterns.Library.surveil] omits the tail entirely for N == 0.
  */
@@ -31,8 +31,8 @@ class EmitSurveiledEventExecutor : EffectExecutor<EmitSurveiledEventEffect> {
         effect: EmitSurveiledEventEffect,
         context: EffectContext
     ): EffectResult {
-        // Actual cards looked at (CR 701.42a); may be 0 if the library was empty, in
-        // which case the trigger still fires per CR 701.42d.
+        // Actual cards looked at (CR 701.25a); may be 0 if the library was empty, in
+        // which case the trigger still fires per CR 701.25d.
         val count = context.pipeline.storedCollections[effect.gatherCollection]?.size ?: 0
 
         val playerId = context.controllerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryMacroExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryMacroExecutors.kt
@@ -11,12 +11,12 @@ import com.wingedsheep.sdk.scripting.effects.SurveilEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for the [ScryEffect] macro (CR 701.18). It carries no gather/select/move logic of its
+ * Executor for the [ScryEffect] macro (CR 701.22). It carries no gather/select/move logic of its
  * own: it expands the marker into the shared [LibraryPatterns.scryPipeline] composite and delegates
  * to the registry's recursive [effectExecutor], which dispatches the composite through
  * `CompositeEffectExecutor`. That executor already owns the choose-pause → `EffectContinuation`
  * plumbing, so the `SelectCardsDecision` pause for "put any number on the bottom" still works, and
- * the `ScriedEvent` tail still fires "Whenever you scry" triggers (CR 701.18d).
+ * the `ScriedEvent` tail still fires "Whenever you scry" triggers (CR 701.22d).
  *
  * Collapsing scry to one node is purely a representation change — execution is byte-for-byte the
  * old expanded pipeline.
@@ -32,7 +32,7 @@ class ScryExecutor(
 }
 
 /**
- * Executor for the [SurveilEffect] macro (CR 701.42) — the surveil twin of [ScryExecutor]. Expands
+ * Executor for the [SurveilEffect] macro (CR 701.25) — the surveil twin of [ScryExecutor]. Expands
  * to [LibraryPatterns.surveilPipeline] and delegates to the same composite machinery; the
  * `SurveiledEvent` tail still fires "Whenever you surveil" / "scry or surveil" triggers.
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -173,7 +173,7 @@ data class TriggeredAbilityOnStackComponent(
      * Blunderbuss". Null for the source's own printed abilities.
      */
     val granterId: EntityId? = null,
-    /** Cards looked at by the scry that fired this trigger (CR 701.18). Null for non-scry triggers. */
+    /** Cards looked at by the scry that fired this trigger (CR 701.22). Null for non-scry triggers. */
     val triggerScryCount: Int? = null,
     /** Cards discarded in the batch that fired this trigger (CR 603.2c). Read via
      *  `ContextPropertyKey.TRIGGER_DISCARD_COUNT` (Magmakin Artillerist). Null for non-discard triggers. */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScryTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScryTriggerScenarioTest.kt
@@ -26,7 +26,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Substrate tests for the "Whenever you scry" trigger (CR 701.18):
+ * Substrate tests for the "Whenever you scry" trigger (CR 701.22):
  * `Patterns.Library.scry(N)` ends by emitting [ScriedEvent], which drives
  * `Triggers.WheneverYouScry` and surfaces "the number of cards looked at" via
  * [ContextPropertyKey.TRIGGER_SCRY_COUNT].
@@ -82,7 +82,7 @@ class ScryTriggerScenarioTest : FunSpec({
         state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
 
     // Truncate a player's library to exactly [size] cards (top of library = front of list),
-    // so scry can be exercised against a library shorter than N (CR 701.18a) or empty (701.18d).
+    // so scry can be exercised against a library shorter than N (CR 701.22a) or empty (701.22d).
     fun GameTestDriver.truncateLibrary(player: EntityId, size: Int) {
         val key = ZoneKey(player, Zone.LIBRARY)
         replaceState(state.copy(zones = state.zones + (key to state.getZone(key).take(size))))
@@ -163,7 +163,7 @@ class ScryTriggerScenarioTest : FunSpec({
         driver.plusOneCounters(counter) shouldBe 4
     }
 
-    test("scry counts only the cards actually looked at when the library is shorter than N (CR 701.18a)") {
+    test("scry counts only the cards actually looked at when the library is shorter than N (CR 701.22a)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -181,7 +181,7 @@ class ScryTriggerScenarioTest : FunSpec({
         driver.plusOneCounters(counter) shouldBe 2
     }
 
-    test("scry with an empty library still fires the trigger with count 0 (CR 701.18d)") {
+    test("scry with an empty library still fires the trigger with count 0 (CR 701.22d)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -198,11 +198,11 @@ class ScryTriggerScenarioTest : FunSpec({
 
         val scried = driver.events.drop(before).filterIsInstance<ScriedEvent>().single()
         scried.count shouldBe 0
-        driver.plusOneCounters(watcher) shouldBe 1 // trigger fired (701.18d)
+        driver.plusOneCounters(watcher) shouldBe 1 // trigger fired (701.22d)
         driver.plusOneCounters(counter) shouldBe 0 // ... but scaled to 0 cards looked at
     }
 
-    test("scry 0 fires no trigger and emits no event (CR 701.18b)") {
+    test("scry 0 fires no trigger and emits no event (CR 701.22b)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurveilTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SurveilTriggerScenarioTest.kt
@@ -27,8 +27,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 /**
- * Substrate tests for the "Whenever you surveil" (CR 701.42) and combined "Whenever you scry or
- * surveil" (CR 701.18 / 701.42) triggers: `Patterns.Library.surveil(N)` ends by emitting
+ * Substrate tests for the "Whenever you surveil" (CR 701.25) and combined "Whenever you scry or
+ * surveil" (CR 701.22 / 701.25) triggers: `Patterns.Library.surveil(N)` ends by emitting
  * [SurveiledEvent], which drives `Triggers.WheneverYouSurveil` /
  * `Triggers.WheneverYouScryOrSurveil` and surfaces "the number of cards looked at" via
  * [ContextPropertyKey.TRIGGER_SCRY_COUNT]. The event is distinct from the scry event, so a scry
@@ -116,7 +116,7 @@ class SurveilTriggerScenarioTest : FunSpec({
         state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
 
     // Truncate a player's library to exactly [size] cards so surveil can be exercised against a
-    // library shorter than N (CR 701.42a) or empty (701.42d).
+    // library shorter than N (CR 701.25a) or empty (701.25d).
     fun GameTestDriver.truncateLibrary(player: EntityId, size: Int) {
         val key = ZoneKey(player, Zone.LIBRARY)
         replaceState(state.copy(zones = state.zones + (key to state.getZone(key).take(size))))
@@ -232,7 +232,7 @@ class SurveilTriggerScenarioTest : FunSpec({
         driver.plusOneCounters(scryWatcher) shouldBe 1 // unchanged
     }
 
-    test("surveil counts only the cards actually looked at when the library is shorter than N (CR 701.42a)") {
+    test("surveil counts only the cards actually looked at when the library is shorter than N (CR 701.25a)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -250,7 +250,7 @@ class SurveilTriggerScenarioTest : FunSpec({
         driver.plusOneCounters(counter) shouldBe 2
     }
 
-    test("surveil with an empty library still fires the trigger with count 0 (CR 701.42d)") {
+    test("surveil with an empty library still fires the trigger with count 0 (CR 701.25d)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -266,11 +266,11 @@ class SurveilTriggerScenarioTest : FunSpec({
 
         val surveiled = driver.events.drop(before).filterIsInstance<SurveiledEvent>().single()
         surveiled.count shouldBe 0
-        driver.plusOneCounters(watcher) shouldBe 1 // trigger fired (701.42d)
+        driver.plusOneCounters(watcher) shouldBe 1 // trigger fired (701.25d)
         driver.plusOneCounters(counter) shouldBe 0 // ... but scaled to 0 cards looked at
     }
 
-    test("surveil 0 fires no trigger and emits no event (CR 701.42c)") {
+    test("surveil 0 fires no trigger and emits no event (CR 701.25c)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!


### PR DESCRIPTION
## What

Corrects the Comprehensive Rules numbers cited for **scry** and **surveil** throughout the codebase. The cited numbers were transposed and have been wrong in every recent CR edition:

| Term | Was cited | Correct | What the wrong number actually is |
|------|-----------|---------|-----------------------------------|
| Scry | `701.18` | **`701.22`** | Play |
| Surveil | `701.42` | **`701.25`** | Meld |

Verified against `MagicCompRules_20260619` (identical numbering in `20260417`), so this is a genuine miscitation, not edition drift. Sub-rule letters map 1:1 — `701.18a/b/d → 701.22a/b/d`, `701.42a/c/d → 701.25a/c/d` — and the sub-rule text matches at the new numbers.

Also fixes one unrelated miscitation the sweep surfaced: **Magmatic Hellkite** cited `701.18c` ("Play with the top card of your library revealed") for its "a search may always fail to find" note. The not-required-to-find principle for a search with a stated quality (a basic land card) is **`701.23b`**; `701.18c` is unrelated.

## Scope

Comment, KDoc, SDK-reference, and test-name strings only — **no behavior change, no code touched**. 16 files:

- `mtg-sdk`: `Effects.kt`, `LibraryPatterns.kt`, `Triggers.kt`, `EventPattern.kt`, `effects/LibraryEffects.kt`, `serialization/LibraryMacroEffectTest.kt`
- `rules-engine`: `core/GameEvent.kt`, `core/CoreContinuations.kt`, `state/components/stack/StackComponents.kt`, `handlers/effects/library/{EmitScriedEventExecutor,EmitSurveiledEventExecutor,LibraryMacroExecutors}.kt`, `scenarios/{ScryTriggerScenarioTest,SurveilTriggerScenarioTest}.kt`
- `mtg-sets`: `tdm/cards/MagmaticHellkite.kt`
- `docs/card-sdk-language-reference.md`

## Testing

No runtime surface — the diff is entirely comments, markdown, and `test("…")` display-name strings, so there is nothing to exercise. `test(...)` names are string literals with no compile impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
