### PR TITLE
Re-seat the table when a multiplayer seat dies, and default to the overview

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -267,12 +267,17 @@ are gated on `players.length > 2`).
   priority seat in hotseat — and is refused inside `followViewTo` while any input is
   pending (the camera never moves under an in-progress selection).
 - **Table overview** (`boardView.overviewMode`, rail toggle or key `0`; desktop/tablet
-  only — phones keep the focused camera): every living opponent's board shares the strip
+  only — phones keep the focused camera). **Every 3+ player game opens on it** — the
+  one-board camera hides most of a pod — and `GameBoard` re-defaults once per game
+  (keyed on the session id), so focusing a single board sticks for the rest of that game
+  but the next one starts on the overview again. Every living opponent's board shares the strip
   side-by-side instead of the one-board camera — cells split the width evenly (padded
   clear of the fixed rail via `railReservedWidth` and of the Fullscreen/Concede row),
   hand fans hide (chips carry the counts), and the per-slot card sizer shrinks cards to
   fit. Each visible cell gets a seat-colored **name plate** (`BoardNamePlate` — the
-  board's "face": name + life) and the viewed cell a subtle seat-colored inset ring.
+  board's "face": name + life), and the **active player's** cell a subtle seat-colored inset
+  ring (`activeTurnRingColor` — on the top row, the bottom row, and your own cell): with every
+  board on screen at once, whose turn it is is the thing worth highlighting.
   Hidden boards stay mounted after the visible cells at full width, overflowing
   off-screen right, so their card anchors keep remapping to rail chips. Selecting a
   single board (chip click / `1`-`9`) exits back to the focused camera. Each cell can
@@ -294,10 +299,15 @@ are gated on `players.length > 2`).
   arrow onto a rail chip. Entering the split respects the camera guards (follow on,
   unpinned, no pending input — `hasPendingInputSelection`); once active it holds for the
   whole combat so boards don't shift mid-fight.
