### PR TITLE
Add five Innistrad Remastered cards with mill-cost support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -243,6 +243,14 @@ excluded.
   cost is unpayable when the controller has not drawn a card this turn or the tracked card has
   since left their hand (matches the Scryfall ruling: "If you do not have the card still in your
   hand, you can't pay the cost").
+- `Costs.MillCard` / `Costs.Mill(count)` — mill a card / `count` cards as a cost ("{T}, Mill a card:
+  Add {C}" — Deranged Assistant). No player selection: the milled cards are the top of the library.
+  Per **CR 701.17b** a player *can't pay a cost that includes milling more cards than their library
+  holds*, so — unlike the mill *effect*, which mills as many as possible — the cost is **unpayable**
+  on a short library and gates legal-action enumeration (including mana-ability enumeration). A
+  `ModifyMillAmount` replacement (Bruvac) still applies to the announced count when the cost is
+  actually paid, and the library→graveyard moves go through `ZoneTransitionService`, so mill triggers
+  fire exactly as they do for an effect's mill.
 - `Costs.ExileSelf` — exile this permanent (or graveyard card, for graveyard-activated abilities).
 - `Costs.ReturnSelfToHand` — return this permanent to its owner's hand (Maze's End: "{3}, {T},
   Return this land to its owner's hand: …"). The bounce-to-hand sibling of `Costs.SacrificeSelf` /
@@ -7278,7 +7286,7 @@ replacementEffect {
   `Effects.MayRevealCardFromHand` to build SOI shadow lands or other "as ~ enters" choices.
   **Scope today:** only wired into the land-play path (`PlayLandHandler`). When the first non-land
   permanent needs this, also wire it into `StackResolver.enterPermanentOnBattlefield`.
-- `EntersWithCounters(counterType?, count, selfOnly?, condition?, appliesTo?)` /
+- `EntersWithCounters(counterType?, count, selfOnly?, condition?, otherOnly?, appliesTo?)` /
   `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?)` — "[permanent] enters with
   N counters." `EntersWithCounters` takes a fixed `count: Int` (Master Biomancer, Metallic Mimic);
   `EntersWithDynamicCounters` takes a `count: DynamicAmount` (Stag Beetle; the SOS Converge "Archaic"
@@ -7287,14 +7295,21 @@ replacementEffect {
   - **Self** (default) — applies to the permanent that owns the replacement. Reserve a *dynamic* count
     for "this creature enters with a counter for each color of mana spent to cast **it**" / "for each X
     it has".
-  - **`otherOnly = true`** — applies to *other* matching creatures entering (Gev, Scaled Scorch:
+  - **`otherOnly = true`** (both variants) — applies to *other* matching creatures entering (Metallic
+    Mimic: "each **other** creature you control of the chosen type enters with an additional +1/+1
+    counter"; Gev, Scaled Scorch:
     "Other creatures you control enter with additional counters"; Wildgrowth Archaic: "whenever you
     cast a creature spell, that creature enters with X additional +1/+1 counters … where X is the
     number of colors of mana spent to cast **it**"). The `count` is always evaluated against the
     **entering object**, not the replacement source — so an entering-object amount like
     `DistinctColorsManaSpent` reads the new creature's own cast (and a token / reanimated creature that
     wasn't cast spent no mana → 0). Player-scoped counts (`TurnTracking(Player.You)`, Gev) still read
-    the replacement source's controller.
+    the replacement source's controller. **Set `otherOnly` on any "each *other* …" wording** — the
+    entering permanent's own entry path applies its printed enters-with effects regardless of
+    `appliesTo` (that's how plain self-counter cards work), so without the flag a group effect also
+    counters its own source as it enters. Source-relative predicates in `appliesTo` (notably
+    `withChosenSubtype()`) resolve against the **replacement source**, so Metallic Mimic's filter reads
+    the type chosen as the Mimic entered, not anything on the entering creature.
 - `EntersWithKeywords(keywords, condition?, selfOnly?, appliesTo?)` — "[permanent] enters with
   [keywords]" (CR 614.1c), the keyword counterpart of `EntersWithCounters`. The grant happens as the
   permanent enters — no trigger, no stack, no response window — as a permanent, entry-timestamped

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -148,6 +148,24 @@ object Costs {
      */
     val DiscardHand: AbilityCost = AbilityCost.DiscardHand
 
+    // =========================================================================
+    // Mill Costs
+    // =========================================================================
+
+    /**
+     * Mill a card as a cost — "{T}, Mill a card: Add {C}" (Deranged Assistant).
+     *
+     * Unpayable with an empty library (CR 701.17b), and takes no player selection: the milled card
+     * is the top of the library.
+     */
+    val MillCard: AbilityCost = AbilityCost.Atom(CostAtom.Mill())
+
+    /**
+     * Mill [count] cards as a cost. Unpayable unless the library holds at least [count] cards
+     * (CR 701.17b).
+     */
+    fun Mill(count: Int): AbilityCost = AbilityCost.Atom(CostAtom.Mill(count))
+
     /**
      * Discard this card (for cycling and similar abilities).
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -450,6 +450,11 @@ data class PermanentsEnterTapped(
  *                  at the moment the permanent enters the battlefield. Used for cards like
  *                  Frilled Sparkshooter ("This creature enters with a +1/+1 counter on it if
  *                  an opponent lost life this turn.").
+ * @param otherOnly When true the source is excluded — "each **other** [filter] … enters with an
+ *                  additional counter" (Metallic Mimic). The [selfOnly] mirror, and the same flag
+ *                  [EntersWithDynamicCounters] carries: the source's own entry path skips an
+ *                  `otherOnly` effect, so the source can never counter itself as it enters. Leave
+ *                  false for a group effect that also covers the source's own entry.
  */
 @SerialName("EntersWithCounters")
 @Serializable
@@ -458,6 +463,7 @@ data class EntersWithCounters(
     val count: Int,
     val selfOnly: Boolean = false,
     val condition: Condition? = null,
+    val otherOnly: Boolean = false,
     override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
         filter = GameObjectFilter.Creature.youControl(),
         to = Zone.BATTLEFIELD

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -60,6 +60,24 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
     }
 
     /**
+     * Mill [count] cards — put that many cards from the top of your library into your graveyard
+     * (CR 701.17a).
+     *
+     * Takes no selection: the cards milled are the top [count], not a player choice. Per CR 701.17b
+     * a player *can't pay a cost that includes milling more cards than their library holds*, so
+     * affordability is a plain library-size check — unlike the mill *effect*, which mills as many as
+     * possible. A `ModifyMillAmount` replacement (Bruvac) still applies to the announced number when
+     * the cost is actually paid, and the resulting library→graveyard zone changes fire mill triggers
+     * exactly as an effect's mill does.
+     */
+    @SerialName("AtomMill")
+    @Serializable
+    data class Mill(val count: Int = 1) : CostAtom {
+        override val description: String get() =
+            if (count == 1) "mill a card" else "mill $count cards"
+    }
+
+    /**
      * Sacrifice [count] permanents matching [filter].
      *
      * @property excludeSelf when true the cost's source permanent is excluded from the candidate

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -32,6 +32,7 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.Sacrifice(GameObjectFilter.Creature, count = 2),
         CostAtom.Discard(count = 1, filter = GameObjectFilter.Any, random = true),
         CostAtom.ExileFrom(Zone.GRAVEYARD, GameObjectFilter.Creature, count = 3),
+        CostAtom.Mill(count = 1),
         CostAtom.ExilePermanents(GameObjectFilter.Artifact, minCount = 1, excludeSelf = true),
         CostAtom.TapPermanents(count = 1, filter = GameObjectFilter.Creature),
         CostAtom.ReturnToHand(GameObjectFilter.Any, count = 1),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/MetallicMimic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/MetallicMimic.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantChosenSubtype
+
+/**
+ * Metallic Mimic
+ * {2}
+ * Artifact Creature — Shapeshifter
+ * 2/1
+ *
+ * As this creature enters, choose a creature type.
+ * This creature is the chosen type in addition to its other types.
+ * Each other creature you control of the chosen type enters with an additional +1/+1 counter on it.
+ *
+ * Same shape as Adaptive Automaton, with a counter-granting replacement in place of the lord:
+ * [EntersWithChoice] captures the creature type as Mimic enters, [GrantChosenSubtype] (default
+ * filter: the source itself) makes it that type in addition to Shapeshifter, and
+ * [EntersWithCounters] is a runtime replacement consulted from the battlefield — `appliesTo`
+ * describes the *affected* permanents, so `withChosenSubtype()` reads Mimic's stored choice and
+ * matches creatures you control entering as that type.
+ *
+ * "Each *other* creature" is `otherOnly = true`: the entering permanent's own entry path applies its
+ * printed enters-with effects regardless of `appliesTo` (that's how the ordinary self-counter cards
+ * work), so without the flag the Mimic would counter itself as it entered. Creatures entering
+ * *simultaneously* with the Mimic get no counter for a different reason and need no flag — the
+ * runtime replacement is only consulted from the battlefield, where the Mimic isn't yet.
+ */
+val MetallicMimic = card("Metallic Mimic") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Shapeshifter"
+    power = 2
+    toughness = 1
+    oracleText = "As this creature enters, choose a creature type.\n" +
+        "This creature is the chosen type in addition to its other types.\n" +
+        "Each other creature you control of the chosen type enters with an additional +1/+1 " +
+        "counter on it."
+
+    // As this creature enters, choose a creature type.
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    // Each other creature you control of the chosen type enters with an additional +1/+1 counter.
+    replacementEffect(
+        EntersWithCounters(
+            count = 1,
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().withChosenSubtype(),
+                to = Zone.BATTLEFIELD,
+            ),
+        )
+    )
+
+    // This creature is the chosen type in addition to its other types.
+    staticAbility {
+        ability = GrantChosenSubtype()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Zack Stella"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg?1783936724"
+        ruling(
+            "2017-02-09",
+            "The choice of creature type is made as Metallic Mimic enters the battlefield. Players " +
+                "can't respond to this choice. Metallic Mimic's second ability starts applying " +
+                "immediately."
+        )
+        ruling(
+            "2017-02-09",
+            "Even though Metallic Mimic is a Shapeshifter, other Shapeshifter creatures you control " +
+                "won't get a +1/+1 counter unless you chose Shapeshifter as Metallic Mimic entered " +
+                "the battlefield."
+        )
+        ruling(
+            "2017-02-09",
+            "You must choose an existing creature type. \"Artifact\" and \"Vehicle\" aren't creature " +
+                "types."
+        )
+        ruling(
+            "2017-02-09",
+            "Creatures of the chosen type that enter the battlefield at the same time as Metallic " +
+                "Mimic won't enter with an additional +1/+1 counter."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ReforgeTheSoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ReforgeTheSoul.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Reforge the Soul
+ * {3}{R}{R}
+ * Sorcery
+ *
+ * Each player discards their hand, then draws seven cards.
+ * Miracle {1}{R}
+ *
+ * A symmetric wheel: [Effects.ForEachPlayer] over [Player.Each] rebinds the body's controller to
+ * the current player in APNAP order, so `Patterns.Hand.discardHand()` (defaulting to the
+ * controller) and the draw both resolve for them. Discard-then-draw is sequenced per player rather
+ * than globally, which matters for a player whose library runs out: they still lose to the empty
+ * draw at the next state check, and the other players' hands are already gone.
+ *
+ * Miracle is the standard [KeywordAbility.miracle] first-draw-of-turn alternative cost.
+ */
+val ReforgeTheSoul = card("Reforge the Soul") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Each player discards their hand, then draws seven cards.\n" +
+        "Miracle {1}{R} (You may cast this card for its miracle cost when you draw it if it's the " +
+        "first card you drew this turn.)"
+
+    spell {
+        effect = Effects.ForEachPlayer(
+            players = Player.Each,
+            effects = listOf(
+                Patterns.Hand.discardHand(),
+                Effects.DrawCards(7),
+            ),
+        )
+    }
+
+    keywordAbility(KeywordAbility.miracle("{1}{R}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Jaime Jones"
+        flavorText = "In a wave of spells called the Cursemute, Avacyn cleansed the world with divine fire."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg?1783940679"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/DerangedAssistantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/DerangedAssistantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deranged Assistant reprint in CMR. Canonical CardDefinition lives in its earliest set (ISD).
+ */
+val DerangedAssistantReprint = Printing(
+    oracleId = "9e1b0034-bd2c-4412-8d81-db3306c8814f",
+    name = "Deranged Assistant",
+    setCode = "CMR",
+    collectorNumber = "65",
+    scryfallId = "73373421-c43d-4152-818a-55abc85b477a",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/73373421-c43d-4152-818a-55abc85b477a.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ThaliaHereticCathar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ThaliaHereticCathar.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+
+/**
+ * Thalia, Heretic Cathar
+ * {2}{W}
+ * Legendary Creature — Human Soldier
+ * 3/2
+ *
+ * First strike
+ * Creatures and nonbasic lands your opponents control enter tapped.
+ *
+ * The last ability is a global [PermanentsEnterTapped] runtime replacement (the group counterpart
+ * of the self-only `EntersTapped`), consulted from the battlefield whenever some *other* permanent
+ * enters — so `appliesTo` describes the *affected* permanents. Two separate replacements rather
+ * than one union filter, because "creature" and "nonbasic land" are independent characteristic
+ * checks: a nonbasic land that's also a creature (Dryad Arbor, an animated land) matches either
+ * one and still just enters tapped.
+ *
+ * The controller-relative `opponentControls()` predicate resolves against Thalia's own controller
+ * at entry time. Two consequences fall out for free and match the rulings:
+ * - Permanents entering *simultaneously* with Thalia are unaffected — the replacement only exists
+ *   once she is on the battlefield.
+ * - A conditional "enters tapped unless …" replacement on the affected permanent (Port Town) does
+ *   not save it: this effect taps it regardless, and per CR 614 only an `EntersUntapped` effect
+ *   could override the tap.
+ */
+val ThaliaHereticCathar = card("Thalia, Heretic Cathar") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "First strike\n" +
+        "Creatures and nonbasic lands your opponents control enter tapped."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    // Creatures your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // Nonbasic lands your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.NonbasicLand.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Magali Villeneuve"
+        flavorText = "\"Salvation will not be granted by the Lunarch Council. It must be earned—" +
+            "at the edge of a sword, if necessary.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg?1783937507"
+        ruling(
+            "2016-07-13",
+            "If an effect states that a creature or land enters the battlefield tapped unless a " +
+                "condition is met, Thalia's last ability has it enter tapped even if that condition " +
+                "is true."
+        )
+        ruling(
+            "2016-07-13",
+            "If Thalia enters the battlefield at the same time as an opponent's creatures or " +
+                "nonbasic lands, those creatures and lands aren't affected by Thalia's last ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DerangedAssistantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DerangedAssistantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deranged Assistant reprint in INR. Canonical CardDefinition lives in its earliest set (ISD).
+ */
+val DerangedAssistantReprint = Printing(
+    oracleId = "9e1b0034-bd2c-4412-8d81-db3306c8814f",
+    name = "Deranged Assistant",
+    setCode = "INR",
+    collectorNumber = "61",
+    scryfallId = "3960ed42-b3e7-4464-b345-1b9b22719efc",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/3960ed42-b3e7-4464-b345-1b9b22719efc.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MetallicMimicReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MetallicMimicReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Metallic Mimic reprint in INR. Canonical CardDefinition lives in its earliest set (AER).
+ */
+val MetallicMimicReprint = Printing(
+    oracleId = "1f91297a-ec2b-4ea8-9198-aa1daac20ff8",
+    name = "Metallic Mimic",
+    setCode = "INR",
+    collectorNumber = "268",
+    scryfallId = "9ad98263-9fe6-4766-a9fb-4776e570c250",
+    artist = "Maxime Minard",
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9ad98263-9fe6-4766-a9fb-4776e570c250.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MoonlightHuntReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MoonlightHuntReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moonlight Hunt reprint in INR. Canonical CardDefinition lives in its earliest set (SOI).
+ */
+val MoonlightHuntReprint = Printing(
+    oracleId = "f38a6cb4-79dd-4c12-9896-8c6655e275f8",
+    name = "Moonlight Hunt",
+    setCode = "INR",
+    collectorNumber = "209",
+    scryfallId = "6d36aecd-4bd8-4350-9161-e6feecc09bb9",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d36aecd-4bd8-4350-9161-e6feecc09bb9.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ReforgeTheSoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ReforgeTheSoulReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reforge the Soul reprint in INR. Canonical CardDefinition lives in its earliest set (AVR).
+ */
+val ReforgeTheSoulReprint = Printing(
+    oracleId = "ece854f8-8c60-4f30-894f-2286d3dd61b9",
+    name = "Reforge the Soul",
+    setCode = "INR",
+    collectorNumber = "167",
+    scryfallId = "1c3509c6-2ae7-45be-8ac9-4d14d69db32f",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c3509c6-2ae7-45be-8ac9-4d14d69db32f.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ThaliaHereticCatharReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ThaliaHereticCatharReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thalia, Heretic Cathar reprint in INR. Canonical CardDefinition lives in its earliest set (EMN).
+ */
+val ThaliaHereticCatharReprint = Printing(
+    oracleId = "13be47e4-9da2-4f9e-baf0-db96f7777ccb",
+    name = "Thalia, Heretic Cathar",
+    setCode = "INR",
+    collectorNumber = "44",
+    scryfallId = "c062937f-d519-4206-99b0-cbea01b85a0d",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c062937f-d519-4206-99b0-cbea01b85a0d.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DerangedAssistant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DerangedAssistant.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Deranged Assistant
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/1
+ *
+ * {T}, Mill a card: Add {C}.
+ *
+ * The mill is part of the *cost*, not the effect — `Costs.MillCard` (CostAtom.Mill). Two things
+ * follow from that, and both are why this can't be modelled as "add mana, then mill":
+ * - Per CR 701.17b the ability can't be activated at all with an empty library, so the mill cost
+ *   gates legal-action enumeration rather than fizzling at resolution.
+ * - Being a mana ability, the cost is paid immediately on activation and (per ruling) can't be
+ *   reversed: back out of the spell you were casting and the mana is still gone and the card is
+ *   still milled.
+ */
+val DerangedAssistant = card("Deranged Assistant") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library " +
+        "into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.MillCard)
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Nils Hamm"
+        flavorText = "\"Garl, adjust the slurry dispensers. Garl, fetch more corpses. Garl, quit " +
+            "crying and give me your brain tissue. If he doesn't stop being so rude, I'm quitting.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg?1783940977"
+        ruling(
+            "2025-01-24",
+            "Once Deranged Assistant's ability has been activated, it can't be reversed for any " +
+                "reason. If you activate it while casting a spell and discover you can't produce " +
+                "enough mana to pay that spell's costs, the spell is reversed, but Deranged " +
+                "Assistant's ability isn't — you'll still have the mana it produced and the milled " +
+                "card will still be in your graveyard."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MoonlightHuntReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MoonlightHuntReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moonlight Hunt reprint in J22. Canonical CardDefinition lives in its earliest set (SOI).
+ */
+val MoonlightHuntReprint = Printing(
+    oracleId = "f38a6cb4-79dd-4c12-9896-8c6655e275f8",
+    name = "Moonlight Hunt",
+    setCode = "J22",
+    collectorNumber = "692",
+    scryfallId = "63f7afc6-dcc2-45ce-99e8-696cd5a11466",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/6/3/63f7afc6-dcc2-45ce-99e8-696cd5a11466.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MoonlightHunt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MoonlightHunt.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Moonlight Hunt
+ * {1}{G}
+ * Instant
+ *
+ * Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf
+ * deals damage equal to its power to that creature.
+ *
+ * A one-sided gang-up: [Effects.ForEachInGroup] walks the Wolves and Werewolves you control at
+ * resolution — an untargeted group, so a pack member entering or leaving between cast and
+ * resolution is simply included or not — and each one deals damage *itself*
+ * (`damageSource = EffectTarget.Self`, the iterated permanent) equal to its own power, read
+ * per-iteration via [EntityReference.IterationEntity] so lords and pump are picked up individually.
+ *
+ * Two details the wording forces:
+ * - The damage sources matter, not just the total: deathtouch, lifelink, and "damage dealt by a
+ *   Werewolf" triggers all key off the individual creature, which is why this can't collapse into a
+ *   single summed damage event.
+ * - Power is read as each creature deals its damage, and the whole loop is one resolution, so a
+ *   creature that dies to an earlier pack member's damage… doesn't: damage isn't lethal until the
+ *   state check after the spell finishes resolving, so every pack member deals its full damage.
+ */
+val MoonlightHunt = card("Moonlight Hunt") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose target creature you don't control. Each creature you control that's a " +
+        "Wolf or a Werewolf deals damage equal to its power to that creature."
+
+    spell {
+        target("creature you don't control", Targets.CreatureOpponentControls)
+
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withAnySubtype("Wolf", "Werewolf").youControl()
+            ),
+            effect = Effects.DealDamage(
+                amount = DynamicAmount.EntityProperty(
+                    EntityReference.IterationEntity,
+                    EntityNumericProperty.Power,
+                ),
+                target = EffectTarget.ContextTarget(0),
+                damageSource = EffectTarget.Self,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Joseph Meehan"
+        flavorText = "Courage alone won't keep you alive."
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg?1783937725"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -33,6 +33,70 @@
     ]
 }
 
+// Metallic Mimic
+{
+    "name": "Metallic Mimic",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Shapeshifter",
+    "oracleText": "As this creature enters, choose a creature type.\nThis creature is the chosen type in addition to its other types.\nEach other creature you control of the chosen type enters with an additional +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            "GrantChosenSubtype"
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "otherOnly": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "HasChosenSubtype"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Zack Stella",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1aa4eba9-9e91-4beb-9296-a18baa73a318.jpg?1783936724",
+        "rulings": [
+            {
+                "date": "2017-02-09",
+                "text": "The choice of creature type is made as Metallic Mimic enters the battlefield. Players can't respond to this choice. Metallic Mimic's second ability starts applying immediately."
+            },
+            {
+                "date": "2017-02-09",
+                "text": "Even though Metallic Mimic is a Shapeshifter, other Shapeshifter creatures you control won't get a +1/+1 counter unless you chose Shapeshifter as Metallic Mimic entered the battlefield."
+            },
+            {
+                "date": "2017-02-09",
+                "text": "You must choose an existing creature type. \"Artifact\" and \"Vehicle\" aren't creature types."
+            },
+            {
+                "date": "2017-02-09",
+                "text": "Creatures of the chosen type that enter the battlefield at the same time as Metallic Mimic won't enter with an additional +1/+1 counter."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Universal Solvent
 {
     "name": "Universal Solvent",

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -792,6 +792,76 @@
     ]
 }
 
+// Reforge the Soul
+{
+    "name": "Reforge the Soul",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player discards their hand, then draws seven cards.\nMiracle {1}{R} (You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)",
+    "keywords": [
+        "MIRACLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Miracle",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Players",
+                "players": "Each"
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "discardedHand"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discardedHand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 7
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Jaime Jones",
+        "flavorText": "In a wave of spells called the Cursemute, Avacyn cleansed the world with divine fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36506caa-2630-46ec-9aa0-e1885749ad90.jpg?1783940679"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Restoration Angel
 {
     "name": "Restoration Angel",

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1581,6 +1581,70 @@
     ]
 }
 
+// Thalia, Heretic Cathar
+{
+    "name": "Thalia, Heretic Cathar",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "First strike\nCreatures and nonbasic lands your opponents control enter tapped.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            },
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsLand",
+                            {
+                                "type": "Not",
+                                "predicate": "IsBasicLand"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByOpponent"
+                    },
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"Salvation will not be granted by the Lunarch Council. It must be earned—at the edge of a sword, if necessary.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab0cee38-5e24-49d0-870c-22843ed4e101.jpg?1783937507",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "If an effect states that a creature or land enters the battlefield tapped unless a condition is met, Thalia's last ability has it enter tapped even if that condition is true."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If Thalia enters the battlefield at the same time as an opponent's creatures or nonbasic lands, those creatures and lands aren't affected by Thalia's last ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thermo-Alchemist
 {
     "name": "Thermo-Alchemist",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -811,6 +811,59 @@
     "colorIdentityOverride": []
 }
 
+// Deranged Assistant
+{
+    "name": "Deranged Assistant",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{T}, Mill a card: Add {C}. (To mill a card, put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomMill"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Garl, adjust the slurry dispensers. Garl, fetch more corpses. Garl, quit crying and give me your brain tissue. If he doesn't stop being so rude, I'm quitting.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4c03171-5ff0-4f79-bb03-16decf7d34ce.jpg?1783940977",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "Once Deranged Assistant's ability has been activated, it can't be reversed for any reason. If you activate it while casting a spell and discover you can't produce enough mana to pay that spell's costs, the spell is reversed, but Deranged Assistant's ability isn't — you'll still have the mana it produced and the milled card will still be in your graveyard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Desperate Ravings
 {
     "name": "Desperate Ravings",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -916,6 +916,57 @@
     ]
 }
 
+// Moonlight Hunt
+{
+    "name": "Moonlight Hunt",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf deals damage equal to its power to that creature.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature Wolf|Werewolf ctrl:you"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "EntityProperty",
+                    "entity": "IterationEntity",
+                    "numericProperty": "Power"
+                },
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "damageSource": "Self"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "creature you don't control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Meehan",
+        "flavorText": "Courage alone won't keep you alive.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9633603-a80f-448d-98d9-00064d379c26.jpg?1783937725"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Open the Armory
 {
     "name": "Open the Armory",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.handlers.effects.library.MillAmountModifier
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.mechanics.mana.ManaPool
@@ -576,6 +577,10 @@ class CostHandler {
             val zone = ZoneKey(controllerId, atom.zone)
             findMatchingCardsUnified(state, state.getZone(zone), atom.filter, controllerId).size >= atom.count
         }
+        // CR 701.17b — a player can't pay a cost that includes milling more cards than their
+        // library holds. Checked against the printed count; a ModifyMillAmount replacement only
+        // enlarges the mill once the cost is actually being paid.
+        is CostAtom.Mill -> state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).size >= atom.count
         is CostAtom.TapPermanents -> {
             val candidates = findUntappedMatchingPermanentsUnified(state, controllerId, atom.filter)
                 .let { targets -> if (atom.excludeSelf) targets.filter { it != sourceId } else targets }
@@ -669,6 +674,18 @@ class CostHandler {
         }
         is CostAtom.ExileFrom ->
             exileCardsFromZone(state, controllerId, atom.zone, atom.count, atom.filter, choices.exileChoices, manaPool)
+        is CostAtom.Mill -> {
+            // Same announcement semantics as the mill effect (GatherCardsExecutor): apply
+            // ModifyMillAmount replacements once to the announced count (CR 616), then take that
+            // many off the top. `take` clamps, so a replacement that enlarges the mill past the
+            // library mills as many as possible — the affordability check above already guaranteed
+            // the printed count is available. Emits plain library→graveyard zone changes, which is
+            // what mill triggers match on.
+            val effectiveCount = MillAmountModifier.apply(state, controllerId, atom.count)
+            val milled = state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).take(effectiveCount)
+            val result = ZoneTransitionService.moveToZoneBatch(state, milled, Zone.GRAVEYARD)
+            CostPaymentResult.success(result.state, manaPool, result.events)
+        }
         is CostAtom.TapPermanents -> payTapPermanents(state, atom, sourceId, controllerId, manaPool, choices)
         is CostAtom.ReturnToHand -> payReturnToHand(state, atom, controllerId, manaPool, choices)
         is CostAtom.RevealFromHand ->
@@ -1044,12 +1061,12 @@ class CostHandler {
                         total >= needed
                     }
                 }
-                // Mana / return-to-hand / reveal / put-counters-on-self / exile-permanents are not
-                // produced as spell additional costs today (put-counters-on-self is inherently
-                // ability-scoped — a spell on the stack has no permanent to put the counters on; and
-                // ExilePermanents is an activated-ability cost only).
+                // Mana / return-to-hand / reveal / put-counters-on-self / exile-permanents / mill
+                // are not produced as spell additional costs today (put-counters-on-self is
+                // inherently ability-scoped — a spell on the stack has no permanent to put the
+                // counters on; and ExilePermanents is an activated-ability cost only).
                 is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand,
-                is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents -> false
+                is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents, is CostAtom.Mill -> false
             }
             is AdditionalCost.PayLifePerTarget -> {
                 // Always payable: choosing zero targets pays zero life. Per-target life

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1550,10 +1550,12 @@ class CastSpellHandler(
                         }
                     }
                     // Mana / reveal are not produced as spell additional costs today;
-                    // put-counters-on-self is ability-scoped (no permanent to accrue them on) and
-                    // ExilePermanents is an activated-ability-only cost, never a spell additional cost.
+                    // put-counters-on-self is ability-scoped (no permanent to accrue them on);
+                    // ExilePermanents and Mill are activated-ability-only costs, never spell
+                    // additional costs (canPayAdditionalCost already reports Mill unpayable).
                     is CostAtom.Mana, is CostAtom.RevealFromHand,
-                    is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents -> {}
+                    is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents,
+                    is CostAtom.Mill -> {}
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> c.amount
@@ -2333,10 +2335,12 @@ class CastSpellHandler(
                         }
                         // PayLife is auto-paid in the loop above; mana / reveal aren't spell additional
                         // costs; put-counters-on-self is ability-scoped (a spell on the stack has no
-                        // permanent to accrue them on) and ExilePermanents is an activated-ability-only
-                        // cost, never a spell additional cost.
+                        // permanent to accrue them on); ExilePermanents and Mill are
+                        // activated-ability-only costs, never spell additional costs (and
+                        // canPayAdditionalCost reports Mill unpayable, so this is unreachable).
                         is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand,
-                        is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents -> {}
+                        is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents,
+                        is CostAtom.Mill -> {}
                         is CostAtom.RemoveCounters -> {
                             val resolvedRemovals = resolveDistributedCounterRemovalsForPayment(action)
                             for (removal in resolvedRemovals) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -48,8 +48,9 @@ class CostPaymentContinuationResumer(
         is PayCost.OwnManaCost ->
             ExecutionResult.error(state, "OwnManaCost should have been resolved before payment")
         is PayCost.Atom -> when (val atom = cost.atom) {
-            // Yes/no costs: mana, life, and random discard.
-            is CostAtom.Mana, is CostAtom.PayLife ->
+            // Yes/no costs: mana, life, mill (the milled cards are the top of the library, so
+            // there is nothing to select), and random discard.
+            is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill ->
                 resumeYesNo(state, continuation, cost, response, checkForMore)
             is CostAtom.Discard ->
                 if (atom.random) resumeYesNo(state, continuation, cost, response, checkForMore)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -104,6 +104,10 @@ object EntersWithReplacements {
         for (effect in cardDef.script.replacementEffects) {
             when (effect) {
                 is EntersWithCounters -> {
+                    // Skip "other only" effects when applying to self (Metallic Mimic's "each other
+                    // creature you control … enters with an additional +1/+1 counter" must not
+                    // counter the Mimic itself). Mirrors the EntersWithDynamicCounters path below.
+                    if (effect.otherOnly) continue
                     if (effect.condition != null) {
                         val condContext = EffectContext(
                             sourceId = entityId,
@@ -192,7 +196,7 @@ object EntersWithReplacements {
                 when (effect) {
                     is EntersWithCounters -> {
                         if (effect.selfOnly) continue
-                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
+                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, newState)) continue
                         if (effect.condition != null) {
                             // A non-self "enters with counters" condition describes the ENTERING
                             // creature ("it was cast from your graveyard", Leonardo), not the
@@ -220,7 +224,7 @@ object EntersWithReplacements {
                     }
                     is EntersWithDynamicCounters -> {
                         if (!effect.otherOnly) continue
-                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
+                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, newState)) continue
                         val counterType = resolveCounterType(effect.counterType)
                         // An "enters with N counters" count always describes the ENTERING object,
                         // not the replacement source — the counters go on the entering permanent and
@@ -251,7 +255,7 @@ object EntersWithReplacements {
                     }
                     is EntersWithKeywords -> {
                         if (effect.selfOnly) continue
-                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
+                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceId, sourceControllerId, newState)) continue
                         // Like the counters branch above: the condition describes the ENTERING
                         // permanent; controllerId stays the source's controller.
                         if (effect.condition != null) {
@@ -317,9 +321,21 @@ object EntersWithReplacements {
         return newState to events
     }
 
+    /**
+     * Does [enteringEntityId] match the `appliesTo` filter of a replacement carried by
+     * [replacementSourceId]?
+     *
+     * `sourceId` in the predicate context is the **replacement's source**, not the entering
+     * permanent: `appliesTo` describes the affected permanents *relative to the source*, so
+     * source-relative predicates have to resolve against it — `HasChosenSubtype` reads the type
+     * chosen as the source entered (Metallic Mimic), and `excludeSelf` means "other than the
+     * source". (Conditions are the opposite and keep `sourceId = enteringEntityId`, because an
+     * "enters with counters" condition describes the entering permanent — see the call sites.)
+     */
     private fun matchesEnterFilter(
         event: com.wingedsheep.sdk.scripting.EventPattern,
         enteringEntityId: EntityId,
+        replacementSourceId: EntityId,
         sourceControllerId: EntityId,
         state: GameState,
     ): Boolean {
@@ -328,7 +344,7 @@ object EntersWithReplacements {
         val filter = event.filter
 
         val predicateContext = PredicateContext(
-            sourceId = enteringEntityId,
+            sourceId = replacementSourceId,
             controllerId = sourceControllerId
         )
         return predicateEvaluator.matches(state, state.projectedState, enteringEntityId, filter, predicateContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -87,6 +87,7 @@ class PayOrSufferExecutor(
                 is CostAtom.ReturnToHand -> EffectResult.error(state, "ReturnToHand payment for PayOrSuffer not yet implemented")
                 is CostAtom.RevealFromHand -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
                 is CostAtom.PutCountersOnSelf -> EffectResult.error(state, "PutCountersOnSelf is an activated-ability cost, not a PayOrSuffer cost")
+                is CostAtom.Mill -> EffectResult.error(state, "Mill payment for PayOrSuffer not yet implemented")
                 is CostAtom.ExilePermanents -> EffectResult.error(state, "ExilePermanents payment for PayOrSuffer not supported")
                 is CostAtom.RemoveCounters -> handleRemoveCountersCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
             }
@@ -714,6 +715,9 @@ class PayOrSufferExecutor(
                 is CostAtom.RevealFromHand -> false
                 is CostAtom.PutCountersOnSelf -> false
                 is CostAtom.ExilePermanents -> false
+                // No printed PayOrSuffer cost mills, and the execute branch above has no handler,
+                // so report it unpayable rather than offering a prompt that would error out.
+                is CostAtom.Mill -> false
                 is CostAtom.RemoveCounters -> {
                     // Can pay if there are permanents matching the filter with enough counters.
                     // Don't exclude the source — removing counters from the source itself is a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -280,6 +280,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         // fall-through behavior for these costs). Putting counters on the source
                         // costs nothing the player must have, so it never gates enumeration either.
                         is CostAtom.PayLife, is CostAtom.RevealFromHand, is CostAtom.PutCountersOnSelf -> {}
+                        // CR 701.17b — a mill cost is unpayable when the library holds fewer cards.
+                        // No selection: the milled cards are the top of the library.
+                        is CostAtom.Mill -> {
+                            if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) continue
+                        }
                         is CostAtom.RemoveCounters -> {
                             val needed = when (val count = atom.count) {
                                 is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> count.amount
@@ -442,6 +447,14 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     // gate here (matching the prior else fall-through for these sub-costs).
                                     is CostAtom.PayLife, is CostAtom.RevealFromHand,
                                     is CostAtom.PutCountersOnSelf -> {}
+                                    // CR 701.17b — a mill cost is unpayable when the library holds
+                                    // fewer cards. No selection: the milled cards are the top.
+                                    is CostAtom.Mill -> {
+                                        if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                    }
                                     is CostAtom.RemoveCounters -> {
                                         val needed = when (val count = atom.count) {
                                             is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> count.amount

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -156,6 +156,12 @@ class ManaAbilityEnumerator : ActionEnumerator {
                             )
                             if (sacrificeTargets.size < atom.count) affordable = false
                         }
+                        // CR 701.17b — a mill cost is unpayable when the library holds fewer cards,
+                        // so the mana ability isn't legal at all (Deranged Assistant on an empty
+                        // library).
+                        is CostAtom.Mill -> {
+                            if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) affordable = false
+                        }
                         // Other atoms (mana, life, discard, …) — engine validates at payment.
                         else -> {}
                     }
@@ -214,6 +220,12 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     }
                                     is CostAtom.ReturnToHand -> {
                                         // Bounce costs not typical for mana abilities but handle for completeness
+                                    }
+                                    // CR 701.17b — see the single-atom branch above.
+                                    is CostAtom.Mill -> {
+                                        if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) {
+                                            affordable = false; break
+                                        }
                                     }
                                     // Other atoms (life, discard, exile, reveal) — engine validates at payment.
                                     else -> {}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.handlers.effects.library.MillAmountModifier
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -130,6 +131,10 @@ class CostPaymentService(private val services: EngineServices) {
                     }
                 is CostAtom.ExileFrom ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInZone(state, payerId, atom.filter, atom.zone), atom.count, useTargetingUI = atom.zone == Zone.BATTLEFIELD)
+                // Milling takes no selection — the cards are the top of the library — so this is a
+                // plain yes/no like paying life.
+                is CostAtom.Mill ->
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "${atom.description.replaceFirstChar { it.uppercase() }}?", atom.description.replaceFirstChar { it.uppercase() })
                 is CostAtom.RevealFromHand ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, atom.filter), atom.count, useTargetingUI = false)
                 is CostAtom.Sacrifice ->
@@ -308,6 +313,7 @@ class CostPaymentService(private val services: EngineServices) {
                 if (atom.random) discardRandom(state, payerId, atom.filter, atom.count)
                 else discardSelected(state, payerId, selected.keys.toList())
             is CostAtom.ExileFrom -> exileSelected(state, payerId, selected.keys.toList(), atom.zone)
+            is CostAtom.Mill -> millTop(state, payerId, atom.count)
             is CostAtom.RevealFromHand -> revealSelected(state, payerId, selected.keys.toList())
             is CostAtom.Sacrifice -> sacrificeSelected(state, payerId, selected.keys.toList())
             is CostAtom.ReturnToHand -> returnSelected(state, selected.keys.toList())
@@ -523,6 +529,19 @@ class CostPaymentService(private val services: EngineServices) {
         return CostPaymentExecution(newState, events, success = true)
     }
 
+    /**
+     * Mill the top [count] cards as a cost payment (CR 701.17a). Mirrors `CostHandler.payAtom`'s
+     * mill branch: the announced count runs through the [MillAmountModifier] replacement chokepoint
+     * (CR 616) and the library→graveyard moves go through [ZoneTransitionService] so mill triggers
+     * and animations see the canonical zone changes.
+     */
+    private fun millTop(state: GameState, payerId: EntityId, count: Int): CostPaymentExecution {
+        val effectiveCount = MillAmountModifier.apply(state, payerId, count)
+        val milled = state.getZone(ZoneKey(payerId, Zone.LIBRARY)).take(effectiveCount)
+        val result = ZoneTransitionService.moveToZoneBatch(state, milled, Zone.GRAVEYARD)
+        return CostPaymentExecution(result.state, result.events, success = true)
+    }
+
     private fun exileSelected(state: GameState, payerId: EntityId, selected: List<EntityId>, zone: Zone): CostPaymentExecution {
         val fromZone = ZoneKey(payerId, zone)
         val exileZone = ZoneKey(payerId, Zone.EXILE)
@@ -624,6 +643,8 @@ class CostPaymentService(private val services: EngineServices) {
                     is CostAtom.PayLife -> life(state, payerId) >= atom.amount
                     is CostAtom.Discard -> cardsInHand(state, payerId, atom.filter).size >= atom.count
                     is CostAtom.ExileFrom -> cardsInZone(state, payerId, atom.filter, atom.zone).size >= atom.count
+                    // CR 701.17b — a mill cost is unpayable when the library holds fewer cards.
+                    is CostAtom.Mill -> state.getZone(ZoneKey(payerId, Zone.LIBRARY)).size >= atom.count
                     is CostAtom.RevealFromHand -> cardsInHand(state, payerId, atom.filter).size >= atom.count
                     is CostAtom.Sacrifice -> {
                         val candidates = controlledMatching(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DerangedAssistantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DerangedAssistantScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.cards.DerangedAssistant
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Deranged Assistant (ISD #52) — {1}{U} 1/1 Human Wizard, "{T}, Mill a card: Add {C}."
+ *
+ * Covers the `CostAtom.Mill` cost vocabulary this card introduced:
+ * - payment mills the top card and produces {C} (happy path),
+ * - CR 701.17b — the mana ability is surfaced as unaffordable on an empty library and submitting it
+ *   anyway is rejected, rather than silently producing free mana,
+ * - the mill is a *cost*, so the card is already in the graveyard by the time the mana exists.
+ */
+class DerangedAssistantScenarioTest : FunSpec({
+
+    val abilityId = DerangedAssistant.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DerangedAssistant)
+        return driver
+    }
+
+    fun libraryOf(driver: GameTestDriver, playerId: com.wingedsheep.sdk.model.EntityId) =
+        driver.state.getZone(ZoneKey(playerId, Zone.LIBRARY))
+
+    test("activating mills the top card of your library and adds {C}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val assistant = driver.putCreatureOnBattlefield(you, "Deranged Assistant")
+        driver.removeSummoningSickness(assistant)
+
+        val libraryBefore = libraryOf(driver, you)
+        val topCard = libraryBefore.first()
+        val graveyardBefore = driver.getGraveyard(you).size
+
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = assistant, abilityId = abilityId))
+
+        // {C} produced.
+        driver.state.getEntity(you)?.get<ManaPoolComponent>()?.colorless shouldBe 1
+        // Tapped as part of the cost.
+        driver.isTapped(assistant) shouldBe true
+        // The top card is now in the graveyard — one card, off the top, not a chosen one.
+        libraryOf(driver, you).size shouldBe libraryBefore.size - 1
+        driver.getGraveyard(you).size shouldBe graveyardBefore + 1
+        (topCard in driver.getGraveyard(you)) shouldBe true
+        (topCard in libraryOf(driver, you)) shouldBe false
+    }
+
+    test("CR 701.17b — the ability is unaffordable and rejected with an empty library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val assistant = driver.putCreatureOnBattlefield(you, "Deranged Assistant")
+        driver.removeSummoningSickness(assistant)
+
+        fun assistantAction() = driver.legalActions(you)
+            .single { it.action.let { a -> a is ActivateAbility && a.sourceId == assistant } }
+
+        // With a library, the mana ability is offered and affordable.
+        assistantAction().affordable shouldBe true
+
+        driver.replaceState(
+            driver.state.copy(zones = driver.state.zones + (ZoneKey(you, Zone.LIBRARY) to emptyList()))
+        )
+
+        // Empty library: the mill cost can't be paid, so the ability is surfaced as unaffordable…
+        assistantAction().affordable shouldBe false
+
+        // …and submitting it anyway is rejected — no free {C}.
+        val result = driver.submit(ActivateAbility(playerId = you, sourceId = assistant, abilityId = abilityId))
+        result.isSuccess shouldBe false
+        driver.state.getEntity(you)?.get<ManaPoolComponent>()?.colorless shouldBe 0
+        driver.isTapped(assistant) shouldBe false
+    }
+
+    test("the mill happens as a cost, so the ability can't be activated twice off one tap") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val assistant = driver.putCreatureOnBattlefield(you, "Deranged Assistant")
+        driver.removeSummoningSickness(assistant)
+
+        val libraryBefore = libraryOf(driver, you).size
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = assistant, abilityId = abilityId))
+        val second = driver.submit(ActivateAbility(playerId = you, sourceId = assistant, abilityId = abilityId))
+
+        second.isSuccess shouldBe false
+        // Exactly one card milled — the failed second activation paid nothing.
+        libraryOf(driver, you).size shouldBe libraryBefore - 1
+        driver.state.getEntity(you)?.get<ManaPoolComponent>()?.colorless shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MetallicMimicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MetallicMimicScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.aer.cards.MetallicMimic
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private val projector = StateProjector()
+
+/**
+ * Metallic Mimic (AER #164) — {2} 2/1 Artifact Creature — Shapeshifter
+ *
+ * "As this creature enters, choose a creature type.
+ *  This creature is the chosen type in addition to its other types.
+ *  Each other creature you control of the chosen type enters with an additional +1/+1 counter on it."
+ *
+ * Exercises the counter-granting replacement through a *real* cast, since the entering-permanent
+ * replacement path is what decides whether the chosen type is read off the Mimic (correct) or off
+ * the entering creature.
+ */
+class MetallicMimicScenarioTest : FunSpec({
+
+    val goblin = CardDefinition.creature(
+        name = "Test Goblin",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 1,
+        toughness = 1
+    )
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MetallicMimic, goblin, bear))
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /**
+     * Cast [cardName] from hand off injected mana and let it resolve. Casting for real (rather than
+     * `putCreatureOnBattlefield`) is the point: only the resolution path runs the enters-with
+     * replacements this card is about.
+     */
+    fun castAndResolve(driver: GameTestDriver, playerId: EntityId, cardName: String): EntityId {
+        val cardId = driver.putCardInHand(playerId, cardName)
+        driver.giveColorlessMana(playerId, 2)
+        driver.submitSuccess(
+            com.wingedsheep.engine.core.CastSpell(
+                playerId = playerId,
+                cardId = cardId,
+                paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool,
+            )
+        )
+        driver.bothPass()
+        return cardId
+    }
+
+    /** Answer the "choose a creature type" entry choice with [type]. */
+    fun chooseCreatureType(driver: GameTestDriver, playerId: EntityId, type: String) {
+        val decision = driver.pendingDecision as ChooseOptionDecision
+        val index = decision.options.indexOfFirst { it.equals(type, ignoreCase = true) }
+        require(index >= 0) { "No option '$type' among ${decision.options.take(20)}…" }
+        driver.submitDecision(playerId, OptionChosenResponse(decision.id, index))
+    }
+
+    test("other creatures you control of the chosen type enter with an extra +1/+1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mimic = castAndResolve(driver, you, "Metallic Mimic")
+        chooseCreatureType(driver, you, "Goblin")
+
+        // The Mimic is the chosen type in addition to Shapeshifter…
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(mimic, "Goblin") shouldBe true
+        projected.hasSubtype(mimic, "Shapeshifter") shouldBe true
+        // …and "each OTHER creature" excludes itself: no counter of its own.
+        plusOneCounters(driver, mimic) shouldBe 0
+        projected.getPower(mimic) shouldBe 2
+        projected.getToughness(mimic) shouldBe 1
+
+        // A Goblin entering afterwards gets the counter.
+        val goblinId = castAndResolve(driver, you, "Test Goblin")
+        plusOneCounters(driver, goblinId) shouldBe 1
+        projector.project(driver.state).getPower(goblinId) shouldBe 2
+
+        // A creature of another type does not.
+        val bearId = castAndResolve(driver, you, "Test Bear")
+        plusOneCounters(driver, bearId) shouldBe 0
+        projector.project(driver.state).getPower(bearId) shouldBe 2
+    }
+
+    test("only creatures YOU control get the counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        castAndResolve(driver, you, "Metallic Mimic")
+        chooseCreatureType(driver, you, "Goblin")
+
+        // Advance to the opponent's turn so they can cast a creature at sorcery speed. Their Goblin
+        // gets no counter — it isn't a creature the Mimic's controller controls.
+        while (driver.activePlayer != opponent) {
+            driver.passPriorityUntil(Step.END)
+            driver.bothPass()
+        }
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val theirGoblin = castAndResolve(driver, opponent, "Test Goblin")
+
+        plusOneCounters(driver, theirGoblin) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlightHuntScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoonlightHuntScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.cards.MoonlightHunt
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Moonlight Hunt (SOI #219) — {1}{G} Instant
+ *
+ * "Choose target creature you don't control. Each creature you control that's a Wolf or a Werewolf
+ *  deals damage equal to its power to that creature."
+ *
+ * The interesting wiring is per-iteration: each pack member is both the damage *source* and the
+ * source of the *amount*. Differently-sized Wolves catch a loop that reads one creature's power for
+ * every iteration, and a Bear plus an opposing Wolf catch a filter that's too wide.
+ */
+class MoonlightHuntScenarioTest : FunSpec({
+
+    fun creature(name: String, subtype: String, power: Int, toughness: Int) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype(subtype)),
+        power = power,
+        toughness = toughness
+    )
+
+    val wolf = creature("Test Wolf", "Wolf", 2, 2)
+    val werewolf = creature("Test Werewolf", "Werewolf", 3, 3)
+    val bear = creature("Test Bear", "Bear", 4, 4)
+    val victim = creature("Test Victim", "Ox", 1, 9)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MoonlightHunt, werewolf, wolf, bear, victim))
+        return driver
+    }
+
+    fun damageOn(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<DamageComponent>()?.amount ?: 0
+
+    fun castHunt(driver: GameTestDriver, playerId: EntityId, target: EntityId) {
+        val hunt = driver.putCardInHand(playerId, "Moonlight Hunt")
+        driver.giveMana(playerId, Color.GREEN, 2)
+        driver.castSpell(playerId, hunt, listOf(target))
+        driver.bothPass()
+    }
+
+    test("every Wolf and Werewolf you control deals its own power to the target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Test Wolf")          // 2 power  → counts
+        driver.putCreatureOnBattlefield(you, "Test Werewolf")      // 3 power  → counts
+        driver.putCreatureOnBattlefield(you, "Test Bear")          // 4 power, wrong type → 0
+        driver.putCreatureOnBattlefield(opponent, "Test Wolf")     // a Wolf, but not yours → 0
+        val target = driver.putCreatureOnBattlefield(opponent, "Test Victim")
+
+        castHunt(driver, you, target)
+
+        // Exactly 2 + 3. Anything that read a single creature's power, or swept in the Bear or the
+        // opponent's Wolf, lands on a different number.
+        damageOn(driver, target) shouldBe 5
+        (target in driver.getPermanents(opponent)) shouldBe true
+    }
+
+    test("with no Wolves or Werewolves the spell resolves and deals nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Test Bear")
+        val target = driver.putCreatureOnBattlefield(opponent, "Test Victim")
+
+        castHunt(driver, you, target)
+
+        driver.state.stack.size shouldBe 0
+        damageOn(driver, target) shouldBe 0
+        (target in driver.getPermanents(opponent)) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReforgeTheSoulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReforgeTheSoulScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.ReforgeTheSoul
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Reforge the Soul (AVR #151) — {3}{R}{R} Sorcery
+ *
+ * "Each player discards their hand, then draws seven cards.
+ *  Miracle {1}{R}"
+ *
+ * A symmetric wheel over `ForEachPlayer(Player.Each)`: the per-player body must rebind to the player
+ * being processed, so the check that matters is that *both* players end on seven cards with their old
+ * hands in their graveyards — not that the caster wheels twice.
+ */
+class ReforgeTheSoulScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ReforgeTheSoul)
+        return driver
+    }
+
+    test("each player discards their hand and draws seven") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val reforge = driver.putCardInHand(you, "Reforge the Soul")
+        val yourOtherCards = driver.getHand(you).filter { it != reforge }
+        val theirCards = driver.getHand(opponent)
+        yourOtherCards.isNotEmpty() shouldBe true
+        theirCards.isNotEmpty() shouldBe true
+
+        driver.giveColorlessMana(you, 3)
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = you, cardId = reforge, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        // Both players wheeled.
+        driver.getHandSize(you) shouldBe 7
+        driver.getHandSize(opponent) shouldBe 7
+
+        // Their old hands were discarded, not shuffled away.
+        val yourGraveyard = driver.getGraveyard(you)
+        yourOtherCards.all { it in yourGraveyard } shouldBe true
+        val theirGraveyard = driver.getGraveyard(opponent)
+        theirCards.all { it in theirGraveyard } shouldBe true
+
+        // The spell itself resolved and is in its owner's graveyard (it isn't discarded — it was on
+        // the stack when hands were discarded).
+        (reforge in yourGraveyard) shouldBe true
+    }
+
+    test("an empty hand still draws seven") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Empty the opponent's hand before the wheel.
+        driver.replaceState(
+            driver.state.copy(
+                zones = driver.state.zones +
+                    (com.wingedsheep.engine.state.ZoneKey(opponent, com.wingedsheep.sdk.core.Zone.HAND) to emptyList())
+            )
+        )
+        driver.getHandSize(opponent) shouldBe 0
+
+        val reforge = driver.putCardInHand(you, "Reforge the Soul")
+        driver.giveColorlessMana(you, 3)
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = you, cardId = reforge, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+
+        driver.getHandSize(opponent) shouldBe 7
+        driver.getHandSize(you) shouldBe 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThaliaHereticCatharScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThaliaHereticCatharScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.emn.cards.ThaliaHereticCathar
+import com.wingedsheep.mtg.sets.definitions.ice.cards.AdarkarWastes
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thalia, Heretic Cathar (EMN #46) — {2}{W} 3/2 Legendary Creature — Human Soldier
+ *
+ * "First strike
+ *  Creatures and nonbasic lands your opponents control enter tapped."
+ *
+ * Two independent `PermanentsEnterTapped` replacements, so the test covers both halves plus the
+ * cases they must *not* touch: your own permanents, and your opponents' basic lands.
+ */
+class ThaliaHereticCatharScenarioTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThaliaHereticCathar, bear, AdarkarWastes))
+        return driver
+    }
+
+    /** Cast [cardName] off injected mana and let it resolve. */
+    fun castAndResolve(driver: GameTestDriver, playerId: EntityId, cardName: String): EntityId {
+        val cardId = driver.putCardInHand(playerId, cardName)
+        driver.giveColorlessMana(playerId, 1)
+        driver.submitSuccess(
+            CastSpell(playerId = playerId, cardId = cardId, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.bothPass()
+        return cardId
+    }
+
+    /** Advance turns until [playerId] is the active player, then stop in their precombat main. */
+    fun handTurnTo(driver: GameTestDriver, playerId: EntityId) {
+        while (driver.activePlayer != playerId) {
+            driver.passPriorityUntil(Step.END)
+            driver.bothPass()
+        }
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("an opponent's creature enters tapped; your own does not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Thalia, Heretic Cathar")
+
+        // Yours is unaffected.
+        val yourBear = castAndResolve(driver, you, "Test Bear")
+        driver.isTapped(yourBear) shouldBe false
+
+        // Theirs enters tapped.
+        handTurnTo(driver, opponent)
+        val theirBear = castAndResolve(driver, opponent, "Test Bear")
+        driver.isTapped(theirBear) shouldBe true
+    }
+
+    test("an opponent's nonbasic land enters tapped but a basic land does not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 30, "Adarkar Wastes" to 10),
+            skipMulligans = true
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Thalia, Heretic Cathar")
+
+        handTurnTo(driver, opponent)
+
+        // Nonbasic land: tapped.
+        val nonbasic = driver.putCardInHand(opponent, "Adarkar Wastes")
+        driver.submitSuccess(com.wingedsheep.engine.core.PlayLand(playerId = opponent, cardId = nonbasic))
+        driver.isTapped(nonbasic) shouldBe true
+
+        // Basic land on the next turn: untapped — the filter is nonbasic lands only.
+        handTurnTo(driver, you)
+        handTurnTo(driver, opponent)
+        val basic = driver.putCardInHand(opponent, "Plains")
+        driver.submitSuccess(com.wingedsheep.engine.core.PlayLand(playerId = opponent, cardId = basic))
+        driver.isTapped(basic) shouldBe false
+    }
+})


### PR DESCRIPTION
Five cards from Innistrad Remastered. Each canonical `CardDefinition` lives in the card's earliest real printing; INR — and any other scaffolded set that prints it — gets a `Printing` row. `just check-card-printing` is clean for all five.

| Card | Canonical | Notes |
|---|---|---|
| Deranged Assistant | ISD #52 | `{T}, Mill a card: Add {C}` — mill as a cost |
| Thalia, Heretic Cathar | EMN #46 | Two `PermanentsEnterTapped` replacements (creatures, nonbasic lands) |
| Metallic Mimic | AER #164 | Chosen creature type + counter-granting entry replacement |
| Moonlight Hunt | SOI #219 | Per-iteration damage source *and* amount |
| Reforge the Soul | AVR #151 | `ForEachPlayer` wheel + miracle |

Reprint rows also added where a scaffolded set prints the card: INR ×5, plus CMR (Deranged Assistant) and J22 (Moonlight Hunt).

## Engine additions

Both were exposed by these cards rather than added speculatively.

**`CostAtom.Mill(count)`** + `Costs.MillCard` / `Costs.Mill(n)`. Deranged Assistant's mill is part of the *cost*, not the effect. Per **CR 701.17b** a player can't pay a cost that includes milling more cards than their library holds, so the atom is unpayable on a short library and gates legal-action enumeration — including mana-ability enumeration, which previously fell through to "engine validates at payment" and would have offered a free `{C}` off an empty library. Payment runs the announced count through `MillAmountModifier` (CR 616) and moves cards via `ZoneTransitionService`, so replacement effects and mill triggers behave exactly as for an effect's mill.

**`EntersWithCounters.otherOnly`** — mirrors the flag `EntersWithDynamicCounters` already carries. The entering permanent's own entry path applies its printed enters-with effects regardless of `appliesTo` (that's how ordinary self-counter cards work), so a group effect like Metallic Mimic's "each *other* creature you control" would otherwise counter its own source as it entered. Relatedly, `appliesTo` filters now evaluate with the replacement's **source** as the predicate context's `sourceId`, so source-relative predicates resolve correctly: `withChosenSubtype()` reads the type chosen as the Mimic entered instead of looking for a choice on the entering creature.

## Verification

- Scenario tests for all five cards, including the empty-library mill gate, the Mimic not countering itself, opponent-vs-own scoping on Thalia and the Mimic, and the 2+3 damage split that distinguishes per-creature power from a single read.
- Every mechanical field re-checked against Scryfall (name, mana cost, type line, P/T, rarity, collector number, artist, oracle text); all image URIs return HTTP 200.
- `just build` and the full test suite pass. Card snapshots re-blessed — only these five cards moved.
- No client changes needed: the mill cost takes no selection, so it contributes no `additionalCostInfo`; the ability renders as `{T}, Mill a card: Add {C}` and greys out when unaffordable. Metallic Mimic's type choice reuses the existing choose-option UI.
- `docs/card-sdk-language-reference.md` updated for both SDK additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)