### PR TITLE
Show United Battlefront's top seven even when nothing matches

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnitedBattlefront.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/UnitedBattlefront.kt
@@ -56,8 +56,14 @@ val UnitedBattlefront = card("United Battlefront") {
                     ),
                     storeSelected = "onto",
                     storeRemainder = "rest",
+                    prompt = "Put up to two noncreature, nonland permanent cards with mana value 3 or less " +
+                        "onto the battlefield",
                     selectedLabel = "Put onto the battlefield",
-                    remainderLabel = "Put on bottom"
+                    remainderLabel = "Put on bottom",
+                    // "Look at the top seven cards" is information the player is owed even when
+                    // nothing among them can be kept — show all seven, with the ineligible ones
+                    // greyed out, instead of silently skipping the prompt.
+                    showAllCards = true
                 ),
                 MoveCollectionEffect(
                     from = "onto",

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -17801,8 +17801,10 @@
                     "filter": "noncreature nonland permanent mv<=3",
                     "storeSelected": "onto",
                     "storeRemainder": "rest",
+                    "prompt": "Put up to two noncreature, nonland permanent cards with mana value 3 or less onto the battlefield",
                     "selectedLabel": "Put onto the battlefield",
-                    "remainderLabel": "Put on bottom"
+                    "remainderLabel": "Put on bottom",
+                    "showAllCards": true
                 },
                 {
                     "type": "MoveCollection",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnitedBattlefrontScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnitedBattlefrontScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * United Battlefront (TDM #32) — {3}{W} Sorcery.
+ *
+ * "Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards
+ *  with mana value 3 or less from among them onto the battlefield. Put the rest on the bottom of
+ *  your library in a random order."
+ *
+ * The "look at" clause is information the player is owed unconditionally, so the selection prompt
+ * shows all seven cards — the ineligible ones greyed out — even when none of them can be kept.
+ */
+class UnitedBattlefrontScenarioTest : FunSpec({
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.library(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.LIBRARY))
+
+    fun GameTestDriver.battlefieldNames(playerId: EntityId): List<String> =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).mapNotNull {
+            state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    /** Cast the sorcery and resolve it up to the selection pause. */
+    fun castAndResolve(driver: GameTestDriver, playerId: EntityId) {
+        val battlefront = driver.putCardInHand(playerId, "United Battlefront")
+        driver.giveMana(playerId, Color.WHITE, 4)
+        driver.castSpell(playerId, battlefront)
+        driver.bothPass()
+    }
+
+    test("shows all seven cards even when none of them can be put onto the battlefield") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A library of Mountains: every one of the top seven is a land, so nothing is eligible.
+        val topSeven = driver.library(p1).take(7)
+
+        castAndResolve(driver, p1)
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+
+        // Nothing is selectable, but the player still sees the seven cards they looked at.
+        select.options.shouldBeEmpty()
+        select.nonSelectableOptions shouldContainExactlyInAnyOrder topSeven
+        select.minSelections shouldBe 0
+        select.maxSelections shouldBe 0
+        topSeven.forEach { cardId -> select.cardInfo?.get(cardId)?.name shouldBe "Mountain" }
+
+        driver.submitDecision(p1, CardsSelectedResponse(decisionId = select.id, selectedCards = emptyList()))
+        driver.isPaused shouldBe false
+
+        // All seven went to the bottom; none of them stuck around on the battlefield.
+        driver.library(p1).takeLast(7) shouldContainExactlyInAnyOrder topSeven
+        driver.battlefieldNames(p1) shouldContainExactlyInAnyOrder emptyList()
+    }
+
+    test("puts up to two matching cards onto the battlefield and the rest on the bottom") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // putCardOnTopOfLibrary prepends, so the last push ends up on top:
+        // top seven = [Copper Tablet, Sol Ring, Mountain x5].
+        val solRing = driver.putCardOnTopOfLibrary(p1, "Sol Ring")
+        val copperTablet = driver.putCardOnTopOfLibrary(p1, "Copper Tablet")
+        val mountains = driver.library(p1).drop(2).take(5)
+
+        castAndResolve(driver, p1)
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options shouldContainExactlyInAnyOrder listOf(solRing, copperTablet)
+        select.nonSelectableOptions shouldContainExactlyInAnyOrder mountains
+        select.maxSelections shouldBe 2
+
+        driver.submitDecision(
+            p1,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(solRing, copperTablet))
+        )
+        driver.isPaused shouldBe false
+
+        driver.battlefieldNames(p1) shouldContainExactlyInAnyOrder listOf("Sol Ring", "Copper Tablet")
+        driver.library(p1).takeLast(5) shouldContainExactlyInAnyOrder mountains
+    }
+
+    test("a single matching card can be kept, and the player may keep none") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Icy Manipulator is a noncreature, nonland permanent, but mana value 4 — too expensive.
+        val icy = driver.putCardOnTopOfLibrary(p1, "Icy Manipulator")
+        val solRing = driver.putCardOnTopOfLibrary(p1, "Sol Ring")
+
+        castAndResolve(driver, p1)
+
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options shouldContainExactlyInAnyOrder listOf(solRing)
+
+        // Declining the choice is legal ("up to two") and sends everything to the bottom.
+        driver.submitDecision(p1, CardsSelectedResponse(decisionId = select.id, selectedCards = emptyList()))
+        driver.isPaused shouldBe false
+
+        driver.battlefieldNames(p1) shouldContainExactlyInAnyOrder emptyList()
+        val bottomSeven = driver.library(p1).takeLast(7)
+        bottomSeven shouldContain solRing
+        bottomSeven shouldContain icy
+    }
+})


