### PR TITLE
Count eligible conditional mana on convoke/delve/waterbend/harmonize paths

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -217,13 +217,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     context.costUtils.canAffordWithConvoke(
                                         state, playerId, atom.cost,
                                         context.costUtils.findConvokeCreatures(state, playerId),
-                                        precomputedSources = context.availableManaSources
+                                        precomputedSources = context.availableManaSources,
+                                        spellContext = abilityContext
                                     )
                                 val affordableViaWaterbend = ability.hasWaterbend &&
                                     context.costUtils.canAffordWithWaterbend(
                                         state, playerId, atom.cost,
                                         context.costUtils.findWaterbendPermanents(state, playerId),
-                                        precomputedSources = context.availableManaSources
+                                        precomputedSources = context.availableManaSources,
+                                        spellContext = abilityContext
                                     )
                                 if (!affordableViaConvoke && !affordableViaWaterbend) {
                                     costAffordable = false
@@ -360,13 +362,15 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                                 context.costUtils.canAffordWithConvoke(
                                                     state, playerId, atom.cost,
                                                     context.costUtils.findConvokeCreatures(state, playerId),
-                                                    precomputedSources = context.availableManaSources
+                                                    precomputedSources = context.availableManaSources,
+                                                    spellContext = abilityContext
                                                 )
                                             val affordableViaWaterbend = ability.hasWaterbend &&
                                                 context.costUtils.canAffordWithWaterbend(
                                                     state, playerId, atom.cost,
                                                     context.costUtils.findWaterbendPermanents(state, playerId),
-                                                    precomputedSources = context.availableManaSources
+                                                    precomputedSources = context.availableManaSources,
+                                                    spellContext = abilityContext
                                                 )
                                             if (!affordableViaConvoke && !affordableViaWaterbend) {
                                                 costCanBePaid = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -40,8 +40,7 @@ import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.WarpGrants
-import com.wingedsheep.engine.mechanics.mana.paymentSubtypesOf
-import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.mechanics.mana.spellPaymentContextFor
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 
 /**
@@ -457,13 +456,22 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     // affordability (CR 701.67); the tap metadata is attached to the emitted actions
                     // by the post-pass at the end of this method.
                     val fixedAltWaterbend = runtimeFixedAltCost?.takeIf { !playForFree && it.waterbend }
+                    val spellContext = spellPaymentContextFor(
+                        cardComponent,
+                        isFromExile = sourceZoneLabel == "EXILE",
+                        isFromHand = false
+                    )
                     val canAfford = playForFree ||
-                        context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources) ||
+                        context.manaSolver.canPay(
+                            state, playerId, effectiveCost,
+                            precomputedSources = context.availableManaSources, spellContext = spellContext
+                        ) ||
                         (fixedAltWaterbend != null && context.costUtils.canAffordWithWaterbend(
                             state, playerId, effectiveCost,
                             context.costUtils.findWaterbendPermanents(state, playerId)
                                 .take(fixedAltWaterbend.fixedCost.genericAmount),
-                            precomputedSources = context.availableManaSources
+                            precomputedSources = context.availableManaSources,
+                            spellContext = spellContext
                         ))
 
                     // Calculate X cost info if the spell has X in its cost (cost still paid even with may-play)
@@ -1361,8 +1369,12 @@ class CastFromZoneEnumerator : ActionEnumerator {
             )
             val costString = effectiveCost.toString()
             val harmonizeCreatures = context.costUtils.findHarmonizeCreatures(state, playerId)
+            // Harmonize casts from the graveyard, so eligible conditional mana is judged with
+            // isFromHand = false (a "cast from a non-hand zone only" restriction applies here).
+            val harmonizeSpellContext = spellPaymentContextFor(cardComponent, isFromHand = false)
             val canAfford = context.costUtils.canAffordWithHarmonize(
-                state, playerId, effectiveCost, harmonizeCreatures, precomputedSources = context.availableManaSources
+                state, playerId, effectiveCost, harmonizeCreatures,
+                precomputedSources = context.availableManaSources, spellContext = harmonizeSpellContext
             )
             // X-cost Harmonize (e.g. Nature's Rhythm {X}{G}{G}{G}{G}): advertise X so the
             // client prompts for it. maxAffordableX folds in the best single-creature tap
@@ -1371,7 +1383,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
             val maxAffordableX: Int? = if (hasXCost) {
                 context.costUtils.maxAffordableXWithHarmonize(
                     state, playerId, effectiveCost, harmonizeCreatures,
-                    precomputedSources = context.availableManaSources
+                    precomputedSources = context.availableManaSources, spellContext = harmonizeSpellContext
                 )
             } else null
 
@@ -1988,18 +2000,14 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 )
                 val kickedManaCost = manaKicker?.manaCost ?: offspringAbility?.manaCost
                 val kickedCost = if (kickedManaCost != null) baseCost + kickedManaCost else baseCost
-                val kickedSpellContext = SpellPaymentContext(
-                    isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
+                // This enumerator only enumerates non-hand-zone casts (command, library, exile,
+                // graveyard, …) — `sourceZone` is never "HAND" here. Mark accordingly so
+                // [ManaRestriction.CastFromNonHandOnly] mana is eligible for the kicked variant.
+                val kickedSpellContext = spellPaymentContextFor(
+                    cardComponent,
                     isKicked = declaredSlot == ChoiceSlot.KICKED,
-                    isCreature = cardComponent.typeLine.isCreature,
-                    manaValue = cardComponent.manaCost.cmc,
-                    hasXInCost = cardComponent.manaCost.hasX,
-                    subtypes = paymentSubtypesOf(cardComponent),
-                    cardTypes = cardComponent.typeLine.cardTypes,
-                    // This enumerator only enumerates non-hand-zone casts (command, library, exile,
-                    // graveyard, …) — `sourceZone` is never "HAND" here. Mark accordingly so
-                    // [ManaRestriction.CastFromNonHandOnly] mana is eligible for the kicked variant.
-                    isFromHand = false,
+                    isFromExile = sourceZone == "EXILE",
+                    isFromHand = false
                 )
                 val canAffordKickedMana = context.manaSolver.canPay(
                     state, playerId, kickedCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -30,8 +30,8 @@ import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.engine.mechanics.mana.ManaSource
-import com.wingedsheep.engine.mechanics.mana.paymentSubtypesOf
 import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.mechanics.mana.spellPaymentContextFor
 
 /**
  * Enumerates legal CastSpell actions for spells in hand.
@@ -473,25 +473,21 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.costUtils.findConvokeCreatures(state, playerId)
             } else null
 
+            // Build spell context for conditional mana restriction awareness. Every affordability
+            // check below takes it, so eligible restricted floating mana (Ashling, Rimebound's
+            // MV4+ mana) counts — including on the convoke/delve/waterbend tap-to-help paths.
+            val spellContext = spellPaymentContextFor(cardComponent)
+
             val hasDelve = context.grantedKeywordResolver.hasKeyword(state, playerId, cardDef, Keyword.DELVE)
             val delveCards = if (hasDelve) {
                 context.costUtils.findDelveCards(state, playerId)
             } else null
             val minDelveNeeded = if (hasDelve && delveCards != null && delveCards.isNotEmpty()) {
-                context.costUtils.calculateMinDelveNeeded(state, playerId, effectiveCost, delveCards, precomputedSources = context.availableManaSources)
+                context.costUtils.calculateMinDelveNeeded(
+                    state, playerId, effectiveCost, delveCards,
+                    precomputedSources = context.availableManaSources, spellContext = spellContext
+                )
             } else null
-
-            // Build spell context for conditional mana restriction awareness
-            val spellContext = SpellPaymentContext(
-                isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
-                isKicked = false,
-                isCreature = cardComponent.typeLine.isCreature,
-                isLegendary = cardComponent.typeLine.isLegendary,
-                manaValue = cardComponent.manaCost.cmc,
-                hasXInCost = cardComponent.manaCost.hasX,
-                subtypes = paymentSubtypesOf(cardComponent),
-                cardTypes = cardComponent.typeLine.cardTypes,
-            )
 
             // "You can spend mana of any type to cast [these] spells" (Vizier of the Menagerie):
             // relax the colored requirements for *payment* only. `effectiveCost` stays the printed
@@ -503,17 +499,23 @@ class CastSpellEnumerator : ActionEnumerator {
             val cachedSources = context.availableManaSources
             val canAfford = if (hasConvoke && convokeCreatures != null && convokeCreatures.isNotEmpty()) {
                 context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
-                    context.costUtils.canAffordWithConvoke(state, playerId, payableCost, convokeCreatures, precomputedSources = cachedSources)
+                    context.costUtils.canAffordWithConvoke(
+                        state, playerId, payableCost, convokeCreatures,
+                        precomputedSources = cachedSources, spellContext = spellContext
+                    )
             } else if (hasDelve && delveCards != null && delveCards.isNotEmpty()) {
                 context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
-                    context.costUtils.canAffordWithDelve(state, playerId, payableCost, delveCards, precomputedSources = cachedSources)
+                    context.costUtils.canAffordWithDelve(
+                        state, playerId, payableCost, delveCards,
+                        precomputedSources = cachedSources, spellContext = spellContext
+                    )
             } else if (mandatoryWaterbend) {
                 // payableCost already includes the mandatory waterbend {N}; taps can cover up to {N}.
                 context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
                     context.costUtils.canAffordWithWaterbend(
                         state, playerId, payableCost,
                         waterbendPermanents.take(spellWaterbend!!.amount),
-                        precomputedSources = cachedSources
+                        precomputedSources = cachedSources, spellContext = spellContext
                     )
             } else {
                 context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources)
@@ -1726,7 +1728,10 @@ class CastSpellEnumerator : ActionEnumerator {
                 val paidCost = baseCost + ManaCost.parse("{${wb.amount}}")
                 val affordablePaid = context.costUtils.canAffordWithWaterbend(
                     state, cs.playerId, paidCost, perms.take(wb.amount),
-                    precomputedSources = context.availableManaSources
+                    precomputedSources = context.availableManaSources,
+                    // Eligible conditional floating mana counts toward the paid variant too.
+                    spellContext = state.getEntity(cs.cardId)?.get<CardComponent>()
+                        ?.let { spellPaymentContextFor(it) }
                 )
                 if (!affordablePaid) continue
                 out.add(la.copy(
@@ -1800,16 +1805,7 @@ class CastSpellEnumerator : ActionEnumerator {
             if (eligibleTapTargets.size < 2) continue
 
             val baseCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
-            val spellContext = SpellPaymentContext(
-                isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
-                isKicked = false,
-                isCreature = cardComponent.typeLine.isCreature,
-                isLegendary = cardComponent.typeLine.isLegendary,
-                manaValue = cardComponent.manaCost.cmc,
-                hasXInCost = cardComponent.manaCost.hasX,
-                subtypes = paymentSubtypesOf(cardComponent),
-                cardTypes = cardComponent.typeLine.cardTypes,
-            )
+            val spellContext = spellPaymentContextFor(cardComponent)
             val canAfford = context.manaSolver.canPay(state, playerId, baseCost, spellContext = spellContext, precomputedSources = context.availableManaSources)
             val autoTapPreview = if (context.skipAutoTapPreview) null else {
                 context.manaSolver.solve(state, playerId, baseCost, spellContext = spellContext, precomputedSources = context.availableManaSources)
@@ -1909,16 +1905,7 @@ class CastSpellEnumerator : ActionEnumerator {
             if (eligibleSacrifices.isEmpty()) continue
 
             val baseCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
-            val spellContext = SpellPaymentContext(
-                isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
-                isKicked = false,
-                isCreature = cardComponent.typeLine.isCreature,
-                isLegendary = cardComponent.typeLine.isLegendary,
-                manaValue = cardComponent.manaCost.cmc,
-                hasXInCost = cardComponent.manaCost.hasX,
-                subtypes = paymentSubtypesOf(cardComponent),
-                cardTypes = cardComponent.typeLine.cardTypes,
-            )
+            val spellContext = spellPaymentContextFor(cardComponent)
             val canAfford = context.manaSolver.canPay(state, playerId, baseCost, spellContext = spellContext, precomputedSources = context.availableManaSources)
             val autoTapPreview = if (context.skipAutoTapPreview) null else {
                 context.manaSolver.solve(state, playerId, baseCost, spellContext = spellContext, precomputedSources = context.availableManaSources)
@@ -2028,16 +2015,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 )
                 val kickedManaCost = manaKicker?.manaCost ?: offspringAbility?.manaCost
                 val kickedCost = if (kickedManaCost != null) baseCost + kickedManaCost else baseCost
-                val kickedSpellContext = SpellPaymentContext(
-                    isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
-                    isKicked = declaredSlot == ChoiceSlot.KICKED,
-                    isCreature = cardComponent.typeLine.isCreature,
-                    isLegendary = cardComponent.typeLine.isLegendary,
-                    manaValue = cardComponent.manaCost.cmc,
-                    hasXInCost = cardComponent.manaCost.hasX,
-                    subtypes = paymentSubtypesOf(cardComponent),
-                    cardTypes = cardComponent.typeLine.cardTypes,
-                )
+                val kickedSpellContext = spellPaymentContextFor(cardComponent, isKicked = declaredSlot == ChoiceSlot.KICKED)
                 val canAffordKickedMana = context.manaSolver.canPay(state, playerId, kickedCost, spellContext = kickedSpellContext, precomputedSources = context.availableManaSources)
                 val kickedCostString = kickedCost.toString()
                 val kickedAutoTapPreview = if (context.skipAutoTapPreview) null else {
@@ -2270,16 +2248,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // unchanged, so the resolving effect's `DynamicAmount.XValue` reads the chosen X.
             val cleaveHasX = cleaveCost.hasX
             val cleaveMaxAffordableX: Int? = if (cleaveHasX) {
-                val spellContext = SpellPaymentContext(
-                    isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
-                    isKicked = false,
-                    isCreature = cardComponent.typeLine.isCreature,
-                    isLegendary = cardComponent.typeLine.isLegendary,
-                    manaValue = cardComponent.manaCost.cmc,
-                    hasXInCost = cleaveCost.hasX,
-                    subtypes = paymentSubtypesOf(cardComponent),
-                    cardTypes = cardComponent.typeLine.cardTypes,
-                )
+                val spellContext = spellPaymentContextFor(cardComponent).copy(hasXInCost = cleaveCost.hasX)
                 val availableSources = context.manaSolver.getAvailableManaCount(
                     state, playerId, precomputedSources = context.availableManaSources, spellContext = spellContext
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.legalactions.*
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.mechanics.mana.ManaSource
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -200,12 +201,20 @@ class CostEnumerationUtils(
         }
     }
 
+    /**
+     * Whether [manaCost] is payable with the help of convoke taps. [spellContext] describes the
+     * spell being cast (or ability being activated) so conditional floating mana — "spend this
+     * mana only to cast spells with mana value 4 or greater" (Ashling, Rimebound) — counts toward
+     * affordability when it is eligible for *this* payment. Passing null ignores restricted mana
+     * entirely, which under-reports affordability and hides the cast from the client.
+     */
     fun canAffordWithConvoke(
         state: GameState,
         playerId: EntityId,
         manaCost: ManaCost,
         convokeCreatures: List<ConvokeCreatureData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Boolean {
         // Convoke creatures with their own mana abilities (e.g. Llanowar Elves) appear in
         // both lists — but tapping the creature can pay either a convoke pip or a mana
@@ -214,7 +223,7 @@ class CostEnumerationUtils(
         val convokeIds = convokeCreatures.mapTo(mutableSetOf()) { it.entityId }
         val sourcesForMana = (precomputedSources ?: manaSolver.findAvailableManaSources(state, playerId))
             .filter { it.entityId !in convokeIds }
-        val availableMana = manaSolver.getAvailableManaCount(state, playerId, sourcesForMana)
+        val availableMana = manaSolver.getAvailableManaCount(state, playerId, sourcesForMana, spellContext)
         val totalResources = availableMana + convokeCreatures.size
         if (totalResources < manaCost.cmc) return false
 
@@ -260,19 +269,21 @@ class CostEnumerationUtils(
      * exactly {1} generic, so colored pips must come from mana sources; the generic portion may
      * be covered by mana sources and/or waterbend permanents. A permanent tapped for waterbend
      * can't also be a mana source, so any that double as mana sources are excluded from the mana
-     * count.
+     * count. [spellContext] lets eligible conditional floating mana count — see
+     * [canAffordWithConvoke].
      */
     fun canAffordWithWaterbend(
         state: GameState,
         playerId: EntityId,
         manaCost: ManaCost,
         waterbendPermanents: List<WaterbendPermanentData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Boolean {
         val waterbendIds = waterbendPermanents.mapTo(mutableSetOf()) { it.entityId }
         val sourcesForMana = (precomputedSources ?: manaSolver.findAvailableManaSources(state, playerId))
             .filter { it.entityId !in waterbendIds }
-        val availableMana = manaSolver.getAvailableManaCount(state, playerId, sourcesForMana)
+        val availableMana = manaSolver.getAvailableManaCount(state, playerId, sourcesForMana, spellContext)
 
         // Colored pips can only be paid by mana — waterbend is generic-only.
         val coloredRequired = manaCost.colorCount.values.sum()
@@ -306,15 +317,21 @@ class CostEnumerationUtils(
      * Can the player pay [manaCost] either as-is or after tapping a single Harmonize creature
      * (reducing the generic portion by its power)? A creature tapped for Harmonize can't also
      * tap for mana, so it is excluded from the mana sources when evaluating its reduction.
+     * [spellContext] lets eligible conditional floating mana count — see [canAffordWithConvoke].
      */
     fun canAffordWithHarmonize(
         state: GameState,
         playerId: EntityId,
         manaCost: ManaCost,
         harmonizeCreatures: List<HarmonizeCreatureData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Boolean {
-        if (manaSolver.canPay(state, playerId, manaCost, precomputedSources = precomputedSources)) return true
+        if (manaSolver.canPay(
+                state, playerId, manaCost,
+                precomputedSources = precomputedSources, spellContext = spellContext
+            )
+        ) return true
         val generic = manaCost.genericAmount
         for (creature in harmonizeCreatures) {
             val reduction = minOf(creature.power, generic)
@@ -322,7 +339,11 @@ class CostEnumerationUtils(
             val reducedCost = manaCost.reduceGeneric(reduction)
             val sourcesForMana = (precomputedSources ?: manaSolver.findAvailableManaSources(state, playerId))
                 .filter { it.entityId != creature.entityId }
-            if (manaSolver.canPay(state, playerId, reducedCost, precomputedSources = sourcesForMana)) return true
+            if (manaSolver.canPay(
+                    state, playerId, reducedCost,
+                    precomputedSources = sourcesForMana, spellContext = spellContext
+                )
+            ) return true
         }
         return false
     }
@@ -341,7 +362,8 @@ class CostEnumerationUtils(
         playerId: EntityId,
         manaCost: ManaCost,
         harmonizeCreatures: List<HarmonizeCreatureData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Int {
         if (!manaCost.hasX) return 0
         val xCount = manaCost.xCount.coerceAtLeast(1)
@@ -350,7 +372,7 @@ class CostEnumerationUtils(
 
         fun maxXFor(reduction: Int, excludeId: EntityId?): Int {
             val usable = if (excludeId == null) sources else sources.filter { it.entityId != excludeId }
-            val available = manaSolver.getAvailableManaCount(state, playerId, usable)
+            val available = manaSolver.getAvailableManaCount(state, playerId, usable, spellContext)
             return ((available - fixedCost + reduction) / xCount).coerceAtLeast(0)
         }
 
@@ -374,29 +396,44 @@ class CostEnumerationUtils(
         }
     }
 
+    /** [spellContext] lets eligible conditional floating mana count — see [canAffordWithConvoke]. */
     fun canAffordWithDelve(
         state: GameState,
         playerId: EntityId,
         manaCost: ManaCost,
         delveCards: List<DelveCardData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Boolean {
         val maxDelve = minOf(delveCards.size, manaCost.genericAmount)
         val reducedCost = manaCost.reduceGeneric(maxDelve)
-        return manaSolver.canPay(state, playerId, reducedCost, precomputedSources = precomputedSources)
+        return manaSolver.canPay(
+            state, playerId, reducedCost,
+            precomputedSources = precomputedSources, spellContext = spellContext
+        )
     }
 
+    /** [spellContext] lets eligible conditional floating mana count — see [canAffordWithConvoke]. */
     fun calculateMinDelveNeeded(
         state: GameState,
         playerId: EntityId,
         manaCost: ManaCost,
         delveCards: List<DelveCardData>,
-        precomputedSources: List<ManaSource>? = null
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
     ): Int {
-        if (manaSolver.canPay(state, playerId, manaCost, precomputedSources = precomputedSources)) return 0
+        if (manaSolver.canPay(
+                state, playerId, manaCost,
+                precomputedSources = precomputedSources, spellContext = spellContext
+            )
+        ) return 0
         val maxDelve = minOf(delveCards.size, manaCost.genericAmount)
         for (delveCount in 1..maxDelve) {
-            if (manaSolver.canPay(state, playerId, manaCost.reduceGeneric(delveCount), precomputedSources = precomputedSources)) {
+            if (manaSolver.canPay(
+                    state, playerId, manaCost.reduceGeneric(delveCount),
+                    precomputedSources = precomputedSources, spellContext = spellContext
+                )
+            ) {
                 return delveCount
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/PaymentSubtypes.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/PaymentSubtypes.kt
@@ -21,3 +21,31 @@ internal fun paymentSubtypesOf(cardComponent: CardComponent): Set<String> {
         printed
     }
 }
+
+/**
+ * The mana-spending context for casting the spell described by [cardComponent] — the shape every
+ * cast path (enumeration, validation, payment) needs so conditional mana ("spend this mana only
+ * to …") is judged against the same characteristics.
+ *
+ * [SpellPaymentContext.manaValue] is the card's *printed* mana value: cost reductions and
+ * alternative payments like convoke pay part of a cost, they never change the spell's mana value
+ * (CR 202.3), so a {3}{R}{R} spell convoked down to one real mana is still MV 5 for
+ * [com.wingedsheep.sdk.scripting.effects.ManaRestriction.SpellsMV4OrGreater] (Ashling, Rimebound).
+ */
+internal fun spellPaymentContextFor(
+    cardComponent: CardComponent,
+    isKicked: Boolean = false,
+    isFromExile: Boolean = false,
+    isFromHand: Boolean = true
+): SpellPaymentContext = SpellPaymentContext(
+    isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
+    isKicked = isKicked,
+    isCreature = cardComponent.typeLine.isCreature,
+    isLegendary = cardComponent.typeLine.isLegendary,
+    manaValue = cardComponent.manaCost.cmc,
+    hasXInCost = cardComponent.manaCost.hasX,
+    subtypes = paymentSubtypesOf(cardComponent),
+    isFromExile = isFromExile,
+    isFromHand = isFromHand,
+    cardTypes = cardComponent.typeLine.cardTypes,
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -1,11 +1,19 @@
 package com.wingedsheep.engine.view
 
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.*
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.buildAbilityPaymentContext
+import com.wingedsheep.engine.mechanics.mana.isSatisfiedBy
+import com.wingedsheep.engine.mechanics.mana.spellPaymentContextFor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.player.RestrictedManaEntry
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
 
 /**
  * Thin mapping layer from engine [LegalAction] to server [LegalActionInfo] DTO.
@@ -19,12 +27,53 @@ class LegalActionEnricher(
 ) {
     fun enrich(actions: List<LegalAction>, state: GameState, playerId: EntityId): List<LegalActionInfo> {
         val manaSourceInfos = buildManaSourceInfos(state, playerId)
-        return actions.map { action -> toLegalActionInfo(action, manaSourceInfos) }
+        val restrictedMana = state.getEntity(playerId)?.get<ManaPoolComponent>()?.restrictedMana ?: emptyList()
+        return actions.map { action ->
+            toLegalActionInfo(
+                action,
+                manaSourceInfos,
+                eligibleRestrictedMana = if (restrictedMana.isEmpty() || !shouldExposeManaSources(action)) null
+                else buildEligibleRestrictedMana(state, action, restrictedMana)
+            )
+        }
+    }
+
+    /**
+     * The subset of [restrictedMana] whose restriction is satisfied by this action's payment —
+     * the mana the client may count as spendable while it does its own cost math (convoke bar,
+     * waterbend/harmonize selectors). Returns null when the action isn't a cast/activation we can
+     * build a payment context for, so the client falls back to unrestricted mana only.
+     */
+    private fun buildEligibleRestrictedMana(
+        state: GameState,
+        action: LegalAction,
+        restrictedMana: List<RestrictedManaEntry>
+    ): List<ClientRestrictedManaEntry>? {
+        val paymentContext = when (val gameAction = action.action) {
+            is CastSpell -> state.getEntity(gameAction.cardId)?.get<CardComponent>()?.let { card ->
+                spellPaymentContextFor(
+                    card,
+                    isKicked = gameAction.declaredCostSlot == ChoiceSlot.KICKED,
+                    isFromExile = action.sourceZone == "EXILE",
+                    // Null sourceZone means the standard hand cast.
+                    isFromHand = action.sourceZone == null || action.sourceZone == "HAND"
+                )
+            }
+            is ActivateAbility -> state.getEntity(gameAction.sourceId)?.get<CardComponent>()?.let { card ->
+                buildAbilityPaymentContext(card, state.projectedState, gameAction.sourceId)
+            }
+            else -> null
+        } ?: return null
+
+        return restrictedMana
+            .filter { it.restriction.isSatisfiedBy(paymentContext) }
+            .map { ClientRestrictedManaEntry(it.color?.symbol?.toString(), it.restriction.description) }
     }
 
     private fun toLegalActionInfo(
         action: LegalAction,
-        manaSourceInfos: List<ManaSourceInfo>?
+        manaSourceInfos: List<ManaSourceInfo>?,
+        eligibleRestrictedMana: List<ClientRestrictedManaEntry>?
     ): LegalActionInfo {
         return LegalActionInfo(
             actionType = action.actionType,
@@ -69,6 +118,7 @@ class LegalActionEnricher(
             minDamagePerTarget = action.minDamagePerTarget,
             autoTapPreview = action.autoTapPreview,
             availableManaSources = if (shouldExposeManaSources(action)) manaSourceInfos else null,
+            eligibleRestrictedMana = eligibleRestrictedMana,
             sourceZone = action.sourceZone,
             tapForPower = action.tapForPower,
             tapForPowerRequired = action.tapForPowerRequired,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -104,6 +104,17 @@ data class LegalActionInfo(
     val minDamagePerTarget: Int? = null,
     val autoTapPreview: List<EntityId>? = null,
     val availableManaSources: List<ManaSourceInfo>? = null,
+    /**
+     * The player's floating *restricted* ("spend this mana only to …") mana that is eligible to
+     * pay for **this** action, one entry per mana unit. Populated alongside
+     * [availableManaSources] — i.e. for the surfaces where the client does its own cost math
+     * (convoke / waterbend / harmonize / delve selectors, X-cost picker).
+     *
+     * The client can't judge eligibility itself: the pool payload only carries a human-readable
+     * restriction string. Without this, a convoke bar (say) would ignore Ashling, Rimebound's
+     * MV4+ mana and grey out a cast the server would happily accept.
+     */
+    val eligibleRestrictedMana: List<ClientRestrictedManaEntry>? = null,
     val requiresManaColorChoice: Boolean = false,
     /**
      * Restricted color names ("WHITE", "BLUE", ...) when the ability can only produce a

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingRimeboundConvokeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshlingRimeboundConvokeScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.LegalActionEnricher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AlternativePaymentChoice
+import com.wingedsheep.sdk.scripting.ConvokePayment
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Real-card version of [ConvokeWithConditionalManaTest]: Ashling, Rimebound's conditional mana
+ * ("add two mana of any one color. Spend this mana only to cast spells with mana value 4 or
+ * greater") paying for a convoked spell, optionally alongside another mana creature.
+ *
+ * Cards: Ashling, Rekindled // Ashling, Rimebound (ECL), Collective Inferno ({3}{R}{R}, convoke,
+ * MV 5), Great Forest Druid ("{T}: Add one mana of any color").
+ */
+class AshlingRimeboundConvokeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20), skipMulligans = true)
+        return driver
+    }
+
+    /**
+     * Put Ashling, Rimebound (the back face) onto the battlefield and let its first-main-phase
+     * trigger add two RED mana restricted to MV4+ spells. Returns Ashling's entity id.
+     *
+     * The two first-main triggers (add mana; may pay {R} to transform) both go on the stack, so
+     * the pending decisions are drained until the pool holds the restricted mana.
+     */
+    fun GameTestDriver.giveAshlingMana(player: EntityId): EntityId {
+        val ashling = putCreatureOnBattlefield(player, "Ashling, Rimebound")
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        drainDecisionsChoosingRed(player)
+        return ashling
+    }
+
+    test("Ashling, Rimebound's first-main trigger floats two MV4+-restricted mana") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.giveAshlingMana(player)
+
+        val pool = driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!
+        pool.restrictedMana.size shouldBe 2
+        pool.restrictedMana.all { it.color == Color.RED } shouldBe true
+        pool.restrictedMana.all { it.restriction == ManaRestriction.SpellsMV4OrGreater } shouldBe true
+    }
+
+    test("Collective Inferno is castable with convoke + Ashling's restricted mana + a Druid") {
+        // {3}{R}{R} (MV 5): convoke two creatures for {R}{R}, Ashling's two restricted red pay
+        // {2} of the generic, and Great Forest Druid taps for the last {1}. No lands untapped.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.giveAshlingMana(player)
+
+        val druid = driver.putCreatureOnBattlefield(player, "Great Forest Druid")
+        driver.removeSummoningSickness(druid)
+        val soldier1 = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        val soldier2 = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+
+        val spellId = driver.putCardInHand(player, "Collective Inferno")
+
+        // What the client sees: the cast is offered, flagged as a convoke cast, and the payload
+        // carries Ashling's two restricted mana as eligible for it.
+        val info = driver.legalActionInfoFor(player, spellId)
+        (info != null) shouldBe true
+        info!!.hasConvoke shouldBe true
+        info.eligibleRestrictedMana?.size shouldBe 2
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        soldier1 to ConvokePayment(color = null),
+                        soldier2 to ConvokePayment(color = null)
+                    )
+                )
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // Both restricted mana were spent; the Druid was tapped for the remainder.
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 0
+    }
+
+    test("Ashling's restricted mana is not advertised for a cheap spell") {
+        // Lightning Bolt is MV 1, so Ashling's MV4+ mana can never pay for it. The Bolt is still
+        // castable off the Druid's mana — the payload must offer the cast with *no* eligible
+        // restricted mana, so the client's cost math doesn't credit mana the server would refuse.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.giveAshlingMana(player)
+        val druid = driver.putCreatureOnBattlefield(player, "Great Forest Druid")
+        driver.removeSummoningSickness(druid)
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        val boltInfo = driver.legalActionInfoFor(player, bolt)
+
+        (boltInfo != null) shouldBe true
+        (boltInfo!!.eligibleRestrictedMana ?: emptyList()).size shouldBe 0
+    }
+})
+
+/**
+ * Drain the stack (Ashling's two first-main triggers), answering "choose a color" with RED and
+ * declining the optional {R} transform payment, until the stack is empty.
+ */
+private fun GameTestDriver.drainDecisionsChoosingRed(player: EntityId) {
+    var guard = 0
+    while (guard++ < 40 && (stackSize > 0 || pendingDecision != null)) {
+        val decision = pendingDecision
+        when {
+            decision is ChooseColorDecision ->
+                submitDecision(player, ColorChosenResponse(decision.id, Color.RED))
+            decision != null -> declinePendingDecision(player)
+            else -> passPriority(priorityPlayer ?: player)
+        }
+    }
+}
+
+/** The client-facing legal-action payload for casting [cardId], or null when not offered. */
+private fun GameTestDriver.legalActionInfoFor(playerId: EntityId, cardId: EntityId) =
+    LegalActionEnricher(ManaSolver(cardRegistry), cardRegistry)
+        .enrich(
+            LegalActionEnumerator.create(cardRegistry).enumerate(state, playerId, EnumerationMode.FULL),
+            state,
+            playerId
+        )
+        .firstOrNull { (it.action as? CastSpell)?.cardId == cardId }
+
+/** Decline a yes/no decision (Ashling's optional {R} transform payment). */
+private fun GameTestDriver.declinePendingDecision(playerId: EntityId) {
+    val decision = pendingDecision ?: return
+    submitDecision(playerId, YesNoResponse(decision.id, false))
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvokeWithConditionalManaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvokeWithConditionalManaTest.kt
@@ -1,0 +1,344 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AlternativePaymentChoice
+import com.wingedsheep.sdk.scripting.ConvokePayment
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Convoke (CR 702.51) paid alongside conditional ("spend this mana only to …") floating mana.
+ *
+ * Driven by Ashling, Rimebound: "add two mana of any one color. Spend this mana only to cast
+ * spells with mana value 4 or greater." A convoked spell keeps its printed mana value
+ * (CR 202.3 — convoke pays part of the cost, it doesn't reduce it), so the restricted mana
+ * stays eligible no matter how many pips convoke covers.
+ */
+class ConvokeWithConditionalManaTest : FunSpec({
+
+    // MV 5 — eligible for Ashling's restricted mana.
+    val convokeBehemoth = card("Convoke Behemoth") {
+        manaCost = "{3}{R}{R}"
+        typeLine = "Creature — Elemental Beast"
+        power = 5
+        toughness = 5
+        oracleText = "Convoke"
+        keywords(Keyword.CONVOKE)
+    }
+
+    // MV 6 — needs one more mana than the restricted pool + convoke can supply on its own.
+    val convokeColossus = card("Convoke Colossus") {
+        manaCost = "{4}{R}{R}"
+        typeLine = "Creature — Elemental Giant"
+        power = 6
+        toughness = 6
+        oracleText = "Convoke"
+        keywords(Keyword.CONVOKE)
+    }
+
+    // MV 3 — never eligible for Ashling's restricted mana, convoke or not.
+    val convokeSprite = card("Convoke Sprite") {
+        manaCost = "{1}{R}{R}"
+        typeLine = "Creature — Faerie Scout"
+        power = 2
+        toughness = 2
+        oracleText = "Convoke"
+        keywords(Keyword.CONVOKE)
+    }
+
+    val redSoldier = card("Red Soldier") {
+        manaCost = "{R}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(convokeBehemoth, convokeColossus, convokeSprite, redSoldier)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20), skipMulligans = true)
+        return driver
+    }
+
+    /** Two untapped red creatures the caster can tap for convoke. */
+    fun twoRedCreatures(driver: GameTestDriver, player: EntityId): Pair<EntityId, EntityId> {
+        val a = driver.putCreatureOnBattlefield(player, "Red Soldier")
+        val b = driver.putCreatureOnBattlefield(player, "Red Soldier")
+        return a to b
+    }
+
+    fun castActionFor(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        return enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .any { (it.action as? CastSpell)?.cardId == cardId }
+    }
+
+    // ---------------------------------------------------------------- payment paths
+
+    test("FromPool: convoke covers {R}{R}, restricted MV4+ mana pays the generic {3}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val (c1, c2) = twoRedCreatures(driver, player)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        c1 to ConvokePayment(color = Color.RED),
+                        c2 to ConvokePayment(color = Color.RED)
+                    )
+                )
+            )
+        )
+
+        result.isSuccess shouldBe true
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 0
+    }
+
+    test("AutoPay: convoke covers {R}{R}, restricted MV4+ mana pays the generic {3}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val (c1, c2) = twoRedCreatures(driver, player)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        c1 to ConvokePayment(color = Color.RED),
+                        c2 to ConvokePayment(color = Color.RED)
+                    )
+                )
+            )
+        )
+
+        result.isSuccess shouldBe true
+    }
+
+    test("convoke-reduced payment keeps the printed mana value: restricted mana stays eligible") {
+        // Cost {3}{R}{R} convoked down to {1} of real mana — the spell is still MV 5, so the
+        // MV4+ restricted mana is legal to spend on it.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val creatures = (1..4).map { driver.putCreatureOnBattlefield(player, "Red Soldier") }
+        driver.giveRestrictedMana(player, Color.RED, 1, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        creatures[0] to ConvokePayment(color = Color.RED),
+                        creatures[1] to ConvokePayment(color = Color.RED),
+                        creatures[2] to ConvokePayment(color = null),
+                        creatures[3] to ConvokePayment(color = null)
+                    )
+                )
+            )
+        )
+
+        result.isSuccess shouldBe true
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 0
+    }
+
+    // ---------------------------------------------------------------- legal actions (UI)
+
+    test("enumerator offers the convoke spell when only convoke + restricted mana can pay") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        twoRedCreatures(driver, player)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        castActionFor(driver, player, spellId) shouldBe true
+    }
+
+    test("enumerator does not offer an MV3 convoke spell payable only with MV4+ restricted mana") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // One creature for a single {R} pip; the rest of {1}{R} would need the restricted mana.
+        driver.putCreatureOnBattlefield(player, "Red Soldier")
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Sprite")
+        castActionFor(driver, player, spellId) shouldBe false
+    }
+
+    test("MV3 convoke spell cannot be paid with MV4+ restricted mana") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val (c1, c2) = twoRedCreatures(driver, player)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Sprite")
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        c1 to ConvokePayment(color = Color.RED),
+                        c2 to ConvokePayment(color = Color.RED)
+                    )
+                )
+            )
+        )
+
+        result.isSuccess shouldBe false
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 3
+    }
+
+    // ------------------------------------------------- combined with other mana abilities
+
+    test("restricted mana + an any-color mana creature + convoke pay a {4}{R}{R} spell") {
+        // Birds of Paradise stands in for Great Forest Druid ("{T}: Add one mana of any color").
+        // {4}{R}{R}: convoke two red creatures for {R}{R}, 3 restricted mana + the Bird's mana
+        // cover the remaining {4}.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val (c1, c2) = twoRedCreatures(driver, player)
+        val bird = driver.putCreatureOnBattlefield(player, "Birds of Paradise")
+        driver.removeSummoningSickness(bird)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Colossus")
+        castActionFor(driver, player, spellId) shouldBe true
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        c1 to ConvokePayment(color = Color.RED),
+                        c2 to ConvokePayment(color = Color.RED)
+                    )
+                )
+            )
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("restricted mana pays the colored pips while convoke pays the generic") {
+        // {3}{R}{R} with three *white* creatures: convoke can only cover the generic {3}, so the
+        // two {R} pips must come from Ashling's restricted red mana.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val whiteCreatures = (1..3).map { driver.putCreatureOnBattlefield(player, "Savannah Lions") }
+        driver.giveRestrictedMana(player, Color.RED, 2, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        castActionFor(driver, player, spellId) shouldBe true
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.FromPool,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = whiteCreatures.associateWith { ConvokePayment(color = null) }
+                )
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 0
+    }
+
+    test("ability convoke + ability-only restricted mana (Heirloom Epic)") {
+        // "{4}, {T}: Draw a card. For each mana in this ability's activation cost, you may tap an
+        // untapped creature you control rather than pay that mana." Two creatures cover {2}; the
+        // other {2} comes from mana restricted to ability activations.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val epic = driver.putPermanentOnBattlefield(player, "Heirloom Epic")
+        val (c1, c2) = twoRedCreatures(driver, player)
+        driver.giveRestrictedMana(player, Color.RED, 2, ManaRestriction.AbilityActivationOnly)
+
+        val abilityId = driver.cardRegistry.requireCard("Heirloom Epic").activatedAbilities.first().id
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val offered = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .any { (it.action as? ActivateAbility)?.sourceId == epic }
+        offered shouldBe true
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = epic,
+                abilityId = abilityId,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(
+                        c1 to ConvokePayment(color = null),
+                        c2 to ConvokePayment(color = null)
+                    )
+                )
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.state.getEntity(player)!!.get<ManaPoolComponent>()!!.restrictedMana.size shouldBe 0
+    }
+
+    test("a mana creature tapped for convoke can't also make mana") {
+        // Only resource besides the pool is the Bird: convoking it pays one pip but then its
+        // mana ability is gone. {3}{R}{R} needs 5; convoke(1) + 3 restricted = 4 → not castable.
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val bird = driver.putCreatureOnBattlefield(player, "Birds of Paradise")
+        driver.removeSummoningSickness(bird)
+        driver.giveRestrictedMana(player, Color.RED, 3, ManaRestriction.SpellsMV4OrGreater)
+
+        val spellId = driver.putCardInHand(player, "Convoke Behemoth")
+        castActionFor(driver, player, spellId) shouldBe false
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spellId,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                alternativePayment = AlternativePaymentChoice(
+                    convokedCreatures = mapOf(bird to ConvokePayment(color = Color.RED))
+                )
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -502,6 +502,12 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         G: floatingPool.green,
         C: floatingPool.colorless,
       }
