### PR TITLE
Let players activate mana abilities during a mana payment (CR 605.3a)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/llm/decision/handlers/SelectManaSourcesHandler.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/llm/decision/handlers/SelectManaSourcesHandler.kt
@@ -14,8 +14,32 @@ class SelectManaSourcesHandler : AiDecisionHandler<SelectManaSourcesDecision> {
 
     override fun canAutoResolve(decision: SelectManaSourcesDecision): Boolean = true
 
-    override fun autoResolve(decision: SelectManaSourcesDecision): DecisionResponse {
-        return ManaSourcesSelectedResponse(decisionId = decision.id, autoPay = true)
+    override fun autoResolve(decision: SelectManaSourcesDecision): DecisionResponse =
+        bestEffortResponse(decision)
+
+    /**
+     * Auto-pay only works when the solver actually found a solution. When [autoPaySuggestion] is
+     * empty — the cost is payable only by sacrificing a Treasure, or by an ability the solver can't
+     * auto-tap at all — submitting `autoPay = true` errors inside the resumer and the engine
+     * re-raises the same decision, looping forever. Mirrors the engine AI's `DecisionResponder`.
+     */
+    private fun bestEffortResponse(decision: SelectManaSourcesDecision): ManaSourcesSelectedResponse {
+        if (decision.autoPaySuggestion.isNotEmpty()) {
+            return ManaSourcesSelectedResponse(decisionId = decision.id, autoPay = true)
+        }
+        // Optional payment with no clean solution — don't burn permanents on it.
+        if (decision.canDecline) {
+            return ManaSourcesSelectedResponse(decisionId = decision.id, declined = true)
+        }
+        // Mandatory (ward, counter-unless-pays): offer everything and let the resumer sort it out.
+        // Sub-cost sources are skipped — the AI can't answer the follow-up tap prompt.
+        return ManaSourcesSelectedResponse(
+            decisionId = decision.id,
+            autoPay = false,
+            selectedSources = decision.availableSources
+                .filterNot { it.requiresTappingAnotherPermanent }
+                .map { it.entityId }
+        )
     }
 
     override fun format(
@@ -33,8 +57,5 @@ class SelectManaSourcesHandler : AiDecisionHandler<SelectManaSourcesDecision> {
         decision: SelectManaSourcesDecision,
         state: ClientGameState,
         parser: AiResponseParser
-    ): DecisionResponse {
-        return ManaSourcesSelectedResponse(decisionId = decision.id, autoPay = true)
-    }
-
+    ): DecisionResponse = bestEffortResponse(decision)
 }

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -997,8 +997,11 @@ blue card and paying 1 life. The `AlternativePaymentHandler` processes these bef
 runs, reducing the remaining cost that must be paid with mana.
 
 **Mana-payment windows (CR 605.3a).** Casting a spell is not the only time a player owes mana.
-Ward, "you may pay {B}", an attack tax, a draw replacement — each stops the game and raises a
-`SelectManaSourcesDecision` asking one player for mana. CR 605.3a says a mana ability may be
+Ward, "you may pay {B}", an attack tax, a draw replacement, "sacrifice this unless you pay {2}",
+a morph's turn-face-up cost — each stops the game and raises a `SelectManaSourcesDecision` asking
+one player for mana. Costs that ask a yes/no question first ("counter unless you pay", pay-or-suffer,
+anything through `CostPaymentService`) raise the window as a *second* step, and only when the
+player's floating mana doesn't already cover the cost — there is nothing to choose when it does. CR 605.3a says a mana ability may be
 activated "whenever a rule or effect asks for a mana payment", so while that decision is open the
 paying player holds no priority but *may* still activate mana abilities. `ManaPaymentWindow` is the
 single definition of that state; both `ActivateAbilityHandler.validate` (the engine's authority
@@ -1013,6 +1016,10 @@ refreshed (a source tapped by hand drops out of the menu), and every payment res
 floating mana before tapping anything — so the player simply confirms. A mana ability that needs a
 decision of its own (choosing a color) nests above a `ReopenManaPaymentDecisionContinuation`, which
 restores the window once it resolves.
+
+Because the window is where the payment actually happens, it is also the only place that may tap
+anything: once it closes, the payer's picks are spent as-is. No resumer falls back to the auto-tap
+solver for a shortfall, which would silently overrule what they chose.
 
 **Affordability vs. auto-tappability.** These payments gate the *prompt itself* on `canPay`: ward
 counters the spell, and a "you may pay" trigger is skipped, without asking when the solver sees no

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1014,6 +1014,17 @@ floating mana before tapping anything — so the player simply confirms. A mana 
 decision of its own (choosing a color) nests above a `ReopenManaPaymentDecisionContinuation`, which
 restores the window once it resolves.
 
+**Affordability vs. auto-tappability.** These payments gate the *prompt itself* on `canPay`: ward
+counters the spell, and a "you may pay" trigger is skipped, without asking when the solver sees no
+way to pay. So `canPay` must know about mana the solver would never auto-tap. It does, via four
+"extras" helpers that contribute production on top of `solve()`: `TapPermanents` (Birchlore
+Rangers), tap+`SacrificeSelf` (Treasure), composite tap+`TapPermanents` (Springleaf Drum), and
+`calculateExplicitActivationBonusMana` for cost shapes `findAvailableManaSources` doesn't model at
+all. They are affordability-only — auto-pay must never silently sacrifice or discard, so the player
+activates these themselves, at priority or inside the payment window. Each helper owns a disjoint
+set of cost shapes; `ExplicitActivationManaSourcesTest` pins that partition so the same source can't
+be counted twice.
+
 **Why three tiers instead of a single "pay cost" function?**
 
 - **Legal action computation.** The server must determine whether each spell in a player's hand is

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -996,6 +996,24 @@ instead of paying generic mana, Convoke taps creatures, and Force of Will can be
 blue card and paying 1 life. The `AlternativePaymentHandler` processes these before the mana solver
 runs, reducing the remaining cost that must be paid with mana.
 
+**Mana-payment windows (CR 605.3a).** Casting a spell is not the only time a player owes mana.
+Ward, "you may pay {B}", an attack tax, a draw replacement — each stops the game and raises a
+`SelectManaSourcesDecision` asking one player for mana. CR 605.3a says a mana ability may be
+activated "whenever a rule or effect asks for a mana payment", so while that decision is open the
+paying player holds no priority but *may* still activate mana abilities. `ManaPaymentWindow` is the
+single definition of that state; both `ActivateAbilityHandler.validate` (the engine's authority
+check) and `GameSession.getLegalActions` (what the server offers the client) read it, and nothing
+else is unlocked — non-mana abilities and spells stay blocked.
+
+This matters because the decision's pre-computed `availableSources` menu is deliberately narrow:
+`findAvailableManaSources` only models `{T}`-shaped abilities, so Ashnod's Altar ("Sacrifice a
+creature: Add {C}{C}") and anything with a discard/Forage sub-cost has no entry in it. The window is
+the general escape hatch. Mana produced this way goes to the pool, the decision is re-raised
+refreshed (a source tapped by hand drops out of the menu), and every payment resumer already spends
+floating mana before tapping anything — so the player simply confirms. A mana ability that needs a
+decision of its own (choosing a color) nests above a `ReopenManaPaymentDecisionContinuation`, which
+restores the window once it resolves.
+
 **Why three tiers instead of a single "pay cost" function?**
 
 - **Legal action computation.** The server must determine whether each spell in a player's hand is

--- a/docs/gym-self-play-testing.md
+++ b/docs/gym-self-play-testing.md
@@ -170,7 +170,7 @@ empty. Post a typed `DecisionResponse` to `POST /envs/{id}/decision`. The JSON d
 | `CHOOSE_OPTION` | `OptionChosenResponse` | `optionIndex: int` |
 | `CHOOSE_REPLACEMENT` | `ReplacementChosenResponse` | `fromIndex: int, toIndex: int` |
 | `ASSIGN_DAMAGE` | `DamageAssignmentResponse` | `assignments: { "<entityId>": int }` |
-| `SELECT_MANA_SOURCES` | `ManaSourcesSelectedResponse` | `selectedSources: ["<id>",…]` or `autoPay: true` |
+| `SELECT_MANA_SOURCES` | `ManaSourcesSelectedResponse` | `selectedSources: ["<id>",…]`, `autoPay: true`, or `declined: true` |
 | `BUDGET_MODAL` | `BudgetModalResponse` | `selectedModeIndices: [int, …]` |
 
 Every response also needs `decisionId` (copy it from `pendingDecision.decisionId`). The

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.priority.AutoPassManager
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
@@ -818,6 +819,17 @@ class GameSession(
 
     fun getLegalActions(playerId: EntityId): List<LegalActionInfo> {
         val state = gameState ?: return emptyList()
+
+        // CR 605.3a — while a rule or effect is asking this seat for a mana payment (ward, "you may
+        // pay {B}", an attack tax) they hold no priority, but they may still activate mana
+        // abilities. Offer exactly those: the pre-computed source menu on the decision only covers
+        // {T}-shaped abilities, so without this a cost payable only with, say, Ashnod's Altar is
+        // unreachable. See [ManaPaymentWindow].
+        ManaPaymentWindow.openFor(state, playerId)?.let { window ->
+            val manaActions = legalActionEnumerator.enumerateManaAbilities(state, window.playerId)
+            return legalActionEnricher.enrich(manaActions, state, window.playerId)
+        }
+
         val priorityPlayer = state.priorityPlayerId ?: return emptyList()
         // Allow either the priority player or, when their turn is hijacked, the controller
         // currently driving them. Legal actions are still enumerated for the affected
@@ -1022,6 +1034,11 @@ class GameSession(
 
         // Can't auto-pass if game is over
         if (state.gameOver) return null
+
+        // Nobody may pass priority while the game is waiting on a decision. This used to be
+        // implicit — getLegalActions returned nothing during a decision — but a mana-payment
+        // window (CR 605.3a) now legitimately offers mana abilities, so state it outright.
+        if (state.pendingDecision != null) return null
 
         // Get the player with priority
         val priorityPlayer = state.priorityPlayerId ?: return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CostPaymentContinuations.kt
@@ -45,3 +45,25 @@ data class CostPaymentContinuation(
     val namedTargets: Map<String, ChosenTarget> = emptyMap(),
     val storedCollections: Map<String, List<EntityId>> = emptyMap()
 ) : ContinuationFrame
+
+/**
+ * Resume after the payer picks mana sources for a [PayCost.Atom] mana cost they already agreed to
+ * pay through [CostPaymentContinuation]'s yes/no.
+ *
+ * Costs paid via `CostPaymentService` used to go straight from "Pay {2}?" to the auto-tap solver,
+ * which meant the payer had no say in which permanents were tapped and no chance to activate a mana
+ * ability (CR 605.3a). Worse, `canAfford` counts mana the solver won't auto-tap — a Treasure, an
+ * Ashnod's Altar — so "yes" could be accepted and then silently fail. This frame inserts the same
+ * second step ward and "counter unless you pay" have always had.
+ *
+ * [inner] carries the original payment untouched: once the chosen sources are tapped and their mana
+ * is in the pool, the resumer performs [CostPaymentContinuation.cost] and runs its `onPaid` /
+ * `onDeclined` follow-up exactly as the direct path would.
+ */
+@Serializable
+data class CostPaymentManaSelectionContinuation(
+    override val decisionId: String,
+    val inner: CostPaymentContinuation,
+    val manaCost: com.wingedsheep.sdk.core.ManaCost,
+    val availableSources: List<ManaSourceOption>
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -403,3 +403,19 @@ data class AddManaPipsContinuation(
     val allowedColors: Set<Color>,
     val restriction: ManaRestriction? = null
 ) : ContinuationFrame
+
+/**
+ * Restores a mana-payment window that was set aside so the player could activate a mana ability
+ * inside it (CR 605.3a).
+ *
+ * Pushed by [com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow.suspend] on top of the payment
+ * continuation the window belongs to, so a decision the mana ability raises for itself (a color
+ * choice for Birds of Paradise, a Fertile Ground tap bonus) nests above this frame and the window
+ * is re-raised only once the ability has fully resolved. Carries the decision verbatim; the
+ * auto-resumer refreshes it against the post-activation board before re-raising it.
+ */
+@Serializable
+data class ReopenManaPaymentDecisionContinuation(
+    override val decisionId: String,
+    val decision: SelectManaSourcesDecision
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -826,8 +826,34 @@ data class ManaSourcesSelectedResponse(
      * Untapped artifacts/creatures the player taps to help pay a Ward—Waterbend cost (Avatar:
      * The Last Airbender) — each pays {1} of the generic. Empty for an ordinary mana payment.
      */
-    val waterbendPermanents: Set<EntityId> = emptySet()
-) : DecisionResponse
+    val waterbendPermanents: Set<EntityId> = emptySet(),
+    /**
+     * The player explicitly refused to pay (only meaningful when
+     * [SelectManaSourcesDecision.canDecline]).
+     *
+     * Declining used to be inferred purely from an empty submission, which stopped being
+     * unambiguous once a player could activate mana abilities during the payment itself
+     * (CR 605.3a — see [com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow]): "I tapped my
+     * own sources and the mana is already floating, just take it" also submits nothing. The flag
+     * separates the two; [isDecline] keeps the old inference as the fallback for clients and AI
+     * players that don't set it.
+     */
+    val declined: Boolean = false
+) : DecisionResponse {
+
+    /**
+     * Whether this submission refuses the payment.
+     *
+     * @param floatingCoversCost true when the player's mana pool already covers the whole cost, in
+     *   which case an empty submission means "pay with what I floated", not "decline".
+     */
+    fun isDecline(floatingCoversCost: Boolean): Boolean = when {
+        declined -> true
+        autoPay -> false
+        selectedSources.isNotEmpty() || waterbendPermanents.isNotEmpty() -> false
+        else -> !floatingCoversCost
+    }
+}
 
 /**
  * Response to cancel a decision and go back to the previous choice.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -261,3 +261,19 @@ data class ReturnFromGraveyardContinuation(
     val sourceName: String?,
     val destination: SearchDestination
 ) : ContinuationFrame
+
+/**
+ * Resume after the payer picks mana sources for a "pay {N} or suffer" cost they already agreed to.
+ *
+ * Same second step [CostPaymentManaSelectionContinuation] adds, for the [PayOrSufferEffect] path:
+ * answering "yes" used to hand the cost straight to the auto-tap solver, so the payer couldn't
+ * choose their sources and couldn't activate a mana ability to cover it (CR 605.3a). Declining at
+ * this step is the same outcome as answering "no" — the suffer effect runs.
+ */
+@Serializable
+data class PayOrSufferManaSelectionContinuation(
+    override val decisionId: String,
+    val inner: PayOrSufferContinuation,
+    val manaCost: ManaCost,
+    val availableSources: List<ManaSourceOption>
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -317,6 +317,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PutOnBottomOfLibraryContinuation::class)
         subclass(ReflexiveTriggerResolveContinuation::class)
         subclass(ReflexiveTriggerTargetContinuation::class)
+        subclass(ReopenManaPaymentDecisionContinuation::class)
         subclass(ReturnFromGraveyardContinuation::class)
         subclass(ReturnFromLinkedExileContinuation::class)
         subclass(CascadeMayCastContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -317,6 +317,8 @@ val engineSerializersModule = SerializersModule {
         subclass(PutOnBottomOfLibraryContinuation::class)
         subclass(ReflexiveTriggerResolveContinuation::class)
         subclass(ReflexiveTriggerTargetContinuation::class)
+        subclass(CostPaymentManaSelectionContinuation::class)
+        subclass(PayOrSufferManaSelectionContinuation::class)
         subclass(ReopenManaPaymentDecisionContinuation::class)
         subclass(ReturnFromGraveyardContinuation::class)
         subclass(ReturnFromLinkedExileContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -23,6 +23,8 @@ import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.toEntityId
 import com.wingedsheep.engine.handlers.effects.bend.BendEvents
 import com.wingedsheep.engine.mechanics.mana.AlternativePaymentHandler
 import com.wingedsheep.engine.mechanics.mana.IntrinsicManaAbilities
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
@@ -126,7 +128,11 @@ class ActivateAbilityHandler(
         if (action.opponentTargetsChosen) {
             return "Internal resume flag cannot be set by a player"
         }
-        if (state.priorityPlayerId != action.playerId) {
+        // CR 605.3a — a mana ability may also be activated "whenever a rule or effect asks for a
+        // mana payment". While such a window is open the paying player holds no priority, so defer
+        // the priority verdict until the ability is known to be a mana ability (checked below).
+        val manaPaymentWindow = ManaPaymentWindow.openFor(state, action.playerId)
+        if (state.priorityPlayerId != action.playerId && manaPaymentWindow == null) {
             return "You don't have priority"
         }
 
@@ -154,6 +160,12 @@ class ActivateAbilityHandler(
             ?: staticGrants.firstOrNull { it.first.id == action.abilityId }?.first
             ?: resolveIntrinsicManaAbility(state, action.sourceId, action.abilityId)
             ?: return "Ability not found on this card"
+
+        // The mana-payment window (CR 605.3a) opens the door for mana abilities only — everything
+        // else still needs priority.
+        if (manaPaymentWindow != null && state.priorityPlayerId != action.playerId && !ability.isManaAbility) {
+            return "Only mana abilities can be activated while paying a cost"
+        }
 
         // Check that the card is in the correct zone for this ability
         if (ability.activateFromZone != Zone.BATTLEFIELD) {
@@ -486,6 +498,47 @@ class ActivateAbilityHandler(
     }
 
     override fun execute(state: GameState, action: ActivateAbility): ExecutionResult {
+        val window = ManaPaymentWindow.openFor(state, action.playerId)
+            ?: return executeActivation(state, action)
+        return executeInManaPaymentWindow(state, action, window)
+    }
+
+    /**
+     * Runs a mana ability activated while the engine is asking [action]'s player for a mana payment
+     * (CR 605.3a — see [ManaPaymentWindow]).
+     *
+     * The window is set aside for the duration so the ability resolves against a decision-free
+     * state, then re-raised. Two things must survive the round trip:
+     *  - **Priority.** The mana-ability path ends with `withPriority(activatingPlayer)` when the
+     *    activation cost fired a trigger. That's right at priority and wrong here — the payment
+     *    resumer will hand priority back itself once the payment completes — so it's restored.
+     *  - **The window.** If the ability paused for a decision of its own, the
+     *    [ReopenManaPaymentDecisionContinuation] pushed by [ManaPaymentWindow.suspend] re-raises it
+     *    afterwards; otherwise it's re-raised here.
+     */
+    private fun executeInManaPaymentWindow(
+        state: GameState,
+        action: ActivateAbility,
+        window: SelectManaSourcesDecision
+    ): ExecutionResult {
+        val result = executeActivation(ManaPaymentWindow.suspend(state, window), action)
+
+        // A failed activation must not eat the window — roll all the way back.
+        result.error?.let { return ExecutionResult.error(state, it) }
+
+        val restored = if (result.state.priorityPlayerId == state.priorityPlayerId) result.state
+        else result.state.copy(
+            priorityPlayerId = state.priorityPlayerId,
+            priorityPassedBy = state.priorityPassedBy
+        )
+        if (result.isPaused) {
+            return ExecutionResult.paused(restored, result.pendingDecision!!, result.events)
+        }
+        return ManaPaymentWindow.resumeIfPending(restored, result.events, cardRegistry)
+            ?: ExecutionResult.success(restored, result.events)
+    }
+
+    private fun executeActivation(state: GameState, action: ActivateAbility): ExecutionResult {
         val container = state.getEntity(action.sourceId)
             ?: return ExecutionResult.error(state, "Source not found")
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -74,7 +74,7 @@ class ActivateAbilityXCostContinuationResumer(
             return ExecutionResult.error(state, "Expected number response for ActivateAbility mana-X choice")
         }
         val chosenX = response.number.coerceAtLeast(0)
-        return handler.execute(state, continuation.action.copy(xValue = chosenX))
+        return reenter(handler.execute(state, continuation.action.copy(xValue = chosenX)), checkForMore)
     }
 
     private fun resumeChooseX(
@@ -98,7 +98,7 @@ class ActivateAbilityXCostContinuationResumer(
                 costPayment = (action.costPayment ?: AdditionalCostPayment())
                     .copy(tappedPermanents = emptyList())
             )
-            return handler.execute(state, replay)
+            return reenter(handler.execute(state, replay), checkForMore)
         }
 
         // Raise the follow-up tap-target selection. minSelections == maxSelections == chosenX so
@@ -169,7 +169,7 @@ class ActivateAbilityXCostContinuationResumer(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(exiledCards = response.selectedCards)
         )
-        return handler.execute(state, replay)
+        return reenter(handler.execute(state, replay), checkForMore)
     }
 
     /**
@@ -210,7 +210,7 @@ class ActivateAbilityXCostContinuationResumer(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(sacrificedPermanents = response.selectedCards)
         )
-        return handler.execute(state, replay)
+        return reenter(handler.execute(state, replay), checkForMore)
     }
 
     /**
@@ -224,7 +224,7 @@ class ActivateAbilityXCostContinuationResumer(
         state: GameState,
         continuation: ActivateAbilityExilePermanentsContinuation,
         response: DecisionResponse,
-        @Suppress("UNUSED_PARAMETER") checkForMore: CheckForMore
+        checkForMore: CheckForMore
     ): ExecutionResult {
         if (response is CancelDecisionResponse) {
             // The exile cost is paid after this pause, so bailing here is side-effect-free.
@@ -251,7 +251,7 @@ class ActivateAbilityXCostContinuationResumer(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(exiledCards = selected)
         )
-        return handler.execute(state, replay)
+        return reenter(handler.execute(state, replay), checkForMore)
     }
 
     /**
@@ -265,7 +265,7 @@ class ActivateAbilityXCostContinuationResumer(
         state: GameState,
         continuation: ActivateAbilityControllerTargetContinuation,
         response: DecisionResponse,
-        @Suppress("UNUSED_PARAMETER") checkForMore: CheckForMore
+        checkForMore: CheckForMore
     ): ExecutionResult {
         if (response is CancelDecisionResponse) {
             // The cost still hasn't been paid at this point, so cancelling is side-effect-free.
@@ -282,7 +282,7 @@ class ActivateAbilityXCostContinuationResumer(
             return ExecutionResult.error(state, "Not enough targets chosen")
         }
         val replay = continuation.action.copy(targets = chosen)
-        return handler.execute(state, replay)
+        return reenter(handler.execute(state, replay), checkForMore)
     }
 
     private fun resumeTapXTargets(
@@ -310,6 +310,20 @@ class ActivateAbilityXCostContinuationResumer(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(tappedPermanents = response.selectedCards)
         )
-        return handler.execute(state, replay)
+        return reenter(handler.execute(state, replay), checkForMore)
     }
+
+    /**
+     * Chains a handler re-entry into `checkForMore` so a continuation pushed *beneath* this
+     * activation still resumes.
+     *
+     * These resumers finish by calling [ActivateAbilityHandler.execute] again with the player's
+     * choice filled in. Returning that result directly strands anything underneath — most visibly a
+     * [com.wingedsheep.engine.core.ReopenManaPaymentDecisionContinuation], which is how a mana
+     * ability activated during a mana payment (CR 605.3a) puts the payment window back up. A paused
+     * or failed re-entry is passed through untouched; its own frame is still in flight.
+     */
+    private fun reenter(result: ExecutionResult, checkForMore: CheckForMore): ExecutionResult =
+        if (result.isPaused || result.error != null) result
+        else checkForMore(result.newState, result.events)
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatTaxContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CombatTaxContinuationResumer.kt
@@ -54,7 +54,7 @@ class CombatTaxContinuationResumer(
         if (response !is ManaSourcesSelectedResponse) {
             return ExecutionResult.error(state, "Expected mana sources selected response for attack tax")
         }
-        if (!response.autoPay && response.selectedSources.isEmpty()) {
+        if (response.isDecline(floatingCovers(state, continuation.attackingPlayer, continuation.manaCost))) {
             // Decline: no mana tapped, no AttackingComponent applied. Drop back into
             // DECLARE_ATTACKERS as a clean no-op (no error banner).
             return ExecutionResult.success(state)
@@ -81,7 +81,7 @@ class CombatTaxContinuationResumer(
         if (response !is ManaSourcesSelectedResponse) {
             return ExecutionResult.error(state, "Expected mana sources selected response for block tax")
         }
-        if (!response.autoPay && response.selectedSources.isEmpty()) {
+        if (response.isDecline(floatingCovers(state, continuation.blockingPlayer, continuation.manaCost))) {
             return ExecutionResult.success(state)
         }
 
@@ -165,4 +165,12 @@ class CombatTaxContinuationResumer(
         }
         return TaxPayment(currentState, events)
     }
+
+    /**
+     * Whether [playerId]'s floating mana already covers [cost] — see
+     * [ManaSourcesSelectedResponse.isDecline]. A player who taps their own sources during the
+     * payment window (CR 605.3a) confirms with an empty selection, which must not read as a refusal.
+     */
+    private fun floatingCovers(state: GameState, playerId: EntityId, cost: ManaCost): Boolean =
+        com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow.floatingManaCovers(state, playerId, cost)
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -169,6 +169,16 @@ class CoreAutoResumerModule(
             )
         },
 
+        // CR 605.3a — the player activated a mana ability while the engine was asking them for a
+        // mana payment, and that ability needed a decision of its own. Now that it has resolved,
+        // put the payment window back up (refreshed: the source they just tapped is gone from the
+        // menu and the auto-pay suggestion covers only what the new floating mana doesn't).
+        autoResumer(ReopenManaPaymentDecisionContinuation::class) { state, continuation, events, _ ->
+            com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow.reopen(
+                state, continuation.decision, events, services.cardRegistry
+            )
+        },
+
         autoResumer(ReflexiveTriggerTargetContinuation::class) { state, continuation, events, checkForMore ->
             // After the action completes, present target selection for the reflexive effect
             val executor = com.wingedsheep.engine.handlers.effects.composite.ReflexiveTriggerEffectExecutor(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -2,6 +2,12 @@ package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.CardsSelectedResponse
 import com.wingedsheep.engine.core.CostPaymentContinuation
+import com.wingedsheep.engine.core.CostPaymentManaSelectionContinuation
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.ExecutionResult
@@ -34,7 +40,8 @@ class CostPaymentContinuationResumer(
     private val paymentService = CostPaymentService(services)
 
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
-        resumer(CostPaymentContinuation::class, ::resume)
+        resumer(CostPaymentContinuation::class, ::resume),
+        resumer(CostPaymentManaSelectionContinuation::class, ::resumeManaSelection)
     )
 
     fun resume(
@@ -87,10 +94,92 @@ class CostPaymentContinuationResumer(
         }
         if (!response.choice) return declined(state, continuation, checkForMore)
 
+        // A mana cost gets a second step: which sources to tap. Ward and "counter unless you pay"
+        // have always worked this way; going straight to the solver here meant the payer couldn't
+        // choose, and couldn't activate a mana ability to cover a cost the solver can't auto-tap
+        // (CR 605.3a — see [ManaPaymentWindow]).
+        manaSourceWindow(state, continuation, cost)?.let { return it }
+
         val execution = paymentService.performPayment(state, continuation.payerId, cost, continuation.sourceId, emptyMap())
         // A defensive payment failure (e.g. mana solve came up short) falls through to declined.
         return if (execution.success) paid(execution.state, execution.events, continuation, checkForMore)
         else declined(state, continuation, checkForMore)
+    }
+
+    /**
+     * Raises the mana-source window for a [cost] the payer just agreed to, or returns null when the
+     * cost isn't mana or their floating mana already covers it (nothing to choose).
+     */
+    private fun manaSourceWindow(
+        state: GameState,
+        continuation: CostPaymentContinuation,
+        cost: PayCost
+    ): ExecutionResult? {
+        val manaCost = ((cost as? PayCost.Atom)?.atom as? CostAtom.Mana)?.cost ?: return null
+        if (ManaPaymentWindow.floatingManaCovers(state, continuation.payerId, manaCost)) return null
+
+        val decisionId = java.util.UUID.randomUUID().toString()
+        val decision = ManaPaymentWindow.buildDecision(
+            state = state,
+            playerId = continuation.payerId,
+            cost = manaCost,
+            decisionId = decisionId,
+            prompt = "Pay $manaCost",
+            context = DecisionContext(
+                sourceId = continuation.sourceId,
+                sourceName = continuation.sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            canDecline = true,
+            cardRegistry = services.cardRegistry
+        )
+        val frame = CostPaymentManaSelectionContinuation(
+            decisionId = decisionId,
+            inner = continuation,
+            manaCost = manaCost,
+            availableSources = decision.availableSources
+        )
+        return ExecutionResult.paused(
+            state.withPendingDecision(decision).pushContinuation(frame),
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = continuation.payerId,
+                    decisionType = "SELECT_MANA_SOURCES",
+                    prompt = decision.prompt
+                )
+            )
+        )
+    }
+
+    /**
+     * Applies the payer's source picks, then finishes the payment [manaSourceWindow] interrupted.
+     * Declining here is the same outcome as answering "no" to the original prompt.
+     */
+    private fun resumeManaSelection(
+        state: GameState,
+        continuation: CostPaymentManaSelectionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is ManaSourcesSelectedResponse) {
+            return ExecutionResult.error(state, "Expected mana sources selected response for cost payment")
+        }
+        val inner = continuation.inner
+        val floated = ManaPaymentWindow.floatSelectedMana(
+            state, inner.payerId, continuation.manaCost, response, continuation.availableSources, services
+        )
+        if (!floated.paid) return declined(floated.state, inner, checkForMore)
+
+        val execution = paymentService.performPayment(
+            floated.state, inner.payerId, inner.cost, inner.sourceId, emptyMap()
+        )
+        return if (execution.success) {
+            paid(execution.state, floated.events + execution.events, inner, checkForMore)
+        } else {
+            declined(floated.state, inner, checkForMore)
+        }
     }
 
     private fun resumeSelection(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.PredicateContext
@@ -405,9 +406,9 @@ class ManaPaymentContinuationResumer(
             return ExecutionResult.error(state, "Expected mana sources selected response")
         }
 
-        // If the player declined (no mana sources, no auto-pay, and no Ward—Waterbend taps to
-        // help), counter the spell.
-        if (!response.autoPay && response.selectedSources.isEmpty() && response.waterbendPermanents.isEmpty()) {
+        // If the player declined (no mana sources, no auto-pay, no Ward—Waterbend taps to help,
+        // and nothing floating that already covers the cost), counter the spell.
+        if (response.isDecline(floatingCovers(state, continuation.payingPlayerId, continuation.manaCost))) {
             val counterResult = if (continuation.exileOnCounter) {
                 services.stackResolver.counterSpellToExile(
                     state, continuation.spellEntityId,
@@ -823,9 +824,10 @@ class ManaPaymentContinuationResumer(
 
         val playerId = continuation.playerId
 
-        // Declined — no mana sources, no auto-pay, and (for a waterbend gate) no taps to help. Run
-        // the "unless" branch (e.g. "discard a card") if one is attached, otherwise nothing happens.
-        if (!response.autoPay && response.selectedSources.isEmpty() && response.waterbendPermanents.isEmpty()) {
+        // Declined — no mana sources, no auto-pay, (for a waterbend gate) no taps to help, and no
+        // floating mana that already covers it. Run the "unless" branch (e.g. "discard a card") if
+        // one is attached, otherwise nothing happens.
+        if (response.isDecline(floatingCovers(state, playerId, continuation.manaCost))) {
             val otherwise = continuation.otherwise
                 ?: return checkForMore(state, emptyList())
             val otherwiseResult = services.effectExecutorRegistry
@@ -1548,4 +1550,12 @@ class ManaPaymentContinuationResumer(
             checkForMore
         )
     }
+
+    /**
+     * Whether [playerId]'s floating mana already covers [cost] — see
+     * [ManaSourcesSelectedResponse.isDecline]. A player who taps their own sources during the
+     * payment window (CR 605.3a) confirms with an empty selection, which must not read as a refusal.
+     */
+    private fun floatingCovers(state: GameState, playerId: EntityId, cost: ManaCost): Boolean =
+        com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow.floatingManaCovers(state, playerId, cost)
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
@@ -17,6 +18,7 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.costs.CostAtom
@@ -31,6 +33,7 @@ class SacrificeAndPayContinuationResumer(
         resumer(SacrificeContinuation::class, ::resumeSacrifice),
         resumer(ExileMultiZoneContinuation::class, ::resumeExileMultiZone),
         resumer(PayOrSufferContinuation::class, ::resumePayOrSuffer),
+        resumer(PayOrSufferManaSelectionContinuation::class, ::resumePayOrSufferManaSelection),
         resumer(PayOrSufferChoiceContinuation::class, ::resumePayOrSufferChoice),
         resumer(AnyPlayerMayPayContinuation::class, ::resumeAnyPlayerMayPay),
         resumer(UntapChoiceContinuation::class, ::resumeUntapChoice)
@@ -462,6 +465,74 @@ class SacrificeAndPayContinuationResumer(
     }
 
     /**
+     * Raises the mana-source window for a "pay or suffer" cost the payer just agreed to.
+     */
+    private fun openManaSourceWindow(
+        state: GameState,
+        continuation: PayOrSufferContinuation,
+        manaCost: ManaCost
+    ): ExecutionResult {
+        val decisionId = java.util.UUID.randomUUID().toString()
+        val decision = ManaPaymentWindow.buildDecision(
+            state = state,
+            playerId = continuation.playerId,
+            cost = manaCost,
+            decisionId = decisionId,
+            prompt = "Pay $manaCost",
+            context = DecisionContext(
+                sourceId = continuation.sourceId,
+                sourceName = continuation.sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            canDecline = true,
+            cardRegistry = services.cardRegistry
+        )
+        val frame = PayOrSufferManaSelectionContinuation(
+            decisionId = decisionId,
+            inner = continuation,
+            manaCost = manaCost,
+            availableSources = decision.availableSources
+        )
+        return ExecutionResult.paused(
+            state.withPendingDecision(decision).pushContinuation(frame),
+            decision,
+            listOf(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = continuation.playerId,
+                    decisionType = "SELECT_MANA_SOURCES",
+                    prompt = decision.prompt
+                )
+            )
+        )
+    }
+
+    /**
+     * Applies the payer's source picks, then re-enters the payment with the mana floating so the
+     * ordinary "pay from pool" path finishes it. Declining is the same outcome as answering "no".
+     */
+    private fun resumePayOrSufferManaSelection(
+        state: GameState,
+        continuation: PayOrSufferManaSelectionContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is ManaSourcesSelectedResponse) {
+            return ExecutionResult.error(state, "Expected mana sources selected response for pay or suffer")
+        }
+        val inner = continuation.inner
+        val floated = ManaPaymentWindow.floatSelectedMana(
+            state, inner.playerId, continuation.manaCost, response, continuation.availableSources, services
+        )
+        if (!floated.paid) return executePayOrSufferConsequence(floated.state, inner, checkForMore)
+
+        // Settle directly rather than re-entering the yes-branch: that would notice a short
+        // submission and raise the window a second time, which is a loop with a stubborn client.
+        // Coming up short here is simply a failure to pay, so the consequence runs.
+        return settleManaPayment(floated.state, inner, continuation.manaCost, floated.events, checkForMore)
+    }
+
+    /**
      * Handle mana cost yes/no choice for pay or suffer.
      */
     private fun resumePayOrSufferMana(
@@ -478,9 +549,33 @@ class SacrificeAndPayContinuationResumer(
             return executePayOrSufferConsequence(state, continuation, checkForMore)
         }
 
-        // Player chose to pay — auto-tap sources and deduct mana
         val manaCost = continuation.manaCost
             ?: return ExecutionResult.error(state, "No mana cost stored in continuation")
+        val playerId = continuation.playerId
+
+        // A second step: which sources to tap. Handing the cost straight to the auto-tap solver
+        // gave the payer no say, and no chance to activate a mana ability for a cost the solver
+        // can't auto-tap — a Treasure, an Ashnod's Altar — which `canPay` counts as affordable, so
+        // "yes" could be accepted and then silently drop through to the suffer effect.
+        // CR 605.3a; see [ManaPaymentWindow].
+        if (!ManaPaymentWindow.floatingManaCovers(state, playerId, manaCost)) {
+            return openManaSourceWindow(state, continuation, manaCost)
+        }
+        return settleManaPayment(state, continuation, manaCost, emptyList(), checkForMore)
+    }
+
+    /**
+     * Spends [manaCost] from the payer's pool and runs the paid branch. Whatever they were going to
+     * tap is already tapped and floating by the time this runs — either they had the mana, or the
+     * source window put it there — so coming up short means the cost simply wasn't paid.
+     */
+    private fun settleManaPayment(
+        state: GameState,
+        continuation: PayOrSufferContinuation,
+        manaCost: ManaCost,
+        priorEvents: List<GameEvent>,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
         val playerId = continuation.playerId
         val playerEntity = state.getEntity(playerId)
             ?: return ExecutionResult.error(state, "Paying player not found")
@@ -497,33 +592,13 @@ class SacrificeAndPayContinuationResumer(
             manaPoolComponent.colorless
         )
 
-        // Try to pay from floating mana first, then tap sources for the rest
-        val partialResult = manaPool.payPartial(manaCost)
-        val remainingCost = partialResult.remainingCost
-        var currentPool = manaPool
+        val currentPool = manaPool
         var currentState = state
-        val events = mutableListOf<GameEvent>()
+        val events = priorEvents.toMutableList()
 
-        if (!remainingCost.isEmpty()) {
-            val manaSolver = ManaSolver(services.cardRegistry)
-            val solution = manaSolver.solve(currentState, playerId, remainingCost)
-                ?: return executePayOrSufferConsequence(state, continuation, checkForMore)
-
-            val (stateAfterTaps, tapEvents) = services.manaAbilitySideEffectExecutor
-                .tapSourcesWithSideEffects(currentState, solution, playerId)
-            currentState = stateAfterTaps
-            events.addAll(tapEvents)
-
-            for ((_, production) in solution.manaProduced) {
-                currentPool = if (production.color != null) {
-                    currentPool.add(production.color)
-                } else {
-                    currentPool.addColorless(production.colorless)
-                }
-            }
-        }
-
-        // Deduct the cost from the pool
+        // No solver fallback here: everything the payer meant to tap is already in the pool —
+        // either they had the mana floating, or the source window put it there. Auto-tapping the
+        // shortfall would silently overrule what they picked.
         val newPool = currentPool.pay(manaCost)
             ?: return executePayOrSufferConsequence(state, continuation, checkForMore)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalActionEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalActionEnumerator.kt
@@ -82,6 +82,31 @@ class LegalActionEnumerator(
         return enumerators.flatMap { it.enumerate(context) }
     }
 
+    /**
+     * Enumerate only [playerId]'s mana abilities, ignoring priority.
+     *
+     * This is the CR 605.3a surface: while a rule or effect is asking a player for a mana payment
+     * they hold no priority, but they may still activate mana abilities to produce the mana. See
+     * [com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow].
+     */
+    fun enumerateManaAbilities(
+        state: GameState,
+        playerId: EntityId,
+        mode: EnumerationMode = EnumerationMode.FULL
+    ): List<LegalAction> = ManaAbilityEnumerator().enumerate(
+        EnumerationContext(
+            state = state,
+            playerId = playerId,
+            cardRegistry = cardRegistry,
+            manaSolver = manaSolver,
+            costCalculator = costCalculator,
+            predicateEvaluator = predicateEvaluator,
+            conditionEvaluator = conditionEvaluator,
+            turnManager = turnManager,
+            mode = mode
+        )
+    )
+
     companion object {
         /**
          * Create a LegalActionEnumerator with the same dependencies as LegalActionsCalculator.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPaymentWindow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPaymentWindow.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.mechanics.mana
+
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.ManaSourceOption
+import com.wingedsheep.engine.core.ReopenManaPaymentDecisionContinuation
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * CR 605.3a — "A player may activate an activated mana ability whenever they have priority,
+ * **whenever they are casting a spell or activating an ability that requires a mana payment, or
+ * whenever a rule or effect asks for a mana payment**, even if it's in the middle of casting or
+ * resolving a spell or activating or resolving an ability."
+ *
+ * A [SelectManaSourcesDecision] is exactly that third clause: the engine has stopped the game to
+ * ask one player for mana (ward, "you may pay {B}", a pay-to-attack tax, a draw replacement, …).
+ * While it is open, that player holds no priority, so the ordinary `priorityPlayerId` gate in
+ * `ActivateAbilityHandler` would reject every mana ability — leaving the pre-computed
+ * [SelectManaSourcesDecision.availableSources] menu as the only way to produce mana. That menu is
+ * deliberately narrow: [ManaSolver.findAvailableManaSources] only models `{T}`-shaped abilities, so
+ * anything with a discard/Forage/sacrifice-something-else sub-cost, or a cost with no `{T}` at all
+ * (Ashnod's Altar), was simply unreachable during a payment.
+ *
+ * This object is the single definition of "a mana payment is being asked for right now". Both the
+ * engine's authority check (`ActivateAbilityHandler.validate`) and the server's offer
+ * (`GameSession.getLegalActions`) read it, so the two can't drift.
+ *
+ * Activating a mana ability inside the window must leave the window itself untouched: the mana goes
+ * to the pool, the decision is re-raised (refreshed — see [refresh]), and the player pays with the
+ * floating mana when they confirm. Every payment resumer already spends the pool before tapping
+ * anything, so no resumer needed to change.
+ */
+object ManaPaymentWindow {
+
+    /**
+     * The open mana-payment decision [playerId] is being asked to pay, or `null` if the game isn't
+     * currently asking them for mana.
+     *
+     * [actorId] is the seat submitting the action, which may be driving another player's turn
+     * (Mindslaver-style control). The window belongs to the *paying* player; the actor only needs
+     * to be whoever currently drives them.
+     */
+    fun openFor(state: GameState, actorId: EntityId): SelectManaSourcesDecision? {
+        val decision = state.pendingDecision as? SelectManaSourcesDecision ?: return null
+        return decision.takeIf { state.actorFor(it.playerId) == actorId }
+    }
+
+    /**
+     * Sets the window aside so a mana ability can resolve against a decision-free state, and
+     * queues its restoration.
+     *
+     * The [ReopenManaPaymentDecisionContinuation] is pushed *above* the payment continuation that
+     * is already on the stack, so if the mana ability raises a decision of its own (choosing a
+     * color for Birds of Paradise, a Fertile Ground tap bonus) that decision nests on top and the
+     * window is re-raised only once the ability has fully resolved.
+     */
+    fun suspend(state: GameState, decision: SelectManaSourcesDecision): GameState =
+        state.clearPendingDecision()
+            .pushContinuation(ReopenManaPaymentDecisionContinuation(decision.id, decision))
+
+    /**
+     * Re-raises the window that [suspend] set aside, popping its continuation frame.
+     *
+     * Returns `null` when the frame isn't on top — the mana ability paused for a nested decision,
+     * so the frame stays put and the auto-resumer will re-raise the window later.
+     */
+    fun resumeIfPending(
+        state: GameState,
+        events: List<GameEvent>,
+        cardRegistry: CardRegistry
+    ): ExecutionResult? {
+        val frame = state.peekContinuation() as? ReopenManaPaymentDecisionContinuation ?: return null
+        val (_, popped) = state.popContinuation()
+        return reopen(popped, frame.decision, events, cardRegistry)
+    }
+
+    /** Re-raises [decision], refreshed against the post-activation board. */
+    fun reopen(
+        state: GameState,
+        decision: SelectManaSourcesDecision,
+        events: List<GameEvent>,
+        cardRegistry: CardRegistry
+    ): ExecutionResult {
+        val refreshed = refresh(state, decision, cardRegistry)
+        return ExecutionResult.paused(state.withPendingDecision(refreshed), refreshed, events)
+    }
+
+    /**
+     * Recomputes the menu against the current board so a source the player just tapped by hand
+     * stops being offered, and the auto-pay suggestion covers only what the floating mana doesn't.
+     *
+     * The refreshed [SelectManaSourcesDecision.availableSources] is always a subset of the original
+     * — activating a mana ability consumes sources, it never creates them — which matters because
+     * the payment continuation still validates the player's final submission against the list it
+     * captured when the window first opened.
+     */
+    fun refresh(
+        state: GameState,
+        decision: SelectManaSourcesDecision,
+        cardRegistry: CardRegistry
+    ): SelectManaSourcesDecision {
+        val solver = ManaSolver(cardRegistry)
+        val stillAvailable = solver.findAvailableManaSources(state, decision.playerId)
+            .map { source ->
+                ManaSourceOption(
+                    entityId = source.entityId,
+                    name = source.name,
+                    producesColors = source.producesColors,
+                    producesColorless = source.producesColorless,
+                    requiresSacrifice = source.requiresSacrifice,
+                    requiresTappingAnotherPermanent = source.tapPermanentsSubCost != null
+                )
+            }
+            .associateBy { it.entityId }
+
+        // Keep the original entries (the continuation validates against those) but drop the ones
+        // the board no longer offers.
+        val availableSources = decision.availableSources.filter { it.entityId in stillAvailable }
+
+        val remaining = remainingCost(state, decision)
+        val autoPaySuggestion = when {
+            remaining == null || remaining.isEmpty() -> emptyList()
+            else -> solver.solve(state, decision.playerId, remaining)?.sources?.map { it.entityId }
+                ?: emptyList()
+        }
+
+        return decision.copy(
+            availableSources = availableSources,
+            autoPaySuggestion = autoPaySuggestion.filter { id -> availableSources.any { it.entityId == id } }
+        )
+    }
+
+    /**
+     * Whether [playerId]'s floating mana already covers [cost] in full.
+     *
+     * Payment resumers use this to tell "I refuse to pay" apart from "I already floated the mana
+     * myself" — both submit an empty source selection.
+     */
+    fun floatingManaCovers(
+        state: GameState,
+        playerId: EntityId,
+        cost: com.wingedsheep.sdk.core.ManaCost
+    ): Boolean {
+        val pool = state.getEntity(playerId)
+            ?.get<com.wingedsheep.engine.state.components.player.ManaPoolComponent>()
+            ?: return false
+        return ManaPool(pool.white, pool.blue, pool.black, pool.red, pool.green, pool.colorless)
+            .payPartial(cost)
+            .remainingCost
+            .isEmpty()
+    }
+
+    /** [SelectManaSourcesDecision.requiredCost] minus what the player already has floating. */
+    private fun remainingCost(
+        state: GameState,
+        decision: SelectManaSourcesDecision
+    ): com.wingedsheep.sdk.core.ManaCost? {
+        val cost = runCatching { com.wingedsheep.sdk.core.ManaCost.parse(decision.requiredCost) }
+            .getOrNull() ?: return null
+        val pool = state.getEntity(decision.playerId)
+            ?.get<com.wingedsheep.engine.state.components.player.ManaPoolComponent>()
+            ?: return cost
+        return ManaPool(pool.white, pool.blue, pool.black, pool.red, pool.green, pool.colorless)
+            .payPartial(cost)
+            .remainingCost
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPaymentWindow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPaymentWindow.kt
@@ -2,6 +2,9 @@ package com.wingedsheep.engine.mechanics.mana
 
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.ManaSourceOption
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.PermanentsSacrificedEvent
+import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.ReopenManaPaymentDecisionContinuation
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.GameEvent
@@ -47,6 +50,184 @@ object ManaPaymentWindow {
         val decision = state.pendingDecision as? SelectManaSourcesDecision ?: return null
         return decision.takeIf { state.actorFor(it.playerId) == actorId }
     }
+
+    /**
+     * Builds a mana-payment window for [cost] — the source menu, the auto-pay suggestion, and the
+     * decision itself. The caller pushes its own continuation with the returned `decisionId` and
+     * pauses; [floatSelectedMana] applies whatever the player submits.
+     *
+     * Sources carrying a secondary tap sub-cost (Springleaf Drum) are left out. Resolving those
+     * needs a nested "which permanent do you tap?" prompt, which only the ward resumer implements —
+     * and since CR 605.3a now lets the player activate any mana ability while the window is open,
+     * leaving them off the menu costs nothing: the player taps the Drum themselves and the mana is
+     * waiting in their pool.
+     */
+    fun buildDecision(
+        state: GameState,
+        playerId: EntityId,
+        cost: com.wingedsheep.sdk.core.ManaCost,
+        decisionId: String,
+        prompt: String,
+        context: com.wingedsheep.engine.core.DecisionContext,
+        canDecline: Boolean,
+        cardRegistry: CardRegistry
+    ): SelectManaSourcesDecision {
+        val solver = ManaSolver(cardRegistry)
+        val options = solver.findAvailableManaSources(state, playerId)
+            .filter { it.tapPermanentsSubCost == null }
+            .map { source ->
+                ManaSourceOption(
+                    entityId = source.entityId,
+                    name = source.name,
+                    producesColors = source.producesColors,
+                    producesColorless = source.producesColorless,
+                    requiresSacrifice = source.requiresSacrifice
+                )
+            }
+        val remaining = remainingAfterFloating(state, playerId, cost)
+        val suggestion = if (remaining.isEmpty()) emptyList()
+            else solver.solve(state, playerId, remaining)?.sources?.map { it.entityId }.orEmpty()
+
+        return SelectManaSourcesDecision(
+            id = decisionId,
+            playerId = playerId,
+            prompt = prompt,
+            context = context,
+            availableSources = options,
+            requiredCost = cost.toString(),
+            autoPaySuggestion = suggestion.filter { id -> options.any { it.entityId == id } },
+            canDecline = canDecline
+        )
+    }
+
+    /** Outcome of applying a [ManaSourcesSelectedResponse] to a window opened by [buildDecision]. */
+    data class FloatResult(
+        val state: GameState,
+        val events: List<GameEvent>,
+        /** False when the player refused, or the submission couldn't produce the mana. */
+        val paid: Boolean
+    )
+
+    /**
+     * Taps (or sacrifices) whatever the player submitted and puts the mana in their pool, leaving
+     * the caller's own payment code to spend it. Floating mana the player already had — including
+     * anything they made with a mana ability inside the window — is left alone and counts toward
+     * the cost.
+     *
+     * Returns `paid = false` for a refusal, or when the submission doesn't add up; the caller runs
+     * its "didn't pay" branch either way.
+     */
+    fun floatSelectedMana(
+        state: GameState,
+        playerId: EntityId,
+        cost: com.wingedsheep.sdk.core.ManaCost,
+        response: ManaSourcesSelectedResponse,
+        availableSources: List<ManaSourceOption>,
+        services: com.wingedsheep.engine.core.EngineServices
+    ): FloatResult {
+        val remaining = remainingAfterFloating(state, playerId, cost)
+        if (response.isDecline(remaining.isEmpty())) return FloatResult(state, emptyList(), paid = false)
+        if (remaining.isEmpty()) return FloatResult(state, emptyList(), paid = true)
+
+        var current = state
+        val events = mutableListOf<GameEvent>()
+        var produced = ManaPool()
+
+        if (response.autoPay) {
+            val solution = ManaSolver(services.cardRegistry).solve(current, playerId, remaining)
+                ?: return FloatResult(state, emptyList(), paid = false)
+            val (afterTaps, tapEvents) = services.manaAbilitySideEffectExecutor
+                .tapSourcesWithSideEffects(current, solution, playerId)
+            current = afterTaps
+            events.addAll(tapEvents)
+            for ((_, p) in solution.manaProduced) {
+                produced = if (p.color != null) produced.add(p.color, p.amount) else produced.addColorless(p.colorless)
+            }
+            // Bonus mana from mana auras / "whenever you tap for mana" riders isn't in
+            // manaProduced; credit it or the cost comes up short (mirrors CostPaymentService.payMana).
+            for (source in solution.sources) {
+                val bonusColor = source.bonusManaColor
+                if (source.bonusManaPerTap > 0 && bonusColor != null) {
+                    produced = produced.add(bonusColor, source.bonusManaPerTap)
+                }
+            }
+        } else {
+            val byId = availableSources.associateBy { it.entityId }
+            for (sourceId in response.selectedSources) {
+                val source = byId[sourceId] ?: return FloatResult(state, emptyList(), paid = false)
+                val tapped = tapOrSacrifice(current, sourceId, source, playerId)
+                current = tapped.first
+                events.addAll(tapped.second)
+                produced = when {
+                    source.producesColors.isNotEmpty() -> produced.add(source.producesColors.first())
+                    source.producesColorless -> produced.addColorless(1)
+                    else -> produced
+                }
+            }
+        }
+
+        return FloatResult(current.addToManaPool(playerId, produced), events, paid = true)
+    }
+
+    /**
+     * Pays a selected source's activation cost: a `{T}, Sacrifice this` source (a Treasure) is
+     * sacrificed, everything else is tapped. A [com.wingedsheep.engine.core.TappedEvent] fires
+     * either way so "becomes tapped" triggers see the tap sub-cost.
+     */
+    private fun tapOrSacrifice(
+        state: GameState,
+        sourceId: EntityId,
+        source: ManaSourceOption,
+        fallbackControllerId: EntityId
+    ): Pair<GameState, List<GameEvent>> {
+        if (!source.requiresSacrifice) {
+            val (tapped, event) = com.wingedsheep.engine.core.tap(state, sourceId)
+            return tapped to listOfNotNull(event)
+        }
+        val controller = state.getEntity(sourceId)
+            ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId
+            ?: fallbackControllerId
+        val events = mutableListOf<GameEvent>(
+            com.wingedsheep.engine.core.TappedEvent(sourceId, source.name)
+        )
+        val preState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+            .trackPermanentSacrifice(state, listOf(sourceId), controller)
+        val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+            .moveToZone(preState, sourceId, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
+        events.add(com.wingedsheep.engine.core.PermanentsSacrificedEvent(controller, listOf(sourceId)))
+        events.addAll(transition.events)
+        return transition.state to events
+    }
+
+    /** [cost] minus [playerId]'s floating mana. */
+    private fun remainingAfterFloating(
+        state: GameState,
+        playerId: EntityId,
+        cost: com.wingedsheep.sdk.core.ManaCost
+    ): com.wingedsheep.sdk.core.ManaCost {
+        val pool = state.getEntity(playerId)
+            ?.get<com.wingedsheep.engine.state.components.player.ManaPoolComponent>()
+            ?: return cost
+        return ManaPool(pool.white, pool.blue, pool.black, pool.red, pool.green, pool.colorless)
+            .payPartial(cost).remainingCost
+    }
+
+    /** Adds [produced] to [playerId]'s pool, preserving restricted mana and provenance. */
+    private fun GameState.addToManaPool(playerId: EntityId, produced: ManaPool): GameState =
+        updateEntity(playerId) { container ->
+            val pool = container.get<com.wingedsheep.engine.state.components.player.ManaPoolComponent>()
+                ?: com.wingedsheep.engine.state.components.player.ManaPoolComponent()
+            container.with(
+                pool.copy(
+                    white = pool.white + produced.white,
+                    blue = pool.blue + produced.blue,
+                    black = pool.black + produced.black,
+                    red = pool.red + produced.red,
+                    green = pool.green + produced.green,
+                    colorless = pool.colorless + produced.colorless
+                )
+            )
+        }
 
     /**
      * Sets the window aside so a mana ability can resolve against a decision-free state, and

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -25,7 +25,10 @@ import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.engine.mechanics.cost.CostPaymentService
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.effects.AddAnyColorManaSpendOnChosenTypeEffect
@@ -1982,9 +1985,12 @@ class ManaSolver(
         //     refuses to auto-tap these because paying SacrificeSelf in the auto-pay flow would
         //     mean silently losing the permanent; the player must opt-in by activating the
         //     ability directly. But the spell is still *affordable* — we just need to know it.
+        //  3. Cost shapes findAvailableManaSources doesn't model at all (Ashnod's Altar's
+        //     "Sacrifice a creature: Add {C}{C}" — no {T} anywhere in the cost).
         val bonus = calculateTapPermanentsBonusMana(state, playerId)
             .plus(calculateSacrificeSelfBonusMana(state, playerId))
             .plus(calculateCompositeTapPermanentsBonusMana(state, playerId))
+            .plus(calculateExplicitActivationBonusMana(state, playerId))
         if (bonus.totalMana == 0) return false
 
         // Allocate any-color bonus mana to the pool based on what the cost needs,
@@ -2047,9 +2053,11 @@ class ManaSolver(
         //  - TapPermanents (e.g., Birchlore Rangers)
         //  - Tap+SacrificeSelf mana abilities (e.g., Treasure tokens)
         //  - Composite Tap+TapPermanents mana abilities (e.g., Springleaf Drum)
+        //  - Costs with no {T} at all, which the solver doesn't model (e.g., Ashnod's Altar)
         val extrasMana = calculateTapPermanentsBonusMana(state, playerId).totalMana +
             calculateSacrificeSelfBonusMana(state, playerId).totalMana +
-            calculateCompositeTapPermanentsBonusMana(state, playerId).totalMana
+            calculateCompositeTapPermanentsBonusMana(state, playerId).totalMana +
+            calculateExplicitActivationBonusMana(state, playerId).totalMana
 
         return floatingMana + sourceMana + extrasMana
     }
@@ -2156,6 +2164,179 @@ class ManaSolver(
         }
 
         return TapPermanentsBonusMana(anyColorTotal, specificColorTotal, colorlessTotal)
+    }
+
+    /**
+     * Calculates extra mana available from mana abilities that can only be produced by activating
+     * them explicitly, because [findAvailableManaSources] does not model their cost shape at all.
+     *
+     * That function accepts exactly three shapes — a bare `{T}`, a bare pay-life, and a composite
+     * containing `{T}` whose other parts are all pay-life/mana — and drops everything else on the
+     * floor (`else -> false // Skip non-tap mana abilities`). So Ashnod's Altar ("Sacrifice a
+     * creature: Add {C}{C}"), a `{T}`-plus-discard ability, or anything with a Forage sub-cost is
+     * invisible to the solver, and therefore to `canPay`. That mattered because ward, "counter
+     * unless you pay", and "you may pay {N}" all gate the *prompt itself* on `canPay`: a player
+     * whose only mana source was one of these had their spell countered without ever being asked.
+     *
+     * Like the other three extras helpers, this only feeds affordability. `solve()` still won't
+     * auto-tap these sources — paying a sacrifice or discard sub-cost silently is not something
+     * auto-pay may do — so the player activates the ability themselves, either at priority or
+     * inside the payment window that
+     * [com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow] opens (CR 605.3a).
+     *
+     * Deliberately conservative: an ability is counted only when every non-mana part of its cost is
+     * verifiably payable right now. Anything whose payability can't be established here (a Craft or
+     * Blight cost, an `{X}`-shaped one) is skipped rather than assumed affordable.
+     */
+    internal fun calculateExplicitActivationBonusMana(
+        state: GameState,
+        playerId: EntityId
+    ): TapPermanentsBonusMana {
+        val projected = state.projectedState
+        var total = TapPermanentsBonusMana()
+
+        for (entityId in projected.getBattlefieldControlledBy(playerId)) {
+            val container = state.getEntity(entityId) ?: continue
+            // Face-down permanents have no abilities (CR 708.2).
+            if (container.has<FaceDownComponent>()) continue
+            val card = container.get<CardComponent>() ?: continue
+
+            val ownAbilities = if (projected.hasLostAllAbilities(entityId)) emptyList()
+                else cardRegistry.getCard(card.cardDefinitionId)?.script?.activatedAbilities.orEmpty()
+            val abilities = ownAbilities + getStaticGrantedManaAbilities(entityId, state)
+
+            for (ability in abilities) {
+                if (!ability.isManaAbility) continue
+                val cost = ability.cost
+                if (manaAbilityIsAlreadyCounted(cost)) continue
+                // A mana sub-cost would recurse straight back into canPay, and its net production
+                // is ambiguous anyway — the same call the tap+SacrificeSelf helper makes.
+                if (costHasManaSubCost(cost)) continue
+                if (!activationRestrictionsSatisfied(state, playerId, entityId, ability)) continue
+                if (!nonManaAbilityCostIsPayable(state, playerId, entityId, cost)) continue
+
+                total += manaProducedByEffect(ability.effect)
+            }
+        }
+
+        return total
+    }
+
+    /**
+     * Whether a mana ability with this cost is already reflected in the mana the affordability
+     * path counts — either modelled by [findAvailableManaSources] or picked up by one of the other
+     * extras helpers. Counting it again in [calculateExplicitActivationBonusMana] would inflate
+     * `canPay` and `getAvailableManaCount`.
+     *
+     * Mirrors the accept conditions of `abilityCanBeUsed` inside [findAvailableManaSources] and the
+     * cost shapes matched by [calculateTapPermanentsBonusMana], [calculateSacrificeSelfBonusMana]
+     * and [calculateCompositeTapPermanentsBonusMana]. `ManaSolverExtrasNoDoubleCountTest` pins the
+     * two together: it asserts the available-mana count for a Treasure / Birchlore / Springleaf
+     * board is unchanged by this helper.
+     */
+    private fun manaAbilityIsAlreadyCounted(cost: AbilityCost): Boolean = when (cost) {
+        // Modelled by findAvailableManaSources.
+        is AbilityCost.Tap -> true
+        is AbilityCost.Atom -> when (cost.atom) {
+            is CostAtom.PayLife -> true                 // modelled (a pain land)
+            is CostAtom.TapPermanents -> true           // calculateTapPermanentsBonusMana
+            else -> false
+        }
+        is AbilityCost.Composite -> {
+            if (cost.costs.none { it is AbilityCost.Tap }) false
+            else if (cost.costs.any { it is AbilityCost.SacrificeSelf }) true               // sac-self helper
+            else if (cost.costs.any { (it as? AbilityCost.Atom)?.atom is CostAtom.TapPermanents }) true // composite helper
+            else cost.costs.all { sub ->
+                sub is AbilityCost.Tap ||
+                    ((sub as? AbilityCost.Atom)?.atom.let { it is CostAtom.PayLife || it is CostAtom.Mana })
+            }
+        }
+        else -> false
+    }
+
+    /** Whether any part of [cost] is a mana payment. */
+    private fun costHasManaSubCost(cost: AbilityCost): Boolean = when (cost) {
+        is AbilityCost.Atom -> cost.atom is CostAtom.Mana
+        is AbilityCost.Composite -> cost.costs.any { costHasManaSubCost(it) }
+        else -> false
+    }
+
+    /**
+     * Whether every non-mana part of [cost] can be paid right now by [playerId] activating the
+     * ability on [sourceId]. Unrecognised cost shapes report false — see the conservatism note on
+     * [calculateExplicitActivationBonusMana].
+     */
+    private fun nonManaAbilityCostIsPayable(
+        state: GameState,
+        playerId: EntityId,
+        sourceId: EntityId,
+        cost: AbilityCost
+    ): Boolean = when (cost) {
+        is AbilityCost.Free -> true
+        is AbilityCost.Tap -> canTapForCost(state, sourceId)
+        // The source itself pays these, and it is on the battlefield by construction.
+        is AbilityCost.SacrificeSelf, is AbilityCost.ExileSelf,
+        is AbilityCost.ReturnSelfToHand, is AbilityCost.DiscardSelf -> true
+        // Discarding an empty hand is a legal payment of "discard your hand".
+        is AbilityCost.DiscardHand -> true
+        is AbilityCost.SacrificeChosenCreatureType -> {
+            val chosenType = state.getEntity(sourceId)?.chosenCreatureType()
+            chosenType != null && controlsMatching(
+                state, playerId, GameObjectFilter.Creature.withSubtype(chosenType), null, 1
+            )
+        }
+        is AbilityCost.TapAttachedCreature -> {
+            val attachedTo = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId
+            attachedTo != null && canTapForCost(state, attachedTo)
+        }
+        // CR 701.58a — forage: exile three cards from your graveyard, or sacrifice a Food.
+        is AbilityCost.Forage -> state.getZone(ZoneKey(playerId, Zone.GRAVEYARD)).size >= 3 ||
+            state.projectedState.getBattlefieldControlledBy(playerId)
+                .any { state.projectedState.hasSubtype(it, Subtype.FOOD.value) }
+        is AbilityCost.Atom -> CostPaymentService.canAfford(
+            state = state,
+            payerId = playerId,
+            cost = PayCost.Atom(cost.atom),
+            sourceId = sourceId,
+            manaSolver = this,
+            // The source pays its own cost unless the atom says otherwise (CR 601.2h) — mirrors
+            // ManaAbilityEnumerator, which only excludes self for an excludeSelf sacrifice.
+            excludeSource = (cost.atom as? CostAtom.Sacrifice)?.excludeSelf == true
+        )
+        is AbilityCost.Composite -> cost.costs.all {
+            nonManaAbilityCostIsPayable(state, playerId, sourceId, it)
+        }
+        else -> false
+    }
+
+    /** Whether [entityId] can pay a `{T}` cost: untapped, and not a summoning-sick creature. */
+    private fun canTapForCost(state: GameState, entityId: EntityId): Boolean {
+        val container = state.getEntity(entityId) ?: return false
+        if (container.has<TappedComponent>()) return false
+        val card = container.get<CardComponent>() ?: return false
+        val projected = state.projectedState
+        // Summoning sickness only bites non-land creatures (CR 302.6).
+        if (!card.typeLine.isLand && projected.isCreature(entityId)) {
+            if (container.has<SummoningSicknessComponent>() &&
+                !projected.hasKeyword(entityId, Keyword.HASTE)
+            ) return false
+        }
+        return true
+    }
+
+    /** Whether [playerId] controls at least [count] permanents matching [filter]. */
+    private fun controlsMatching(
+        state: GameState,
+        playerId: EntityId,
+        filter: GameObjectFilter,
+        excludeId: EntityId?,
+        count: Int
+    ): Boolean {
+        val projected = state.projectedState
+        val context = PredicateContext(controllerId = playerId)
+        return projected.getBattlefieldControlledBy(playerId).count { id ->
+            id != excludeId && predicateEvaluator.matches(state, projected, id, filter, context)
+        } >= count
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mana/ExplicitActivationManaSourcesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mana/ExplicitActivationManaSourcesTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.mana
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.AshnodsAltar
+import com.wingedsheep.mtg.sets.definitions.lrw.cards.SpringleafDrum
+import com.wingedsheep.mtg.sets.definitions.ons.cards.BirchloreRangers
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [ManaSolver.calculateExplicitActivationBonusMana] — the fourth "extras" helper.
+ *
+ * `findAvailableManaSources` models exactly three cost shapes (a bare `{T}`, a bare pay-life, and a
+ * `{T}`-bearing composite of pay-life/mana parts) and skips everything else. Ward, "counter unless
+ * you pay" and "you may pay {N}" all gate the *prompt* on `canPay`, so a player whose only mana
+ * source had an unmodelled cost shape was never asked to pay at all.
+ *
+ * The counting must stay exact in both directions: the new helper has to see Ashnod's Altar, and it
+ * must not re-count the sources the other three extras helpers already cover.
+ */
+class ExplicitActivationManaSourcesTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                AshnodsAltar, BirchloreRangers, SpringleafDrum, PredefinedTokens.Treasure,
+            )
+        )
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun solver(driver: GameTestDriver) = ManaSolver(driver.cardRegistry)
+
+    test("Ashnod's Altar makes a cost affordable even though the solver can't tap it") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        val s = solver(driver)
+        // No lands, so the auto-tap solver finds nothing…
+        s.solve(driver.state, player, ManaCost.parse("{2}")) shouldBe null
+        // …but "Sacrifice a creature: Add {C}{C}" is a real payment the player can make.
+        s.canPay(driver.state, player, ManaCost.parse("{2}")) shouldBe true
+        s.calculateExplicitActivationBonusMana(driver.state, player).totalMana shouldBe 2
+    }
+
+    test("an altar with nothing to sacrifice pays for nothing") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+
+        val s = solver(driver)
+        s.calculateExplicitActivationBonusMana(driver.state, player).totalMana shouldBe 0
+        s.canPay(driver.state, player, ManaCost.parse("{2}")) shouldBe false
+    }
+
+    test("colorless production does not make a colored cost affordable") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        val s = solver(driver)
+        s.canPay(driver.state, player, ManaCost.parse("{G}")) shouldBe false
+        s.canPay(driver.state, player, ManaCost.parse("{1}")) shouldBe true
+    }
+
+    test("a tapped altar still works — its cost has no {T}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val altar = driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.tapPermanent(altar)
+
+        solver(driver).calculateExplicitActivationBonusMana(driver.state, player).totalMana shouldBe 2
+    }
+
+    context("no double-counting with the other extras helpers") {
+        test("Treasure is counted only by the tap+SacrificeSelf helper") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            driver.putPermanentOnBattlefield(player, "Treasure")
+
+            val s = solver(driver)
+            s.calculateExplicitActivationBonusMana(driver.state, player).totalMana shouldBe 0
+            s.getAvailableManaCount(driver.state, player) shouldBe 1
+        }
+
+        test("Birchlore Rangers is counted only by the TapPermanents helper") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            driver.putCreatureOnBattlefield(player, "Birchlore Rangers")
+            driver.putCreatureOnBattlefield(player, "Llanowar Elves")
+
+            solver(driver).calculateExplicitActivationBonusMana(driver.state, player)
+                .totalMana shouldBe 0
+        }
+
+        test("Springleaf Drum is counted only by the composite TapPermanents helper") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            driver.putPermanentOnBattlefield(player, "Springleaf Drum")
+            driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+            solver(driver).calculateExplicitActivationBonusMana(driver.state, player)
+                .totalMana shouldBe 0
+        }
+
+        test("plain lands and mana dorks are counted only as ordinary sources") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            driver.putPermanentOnBattlefield(player, "Forest")
+            driver.removeSummoningSickness(driver.putCreatureOnBattlefield(player, "Llanowar Elves"))
+            driver.removeSummoningSickness(driver.putCreatureOnBattlefield(player, "Birds of Paradise"))
+
+            val s = solver(driver)
+            s.calculateExplicitActivationBonusMana(driver.state, player).totalMana shouldBe 0
+            s.getAvailableManaCount(driver.state, player) shouldBe 3
+        }
+    }
+
+    test("floating mana plus an altar covers a cost neither covers alone") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.giveMana(player, Color.GREEN, 1)
+
+        solver(driver).canPay(driver.state, player, ManaCost.parse("{2}{G}")) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -28,7 +28,11 @@ import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -69,7 +73,44 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
 
+            // Agreeing to a mana cost now opens the source window (CR 605.3a) instead of handing
+            // the cost straight to the auto-tap solver. Auto-pay picks the Forest.
+            val sources = game.state.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+            sources.availableSources.map { it.entityId } shouldBe listOf(forest)
+            game.submitDecision(ManaSourcesSelectedResponse(sources.id, autoPay = true))
+
             game.state.getEntity(forest)!!.has<TappedComponent>().shouldBeTrue()
+        }
+
+        test("Mana: a Treasure auto-pay refuses can still be picked by hand in the source window") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Treasure")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val treasure = bfCardByName(game.state, game.player1Id, "Treasure")
+
+            // The solver won't auto-tap a Treasure (paying its sacrifice sub-cost silently isn't
+            // something auto-pay may do), but the cost is affordable and the window offers it.
+            service.canAfford(game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{G}")), source).shouldBeTrue()
+
+            val pending = service.pay(game.state, game.player1Id, Costs.pay.Mana(ManaCost.parse("{G}")), source)
+                as PaymentResult.Pending
+            game.state = pending.state
+            game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+
+            val window = game.state.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+            window.availableSources.single().requiresSacrifice.shouldBeTrue()
+            window.autoPaySuggestion.shouldBeEmpty()
+
+            game.submitDecision(
+                ManaSourcesSelectedResponse(window.id, selectedSources = listOf(treasure))
+            )
+
+            // Sacrificed for the mana, and the cost is paid.
+            game.state.getBattlefield(game.player1Id) shouldNotContain treasure
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain treasure
         }
 
         test("Mana: declining leaves the source untapped and runs onDeclined") {
@@ -111,6 +152,9 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val pending = service.pay(game.state, game.player1Id, PayCost.OwnManaCost, source) as PaymentResult.Pending
             game.state = pending.state
             game.submitDecision(YesNoResponse(pending.pendingDecision.id, true))
+            game.submitDecision(
+                ManaSourcesSelectedResponse(game.state.pendingDecision!!.id, autoPay = true)
+            )
 
             game.state.getEntity(mountain)!!.has<TappedComponent>().shouldBeTrue()
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilitiesDuringPaymentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilitiesDuringPaymentTest.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -194,6 +195,56 @@ class ManaAbilitiesDuringPaymentTest : FunSpec({
         driver.bothPass()
 
         driver.findPermanent(opponent, "Warded Bear") shouldBe null
+    }
+
+    test("ward prompts at all when the only mana source is one the solver can't tap") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Warded Bear")
+        // No lands at all — Blood Chalice's "Sacrifice this artifact: Add {B}" is the only way to
+        // pay ward {1}, and `findAvailableManaSources` cannot see it. Before the affordability
+        // path learned about explicit-activation sources, the pre-gate concluded "can't pay" and
+        // countered the spell without ever asking.
+        val chalice = driver.putPermanentOnBattlefield(caster, "Blood Chalice")
+
+        driver.giveMana(caster, Color.RED, 1)
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(bear)))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        decision.availableSources.shouldBeEmpty()
+
+        driver.submit(ActivateAbility(caster, chalice, driver.manaAbilityOf("Blood Chalice").id))
+            .error shouldBe null
+        driver.submitDecision(caster, ManaSourcesSelectedResponse(driver.pendingDecision!!.id))
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Warded Bear") shouldBe null
+    }
+
+    test("ward still counters with no way at all to pay") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Warded Bear")
+        // A Blood Chalice with nothing to sacrifice… is fine, it sacrifices itself. Give the
+        // caster nothing instead: the pre-gate must still short-circuit to countered.
+        driver.giveMana(caster, Color.RED, 1)
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(bear)))
+        driver.bothPass()
+
+        driver.pendingDecision shouldBe null
+        driver.findPermanent(opponent, "Warded Bear").shouldNotBeNull()
     }
 
     test("declining a ward explicitly still counters the spell even with mana floating") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilitiesDuringPaymentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilitiesDuringPaymentTest.kt
@@ -1,0 +1,241 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ecl.LorwynEclipsedSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * CR 605.3a — "A player may activate an activated mana ability whenever they have priority,
+ * whenever they are casting a spell or activating an ability that requires a mana payment, **or
+ * whenever a rule or effect asks for a mana payment**."
+ *
+ * That last clause is what these tests cover. A [SelectManaSourcesDecision] is the engine asking a
+ * player for mana (ward, "you may pay {B}", an attack tax); the player holds no priority while it
+ * is open, but they may still activate mana abilities to produce what they need.
+ *
+ * Before this, the decision's pre-computed `availableSources` menu was the only way to make mana
+ * during a payment — and [com.wingedsheep.engine.mechanics.mana.ManaSolver.findAvailableManaSources]
+ * only models `{T}`-shaped abilities, so anything else (Ashnod's Altar's "Sacrifice a creature: Add
+ * {C}{C}") was simply unreachable.
+ */
+class ManaAbilitiesDuringPaymentTest : FunSpec({
+
+    /**
+     * An Ashnod's-Altar-shaped mana source: the activation cost has no `{T}`, so the solver skips
+     * it and it never appears in a [SelectManaSourcesDecision]'s source menu.
+     */
+    val bloodChalice = card("Blood Chalice") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        activatedAbility {
+            cost = Costs.SacrificeSelf
+            effect = Effects.AddMana(Color.BLACK)
+            manaAbility = true
+        }
+    }
+
+    /** A plain non-mana activated ability — must stay locked while a payment window is open. */
+    val tomeOfIdeas = card("Tome of Ideas") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    val wardedBear = card("Warded Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+        keywordAbility(KeywordAbility.ward("{1}"))
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + LorwynEclipsedSet.cards + listOf(bloodChalice, tomeOfIdeas, wardedBear))
+        return driver
+    }
+
+    fun GameTestDriver.manaPool(playerId: com.wingedsheep.sdk.model.EntityId): ManaPoolComponent =
+        state.getEntity(playerId)!!.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    fun GameTestDriver.manaAbilityOf(cardName: String) =
+        cardRegistry.getCard(cardName)!!.script.activatedAbilities.first { it.isManaAbility }
+
+    /** Advance to the controller's next first main phase so Eirdu's may-pay trigger fires. */
+    fun GameTestDriver.advanceToNextFirstMain() {
+        passPriorityUntil(Step.END)
+        bothPass()
+        passPriorityUntil(Step.END)
+        bothPass()
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Eirdu's first-main trigger, answered "yes", leaves a mana-source decision open. */
+    fun openEirduPaymentWindow(driver: GameTestDriver): Pair<com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val eirdu = driver.putCreatureOnBattlefield(caster, "Eirdu, Carrier of Dawn")
+        val birds = driver.putCreatureOnBattlefield(caster, "Birds of Paradise")
+        driver.advanceToNextFirstMain()
+        driver.bothPass()
+        driver.submitYesNo(caster, true)
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        return eirdu to birds
+    }
+
+    test("mana ability can be activated while a may-pay mana source decision is open") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), skipMulligans = true)
+        val caster = driver.activePlayer!!
+        val (eirdu, birds) = openEirduPaymentWindow(driver)
+
+        val result = driver.submit(
+            ActivateAbility(caster, birds, driver.manaAbilityOf("Birds of Paradise").id, manaColorChoice = Color.BLACK)
+        )
+        result.error shouldBe null
+
+        // The mana is floating and the window is still open.
+        driver.manaPool(caster).black shouldBe 1
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+
+        // Confirming with nothing selected now pays from the floating mana instead of declining.
+        driver.submitDecision(caster, ManaSourcesSelectedResponse(driver.pendingDecision!!.id))
+        driver.bothPass()
+
+        driver.state.getEntity(eirdu)!!.get<DoubleFacedComponent>()!!.currentFace shouldBe
+            DoubleFacedComponent.Face.BACK
+        driver.manaPool(caster).black shouldBe 0
+    }
+
+    test("a source tapped by hand drops out of the refreshed source menu") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), skipMulligans = true)
+        val caster = driver.activePlayer!!
+        val (_, birds) = openEirduPaymentWindow(driver)
+
+        (driver.pendingDecision as SelectManaSourcesDecision)
+            .availableSources.map { it.entityId } shouldContain birds
+
+        driver.submit(
+            ActivateAbility(caster, birds, driver.manaAbilityOf("Birds of Paradise").id, manaColorChoice = Color.BLACK)
+        ).error shouldBe null
+
+        (driver.pendingDecision as SelectManaSourcesDecision)
+            .availableSources.map { it.entityId } shouldNotContain birds
+    }
+
+    test("non-mana abilities are still rejected while a payment window is open") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), skipMulligans = true)
+        val caster = driver.activePlayer!!
+        openEirduPaymentWindow(driver)
+
+        val tome = driver.putPermanentOnBattlefield(caster, "Tome of Ideas")
+        val drawAbility = driver.cardRegistry.getCard("Tome of Ideas")!!
+            .script.activatedAbilities.first { !it.isManaAbility }
+
+        driver.submit(ActivateAbility(caster, tome, drawAbility.id))
+            .error shouldBe "Only mana abilities can be activated while paying a cost"
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+    }
+
+    test("ward is paid with a mana ability the source menu cannot offer") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Warded Bear")
+        val chalice = driver.putPermanentOnBattlefield(caster, "Blood Chalice")
+        // A Mountain is what the solver can see; it keeps the ward affordability pre-gate happy.
+        driver.putPermanentOnBattlefield(caster, "Mountain")
+
+        driver.giveMana(caster, Color.RED, 1)
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(bear)))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        // "Sacrifice this artifact: Add {B}" has no {T} in its cost, so the solver never models it.
+        decision.availableSources.map { it.entityId } shouldNotContain chalice
+
+        driver.submit(ActivateAbility(caster, chalice, driver.manaAbilityOf("Blood Chalice").id))
+            .error shouldBe null
+        driver.manaPool(caster).black shouldBe 1
+
+        // Confirm with nothing selected — the floating {B} covers ward {1}, so this pays rather
+        // than declining, and the bolt is not countered.
+        driver.submitDecision(caster, ManaSourcesSelectedResponse(driver.pendingDecision!!.id))
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Warded Bear") shouldBe null
+    }
+
+    test("declining a ward explicitly still counters the spell even with mana floating") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Warded Bear")
+        driver.putPermanentOnBattlefield(caster, "Mountain")
+
+        driver.giveMana(caster, Color.RED, 2)
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(bear)))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        decision.canDecline shouldBe true
+
+        // A leftover {R} is floating and would cover ward {1} — only the explicit flag means "no".
+        driver.manaPool(caster).red shouldBe 1
+        driver.submitDecision(caster, ManaSourcesSelectedResponse(decision.id, declined = true))
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Warded Bear").shouldNotBeNull()
+    }
+
+    test("the mana-payment window does not let a player cast spells or hold priority") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), skipMulligans = true)
+        val caster = driver.activePlayer!!
+        openEirduPaymentWindow(driver)
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        val error = driver.submit(
+            com.wingedsheep.engine.core.CastSpell(caster, bolt)
+        ).error
+        error.shouldNotBeNull()
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayOrSufferManaWindowTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayOrSufferManaWindowTest.kt
@@ -1,0 +1,175 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.atq.cards.AshnodsAltar
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * "Sacrifice this unless you pay {2}" — [PayOrSufferEffect] with a mana cost.
+ *
+ * Agreeing to pay used to hand the cost straight to the auto-tap solver: the player couldn't choose
+ * which permanents were tapped, and couldn't activate a mana ability to cover it (CR 605.3a). Once
+ * `canPay` learned to count mana the solver won't auto-tap (a Treasure, an Ashnod's Altar), that
+ * became an outright bug — the yes/no was offered, the player said yes, and the permanent was
+ * sacrificed anyway because `solve()` came up empty.
+ *
+ * The fix gives this path the same second step ward and "counter unless you pay" have always had.
+ */
+class PayOrSufferManaWindowTest : FunSpec({
+
+    /** "At the beginning of your upkeep, sacrifice this creature unless you pay {2}." */
+    val upkeepToll = card("Upkeep Toll") {
+        manaCost = "{1}"
+        typeLine = "Creature — Spirit"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = PayOrSufferEffect(
+                cost = Costs.pay.Mana("{2}"),
+                suffer = SacrificeSelfEffect
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AshnodsAltar, upkeepToll))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Ends the current turn so the controller's next upkeep fires the toll. */
+    fun GameTestDriver.advanceToMyNextUpkeep() {
+        passPriorityUntil(Step.END)
+        bothPass()
+        passPriorityUntil(Step.END)
+        bothPass()
+        passPriorityUntil(Step.UPKEEP)
+    }
+
+    fun GameTestDriver.manaPool(playerId: com.wingedsheep.sdk.model.EntityId) =
+        state.getEntity(playerId)!!.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    test("agreeing to pay opens a mana source window instead of auto-tapping") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Upkeep Toll")
+        val forestA = driver.putPermanentOnBattlefield(player, "Forest")
+        driver.putPermanentOnBattlefield(player, "Forest")
+
+        driver.advanceToMyNextUpkeep()
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(player, true)
+
+        // The second step: which sources to tap.
+        val window = driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        window.requiredCost shouldBe "{2}"
+        window.canDecline shouldBe true
+
+        // Pick one Forest by hand; auto-pay would have chosen for us.
+        driver.submitDecision(
+            player,
+            ManaSourcesSelectedResponse(window.id, selectedSources = listOf(forestA))
+        )
+        // Only one Forest covers {1} of {2}, so the payment falls short and the toll is collected.
+        driver.findPermanent(player, "Upkeep Toll") shouldBe null
+    }
+
+    test("the toll is paid with a mana ability activated inside the window") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val toll = driver.putCreatureOnBattlefield(player, "Upkeep Toll")
+        val altar = driver.putPermanentOnBattlefield(player, "Ashnod's Altar")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        driver.advanceToMyNextUpkeep()
+        driver.bothPass()
+
+        // No lands at all — the only mana is "Sacrifice a creature: Add {C}{C}", which the solver
+        // cannot auto-tap. The prompt is offered because canPay counts it.
+        driver.submitYesNo(player, true)
+        val window = driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        window.availableSources shouldBe emptyList()
+        window.autoPaySuggestion shouldBe emptyList()
+
+        // CR 605.3a — activate the Altar while the window is open. Its cost needs a creature
+        // chosen, so the ability raises a decision of its own *inside* the window.
+        val altarAbility = driver.cardRegistry.getCard("Ashnod's Altar")!!
+            .script.activatedAbilities.first { it.isManaAbility }
+        driver.submit(ActivateAbility(player, altar, altarAbility.id)).error shouldBe null
+
+        val bears = driver.findPermanent(player, "Grizzly Bears").shouldNotBeNull()
+        driver.submitCardSelection(player, listOf(bears))
+
+        // The nested decision resolved and the window came back up on its own.
+        driver.manaPool(player).colorless shouldBe 2
+        driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+
+        driver.submitDecision(player, ManaSourcesSelectedResponse(driver.pendingDecision!!.id))
+
+        driver.state.getEntity(toll).shouldNotBeNull()
+        driver.findPermanent(player, "Upkeep Toll").shouldNotBeNull()
+        driver.manaPool(player).colorless shouldBe 0
+    }
+
+    test("declining in the window collects the toll, same as answering no") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Upkeep Toll")
+        driver.putPermanentOnBattlefield(player, "Forest")
+        driver.putPermanentOnBattlefield(player, "Forest")
+
+        driver.advanceToMyNextUpkeep()
+        driver.bothPass()
+        driver.submitYesNo(player, true)
+
+        val window = driver.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        driver.submitDecision(player, ManaSourcesSelectedResponse(window.id, declined = true))
+
+        driver.findPermanent(player, "Upkeep Toll") shouldBe null
+    }
+
+    test("floating mana pays without opening a window at all") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Upkeep Toll")
+
+        driver.advanceToMyNextUpkeep()
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.GREEN, 2)
+        driver.bothPass()
+
+        driver.submitYesNo(player, true)
+
+        // Nothing to choose — the pool already covers it.
+        driver.pendingDecision shouldBe null
+        driver.findPermanent(player, "Upkeep Toll").shouldNotBeNull()
+        driver.manaPool(player).green shouldBe 0
+    }
+})