### PR DESCRIPTION
## Problem

United Battlefront reads *"Look at the top seven cards of your library. Put up to two noncreature, nonland permanent cards with mana value 3 or less from among them onto the battlefield."*

The selection step was filtered-only. `SelectFromCollectionExecutor` narrows the gathered seven to the eligible ones, and for `ChooseUpTo` with an empty eligible set and `showAllCards = false` it stores empty collections and returns without pausing. So when none of the top seven matched, the spell resolved in silence — the player paid `{3}{W}`, never saw the cards they "looked at", and the seven went to the bottom with no feedback. The partial case was wrong too: with two matching cards, only those two were shown, not the seven.

## Fix

Set `showAllCards = true` on the select step. That's the existing mechanism for exactly this shape — `LibraryPatterns.lookAtTopRevealMatchingToHand` (Radagast the Brown / Star Charter) uses it, as do Kaslem's Stonetree and friends. All seven cards render, ineligible ones greyed out as `nonSelectableOptions`, and the player confirms with "Select None" when nothing is keepable.

Also gave the step an explicit prompt: with nothing eligible the generated prompt would have been "Choose up to 0 cards".

No engine change — the empty-eligible-plus-`showAllCards` path already existed and the client already renders `nonSelectableOptions` and a `Select None` confirm button. The built-in AI handles `min == options.size == 0` by returning an empty selection, so AI games are unaffected.

## Tests

New `UnitedBattlefrontScenarioTest` (3 cases, all passing):
- **none matching** — a Mountain library, so all seven are lands: asserts the resolution pauses, `options` is empty, all seven appear in `nonSelectableOptions`, and after confirming nothing they all end up on the bottom. This case failed before the change (no pause at all).
- **two matching** — Sol Ring + Copper Tablet on top: both selectable, five Mountains shown greyed out, both enter the battlefield, rest to the bottom.
- **one matching, declined** — Sol Ring eligible, Icy Manipulator (MV 4) shown but not: "up to two" lets the player keep none.

Gates run: `just test-class UnitedBattlefrontScenarioTest`, plus `:mtg-sets` `CardLintTest`, `FacadeBoundaryTest`, and `CardDefinitionSnapshotTest`. The TDM golden was re-blessed with `just rebless-cards`; only this card's two new fields moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)