-- **Eliminated spectator** (`boardView.eliminatedSpectating`): a personal
-  `PlayerEliminatedMessage` marks the defeat overlay `GameOverState.eliminated`, which
-  adds a "Keep Watching" button. It dismisses the overlay, turns on the table overview,
-  and hides all action UI (hand/pass/undo/concede) behind a "spectating" banner + Leave
+- **Eliminated spectator** (`isViewerEliminated`, in the `boardView` slice): the layout is
+  **derived from the roster** — the local seat is `hasLost` while two or more seats are still
+  standing, in a non-hotseat 3+ player game — not from any message or click, so it holds
+  however the seat died (conceding, damage, decking out, poison) and survives a reconnect.
+  Alongside it the server sends a personal `PlayerEliminatedMessage` (from
+  `GamePlayHandler.notifyEliminatedSeats`, once per seat, for *every* loss reason) which marks
+  the defeat overlay `GameOverState.eliminated` and adds a "Keep Watching" button;
+  `boardView.eliminatedSpectating` records only that the player took it, dismissing the overlay.
+  The layout hides all action UI (hand/pass/undo/concede) behind a "spectating" banner + Leave
   Game button. An eliminated player is just an observer without a board of their own
   (`viewerIsObserver` = spectating ‖ eliminated), so they get the same two-row overview a
   spectator gets: the survivors face each other across the table, with a survivor's board

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -550,10 +550,10 @@ class GamePlayHandler(
 
     /**
      * Concede [playerId]'s seat. If that ends the game (≤1 player remains, CR 104.2a) the match
-     * is finalized; otherwise the game continues for the remaining seats (CR 800.4a) — the
-     * conceder gets a personal [ServerMessage.PlayerEliminated] so their client can leave the
-     * table, and everyone else sees the seat drop out via the state rebroadcast. In a 2-player
-     * game conceding always ends it — the degenerate case.
+     * is finalized; otherwise the game continues for the remaining seats (CR 800.4a) and the
+     * rebroadcast below tells the conceder they're out (see [notifyEliminatedSeats]) while
+     * everyone else just sees the seat drop out of the state. In a 2-player game conceding always
+     * ends it — the degenerate case.
      */
     private fun concedeSeat(gameSession: GameSession, playerId: EntityId) {
         gameSession.playerConcedes(playerId)
@@ -561,32 +561,47 @@ class GamePlayHandler(
             handleGameOver(gameSession, GameOverReason.CONCESSION)
             return
         }
+        broadcastStateUpdate(gameSession, emptyList())
+    }
 
-        // In a hotseat pod the conceding identity may still control other live seats
-        // (scenario builder self-play) — keep them at the table instead of showing the
-        // personal elimination overlay.
+    /**
+     * Tell each newly dead seat that it is out while the table plays on (CR 800.4a): a personal
+     * [ServerMessage.PlayerEliminated] so their client can show the defeat overlay and offer to
+     * keep watching or leave. Every way of losing goes through here — conceding, damage, decking
+     * out, poison — because the engine marks the seat identically; before this, only a concession
+     * produced a notice, so a player who was simply killed sat on a dead board with no feedback.
+     *
+     * Skipped when the game itself has ended (everyone gets [ServerMessage.GameOver] instead) and
+     * for a hotseat / Mindslaver identity that still drives a living seat, which would otherwise be
+     * thrown out of a game it is still playing.
+     */
+    private fun notifyEliminatedSeats(gameSession: GameSession) {
+        if (gameSession.isGameOver()) return
+        val pending = gameSession.unnotifiedEliminations()
+        if (pending.isEmpty()) return
         val state = gameSession.getStateSnapshot()
-        val stillControlsLiveSeat = state != null && state.turnOrder.any { seat ->
-            seat != playerId && seat in state.activePlayers && state.actorFor(seat) == playerId
-        }
-        val conceder = gameSession.getPlayerSession(playerId)
-        if (!stillControlsLiveSeat && conceder != null) {
-            if (conceder.webSocketSession.isOpen) {
-                sender.send(conceder.webSocketSession, ServerMessage.PlayerEliminated(
+        for (playerId in pending) {
+            val stillControlsLiveSeat = state != null && state.turnOrder.any { seat ->
+                seat != playerId && seat in state.activePlayers && state.actorFor(seat) == playerId
+            }
+            if (stillControlsLiveSeat) continue
+            gameSession.markEliminationNotified(playerId)
+            val eliminated = gameSession.getPlayerSession(playerId) ?: continue
+            if (eliminated.webSocketSession.isOpen) {
+                sender.send(eliminated.webSocketSession, ServerMessage.PlayerEliminated(
                     gameId = gameSession.sessionId,
-                    reason = GameOverReason.CONCESSION,
+                    reason = gameSession.getEliminationReason(playerId),
                 ))
             }
-            // The conceder is out of the game (the table plays on without them). Clear their
-            // game-session routing — exactly as handleGameOver does for everyone — so that
-            // returning to the lobby sticks: a reconnect/refresh treats them as "waiting" instead
-            // of dropping them back into a game they've left. They stay seated in the engine state
-            // (CR 800.4a) and still receive the rebroadcast below until they choose to leave.
-            conceder.currentGameSessionId = null
-            sessionRegistry.getIdentityByWsId(conceder.webSocketSession.id)?.currentGameSessionId = null
-            sessionRegistry.getPlayerSession(conceder.webSocketSession.id)?.currentGameSessionId = null
+            // They're out of the game (the table plays on without them). Clear their game-session
+            // routing — exactly as handleGameOver does for everyone — so that returning to the
+            // lobby sticks: a reconnect/refresh treats them as "waiting" instead of dropping them
+            // back into a game they've left. They stay seated in the engine state (CR 800.4a) and
+            // keep receiving the rebroadcast until they choose to leave.
+            eliminated.currentGameSessionId = null
+            sessionRegistry.getIdentityByWsId(eliminated.webSocketSession.id)?.currentGameSessionId = null
+            sessionRegistry.getPlayerSession(eliminated.webSocketSession.id)?.currentGameSessionId = null
         }
-        broadcastStateUpdate(gameSession, emptyList())
     }
 
     fun handleGameOver(gameSession: GameSession, reason: GameOverReason? = null, events: List<GameEvent> = emptyList()) {
@@ -829,6 +844,10 @@ class GamePlayHandler(
                 if (update != null) sender.send(session.webSocketSession, update)
                 else logger.warn("createStateUpdate returned null for player ${session.playerId.value}")
             }
+
+            // After the state (so a client's roster already shows the seat as lost, and its board
+            // has re-seated behind the overlay) but before the spectator feed.
+            notifyEliminatedSeats(gameSession)
 
             // Update spectators. (Replay recording no longer happens here — the compact replay
             // records the input stream as actions are applied, and reconstructs snapshots on demand.)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -95,6 +95,28 @@ class GameSession(
     /** Players in the order they lost (first eliminated first). Empty while everyone is alive. */
     fun getEliminationOrder(): List<EntityId> = eliminationOrder.toList()
 
+    /**
+     * Seats already sent their personal [ServerMessage.PlayerEliminated]. A seat is told exactly
+     * once, however it died — conceding, damage, decking out — so its client shows the "you're out,
+     * the table plays on" overlay a single time.
+     */
+    private val eliminationNotified = ConcurrentHashMap.newKeySet<EntityId>()
+
+    /** Eliminated seats that haven't been told yet, in elimination order. */
+    fun unnotifiedEliminations(): List<EntityId> = eliminationOrder.filter { it !in eliminationNotified }
+
+    /** Record that [playerId] has been told they're out, so it isn't told again. */
+    fun markEliminationNotified(playerId: EntityId) {
+        eliminationNotified.add(playerId)
+    }
+
+    /**
+     * Why [playerId] is out of the game, in client terms. Falls back to [GameOverReason.LIFE_ZERO]
+     * for a seat with no loss marker — same fallback [getGameOverReason] uses.
+     */
+    fun getEliminationReason(playerId: EntityId): GameOverReason =
+        gameOverReasonFor(gameState?.getEntity(playerId)?.get<PlayerLostComponent>()?.reason)
+
     /** Checkpoint for undoing the last non-respondable action (e.g., play land, declare attackers) */
     @Volatile
     private var undoCheckpoint: GameState? = null
@@ -1248,16 +1270,19 @@ class GameSession(
         val reason = lostReasons.firstOrNull { it != LossReason.TEAM_DEFEATED }
             ?: lostReasons.firstOrNull()
 
-        return when (reason) {
-            LossReason.LIFE_ZERO -> GameOverReason.LIFE_ZERO
-            LossReason.EMPTY_LIBRARY -> GameOverReason.DECK_OUT
-            LossReason.POISON_COUNTERS -> GameOverReason.POISON_COUNTERS
-            LossReason.CONCESSION -> GameOverReason.CONCESSION
-            LossReason.CARD_EFFECT -> GameOverReason.CARD_EFFECT
-            LossReason.COMMANDER_DAMAGE -> GameOverReason.COMMANDER_DAMAGE
-            LossReason.TEAM_DEFEATED -> GameOverReason.CARD_EFFECT
-            null -> GameOverReason.LIFE_ZERO // Fallback
-        }
+        return gameOverReasonFor(reason)
+    }
+
+    /** Engine loss reason → the client-facing reason code. */
+    private fun gameOverReasonFor(reason: LossReason?): GameOverReason = when (reason) {
+        LossReason.LIFE_ZERO -> GameOverReason.LIFE_ZERO
+        LossReason.EMPTY_LIBRARY -> GameOverReason.DECK_OUT
+        LossReason.POISON_COUNTERS -> GameOverReason.POISON_COUNTERS
+        LossReason.CONCESSION -> GameOverReason.CONCESSION
+        LossReason.CARD_EFFECT -> GameOverReason.CARD_EFFECT
+        LossReason.COMMANDER_DAMAGE -> GameOverReason.COMMANDER_DAMAGE
+        LossReason.TEAM_DEFEATED -> GameOverReason.CARD_EFFECT
+        null -> GameOverReason.LIFE_ZERO // Fallback
     }
 
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/EliminationNoticeTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/EliminationNoticeTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.LossReason
+import com.wingedsheep.engine.state.components.player.PlayerLostComponent
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.protocol.GameOverReason
+import com.wingedsheep.gameserver.scenario.PlayerConfig
+import com.wingedsheep.gameserver.scenario.ScenarioBuilderService
+import com.wingedsheep.gameserver.scenario.ScenarioMode
+import com.wingedsheep.gameserver.scenario.ScenarioRequest
+import com.wingedsheep.gameserver.scenario.ScenarioSeat
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * A seat that dies while the pod plays on (CR 800.4a) must be told exactly once, whatever killed
+ * it. `GamePlayHandler.notifyEliminatedSeats` drives the personal `PlayerEliminated` notice off
+ * this bookkeeping; before it existed only a concession produced one, so a player who was simply
+ * burned out sat on a dead board with no defeat overlay and no re-seated table.
+ */
+class EliminationNoticeTest : ScenarioTestBase() {
+
+    private val service get() = ScenarioBuilderService(cardRegistry)
+
+    private fun threeSeatState(): Pair<GameState, List<EntityId>> {
+        val build = service.buildScenario(
+            ScenarioRequest(
+                players = listOf(
+                    ScenarioSeat("Alice", PlayerConfig()),
+                    ScenarioSeat("Bob", PlayerConfig()),
+                    ScenarioSeat("Charlie", PlayerConfig()),
+                ),
+                mode = ScenarioMode.SELF,
+            )
+        )
+        return build.state to build.playerIds
+    }
+
+    private fun newSession() = GameSession(cardRegistry = cardRegistry)
+
+    private fun GameState.markLost(playerId: EntityId, reason: LossReason): GameState =
+        updateEntity(playerId) { it.with(PlayerLostComponent(reason)) }
+
+    init {
+        test("a seat killed by damage is pending a notice, with its own loss reason") {
+            val (state, players) = threeSeatState()
+            val session = newSession()
+            session.injectStateForDevScenario(state)
+            session.unnotifiedEliminations().shouldBeEmpty()
+
+            session.injectStateForDevScenario(state.markLost(players[1], LossReason.LIFE_ZERO))
+
+            session.unnotifiedEliminations() shouldContainExactly listOf(players[1])
+            session.getEliminationReason(players[1]) shouldBe GameOverReason.LIFE_ZERO
+        }
+
+        test("every loss reason reaches the client, not just concession") {
+            val (state, players) = threeSeatState()
+            val session = newSession()
+            session.injectStateForDevScenario(state.markLost(players[2], LossReason.EMPTY_LIBRARY))
+
+            session.unnotifiedEliminations() shouldContainExactly listOf(players[2])
+            session.getEliminationReason(players[2]) shouldBe GameOverReason.DECK_OUT
+        }
+
+        test("a seat is only pending until it has been told — the notice never repeats") {
+            val (state, players) = threeSeatState()
+            val session = newSession()
+            val afterDeath = state.markLost(players[0], LossReason.POISON_COUNTERS)
+            session.injectStateForDevScenario(afterDeath)
+
+            session.markEliminationNotified(players[0])
+            session.unnotifiedEliminations().shouldBeEmpty()
+
+            // Every later broadcast re-injects state; the seat stays dead but stays notified.
+            session.injectStateForDevScenario(afterDeath)
+            session.unnotifiedEliminations().shouldBeEmpty()
+        }
+
+        test("seats queue in elimination order, and a survivor is never pending") {
+            val (state, players) = threeSeatState()
+            val session = newSession()
+            val firstOut = state.markLost(players[2], LossReason.LIFE_ZERO)
+            session.injectStateForDevScenario(firstOut)
+            session.injectStateForDevScenario(firstOut.markLost(players[0], LossReason.CONCESSION))
+
+            // Bob is still alive, so he never queues.
+            session.unnotifiedEliminations() shouldContainExactly listOf(players[2], players[0])
+        }
+    }
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1166,15 +1166,20 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       )}
 
       {/* Show-table bottom row: the viewer's team (team game) or the balanced bottom half (FFA)
-          shares the bottom as a multi-board strip (rows 4-5), mirroring the top row. Your own
-          board (when playing) keeps its interactive battlefield + fixed hand; every other seat —
-          including every seat for an observer — renders as an overview cell (lands toward the
-          bottom edge) with per-board collapse. Otherwise the classic single bottom board. */}
+          shares the bottom as a multi-board strip, mirroring the top row. Your own board (when
+          playing) keeps its interactive battlefield + fixed hand; every other seat — including
+          every seat for an observer — renders as an overview cell (lands toward the bottom edge)
+          with per-board collapse. Otherwise the classic single bottom board.
+
+          Rows: an observer has no hand of their own down here, so the strip takes row 5 as well
+          (the mirror of the top strip claiming row 1 once opponent hands are hidden). A *playing*
+          viewer's fixed hand fan still paints in row 5 — the strip must stop above it, or the
+          bottom boards size themselves into that band and their land row runs off the screen. */}
       {bottomStripActive ? (
         <div
           data-team-strip="bottom"
           style={{
-            gridRow: '4 / 6',
+            gridRow: viewerIsObserver ? '4 / 6' : '4 / 5',
             position: 'relative',
             display: 'flex',
             overflow: 'hidden',

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useRef, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { useInteraction } from '@/hooks/useInteraction'
-import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId } from '@/store/selectors'
+import { useViewingPlayer, useOpponent, useOpponents, useViewedOpponent, useStackCards, selectPriorityMode, useGhostCards, useBattlefieldCards, selectTeamMap, useIdentityColor, useViewerTeamIndex, useIsAlly, identitySeatColor, selectViewingPlayerId, useEliminatedBottomSeatId, useViewerEliminated } from '@/store/selectors'
 import { useMultiplayerView, useCombatDefenderFocus } from '@/hooks/useMultiplayerView'
 import { OpponentRail, railReservedWidth } from './OpponentRail'
 import { hand, getNextStep, StepShortNames } from '@/types'
@@ -47,6 +47,7 @@ interface GameBoardProps {
 export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardProps) {
   const playerGameState = useGameStore((state) => state.gameState)
   const spectatingState = useGameStore((state) => state.spectatingState)
+  const sessionId = useGameStore((state) => state.sessionId)
   const playerId = useGameStore((state) => state.playerId)
   const submitAction = useGameStore((state) => state.submitAction)
   const combatState = useGameStore((state) => state.combatState)
@@ -102,16 +103,17 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
   const overviewModeOn = useGameStore((state) => state.overviewMode)
   const collapsedSeats = useGameStore((state) => state.collapsedSeats)
   const toggleSeatCollapsed = useGameStore((state) => state.toggleSeatCollapsed)
-  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const viewerEliminated = useViewerEliminated()
   const eliminatedBottomSeatId = useEliminatedBottomSeatId()
   const setEliminatedBottomSeat = useGameStore((state) => state.setEliminatedBottomSeat)
   const returnToMenu = useGameStore((state) => state.returnToMenu)
   const viewingPlayer = useViewingPlayer()
-  // Eliminated-spectator layout: the local player is out of a multiplayer game and chose
-  // "Keep watching" — their own board is gone and all action UI hides, so they watch the
-  // surviving seats spread across the table like any other spectator.
-  const isEliminatedSpectator =
-    isMulti && !spectatorMode && eliminatedSpectating && (viewingPlayer?.hasLost ?? false)
+  // Eliminated-spectator layout: the local player is out of a multiplayer game that plays on —
+  // their own board is dead and all action UI hides, so they watch the surviving seats spread
+  // across the table like any other spectator. Keyed off the roster (see `isViewerEliminated`)
+  // rather than the "Keep watching" click, so the table re-seats itself however the seat died,
+  // not just on a concession.
+  const isEliminatedSpectator = isMulti && !spectatorMode && viewerEliminated
   // The viewer has no board of their own in this game: a spectator/replay stream, or a player
   // who was eliminated and kept watching. Nothing in the bottom half is theirs — it belongs to
   // a survivor — so no cell there is interactive and their own hand never renders.
@@ -206,21 +208,21 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
 
   const responsive = useResponsive(effectiveTopOffset, zoneRowCounts)
 
-  // Anyone watching without a board of their own — a spectator/replay viewer, or a player who
-  // was eliminated and kept watching — defaults to the all-boards table overview: the survivors
-  // spread across both halves of the table, rather than a one-board camera that hides most of the
-  // game. One-shot on entry so an observer who then focuses a single board (rail-chip click /
-  // key 0) isn't yanked back. Desktop only — GameBoard degrades overview to the single-board
-  // camera on phones anyway.
-  const didDefaultObserverOverview = useRef(false)
+  // Every multiplayer game opens on the all-boards table overview — with three or more seats the
+  // one-board sliding camera hides most of what's happening, and seeing the whole table is the
+  // point of a pod. One-shot *per game*, so someone who focuses a single board (rail-chip click /
+  // keys 1-9 / key 0) isn't yanked back out of it, while the next game still starts on the
+  // overview. Desktop only — GameBoard degrades the overview to the single-board camera on phones
+  // anyway.
+  const overviewDefaultKey = spectatorMode ? spectatingState?.gameSessionId ?? null : sessionId
+  const defaultedOverviewFor = useRef<string | null>(null)
   useEffect(() => {
-    if (didDefaultObserverOverview.current) return
-    if (viewerIsObserver && isMulti && !responsive.isMobile) {
-      didDefaultObserverOverview.current = true
-      const store = useGameStore.getState()
-      if (!store.overviewMode) store.toggleOverviewMode()
-    }
-  }, [viewerIsObserver, isMulti, responsive.isMobile])
+    if (!isMulti || responsive.isMobile || !overviewDefaultKey) return
+    if (defaultedOverviewFor.current === overviewDefaultKey) return
+    defaultedOverviewFor.current = overviewDefaultKey
+    const store = useGameStore.getState()
+    if (!store.overviewMode) store.toggleOverviewMode()
+  }, [isMulti, responsive.isMobile, overviewDefaultKey])
 
   // Grid row 1: keeps the battlefield clear of the fixed/absolute opponent hand.
   const oppHandReservation =
@@ -386,8 +388,14 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       .sort((a, b) => (a.playerId === anchorId ? -1 : b.playerId === anchorId ? 1 : 0))
   }, [twoRowActive, gameState, bottomRowIds, anchorId])
   // The bottom half becomes a multi-board strip only when it holds more than the anchor (team
-  // games; 4+ player free-for-alls). A lone anchor keeps the classic single bottom board.
-  const bottomStripActive = twoRowActive && bottomRowOrdered.length > 1
+  // games; 4+ player free-for-alls). A lone anchor keeps the classic single bottom board — but
+  // only when it really is the anchor: the single-board paths below draw the anchor's board, so
+  // a lone *non-anchor* seat (a viewer parked on a seat that has since died) has to go through
+  // the strip or its board would never render at all.
+  const bottomStripActive =
+    twoRowActive &&
+    (bottomRowOrdered.length > 1 ||
+      (bottomRowOrdered.length === 1 && bottomRowOrdered[0]?.playerId !== anchorId))
   // Any bottom board may collapse to a tab — except your own interactive board when *playing*
   // (there's no collapse control on it, and folding the board you act from makes no sense). An
   // observer's anchor seat is just another board, so it stays collapsible.
@@ -893,8 +901,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                       // The viewed board's anchors stay on the center-HUD orb; every other
                       // expanded board's plate takes over from its rail chip.
                       plateCarriesAnchors={multiView && expandedCell && !isViewedCell}
-                      {...(multiView && expandedCell && isViewedCell
-                        ? { viewedRingColor: identitySeatColor(teamMap, o.playerId, gameState.players.findIndex((p) => p.playerId === o.playerId)).base }
+                      // With every board on screen the useful highlight is whose turn it is,
+                      // not which cell the camera nominally tracks.
+                      {...(multiView && expandedCell && o.playerId === gameState.activePlayerId
+                        ? { activeTurnRingColor: identitySeatColor(teamMap, o.playerId, gameState.players.findIndex((p) => p.playerId === o.playerId)).base }
                         : {})}
                       // Fold-away control — table overview only; the combat split and the
                       // focused camera keep their deliberate board sets.
@@ -1116,7 +1126,21 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           rendered read-only the way spectating renders a bottom seat. When the bottom row
           holds several seats the strip below takes over. */}
       {isEliminatedSpectator && eliminatedBottomSeat && !bottomStripActive && (
-        <div style={styles.playerArea}>
+        <div style={{ ...styles.playerArea, position: 'relative' }}>
+          {/* Same active-turn ring the strip cells carry, so the highlight keeps meaning
+              "whose turn it is" on the bottom half too. */}
+          {eliminatedBottomSeat.playerId === gameState.activePlayerId && (
+            <div
+              aria-hidden
+              style={{
+                position: 'absolute',
+                inset: 2,
+                pointerEvents: 'none',
+                borderRadius: 10,
+                boxShadow: `inset 0 0 0 2px ${bottomHudSeatColor.base}55, inset 0 0 18px ${bottomHudSeatColor.base}22`,
+              }}
+            />
+          )}
           <div style={styles.playerRowWithZones}>
             <CommandZone player={eliminatedBottomSeat} />
             <div style={styles.playerMainArea}>
@@ -1183,6 +1207,19 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                     position: 'relative',
                   }}
                 >
+                  {/* Your own cell carries the same active-turn ring as every other board. */}
+                  {p.playerId === gameState.activePlayerId && (
+                    <div
+                      aria-hidden
+                      style={{
+                        position: 'absolute',
+                        inset: 2,
+                        pointerEvents: 'none',
+                        borderRadius: 10,
+                        boxShadow: `inset 0 0 0 2px ${selfSeatColor.base}55, inset 0 0 18px ${selfSeatColor.base}22`,
+                      }}
+                    />
+                  )}
                   {/* Reservation band mirrors the other cells' name-plate band so all bottom
                       boards line up. */}
                   <div style={{ height: 34, flexShrink: 0 }} aria-hidden />
@@ -1208,6 +1245,11 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 bottomHalf
                 plateCarriesAnchors={p.playerId !== bottomHudPlayer?.playerId}
                 onToggleCollapse={() => toggleSeatCollapsed(p.playerId)}
+                // Same active-turn ring as the top row — the highlight has to mean the same
+                // thing on both halves of the table.
+                {...(p.playerId === gameState.activePlayerId
+                  ? { activeTurnRingColor: identitySeatColor(teamMap, p.playerId, gameState.players.findIndex((q) => q.playerId === p.playerId)).base }
+                  : {})}
                 // `bottomHalf` orients the board as a bottom-side board, which would also make
                 // it interactive — so an observer's bottom cells must render read-only.
                 spectatorMode={viewerIsObserver}

--- a/web-client/src/components/game/board/OpponentBoardArea.tsx
+++ b/web-client/src/components/game/board/OpponentBoardArea.tsx
@@ -31,7 +31,7 @@ export function OpponentBoardArea({
   stripBasis = '100%',
   hideHand = false,
   plateCarriesAnchors = false,
-  viewedRingColor,
+  activeTurnRingColor,
   onToggleCollapse,
   spectatorMode,
   isHijacking,
@@ -67,10 +67,12 @@ export function OpponentBoardArea({
    */
   plateCarriesAnchors?: boolean
   /**
-   * Shared-strip view only: seat color for a persistent inset ring marking this cell as
-   * the *viewed* board (the one the center-HUD orb and keys 1-9 track). Undefined = no ring.
+   * Shared-strip view only: seat color for a persistent inset ring marking this cell as the
+   * board of the player whose **turn** it is. With every board on screen at once, "whose turn
+   * is it" is the thing worth a highlight — which cell the camera nominally tracks isn't.
+   * Undefined = no ring.
    */
-  viewedRingColor?: string
+  activeTurnRingColor?: string
   /**
    * Table overview only: fold this cell down to a narrow tab (MTGO-style per-board
    * collapse) so the other boards split the freed width. Rendered as a small "−"
@@ -266,8 +268,8 @@ export function OpponentBoardArea({
           −
         </button>
       )}
-      {/* Persistent inset ring marking the viewed cell in a shared-strip view. */}
-      {viewedRingColor && (
+      {/* Persistent inset ring marking the active player's cell in a shared-strip view. */}
+      {activeTurnRingColor && (
         <div
           aria-hidden
           style={{
@@ -275,7 +277,7 @@ export function OpponentBoardArea({
             inset: 2,
             pointerEvents: 'none',
             borderRadius: 10,
-            boxShadow: `inset 0 0 0 2px ${viewedRingColor}55, inset 0 0 18px ${viewedRingColor}22`,
+            boxShadow: `inset 0 0 0 2px ${activeTurnRingColor}55, inset 0 0 18px ${activeTurnRingColor}22`,
           }}
         />
       )}

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -9,6 +9,7 @@ import type {
   ZoneId,
 } from '@/types'
 import { ZoneType, zoneIdEquals, graveyard, library } from '@/types'
+import { isViewerEliminated } from './slices/ui/boardViewSlice'
 import { seatColor, teamColor, type SeatColor } from '@/styles/seatColors'
 import {
   type GroupedCard,
@@ -239,6 +240,15 @@ export function useOpponents(): readonly ClientPlayer[] {
 }
 
 /**
+ * True when the local player's seat is out of a multiplayer game the others are still playing.
+ * See [isViewerEliminated] — derived from the roster, not from the elimination message, so it
+ * is right however the seat died.
+ */
+export function useViewerEliminated(): boolean {
+  return useGameStore(isViewerEliminated)
+}
+
+/**
  * The living seat that holds the bottom half of the table for an eliminated spectator.
  * A dead player has no board of their own to sit there, so the bottom side of the table
  * belongs to a survivor: their explicit pick from the spectating banner, or — by default —
@@ -246,19 +256,19 @@ export function useOpponents(): readonly ClientPlayer[] {
  * that seat dies. Null outside the eliminated-spectator layout, or when nobody is left.
  */
 export function useEliminatedBottomSeatId(): EntityId | null {
-  const eliminatedSpectating = useGameStore((state) => state.eliminatedSpectating)
+  const eliminated = useGameStore(isViewerEliminated)
   const pickedSeatId = useGameStore((state) => state.eliminatedBottomSeatId)
   const opponents = useOpponents()
   const teamMap = useGameStore(selectTeamMap)
   const viewerTeam = useViewerTeamIndex()
   return useMemo(() => {
-    if (!eliminatedSpectating) return null
+    if (!eliminated) return null
     const living = opponents.filter((p) => !p.hasLost)
     const picked = living.find((p) => p.playerId === pickedSeatId)
     if (picked) return picked.playerId
     const ally = viewerTeam != null ? living.find((p) => teamMap[p.playerId] === viewerTeam) : undefined
     return (ally ?? living[0])?.playerId ?? null
-  }, [eliminatedSpectating, pickedSeatId, opponents, teamMap, viewerTeam])
+  }, [eliminated, pickedSeatId, opponents, teamMap, viewerTeam])
 }
 
 /**

--- a/web-client/src/store/slices/ui/boardViewSlice.ts
+++ b/web-client/src/store/slices/ui/boardViewSlice.ts
@@ -30,6 +30,28 @@ export function hasPendingInputSelection(state: GameStore): boolean {
   )
 }
 
+/**
+ * True when the local player's own seat is out of a multiplayer game the others are still
+ * playing (CR 800.4a). That's the spectator layout: a survivor takes over the bottom half of
+ * the table and all action UI hides.
+ *
+ * Derived from the authoritative roster (`hasLost`) rather than from the elimination message
+ * or the "Keep watching" click, so it holds however the seat died — conceding, damage, decking
+ * out, poison — and survives a refresh or reconnect.
+ *
+ * False while watching a spectator/replay stream (no seat of our own to lose), in a hotseat pod
+ * (this client still drives the living seats), and once the game itself is over — fewer than two
+ * seats left standing is the game-over overlay's business, not the spectator layout's.
+ */
+export function isViewerEliminated(state: GameStore): boolean {
+  const gameState = state.gameState
+  const playerId = state.playerId
+  if (state.spectatingState || !gameState || !playerId) return false
+  if (gameState.players.length <= 2 || gameState.hotseat) return false
+  if (!gameState.players.find((p) => p.playerId === playerId)?.hasLost) return false
+  return gameState.players.filter((p) => !p.hasLost).length >= 2
+}
+
 function loadFollowAction(): boolean {
   try {
     return localStorage.getItem(FOLLOW_ACTION_KEY) !== 'false'
@@ -66,9 +88,11 @@ export interface BoardViewSliceState {
    */
   collapsedSeats: readonly EntityId[]
   /**
-   * The local player was eliminated from a multiplayer game and chose "Keep watching"
-   * on the defeat overlay: their dead bottom half collapses, the freed space goes to the
-   * opponent boards, and all action UI hides. Cleared on reset (new game / leave).
+   * The local player dismissed the defeat overlay with "Keep watching" and stayed at the
+   * table. Only records that choice — the spectator *layout* is derived from the roster by
+   * [isViewerEliminated], so it is already correct while the overlay is still up and for a
+   * seat that died without an elimination message reaching it. Cleared on reset (new game /
+   * leave).
    */
   eliminatedSpectating: boolean
   /**
@@ -159,7 +183,7 @@ export const createBoardViewSlice: SliceCreator<BoardViewSlice> = (set, get) => 
     if (gameState && !gameState.players.some((p) => p.playerId === playerId)) return
     // The eliminated spectator's chosen bottom board is already fully visible at the
     // bottom — it never also occupies the viewed strip slot.
-    if (get().eliminatedSpectating && playerId === get().eliminatedBottomSeatId) return
+    if (isViewerEliminated(get()) && playerId === get().eliminatedBottomSeatId) return
     const pin = opts?.pin ?? true
     // Pinning a board and follow-the-action are mutually exclusive: pinning turns follow off
     // (the camera is locked), so the Follow toggle reflects that rather than lying "on".


### PR DESCRIPTION
Four related multiplayer fixes.

## A survivor takes your place at the bottom of the screen when you die

The eliminated-spectator layout was gated on `boardView.eliminatedSpectating`, set only by the **Keep watching** button on the defeat overlay — and that overlay only appears on a `PlayerEliminated` message, which the server only sent on a **concession**.

Die to damage, poison, or decking out in a pod that plays on and you got: no overlay, no notice at all, and a layout still anchored to your own dead board. `anchorId` pointed at a seat missing from `living`, so the overview handed the bottom row to an arbitrary survivor and then **dropped that survivor's board entirely** — a lone non-anchor bottom seat fell through to the "your own board" branch. That is also the root cause of *"overview mode doesn't work anymore after you die"*: same bug, second symptom.

- **The layout is derived from the roster now** (`isViewerEliminated`: our seat is `hasLost` while two or more seats still stand, non-hotseat, 3+ players) instead of from a message or a click — so it holds however the seat died and survives a reconnect. `eliminatedSpectating` now records only that the player dismissed the overlay.
- **`GamePlayHandler.notifyEliminatedSeats`** sends the personal `PlayerEliminated` for *every* loss reason, once per seat, driven off `GameSession`'s elimination bookkeeping. A killed player now gets the same defeat overlay, "Keep watching" button, and lobby-routing cleanup a conceder already got. `concedeSeat` routes through it instead of hand-rolling the same block.
- A lone bottom-row seat that isn't the anchor renders through the strip — the single-board paths draw the anchor, so it would otherwise never appear.

## Every 3+ player game opens on the table overview

The one-board sliding camera hides most of a pod. Re-defaults **once per game** (keyed on the session id), so focusing a single board sticks for the rest of that game while the next one starts on the overview again. Desktop only, as before.

## The board highlight follows the active player

With every board on screen at once, whose turn it is is the thing worth a ring — which cell the camera nominally tracks is not. `viewedRingColor` → `activeTurnRingColor`, and it now also renders on the bottom row, on your own cell, and on an eliminated spectator's bottom board.

## The bottom boards no longer run off the screen edge

The bottom strip claimed grid rows 4–6, mirroring the top strip claiming 1–2. That works up top — the overview hides opponent hands, so row 1's reservation is genuinely free. It does not work at the bottom: a **playing** viewer's hand fan is a `position: fixed` overlay pinned to the bottom of the screen, in exactly the band row 5 reserves. The strip took the row anyway, so each bottom board sized its battlefield into it and laid the land row out under the hand and past the viewport edge.

The strip now takes row 5 only when nothing paints there (observer, or a spectator team-split). Before / after, same board:

![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-eliminated-seat-fix-screenshots/clip-before.png)
![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-eliminated-seat-fix-screenshots/clip-after.png)

## Screenshots

4-player FFA, you alive — overview is the default, your board shares the bottom row, Samwise's cell carries the active-turn ring, and both bottom boards fit above the hand:

![overview default](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-eliminated-seat-fix-screenshots/3-ffa4-overview-alive.png)

Same pod after your seat dies (no concession, no click) — Rick takes over the bottom half, your rail chip is a tombstone, the banner offers the bottom-seat picker, and the ring still marks Samwise's turn:

![eliminated spectator](https://raw.githubusercontent.com/wingedsheep/argentum-engine/multiplayer-eliminated-seat-fix-screenshots/4-ffa4-eliminated.png)

*(`multiplayer-eliminated-seat-fix-screenshots` is a throwaway branch — delete it once this merges.)*

## Verification

- `just test-server` — green, including `FreeForAllLobbyTest`, which asserts the conceder still gets `PlayerEliminated` through the new path.
- New `EliminationNoticeTest` (4 cases): a seat killed by damage queues a notice with its own reason, every loss reason maps through (not just concession), the notice never repeats across re-broadcasts, and survivors never queue.
- `npm run typecheck` + `npm run build` green; every screenshot above is the running app.
- Layout checked by measuring each cell's slot against its rendered cards in the page — before the row fix the bottom cell's cards ended exactly at the viewport bottom (`belowViewport: 0`), after it they clear it by 116px, with the top row unchanged.
- E2E suite not run (too slow) — targeted Playwright walk instead.

## Notes

- The active player's board is half-width in a 4-player pod by default now; that is the layout chosen for this change.
- `docs/web-client-architecture.md` updated for all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)