--- a/web-client/src/components/decisions/ManaSourceSelectionUI.tsx
+++ b/web-client/src/components/decisions/ManaSourceSelectionUI.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
+import { usePlayer } from '@/store/selectors'
 import type { DecisionSelectionState } from '@/store/slices'
 import type {
+  ClientManaPool,
   EntityId,
   ManaSourceOption,
   SelectManaSourcesDecision,
 } from '@/types'
 import { parseManaCost } from '@/utils/manaCost'
-import { AbilityText } from '../ui/ManaSymbols'
+import { AbilityText, ManaSymbol } from '../ui/ManaSymbols'
 import { DraggableBanner } from './DraggableBanner'
 import styles from './DecisionUI.module.css'
 
@@ -18,57 +20,98 @@ const COLOR_NAME_TO_PIP: Record<string, string> = {
 
 const toPip = (color: string): string => COLOR_NAME_TO_PIP[color] ?? color
 
-/**
- * Greedy check: do the selected sources produce enough mana to cover `costSymbols`?
- * Mirrors the engine's solver well enough for a UI hint — the server still re-solves
- * on submit. Skips X (variable). `extraGeneric` folds in non-mana payment (each tapped
- * Waterbend permanent pays {1} generic).
- */
-function selectionCoversCost(
-  selectedIds: readonly EntityId[],
-  availableSources: readonly ManaSourceOption[],
-  costSymbols: readonly string[],
-  extraGeneric = 0,
-): boolean {
-  const sourceById = new Map(availableSources.map((s) => [s.entityId, s]))
-  const coloredReqs: Record<string, number> = {}
-  let genericReq = 0
-  for (const s of costSymbols) {
-    if (s === 'X') continue
-    const num = parseInt(s, 10)
-    if (!isNaN(num)) genericReq += num
-    else coloredReqs[s] = (coloredReqs[s] ?? 0) + 1
-  }
-
-  // Waterbend taps pay generic only (CR — each tapped artifact/creature pays {1}).
-  genericReq = Math.max(0, genericReq - extraGeneric)
-
-  for (const id of selectedIds) {
-    const src = sourceById.get(id)
-    if (!src) continue
-    const colors = (src.producesColors ?? []).map(toPip)
-    let consumed = false
-    for (const color of colors) {
-      if ((coloredReqs[color] ?? 0) > 0) {
-        coloredReqs[color]!--
-        consumed = true
-        break
-      }
-    }
-    if (!consumed && genericReq > 0) {
-      genericReq--
-    }
-  }
-
-  if (genericReq > 0) return false
-  for (const v of Object.values(coloredReqs)) if (v > 0) return false
-  return true
+interface PipCoverage {
+  symbol: string
+  /** Covered by mana already floating in the pool. */
+  floating: boolean
+  /** Covered by a source the player has selected but not yet tapped. */
+  pending: boolean
 }
 
 /**
- * Mana source selection UI for SelectManaSourcesDecision.
- * Shows a side banner and allows clicking lands/sources on the battlefield,
- * with an "Auto Pay" shortcut button.
+ * Works out which pips of the cost are already covered, and by what.
+ *
+ * Floating mana is applied first (it is real, and the resumers spend the pool before tapping
+ * anything), then the selected sources. Mirrors the engine's solver well enough for a UI readout —
+ * the server still re-solves on submit. Skips X (variable). `extraGeneric` folds in non-mana
+ * payment: each tapped Waterbend permanent pays {1} generic.
+ */
+function computeCoverage(
+  costSymbols: readonly string[],
+  pool: ClientManaPool | null,
+  selectedIds: readonly EntityId[],
+  availableSources: readonly ManaSourceOption[],
+  extraGeneric = 0,
+): PipCoverage[] {
+  const pips: PipCoverage[] = costSymbols.map((symbol) => ({ symbol, floating: false, pending: false }))
+
+  const floatingByColor: Record<string, number> = {
+    W: pool?.white ?? 0,
+    U: pool?.blue ?? 0,
+    B: pool?.black ?? 0,
+    R: pool?.red ?? 0,
+    G: pool?.green ?? 0,
+    C: pool?.colorless ?? 0,
+  }
+
+  // Pass 1 — floating mana against coloured pips it exactly matches.
+  for (const pip of pips) {
+    const have = floatingByColor[pip.symbol]
+    if (have !== undefined && have > 0) {
+      floatingByColor[pip.symbol] = have - 1
+      pip.floating = true
+    }
+  }
+
+  // Pass 2 — selected sources against the coloured pips still open.
+  const sourceById = new Map(availableSources.map((s) => [s.entityId, s]))
+  const flexibleSources: ManaSourceOption[] = []
+  for (const id of selectedIds) {
+    const source = sourceById.get(id)
+    if (!source) continue
+    const colors = (source.producesColors ?? []).map(toPip)
+    const match = pips.find(
+      (pip) => !pip.floating && !pip.pending && colors.includes(pip.symbol),
+    )
+    if (match) match.pending = true
+    else flexibleSources.push(source)
+  }
+
+  // Pass 3 — whatever is left (leftover floating, sources that matched no coloured pip, Waterbend
+  // taps) pays generic pips, cheapest first.
+  let leftoverFloating = Object.values(floatingByColor).reduce((a, b) => a + b, 0)
+  let leftoverPending = flexibleSources.length + extraGeneric
+  for (const pip of pips) {
+    if (pip.floating || pip.pending) continue
+    const amount = parseInt(pip.symbol, 10)
+    if (isNaN(amount)) continue
+    if (leftoverFloating >= amount) {
+      leftoverFloating -= amount
+      pip.floating = true
+    } else if (leftoverFloating + leftoverPending >= amount) {
+      leftoverPending -= amount - leftoverFloating
+      leftoverFloating = 0
+      pip.pending = true
+    }
+  }
+
+  return pips
+}
+
+/** X is chosen elsewhere, so an X pip never blocks the Pay button. */
+const isCovered = (pip: PipCoverage) => pip.floating || pip.pending || pip.symbol === 'X'
+
+/**
+ * Payment UI for a [SelectManaSourcesDecision] — the engine asking one player for mana outside of
+ * casting a spell (ward, "you may pay {B}", an attack tax, a draw replacement).
+ *
+ * There are two ways to produce the mana, and the banner has to make both discoverable:
+ *  1. **Click a highlighted source.** The engine pre-computed a menu of `{T}`-shaped sources; they
+ *     light up on the battlefield and are tapped when the player confirms.
+ *  2. **Activate a mana ability from a permanent's menu.** CR 605.3a allows this whenever a rule or
+ *     effect asks for a mana payment, and it is the only route for anything the solver can't model
+ *     — Ashnod's Altar, a Forage sub-cost, an ability with no `{T}` in its activation cost. That
+ *     mana lands in the pool immediately, so the readout below counts it as already paid.
  */
 export function ManaSourceSelectionUI({
   decision,
@@ -79,6 +122,7 @@ export function ManaSourceSelectionUI({
   const decisionSelectionState = useGameStore((s) => s.decisionSelectionState)
   const cancelDecisionSelection = useGameStore((s) => s.cancelDecisionSelection)
   const submitManaSourcesDecision = useGameStore((s) => s.submitManaSourcesDecision)
+  const manaPool = usePlayer(decision.playerId)?.manaPool ?? null
 
   const waterbendPermanents = decision.waterbendPermanents ?? []
   const waterbendIds = useMemo(
@@ -88,6 +132,13 @@ export function ManaSourceSelectionUI({
 
   // Start decision selection state when this component mounts. Both mana sources and
   // Waterbend-eligible permanents are clickable on the battlefield; they're partitioned on submit.
+  //
+  // Re-runs on `autoPaySuggestion` as well as on a new decision id. Activating a mana ability
+  // mid-payment re-raises the *same* decision, refreshed: the source just tapped is gone from
+  // `availableSources` and the suggestion now covers only what the new floating mana doesn't. That
+  // is the signal that the board moved under the player, so the selection is re-seeded from it —
+  // otherwise a pre-selected land stays ticked and Pay taps it on top of mana already in the pool.
+  const suggestionKey = decision.autoPaySuggestion.join(',')
   useEffect(() => {
     const validOptions = [
       ...decision.availableSources.map((s) => s.entityId),
@@ -96,7 +147,7 @@ export function ManaSourceSelectionUI({
     const selectionState: DecisionSelectionState = {
       decisionId: decision.id,
       validOptions,
-      selectedOptions: [...decision.autoPaySuggestion],
+      selectedOptions: decision.autoPaySuggestion.filter((id) => validOptions.includes(id)),
       minSelections: 1,
       maxSelections: validOptions.length,
       prompt: decision.prompt,
@@ -106,9 +157,8 @@ export function ManaSourceSelectionUI({
     return () => {
       cancelDecisionSelection()
     }
-  }, [decision.id])
+  }, [decision.id, suggestionKey])
 
-  const selectedCount = decisionSelectionState?.selectedOptions.length ?? 0
   const selectedOptions = decisionSelectionState?.selectedOptions
 
   // Partition the clicked permanents: mana sources vs Waterbend taps (each pays {1} generic).
@@ -133,16 +183,19 @@ export function ManaSourceSelectionUI({
     () => parseManaCost(decision.requiredCost),
     [decision.requiredCost],
   )
-  const isSelectionSufficient = useMemo(
+  const coverage = useMemo(
     () =>
-      selectionCoversCost(
+      computeCoverage(
+        costSymbols,
+        manaPool,
         selectedManaSources,
         decision.availableSources,
-        costSymbols,
         selectedWaterbend.length,
       ),
-    [selectedManaSources, selectedWaterbend, decision.availableSources, costSymbols],
+    [costSymbols, manaPool, selectedManaSources, selectedWaterbend, decision.availableSources],
   )
+  const isCostCovered = coverage.every(isCovered)
+  const floatingCoversAll = coverage.every((pip) => pip.floating || pip.symbol === 'X')
 
   const handleAutoPay = () => {
     submitManaSourcesDecision([], true)
@@ -150,31 +203,57 @@ export function ManaSourceSelectionUI({
   }
 
   const handleConfirm = () => {
-    if (decisionSelectionState && isSelectionSufficient) {
-      submitManaSourcesDecision(selectedManaSources, false, selectedWaterbend)
-      cancelDecisionSelection()
-    }
+    if (!isCostCovered) return
+    // A payment made entirely from mana the player floated themselves submits no sources; the
+    // server distinguishes it from a refusal by the absence of the `declined` flag.
+    submitManaSourcesDecision(selectedManaSources, false, selectedWaterbend)
+    cancelDecisionSelection()
   }
 
   const handleDecline = () => {
-    submitManaSourcesDecision([], false)
+    submitManaSourcesDecision([], false, [], true)
     cancelDecisionSelection()
   }
+
+  const payLabel = floatingCoversAll && selectedManaSources.length === 0 ? 'Pay' : `Pay (${selectedManaSources.length})`
 
   return (
     <DraggableBanner className={styles.sideBannerSelection}>
       <div className={styles.bannerTitleSelection}>
-        {decision.canDecline ? 'Activate Ability?' : 'Select Mana Sources'}
+        {decision.canDecline ? 'Pay cost?' : 'Pay cost'}
       </div>
       {decision.context.sourceName && (
         <div className={styles.hint}>
           <AbilityText text={decision.prompt} size={13} />
         </div>
       )}
+
+      {/* Live readout: solid = already floating, outlined = will be tapped on Pay, dim = missing. */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, margin: '6px 0' }}>
+        {coverage.map((pip, i) => (
+          <span
+            key={i}
+            title={pip.floating ? 'Paid from your mana pool' : pip.pending ? 'Covered by a selected source' : 'Not yet covered'}
+            style={{
+              display: 'inline-flex',
+              borderRadius: '50%',
+              opacity: pip.floating ? 1 : pip.pending ? 0.85 : 0.3,
+              filter: isCovered(pip) ? 'none' : 'grayscale(70%)',
+              boxShadow: pip.pending ? '0 0 0 2px rgba(120, 220, 140, 0.9)' : 'none',
+              transition: 'opacity 0.15s, filter 0.15s, box-shadow 0.15s',
+            }}
+          >
+            <ManaSymbol symbol={pip.symbol} size={20} />
+          </span>
+        ))}
+      </div>
+
       <div className={styles.hint}>
-        {selectedCount > 0
-          ? `${selectedCount} source${selectedCount !== 1 ? 's' : ''} selected`
-          : 'Click lands to select'}
+        {isCostCovered ? 'Cost covered — press Pay.' : 'Click a highlighted source to tap it.'}
+      </div>
+      {/* Always visible: the escape hatch for costs the highlighted menu can't cover. */}
+      <div className={styles.hint} style={{ opacity: 0.7, fontSize: 11 }}>
+        You can also click any permanent to use its mana ability.
       </div>
       {waterbendPermanents.length > 0 && (
         <div className={styles.hint}>
@@ -187,11 +266,6 @@ export function ManaSourceSelectionUI({
           )}
         </div>
       )}
-      {!isSelectionSufficient && (
-        <div className={styles.effectHint}>
-          Not enough mana selected
-        </div>
-      )}
       {sacrificedSources.length > 0 && (
         <div className={styles.effectHint}>
           Will sacrifice: {sacrificedSources.map((s) => s.name).join(', ')}
@@ -199,38 +273,28 @@ export function ManaSourceSelectionUI({
       )}
 
       <div className={styles.buttonContainerSmall}>
-        {decision.canDecline ? (
-          <>
-            <button
-              onClick={handleConfirm}
-              disabled={!isSelectionSufficient}
-              className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
-            >
-              Confirm
-            </button>
-            <button
-              onClick={handleDecline}
-              className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
-            >
-              Decline
-            </button>
-          </>
-        ) : (
-          <>
-            <button
-              onClick={handleAutoPay}
-              className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
-            >
-              Auto Pay
-            </button>
-            <button
-              onClick={handleConfirm}
-              disabled={!isSelectionSufficient}
-              className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
-            >
-              Confirm ({selectedCount})
-            </button>
-          </>
+        {!decision.canDecline && (
+          <button
+            onClick={handleAutoPay}
+            className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
+          >
+            Auto Pay
+          </button>
+        )}
+        <button
+          onClick={handleConfirm}
+          disabled={!isCostCovered}
+          className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
+        >
+          {payLabel}
+        </button>
+        {decision.canDecline && (
+          <button
+            onClick={handleDecline}
+            className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}
+          >
+            Decline
+          </button>
         )}
       </div>
     </DraggableBanner>

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -415,7 +415,12 @@ function GameCardImpl({
   // Valid blockers with legal actions (e.g., activated abilities) are still playable since blocking uses drag.
   // Face-down cards can be playable too (for TurnFaceUp action)
   const isCombatRoleCard = isValidAttacker || (isValidBlocker && !hasLegalActions) || isAttackingInBlockerMode
-  const hasActiveDecision = pendingDecision !== null
+  // A mana-payment decision is the one kind that still leaves actions open: CR 605.3a lets the
+  // paying player activate mana abilities, and the server sends exactly those as legal actions
+  // while the window is up. Sources already offered in the decision's own menu are excluded —
+  // those get the selection highlight and a click toggles them rather than opening a menu.
+  const isManaPaymentWindow = pendingDecision?.type === 'SelectManaSourcesDecision'
+  const hasActiveDecision = pendingDecision !== null && !(isManaPaymentWindow && !isValidDecisionSelection)
   const isPlayable = interactive && hasLegalActions && (!isInCombatMode || !isCombatRoleCard) && !hasActiveDecision
 
   const cardImageUrl = faceDown

--- a/web-client/src/store/slices/gameplaySlice.ts
+++ b/web-client/src/store/slices/gameplaySlice.ts
@@ -422,6 +422,7 @@ export const createGameplaySlice: SliceCreator<GameplaySlice> = (set, get) => ({
     selectedSources: readonly EntityId[],
     autoPay: boolean,
     waterbendPermanents: readonly EntityId[] = [],
+    declined = false,
   ) => {
     const { pendingDecision, playerId } = get()
     if (!pendingDecision || !playerId) return
@@ -439,6 +440,9 @@ export const createGameplaySlice: SliceCreator<GameplaySlice> = (set, get) => ({
         autoPay,
         // Artifacts/creatures tapped to pay {1} each via Waterbend (Ward—Waterbend).
         waterbendPermanents: [...waterbendPermanents],
+        // Explicit refusal. An empty submission alone is ambiguous now that the player can float
+        // mana themselves during the payment (CR 605.3a) and then confirm with nothing selected.
+        declined,
       },
     }
     getWebSocket()?.send(createSubmitActionMessage(action))

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -865,6 +865,7 @@ export type GameStore = {
     selectedSources: readonly EntityId[],
     autoPay: boolean,
     waterbendPermanents?: readonly EntityId[],
+    declined?: boolean,
   ) => void
   submitCancelDecision: () => void
   submitSplitPilesDecision: (piles: readonly (readonly EntityId[])[]) => void


### PR DESCRIPTION
## The bug

> Cannot use activated abilities of cards to create mana. For example tapping a creature for mana … to pay for a flip card trigger or pay for ward.

Two things were broken, and the second hides the first. Ward, "you may pay {B}" (Eirdu, Carrier of Dawn), an attack tax — each stops the game and raises a `SelectManaSourcesDecision` asking one player for mana. While that decision is open the player holds no priority, so `ActivateAbilityHandler` rejected **every** mana ability with `"You don't have priority"`. The decision's pre-computed source menu was the only way to make mana.

That menu is deliberately narrow. `ManaSolver.findAvailableManaSources` only models `{T}`-shaped abilities (`else -> false // Skip non-tap mana abilities`), so Ashnod's Altar, anything with a discard/Forage sub-cost, and any cost without `{T}` in it were simply unreachable mid-payment.

**CR 605.3a** — "A player may activate an activated mana ability whenever they have priority, whenever they are casting a spell or activating an ability that requires a mana payment, **or whenever a rule or effect asks for a mana payment**, even if it's in the middle of casting or resolving a spell or activating or resolving an ability."

## Engine

- **`ManaPaymentWindow`** is the single definition of "a mana payment is being asked for right now". Both the engine's authority check (`ActivateAbilityHandler.validate`) and the server's offer (`GameSession.getLegalActions`) read it, so the two can't drift. Nothing but mana abilities is unlocked — spells and non-mana abilities still get rejected.
- Activating inside the window **sets the decision aside, runs the ability, then re-raises it refreshed**: the source just tapped drops out of the menu, and the auto-pay suggestion covers only what the new floating mana doesn't. An ability that needs a decision of its own (choosing a color for Birds of Paradise) nests above a `ReopenManaPaymentDecisionContinuation`, which restores the window once it resolves. Priority is restored across the round trip — the mana-ability path ends with `withPriority(activatingPlayer)` when the cost fires a trigger, which is right at priority and wrong here.
- No payment resumer needed to change: they all spend the pool before tapping anything.
- **`ManaSourcesSelectedResponse.declined`.** An empty submission alone stopped being unambiguous — "I floated the mana myself, just take it" also submits nothing. `isDecline()` keeps the old inference as the fallback for clients and AI players that don't set the flag, so declining a cost you can't pay still works unchanged.
- `getAutoPassPlayer` now says outright that nobody passes priority while a decision is pending. That used to be implicit in `getLegalActions` returning nothing.

## Client

The old banner said **"Activate Ability?"** with Confirm/Decline, no cost readout, and no indication that clicking permanents was the mechanism.

| | |
|---|---|
| ![payment window](https://raw.githubusercontent.com/wingedsheep/argentum-engine/mana-abilities-during-payment-screenshots/1-payment-window.png) | Live pip readout — dim `{2}` means uncovered, `Pay` is disabled. Both hints are visible: click a highlighted source, **or** use any permanent's mana ability. |
| ![mana ability menu](https://raw.githubusercontent.com/wingedsheep/argentum-engine/mana-abilities-during-payment-screenshots/2-mana-ability-menu.png) | Ashnod's Altar opens its action menu *during* the ward payment, offering "Sacrifice a creature: Add {C}{C}" — the case that was impossible before. |
| ![cost covered](https://raw.githubusercontent.com/wingedsheep/argentum-engine/mana-abilities-during-payment-screenshots/3-cost-covered.png) | The `{2}` pip goes solid (paid from the pool), the pre-selected lands are dropped so `Pay` won't over-tap them, and the HUD shows the floating mana. |

Pip states: solid = already floating, outlined green = covered by a selected source, dim = missing.

*(Screenshots live on a throwaway `mana-abilities-during-payment-screenshots` branch, not in this diff.)*

## Verification

`ManaAbilitiesDuringPaymentTest` — 6 scenarios, all failing before this change on the first assertion:

- mana ability activated while a may-pay window is open (Eirdu + Birds of Paradise)
- a source tapped by hand drops out of the refreshed menu
- non-mana abilities are still rejected during the window
- **ward paid with a mana ability the source menu cannot offer** (a sacrifice-cost mana source, asserted absent from `availableSources`)
- **ward prompts at all when that source is the only one** — the pre-gate case
- ward with no way to pay still counters silently
- declining a ward explicitly still counters the spell even with mana floating
- the window does not let a player cast spells or hold priority

`ExplicitActivationManaSourcesTest` — 9 cases on the solver: affordability, colour accuracy, a tapped Altar (its cost has no `{T}`), floating mana + Altar together, and the four no-double-count boards.

`just build`, `just test-server`, `just test-ai`, `just test-gym`, and `npm run typecheck` all pass. Also driven end-to-end in the real client against a dev scenario — the flow in the screenshots is a real game, and the Shock resolved with both Mountains still untapped.

## The pre-gate

These payments gate the **prompt itself** on `manaSolver.canPay` — when it says no, ward counters the spell and a may-pay trigger is skipped with no prompt at all. So the window above couldn't help a player whose only source was one the solver can't see: it never opened.

`canPay` already had the right shape for this. Three "extras" helpers feed it production `solve()` refuses to auto-tap — Birchlore Rangers' `TapPermanents`, Treasure's tap+`SacrificeSelf`, Springleaf Drum's composite — with the existing comment saying why: *"so a ward (or other 'counter unless pays') doesn't short-circuit to countered when the player would actually be able to pay manually."* This adds the fourth, for cost shapes `findAvailableManaSources` skips outright.

Going through that channel rather than a "player has an unmodelled source" boolean keeps affordability **colour-accurate** — an Altar makes `{2}` payable but not `{G}` — and fixes every `canPay` call site at once. `solve()` is untouched, so auto-pay still never sacrifices or discards on its own.

Affordability is established, not assumed:
- each non-mana part of the cost is checked payable *now*, reusing `CostPaymentService.canAfford` for the `CostAtom` cases rather than duplicating it;
- an unrecognised shape (Craft, Blight, an `{X}` cost) is skipped rather than counted;
- abilities carrying a mana sub-cost are skipped — that would recurse back into `canPay`, and their net production is ambiguous. Same call the tap+`SacrificeSelf` helper already makes.

`manaAbilityIsAlreadyCounted` keeps the four helpers' cost shapes disjoint. `ExplicitActivationManaSourcesTest` pins that partition (Treasure / Birchlore / Springleaf boards must contribute **0** to the new helper) so nothing is counted twice — that's the guard against the classification drifting from `abilityCanBeUsed`.

Two scenario tests bracket the behaviour change: ward with an Altar as the **only** source now prompts (fails without the fix), and ward with **no** way to pay still counters silently (passes either way).

## The last two auto-tap paths

`CostPaymentService` and `PayOrSuffer` were the remaining mana payments that went straight from a yes/no to the solver. Once `canPay` started counting mana the solver won't auto-tap, that turned into an outright bug: Drifting Djinn's upkeep toll offered the prompt, took the "yes", and **sacrificed the Djinn anyway** because `solve()` came up empty.

Both now raise the window as a second step, and only when floating mana doesn't already cover the cost — the same shape "counter unless you pay" has always had. Declining there is the same outcome as answering no.

The shared parts moved onto `ManaPaymentWindow`: `buildDecision` (source menu + auto-pay suggestion) and `floatSelectedMana` (tap or sacrifice the picks, put the mana in the pool, let the caller's own payment code spend it). Sources with a secondary tap sub-cost are left off the menu — resolving those needs a nested prompt only the ward resumer implements, and the player can now just activate the Drum themselves.

Two things fell out of getting this working:

- **PayOrSuffer's settle step no longer falls back to the solver for a shortfall.** After the window, everything the payer meant to tap is already floating; auto-tapping the difference would silently overrule what they picked. Coming up short is now simply a failure to pay. (Caught by a test that submitted one Forest against `{2}` and watched the engine quietly tap the second one.)
- **`ActivateAbilityXCostContinuationResumer`'s re-entries returned `handler.execute(...)` directly**, stranding any frame pushed *beneath* the activation — including the `ReopenManaPaymentDecisionContinuation` that puts the payment window back up. So activating a mana ability that has its own cost prompt (Ashnod's Altar asking which creature to sacrifice) inside a window left the payment hanging with no pending decision. Routing those re-entries through `checkForMore` — which is what the contract says they should do — fixes it.

Also hardened the LLM AI's `SelectManaSourcesHandler`, which blanket-submitted `autoPay = true`. With no auto-pay solution that errors in the resumer and the engine re-raises the same decision forever; `DecisionResponder` already guarded against this, the LLM handler didn't.

`PayOrSufferManaWindowTest` — 4 cases: the window replaces auto-tap, a short submission fails to pay, declining collects the toll, floating mana skips the window entirely, and the headline one — **the toll paid by activating Ashnod's Altar inside the window**, including the nested sacrifice prompt and the window re-raising itself afterwards. `CostPaymentServiceTest` gains the Treasure case (auto-pay refuses it; manual selection sacrifices it) and its two mana tests now assert the second step exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