+      // Restricted ("spend this mana only to …") mana counts too, but only the units the server
+      // judged eligible for this action — Ashling, Rimebound's MV4+ mana on an MV4+ spell.
+      for (const entry of manaSelectionState.actionInfo.eligibleRestrictedMana ?? []) {
+        const pip = entry.color ?? 'C'
+        if (pip in poolByPip) poolByPip[pip]!++
+      }
       // Spend exact-color pool first against colored pips
       for (const pip of Object.keys(poolByPip)) {
         while ((poolByPip[pip] ?? 0) > 0 && (remainingColorReqs[pip] ?? 0) > 0) {

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -643,7 +643,13 @@ function ActionOptionButton({
         </span>
         {showSeparateCost && (
           hasFloatingMana && manaPool
-            ? <ManaCostProgress cost={option.manaCost} manaPool={manaPool} size={16} gap={2} />
+            ? <ManaCostProgress
+                cost={option.manaCost}
+                manaPool={manaPool}
+                eligibleRestrictedMana={option.action?.eligibleRestrictedMana ?? []}
+                size={16}
+                gap={2}
+              />
             : <ManaCost cost={option.manaCost} size={16} gap={2} />
         )}
       </button>

--- a/web-client/src/components/ui/ConvokeSelector.tsx
+++ b/web-client/src/components/ui/ConvokeSelector.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useGameStore, ConvokeCreatureSelection } from '@/store/gameStore.ts'
 import { Color, ColorSymbols } from '@/types/enums'
 import { useViewingPlayer } from '@/store/selectors'
-import type { ClientManaPool } from '@/types/gameState'
+import { applyManaPoolToCost, totalManaNeeded } from '@/utils/manaCost'
 import { ManaSymbol } from './ManaSymbols'
 
 /**
@@ -81,71 +81,6 @@ function calculateRemainingCost(
 }
 
 /**
- * Subtract the player's floating mana from [symbols], paying exact-color pips first,
- * then hybrid pips, then generic. Returns the symbols still owed after the pool is
- * applied. Mirrors the order the server's autoPay uses so the affordability check
- * matches the actual payment.
- */
-function applyManaPool(symbols: string[], pool: ClientManaPool | undefined): string[] {
-  if (!pool) return symbols
-  const remaining = [...symbols]
-  const available: Record<string, number> = {
-    W: pool.white,
-    U: pool.blue,
-    B: pool.black,
-    R: pool.red,
-    G: pool.green,
-    C: pool.colorless,
-  }
-
-  for (const pip of ['W', 'U', 'B', 'R', 'G', 'C']) {
-    while (available[pip]! > 0) {
-      const idx = remaining.indexOf(pip)
-      if (idx < 0) break
-      remaining.splice(idx, 1)
-      available[pip]!--
-    }
-  }
-
-  for (const pip of ['W', 'U', 'B', 'R', 'G']) {
-    while (available[pip]! > 0) {
-      const idx = remaining.findIndex(s => hybridCoversColor(s, pip))
-      if (idx < 0) break
-      remaining.splice(idx, 1)
-      available[pip]!--
-    }
-  }
-
-  let generic = available.W! + available.U! + available.B! + available.R! + available.G! + available.C!
-  while (generic > 0) {
-    const idx = remaining.findIndex(s => /^\d+$/.test(s))
-    if (idx < 0) break
-    const value = parseInt(remaining[idx]!, 10)
-    if (value > 1) {
-      remaining[idx] = String(value - 1)
-    } else {
-      remaining.splice(idx, 1)
-    }
-    generic--
-  }
-
-  return remaining
-}
-
-/**
- * Calculate the total mana value of remaining cost symbols.
- * Generic symbols count as their numeric value, colored symbols count as 1 each.
- */
-function totalManaNeeded(symbols: string[]): number {
-  let total = 0
-  for (const s of symbols) {
-    const num = parseInt(s, 10)
-    total += isNaN(num) ? 1 : num
-  }
-  return total
-}
-
-/**
  * Calculate the total mana available from mana sources, excluding entities the
  * player has already chosen to tap for convoke (a creature with its own mana
  * ability, e.g. Llanowar Elves, can pay either a convoke pip or a mana ability —
@@ -186,9 +121,13 @@ export function ConvokeSelector() {
     return calculateRemainingCost(originalSymbols, convokeSelectionState.selectedCreatures)
   }, [originalSymbols, convokeSelectionState?.selectedCreatures])
 
+  // Conditional mana ("spend this mana only to …") counts only when the server flagged it
+  // eligible for this exact cast — e.g. Ashling, Rimebound's mana on an MV4+ spell.
+  const eligibleRestricted = convokeSelectionState?.actionInfo.eligibleRestrictedMana
+
   const symbolsAfterPool = useMemo(
-    () => applyManaPool(remainingSymbols, manaPool),
-    [remainingSymbols, manaPool]
+    () => applyManaPoolToCost(remainingSymbols, manaPool, eligibleRestricted),
+    [remainingSymbols, manaPool, eligibleRestricted]
   )
 
   const convokedIds = useMemo(

--- a/web-client/src/components/ui/HarmonizeSelector.tsx
+++ b/web-client/src/components/ui/HarmonizeSelector.tsx
@@ -1,50 +1,13 @@
 import { useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useViewingPlayer } from '@/store/selectors'
-import type { ClientManaPool } from '@/types/gameState'
-import { parseManaCost, getRemainingCostSymbols } from '@/utils/manaCost'
+import {
+  applyManaPoolToCost,
+  getRemainingCostSymbols,
+  parseManaCost,
+  totalManaNeeded,
+} from '@/utils/manaCost'
 import { ManaSymbol } from './ManaSymbols'
-
-/**
- * Subtract the player's floating mana from [symbols] — colored pips first, then generic —
- * returning what's still owed. Mirrors the server autoPay order so the affordability check
- * matches the actual payment.
- */
-function applyManaPool(symbols: string[], pool: ClientManaPool | undefined): string[] {
-  if (!pool) return symbols
-  const remaining = [...symbols]
-  const available: Record<string, number> = {
-    W: pool.white, U: pool.blue, B: pool.black, R: pool.red, G: pool.green, C: pool.colorless,
-  }
-  for (const pip of ['W', 'U', 'B', 'R', 'G', 'C']) {
-    while (available[pip]! > 0) {
-      const idx = remaining.indexOf(pip)
-      if (idx < 0) break
-      remaining.splice(idx, 1)
-      available[pip]!--
-    }
-  }
-  let generic = available.W! + available.U! + available.B! + available.R! + available.G! + available.C!
-  while (generic > 0) {
-    const idx = remaining.findIndex((s) => /^\d+$/.test(s))
-    if (idx < 0) break
-    const value = parseInt(remaining[idx]!, 10)
-    if (value > 1) remaining[idx] = String(value - 1)
-    else remaining.splice(idx, 1)
-    generic--
-  }
-  return remaining
-}
-
-/** Total mana value of the remaining cost (generic = its value, colored pips = 1 each). */
-function totalManaNeeded(symbols: string[]): number {
-  let total = 0
-  for (const s of symbols) {
-    const num = parseInt(s, 10)
-    total += isNaN(num) ? 1 : num
-  }
-  return total
-}
 
 /**
  * Floating HUD bar for the Harmonize creature-tap step. The player may tap one creature
@@ -78,9 +41,12 @@ export function HarmonizeSelector() {
     [originalSymbols, reduction],
   )
 
+  // Conditional mana counts only where the server judged it eligible for this payment.
+  const eligibleRestricted = harmonizeSelectionState?.actionInfo.eligibleRestrictedMana
+
   const symbolsAfterPool = useMemo(
-    () => applyManaPool(remainingSymbols, manaPool),
-    [remainingSymbols, manaPool],
+    () => applyManaPoolToCost(remainingSymbols, manaPool, eligibleRestricted),
+    [remainingSymbols, manaPool, eligibleRestricted],
   )
 
   if (!harmonizeSelectionState) return null

--- a/web-client/src/components/ui/ManaCostProgress.tsx
+++ b/web-client/src/components/ui/ManaCostProgress.tsx
@@ -3,7 +3,7 @@
  * Shows which parts of a spell's mana cost are covered by the current mana pool.
  */
 
-import type { ClientManaPool } from '@/types'
+import type { ClientManaPool, ClientRestrictedManaEntry } from '@/types'
 import { ManaSymbol } from './ManaSymbols'
 
 interface ManaCostProgressProps {
@@ -11,24 +11,20 @@ interface ManaCostProgressProps {
   cost: string | null
   /** Current floating mana pool */
   manaPool: ClientManaPool
+  /**
+   * Restricted ("spend this mana only to …") mana the server flagged eligible for *this* action
+   * (`LegalActionInfo.eligibleRestrictedMana`). Counted as spendable, so a cast payable with
+   * Ashling, Rimebound's MV4+ mana doesn't render as unpaid.
+   */
+  eligibleRestrictedMana?: readonly ClientRestrictedManaEntry[]
   /** Symbol size in pixels */
   size?: number
   /** Gap between symbols */
   gap?: number
 }
 
-/** Numeric mana pool keys (excludes the restrictedMana list field). */
-type NumericPoolKey = 'white' | 'blue' | 'black' | 'red' | 'green' | 'colorless'
-
-/** Mana color codes mapped to pool keys */
-const COLOR_TO_POOL_KEY: Record<string, NumericPoolKey> = {
-  W: 'white',
-  U: 'blue',
-  B: 'black',
-  R: 'red',
-  G: 'green',
-  C: 'colorless',
-}
+/** Pip letters, in the order the pool is consumed. */
+const PIPS = ['W', 'U', 'B', 'R', 'G', 'C'] as const
 
 interface SymbolStatus {
   symbol: string
@@ -39,24 +35,36 @@ interface SymbolStatus {
  * Greedily assign mana pool to cost symbols.
  * Colored symbols are matched first, then generic costs use remaining pool.
  */
-function computeProgress(symbols: string[], pool: ClientManaPool): SymbolStatus[] {
-  // Work with a mutable copy of the pool
-  const remaining = { ...pool }
+function computeProgress(
+  symbols: string[],
+  pool: ClientManaPool,
+  eligibleRestricted: readonly ClientRestrictedManaEntry[],
+): SymbolStatus[] {
+  const available: Record<string, number> = {
+    W: pool.white,
+    U: pool.blue,
+    B: pool.black,
+    R: pool.red,
+    G: pool.green,
+    C: pool.colorless,
+  }
+  for (const entry of eligibleRestricted) {
+    const pip = entry.color ?? 'C'
+    if (pip in available) available[pip]!++
+  }
 
   const result: SymbolStatus[] = symbols.map((s) => ({ symbol: s, paid: false }))
 
   // Pass 1: Match colored/colorless symbols
   for (const entry of result) {
-    const poolKey = COLOR_TO_POOL_KEY[entry.symbol]
-    if (poolKey && remaining[poolKey] > 0) {
-      remaining[poolKey]--
+    if (available[entry.symbol] !== undefined && available[entry.symbol]! > 0) {
+      available[entry.symbol]!--
       entry.paid = true
     }
   }
 
   // Pass 2: Match generic (numeric) symbols with any remaining mana
-  let totalRemaining =
-    remaining.white + remaining.blue + remaining.black + remaining.red + remaining.green + remaining.colorless
+  let totalRemaining = PIPS.reduce((sum, pip) => sum + available[pip]!, 0)
 
   for (const entry of result) {
     if (entry.paid) continue
@@ -77,14 +85,20 @@ function computeProgress(symbols: string[], pool: ClientManaPool): SymbolStatus[
  * Renders a mana cost string with visual indicators for which symbols
  * are already payable from the current mana pool.
  */
-export function ManaCostProgress({ cost, manaPool, size = 16, gap = 2 }: ManaCostProgressProps) {
+export function ManaCostProgress({
+  cost,
+  manaPool,
+  eligibleRestrictedMana = [],
+  size = 16,
+  gap = 2,
+}: ManaCostProgressProps) {
   if (!cost) return null
 
   const matches = cost.match(/\{([^}]+)\}/g)
   if (!matches || matches.length === 0) return null
 
   const symbols = matches.map((m) => m.slice(1, -1))
-  const progress = computeProgress(symbols, manaPool)
+  const progress = computeProgress(symbols, manaPool, eligibleRestrictedMana)
 
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap }}>

--- a/web-client/src/components/ui/WaterbendSelector.tsx
+++ b/web-client/src/components/ui/WaterbendSelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useViewingPlayer } from '@/store/selectors'
-import type { ClientManaPool } from '@/types/gameState'
+import { applyManaPoolToCost, totalManaNeeded } from '@/utils/manaCost'
 import { ManaSymbol } from './ManaSymbols'
 
 /**
@@ -30,45 +30,6 @@ function reduceGenericBy(symbols: string[], count: number): string[] {
     else remaining.splice(idx, 1)
   }
   return remaining
-}
-
-/**
- * Subtract the player's floating mana: exact-color pips first, then generic. Returns what's still owed.
- */
-function applyManaPool(symbols: string[], pool: ClientManaPool | undefined): string[] {
-  if (!pool) return symbols
-  const remaining = [...symbols]
-  const available: Record<string, number> = {
-    W: pool.white, U: pool.blue, B: pool.black, R: pool.red, G: pool.green, C: pool.colorless,
-  }
-  for (const pip of ['W', 'U', 'B', 'R', 'G', 'C']) {
-    while (available[pip]! > 0) {
-      const idx = remaining.indexOf(pip)
-      if (idx < 0) break
-      remaining.splice(idx, 1)
-      available[pip]!--
-    }
-  }
-  let generic = available.W! + available.U! + available.B! + available.R! + available.G! + available.C!
-  while (generic > 0) {
-    const idx = remaining.findIndex((s) => /^\d+$/.test(s))
-    if (idx < 0) break
-    const value = parseInt(remaining[idx]!, 10)
-    if (value > 1) remaining[idx] = String(value - 1)
-    else remaining.splice(idx, 1)
-    generic--
-  }
-  return remaining
-}
-
-/** Total mana value of a list of cost symbols (generic counts as its value, colored as 1). */
-function totalManaNeeded(symbols: string[]): number {
-  let total = 0
-  for (const s of symbols) {
-    const num = parseInt(s, 10)
-    total += isNaN(num) ? 1 : num
-  }
-  return total
 }
 
 function totalManaAvailable(
@@ -106,9 +67,12 @@ export function WaterbendSelector() {
     return reduceGenericBy(originalSymbols, waterbendSelectionState.selectedPermanents.length)
   }, [originalSymbols, waterbendSelectionState?.selectedPermanents])
 
+  // Conditional mana counts only where the server judged it eligible for this payment.
+  const eligibleRestricted = waterbendSelectionState?.actionInfo.eligibleRestrictedMana
+
   const symbolsAfterPool = useMemo(
-    () => applyManaPool(remainingSymbols, manaPool),
-    [remainingSymbols, manaPool],
+    () => applyManaPoolToCost(remainingSymbols, manaPool, eligibleRestricted),
+    [remainingSymbols, manaPool, eligibleRestricted],
   )
 
   const tappedIds = useMemo(

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -2,7 +2,7 @@ import { ErrorCode, GameOverReason } from './enums'
 import { EntityId } from './entities'
 import { GameAction } from './actions'
 import { ClientEvent } from './events'
-import { ClientGameState, ClientCard, ClientZone, ClientPlayer, ClientCombatState, ClientCommanderDamage, ClientDeckCard } from './gameState'
+import { ClientGameState, ClientCard, ClientZone, ClientPlayer, ClientCombatState, ClientCommanderDamage, ClientDeckCard, ClientRestrictedManaEntry } from './gameState'
 
 // ============================================================================
 // Server Messages (received from server)
@@ -885,6 +885,14 @@ export interface LegalActionInfo {
   readonly autoTapPreview?: readonly EntityId[]
   /** Available mana sources for pre-cast selection */
   readonly availableManaSources?: readonly ManaSourceInfo[]
+  /**
+   * Floating restricted ("spend this mana only to …") mana that the server has determined is
+   * eligible to pay for *this* action — one entry per mana unit. Sent alongside
+   * `availableManaSources`. The client must count these as spendable when it does its own cost
+   * math (convoke / waterbend / harmonize bars); it cannot judge eligibility itself, since the
+   * mana pool payload carries only a human-readable restriction string.
+   */
+  readonly eligibleRestrictedMana?: readonly ClientRestrictedManaEntry[]
   /** Whether this ability produces mana of any color and needs a color choice from the player */
   readonly requiresManaColorChoice?: boolean
   /**

--- a/web-client/src/utils/manaCost.ts
+++ b/web-client/src/utils/manaCost.ts
@@ -164,6 +164,105 @@ export function getRemainingCostAfterConvoke(
 }
 
 /**
+ * A unit of floating mana available for a payment: a pip letter ("W".."G", "C" for colorless).
+ * Mirrors the numeric pool fields plus the server's per-action eligible restricted entries.
+ */
+interface AvailableMana {
+  readonly white: number
+  readonly blue: number
+  readonly black: number
+  readonly red: number
+  readonly green: number
+  readonly colorless: number
+}
+
+/** A single unit of restricted mana the server flagged eligible for this payment. */
+interface EligibleRestrictedMana {
+  /** Pip letter ("W".."G") or null/undefined for colorless. */
+  readonly color?: string | null
+}
+
+/**
+ * Subtract the player's floating mana from [symbols] and return the symbols still owed.
+ *
+ * Pays exact-color pips first, then hybrid pips (CR 107.4e — a hybrid symbol is a colored symbol
+ * of both halves), then generic — the same order the server's `ManaPool.payPartial` uses, so the
+ * client's affordability check matches the actual payment.
+ *
+ * [eligibleRestricted] is the conditional mana ("spend this mana only to …") the *server* has
+ * already judged eligible for this specific action (`LegalActionInfo.eligibleRestrictedMana`).
+ * It spends exactly like unrestricted mana here; ignoring it greys out casts the server would
+ * accept — e.g. convoking a big creature while Ashling, Rimebound's MV4+ mana is floating.
+ */
+export function applyManaPoolToCost(
+  symbols: string[],
+  pool: AvailableMana | undefined,
+  eligibleRestricted: readonly EligibleRestrictedMana[] | undefined = undefined,
+): string[] {
+  const remaining = [...symbols]
+  const available: Record<string, number> = {
+    W: pool?.white ?? 0,
+    U: pool?.blue ?? 0,
+    B: pool?.black ?? 0,
+    R: pool?.red ?? 0,
+    G: pool?.green ?? 0,
+    C: pool?.colorless ?? 0,
+  }
+  for (const entry of eligibleRestricted ?? []) {
+    const pip = entry.color ?? 'C'
+    if (pip in available) available[pip]!++
+  }
+
+  const pips = ['W', 'U', 'B', 'R', 'G', 'C']
+  for (const pip of pips) {
+    while (available[pip]! > 0) {
+      const idx = remaining.indexOf(pip)
+      if (idx < 0) break
+      remaining.splice(idx, 1)
+      available[pip]!--
+    }
+  }
+
+  for (const pip of pips) {
+    if (pip === 'C') continue
+    while (available[pip]! > 0) {
+      const idx = remaining.findIndex((s) => s.includes('/') && s.split('/').includes(pip))
+      if (idx < 0) break
+      remaining.splice(idx, 1)
+      available[pip]!--
+    }
+  }
+
+  let generic = pips.reduce((sum, pip) => sum + available[pip]!, 0)
+  while (generic > 0) {
+    const idx = remaining.findIndex((s) => /^\d+$/.test(s))
+    if (idx < 0) break
+    const value = parseInt(remaining[idx]!, 10)
+    if (value > 1) {
+      remaining[idx] = String(value - 1)
+    } else {
+      remaining.splice(idx, 1)
+    }
+    generic--
+  }
+
+  return remaining
+}
+
+/**
+ * Total mana still needed for [symbols]: generic symbols count as their value, every other
+ * symbol as one.
+ */
+export function totalManaNeeded(symbols: string[]): number {
+  let total = 0
+  for (const s of symbols) {
+    const num = parseInt(s, 10)
+    total += isNaN(num) ? 1 : num
+  }
+  return total
+}
+
+/**
  * Minimal description of a mana source needed for preview trimming.
  * Mirrors the server-provided `ManaSourceInfo` shape. Generic over the
  * entityId type so callers using a branded `EntityId` don't lose that type.


### PR DESCRIPTION
## The bug

Ashling, Rimebound's "add two mana of any one color. Spend this mana only to cast spells with mana value 4 or greater" mana **paid** for a convoked spell just fine — but the spell was never *offered*. `CostEnumerationUtils.canAffordWithConvoke` called `getAvailableManaCount(...)` without a `SpellPaymentContext`, so eligible restricted floating mana counted as **zero** on exactly the path where convoke help is needed. With 2 restricted red mana and two creatures to tap, a {3}{R}{R} convoke spell stayed greyed out in hand, even though the engine would have accepted the cast.

The same omission existed in every sibling helper: `canAffordWithDelve`, `calculateMinDelveNeeded`, `canAffordWithWaterbend`, `canAffordWithHarmonize`, `maxAffordableXWithHarmonize`, and the ability-level convoke/waterbend checks in `ActivatedAbilityEnumerator`. All now take the payment context.

## Printed mana value is load-bearing

Five copy-pasted `SpellPaymentContext(...)` literals in the enumerators collapse into `spellPaymentContextFor(cardComponent, …)` (`PaymentSubtypes.kt`). One place to state the rule that matters here: the context's mana value is the card's **printed** MV, because convoke pays part of a cost and never lowers mana value — a {3}{R}{R} spell convoked down to one real mana is still MV 5, so the MV4+ mana stays legal to spend on it. The factory also recovers two fields the kicked non-hand variant had dropped (`isLegendary`, `isFromExile`).

## Client

The client had the same bug and **could not fix itself**: the mana-pool payload carries only a human-readable restriction string, so eligibility is undecidable client-side. The server now ships `LegalActionInfo.eligibleRestrictedMana` — the units it judged eligible for that specific action, computed in `LegalActionEnricher` alongside `availableManaSources` (skipped entirely when the pool holds no restricted mana).

- **Convoke / waterbend / harmonize bars** — the three duplicated `applyManaPool` helpers collapse into one `applyManaPoolToCost` in `utils/manaCost.ts` that credits eligible restricted mana. The Cast button no longer stays disabled with Ashling's mana floating.
- **ActionMenu cost progress** — pips payable by restricted mana render as paid instead of greyed out.
- **Mana-source selection HUD** — the `n/total` counter credits it, as it already did for unrestricted floating mana.

Ineligible mana is never credited: Lightning Bolt (MV 1) reports zero eligible entries with Ashling's MV4+ mana in the pool.

No screenshot: the client change is purely behavioral (button enablement, pip opacity) — no layout, component, asset, or copy change. Reproducing the before/after on screen needs a live game with Ashling transformed and a convoke spell in hand; happy to add a walkthrough capture if you want it.

## Tests

`ConvokeWithConditionalManaTest` (rules-engine, 10 cases):
- FromPool / AutoPay: convoke covers {R}{R}, restricted mana pays the generic
- restricted mana pays the *colored* pips while convoke covers the generic
- convoke-reduced payment keeps the printed MV, so the mana stays eligible
- **the regression**: the enumerator offers the cast when only convoke + restricted mana can pay
- fail-closed: an MV3 convoke spell is neither offered nor castable with MV4+ mana
- an any-color mana creature (Great Forest Druid's shape) alongside restricted mana + convoke
- a mana creature tapped for convoke isn't double-counted as a mana source
- ability convoke (Heirloom Epic) with ability-activation-only restricted mana

`AshlingRimeboundConvokeScenarioTest` (real cards): Ashling, Rimebound's first-main trigger floats the two MV4+ mana; Collective Inferno ({3}{R}{R}, convoke) casts off convoke + those two mana + Great Forest Druid; asserts the client payload (`hasConvoke`, `eligibleRestrictedMana`) and the negative case for Lightning Bolt.

Gates: `just test-rules`, `just test-server`, `npm run typecheck`, `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
