### PR TITLE
Fizzle targets that were blinked in response (CR 400.7 / 608.2b)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -689,7 +689,7 @@ class ManaPaymentContinuationResumer(
 
         val newTargets = listOf(newTarget)
         val updatedState = state.updateEntity(continuation.spellEntityId) { container ->
-            container.with(TargetsComponent(newTargets, targetsComponent.targetRequirements))
+            container.with(TargetsComponent.capture(state, newTargets, targetsComponent.targetRequirements))
         }
 
         return checkForMore(updatedState, emptyList())

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ContestedRetargetExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ContestedRetargetExecutors.kt
@@ -166,7 +166,7 @@ object ContestedRetargetLogic {
         val requirements = state.getEntity(stackObjectId)?.get<TargetsComponent>()?.targetRequirements
             ?: emptyList()
         val updatedState = state.updateEntity(stackObjectId) { container ->
-            container.with(TargetsComponent(acc, requirements))
+            container.with(TargetsComponent.capture(state, acc, requirements))
         }
         return EffectResult.success(updatedState)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReselectTargetRandomlyExecutor.kt
@@ -70,8 +70,10 @@ class ReselectTargetRandomlyExecutor : EffectExecutor<ReselectTargetRandomlyEffe
             ?: return EffectResult.success(stateAfterPick)
 
         // 6. Update the target on the stack entity
-        val newTargetsComponent = targetsComponent.copy(
-            targets = listOf(newTarget)
+        val newTargetsComponent = TargetsComponent.capture(
+            stateAfterPick,
+            listOf(newTarget),
+            targetsComponent.targetRequirements
         )
         val newState = stateAfterPick.updateEntity(triggeringEntityId) { container ->
             container.with(newTargetsComponent)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -215,7 +215,9 @@ class StackResolver(
                 castTimeFlags = castTimeFlags
             ))
             if (effectiveTargets.isNotEmpty()) {
-                updated = updated.with(TargetsComponent(effectiveTargets, effectiveTargetRequirements))
+                updated = updated.with(
+                    TargetsComponent.capture(state, effectiveTargets, effectiveTargetRequirements)
+                )
             }
             // Add morph data for creatures with morph (needed for face-down casting and
             // for effects like Backslide that target "creature with a morph ability")
@@ -471,7 +473,7 @@ class StackResolver(
 
         var container = ComponentContainer.of(ability)
         if (targets.isNotEmpty()) {
-            container = container.with(TargetsComponent(targets, targetRequirements))
+            container = container.with(TargetsComponent.capture(state, targets, targetRequirements))
         }
 
         var newState = stateWithId.withEntity(abilityId, container)
@@ -588,7 +590,7 @@ class StackResolver(
 
         var container = ComponentContainer.of(copiedCardComp, copiedSpellComp)
         if (effectiveTargets.isNotEmpty()) {
-            container = container.with(TargetsComponent(effectiveTargets, effectiveRequirements))
+            container = container.with(TargetsComponent.capture(state, effectiveTargets, effectiveRequirements))
         }
         container = container.with(
             CopyOfComponent(
@@ -643,7 +645,7 @@ class StackResolver(
 
         var container = ComponentContainer.of(ability)
         if (targets.isNotEmpty()) {
-            container = container.with(TargetsComponent(targets, targetRequirements))
+            container = container.with(TargetsComponent.capture(state, targets, targetRequirements))
         }
         // CR 707.10e — "This ability can't be copied": tag the ability instance on the stack so a
         // copy-ability effect (e.g. Gogo, Master of Mimicry) makes no copy of it.
@@ -760,7 +762,8 @@ class StackResolver(
                 spellComponent.casterId, targetsComponent.targetRequirements,
                 sourceId = spellId,
                 targetingSourceType = TargetingSourceType.SPELL,
-                xValue = spellComponent.xValue
+                xValue = spellComponent.xValue,
+                targetEntryStamps = targetsComponent.targetEntryStamps
             )
             if (validTargets.isEmpty()) {
                 // All targets invalid - spell fizzles
@@ -2269,6 +2272,7 @@ class StackResolver(
                 xValue = abilityComponent.xValue,
                 triggeringEntityId = abilityComponent.triggeringEntityId,
                 triggeringPlayerId = abilityComponent.triggeringPlayerId,
+                targetEntryStamps = targetsComponent.targetEntryStamps,
             )
             if (validTargets.isEmpty()) {
                 // Fizzle - remove ability entity
@@ -2406,7 +2410,8 @@ class StackResolver(
                 state, targetsComponent.targets, sourceColors, sourceSubtypes,
                 abilityComponent.controllerId, targetsComponent.targetRequirements,
                 sourceId = abilityComponent.sourceId,
-                xValue = abilityComponent.xValue
+                xValue = abilityComponent.xValue,
+                targetEntryStamps = targetsComponent.targetEntryStamps
             )
             if (validTargets.isEmpty()) {
                 val newState = state.removeEntity(abilityId)
@@ -2862,7 +2867,13 @@ class StackResolver(
         targetingSourceType: TargetingSourceType = TargetingSourceType.ANY,
         xValue: Int? = null,
         triggeringEntityId: EntityId? = null,
-        triggeringPlayerId: EntityId? = null
+        triggeringPlayerId: EntityId? = null,
+        /**
+         * The object-identity stamps captured when these targets were chosen
+         * ([TargetsComponent.targetEntryStamps]) — a permanent that left the battlefield and came
+         * back in the meantime is a different object and no longer a legal target (CR 400.7).
+         */
+        targetEntryStamps: Map<EntityId, Long> = emptyMap()
     ): List<ChosenTarget> {
         // Always project state for shroud/hexproof checks (Rule 702.18, 702.11)
         val projected = state.projectedState
@@ -2894,6 +2905,13 @@ class StackResolver(
                 is ChosenTarget.Permanent -> {
                     // Permanent is valid if still on battlefield
                     if (target.entityId !in state.getBattlefield()) return@filterIndexed false
+
+                    // ...and if it's still the same object. A permanent blinked in response
+                    // (Personify, Cloudshift) reuses its entity id here, but it returned as a new
+                    // object (CR 400.7) that was never targeted, so the target is illegal.
+                    if (TargetsComponent.isDifferentObject(state, target.entityId, targetEntryStamps)) {
+                        return@filterIndexed false
+                    }
 
                     // Check shroud — can't be targeted by anyone (Rule 702.18)
                     if (projected.hasKeyword(target.entityId, "SHROUD")) return@filterIndexed false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.state.components.stack
 
 import com.wingedsheep.engine.state.Component
+import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
@@ -301,12 +302,74 @@ data class AbilityOnStackComponent(
  * @property targets The chosen targets
  * @property targetRequirements The original target requirements, used for re-validation
  *           on resolution (Rule 608.2b — targets must still be legal when the spell/ability resolves)
+ * @property targetEntryStamps Object-identity stamps for the permanent targets (CR 400.7),
+ *           captured when the targets were chosen — see [capture].
  */
 @Serializable
 data class TargetsComponent(
     val targets: List<ChosenTarget>,
-    val targetRequirements: List<TargetRequirement> = emptyList()
-) : Component
+    val targetRequirements: List<TargetRequirement> = emptyList(),
+    val targetEntryStamps: Map<EntityId, Long> = emptyMap()
+) : Component {
+
+    companion object {
+        /**
+         * Build the component, snapshotting each permanent target's
+         * [com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent]
+         * as it is targeted.
+         *
+         * Entity ids survive zone round-trips in this engine, so "that id is still a creature on
+         * the battlefield" doesn't prove the target is still the object that was targeted: a
+         * permanent blinked in response (Personify, Cloudshift, bounce-and-recast) comes back as a
+         * *new object* (CR 400.7), and a spell or ability that targeted the old one has an illegal
+         * target — if that's its only target, it doesn't resolve (CR 608.2b). Comparing the entry
+         * stamp at resolution is what makes that visible; see [isDifferentObject].
+         *
+         * Every path that chooses or *re-*chooses targets for a stack object goes through here
+         * (putting a spell / triggered / activated ability on the stack, and the retarget
+         * executors) — a target changed by Misdirection or Grip of Chaos is stamped at the moment
+         * it becomes the new target. Copies inherit their source's stamps along with its targets.
+         */
+        fun capture(
+            state: GameState,
+            targets: List<ChosenTarget>,
+            targetRequirements: List<TargetRequirement> = emptyList()
+        ): TargetsComponent = TargetsComponent(
+            targets = targets,
+            targetRequirements = targetRequirements,
+            targetEntryStamps = targets.filterIsInstance<ChosenTarget.Permanent>()
+                .filter { it.entityId in state.getBattlefield() }
+                .associate { it.entityId to entryStamp(state, it.entityId) }
+        )
+
+        /**
+         * True when [entityId] is no longer the object that was targeted — it left the battlefield
+         * and returned between targeting and now (CR 400.7). Ids with no captured stamp (targets
+         * chosen off the battlefield, or a stack object built before the stamps existed) are
+         * treated as unchanged.
+         */
+        fun isDifferentObject(
+            state: GameState,
+            entityId: EntityId,
+            capturedStamps: Map<EntityId, Long>
+        ): Boolean {
+            val captured = capturedStamps[entityId] ?: return false
+            return entryStamp(state, entityId) != captured
+        }
+
+        /**
+         * The permanent's battlefield-entry stamp, or 0 for a permanent that never got one —
+         * boards assembled directly (test fixtures) rather than through a real ETB. Capture and
+         * comparison read it the same way, so an unstamped permanent still registers as a new
+         * object once it re-enters for real.
+         */
+        private fun entryStamp(state: GameState, entityId: EntityId): Long =
+            state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
+                ?.timestamp
+                ?: 0L
+    }
+}
 
 /**
  * Represents a chosen target for a spell or ability.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlinkedTargetFizzleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlinkedTargetFizzleScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 400.7 / 608.2b — a permanent that leaves the battlefield and comes back is a *new object*.
+ * A spell or ability that targeted the old object no longer has a legal target, so it doesn't
+ * resolve.
+ *
+ * Entity ids survive zone round-trips in this engine, so target validation must compare the
+ * battlefield-entry stamp captured when the target was chosen, not just "is that id still a
+ * creature on the battlefield".
+ */
+class BlinkedTargetFizzleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("a target blinked in response is a new object") {
+
+            test("Emptiness' -1/-1 trigger fizzles when its target is blinked by Personify") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // Opponent (P2) casts Emptiness with {B}{B} among the mana spent.
+                    .withCardInHand(2, "Emptiness")
+                    .withLandsOnBattlefield(2, "Swamp", 6)
+                    // I control Eirdu and hold Personify.
+                    .withCardOnBattlefield(1, "Eirdu, Carrier of Dawn", summoningSickness = false)
+                    .withCardInHand(1, "Personify")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Emptiness").error shouldBe null
+                game.resolveStack()
+
+                // The black gate trigger asks for its "up to one target creature".
+                val triggerTargets = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the -1/-1 trigger; got ${game.state.pendingDecision}")
+                val eirdu = game.findPermanent("Eirdu, Carrier of Dawn")
+                    ?: error("Eirdu should be on the battlefield")
+                game.submitDecision(TargetsResponse(triggerTargets.id, mapOf(0 to listOf(eirdu))))
+
+                withClue("the trigger should be waiting on the stack") {
+                    game.state.stack.isNotEmpty() shouldBe true
+                }
+
+                // P2 passes; I respond by blinking Eirdu with Personify.
+                if (game.state.priorityPlayerId != game.state.turnOrder[0]) {
+                    game.passPriority()
+                }
+                game.castSpell(1, "Personify", eirdu).error shouldBe null
+
+                game.resolveStack()
+
+                val returned = game.findPermanent("Eirdu, Carrier of Dawn")
+                    ?: error("Eirdu should have returned to the battlefield")
+                val counters = game.state.getEntity(returned)?.get<CountersComponent>()
+                withClue("the returned Eirdu is a new object — the trigger's target is illegal, so it doesn't resolve") {
+                    (counters?.getCount(CounterType.MINUS_ONE_MINUS_ONE) ?: 0) shouldBe 0
+                }
+            }
+
+            test("without the blink the same trigger still puts its three -1/-1 counters on") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Emptiness")
+                    .withLandsOnBattlefield(2, "Swamp", 6)
+                    .withCardOnBattlefield(1, "Eirdu, Carrier of Dawn", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Emptiness").error shouldBe null
+                game.resolveStack()
+
+                val triggerTargets = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the -1/-1 trigger; got ${game.state.pendingDecision}")
+                val eirdu = game.findPermanent("Eirdu, Carrier of Dawn")
+                    ?: error("Eirdu should be on the battlefield")
+                game.submitDecision(TargetsResponse(triggerTargets.id, mapOf(0 to listOf(eirdu))))
+                game.resolveStack()
+
+                val counters = game.state.getEntity(eirdu)?.get<CountersComponent>()
+                counters?.getCount(CounterType.MINUS_ONE_MINUS_ONE) shouldBe 3
+            }
+
+            test("a removal spell fizzles when its target is blinked in response") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Murder")
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Eirdu, Carrier of Dawn", summoningSickness = false)
+                    .withCardInHand(1, "Personify")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val eirdu = game.findPermanent("Eirdu, Carrier of Dawn")
+                    ?: error("Eirdu should be on the battlefield")
+                game.castSpell(2, "Murder", eirdu).error shouldBe null
+
+                if (game.state.priorityPlayerId != game.state.turnOrder[0]) {
+                    game.passPriority()
+                }
+                game.castSpell(1, "Personify", eirdu).error shouldBe null
+
+                game.resolveStack()
+
+                withClue("Murder's target left and returned as a new object, so Murder doesn't resolve") {
+                    game.isOnBattlefield("Eirdu, Carrier of Dawn") shouldBe true
+                }
+            }
+
+            test("a removal spell that is not answered still resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Murder")
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Eirdu, Carrier of Dawn", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val eirdu = game.findPermanent("Eirdu, Carrier of Dawn")
+                    ?: error("Eirdu should be on the battlefield")
+                game.castSpell(2, "Murder", eirdu).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Eirdu, Carrier of Dawn") shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The report

> Opponent casts Emptiness with two black mana and gives three -1/-1 counters to my Eirdu, Carrier of Dawn. Then I play Personify on my Eirdu so it goes above it on the stack. Should the Eirdu, when it comes back into play, still get the -1/-1 counters?

**No.** Personify exiles Eirdu and returns it, and a permanent that changes zones becomes a new object with no relation to its previous existence (CR 400.7). When Emptiness' trigger goes to resolve, its target is no longer the object that was targeted, so it's illegal — and since that's the trigger's only target, the trigger doesn't resolve at all (CR 608.2b). No counters.

The engine got this wrong: the returned Eirdu came back with three -1/-1 counters.

## Cause

Entity ids survive zone round-trips here (`ZoneTransitionService` reuses the id across a blink), so the resolution-time legality check in `StackResolver.validateTargets` — "is that id still a permanent on the battlefield?" — happily said yes. Nothing on the stack object recorded *which* incarnation of the permanent had been targeted.

The engine already has the identity marker: `BattlefieldEntryTimestampComponent`, stamped by `PermanentEntryTracker.record` on every battlefield entry and stripped on leave. Delayed triggers (warp) already compare it. Targeting didn't.

## Fix

- `TargetsComponent` gains `targetEntryStamps` — each permanent target's entry stamp at the moment it was targeted — plus a `capture(state, targets, requirements)` factory and an `isDifferentObject(...)` comparison.
- Every path that chooses or re-chooses targets for a stack object goes through `capture`: putting a spell, a triggered ability, an activated ability, or a spell copy on the stack, and the retarget paths (Misdirection-style change-target, contested retarget, Grip of Chaos' random reselect). A changed target is stamped when it becomes the target.
- `StackResolver.validateTargets` drops a permanent target whose stamp no longer matches, alongside the existing zone / shroud / hexproof / protection checks. Copies inherit their source's stamps with its targets.

Scope note: this covers permanent targets. `ChosenTarget.Card` and `ChosenTarget.Spell` still only check the zone, so the (much rarer) graveyard-card-that-left-and-returned case is unchanged.

## Tests

`BlinkedTargetFizzleScenarioTest` — the reported line (trigger fizzles, zero counters), the same trigger with no response (still three counters), a removal spell blinked out from under (fizzles), and a removal spell nobody answers (still kills).

`just test` — 9932 tests, 0 failures.