### PR TITLE
Make "Random pool" survive into the lobby, and match the landing card's width

### DIFF
--- a/web-client/src/components/lobby/lobbyViewModel.ts
+++ b/web-client/src/components/lobby/lobbyViewModel.ts
@@ -23,6 +23,7 @@ import {
   axesFromQuickGameLobby,
   isCommanderLimited,
   type AxisTriple,
+  type CardsKind,
 } from './axes'
 
 /** Which server implementation is backing this lobby. */
@@ -119,6 +120,7 @@ export function fromQuickGameLobby(
   const isMomir = lobby.momirBasic ?? false
   const youReady = you?.ready ?? false
   const needsDeck = !isMomir && (!opts.deckValid || !you?.deckSelected)
+  const axes = axesFromQuickGameLobby(lobby, you, opts.deckTab)
 
   const players = lobby.players.map((p): LobbyViewPlayer => ({
     playerId: p.playerId,
@@ -140,18 +142,12 @@ export function fromQuickGameLobby(
     kind: 'QUICK',
     lobbyId: lobby.lobbyId,
     title: lobby.vsAi ? 'vs AI' : 'Lobby',
-    subtitle: isMomir
-      ? lobby.vsAi
-        ? 'No deckbuilding — ready up and the AI starts. Flip creatures with the Momir Vig avatar.'
-        : 'No deckbuilding — share the invite code, then both players ready up.'
-      : lobby.vsAi
-        ? 'Pick a deck and ready up — the AI starts as soon as you do.'
-        : 'Share the invite code with a friend, then both players ready up.',
+    subtitle: quickSubtitle(axes.cards.kind, lobby.vsAi),
     isHost,
     // A quick lobby has no state machine: it is staging right up until the game starts.
     isWaiting: true,
     invitable: !lobby.vsAi,
-    axes: axesFromQuickGameLobby(lobby, you, opts.deckTab),
+    axes,
     players,
     you: players.find((p) => p.isYou),
     maxPlayers: 2,
@@ -171,6 +167,29 @@ export function fromQuickGameLobby(
     // The server's `QuickGameLobby.twoHeadedGiant` exists but no client has ever reached it (gap
     // #6): it isn't in `QuickGameLobbyStateMessage` at all, so there is nothing here to read.
     teams: { mode: 'NONE' },
+  }
+}
+
+/**
+ * The line under a quick lobby's title: what it still needs from you, and how it starts.
+ *
+ * It follows the **Cards** axis and not just `vsAi`, because the three values ask for different
+ * things — and two of them ask for nothing. The previous copy branched on `vsAi` alone, so a lobby
+ * created from the wizard's "Random pool" opened telling the player to "pick a deck", which is the
+ * one instruction that answer had already made obsolete.
+ */
+function quickSubtitle(cards: CardsKind, vsAi: boolean): string {
+  const start = vsAi
+    ? 'Ready up and the AI starts.'
+    : 'Share the invite code with a friend, then both players ready up.'
+  switch (cards) {
+    case 'RANDOM':
+      // 8 boosters, auto-built into a 40-card deck — `SealedDeckGenerator.generate`.
+      return `Nothing to prepare — the server opens boosters and builds your deck when the game starts. ${start}`
+    case 'MOMIR':
+      return `No deckbuilding — everyone runs 60 basics and flips creatures with the Momir Vig avatar. ${start}`
+    default:
+      return `Pick a deck. ${start}`
   }
 }
 

--- a/web-client/src/components/ui/DeckPicker.module.css
+++ b/web-client/src/components/ui/DeckPicker.module.css
@@ -1,11 +1,13 @@
 /* DeckPicker — layout for the tabbed deck builder used by quick-game and (later) tournament Custom Decks. */
 
+/* No width cap of its own: both call sites are panels inside the lobby card, which is already
+   capped at `--screen-card-w`. The 540px it used to carry was a second, narrower answer to the same
+   question, so the picker sat short of its own panel's right edge once the card grew. */
 .picker {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
   width: 100%;
-  max-width: 540px;
   background: rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-md);
@@ -100,6 +102,56 @@
   display: flex;
   gap: var(--space-2);
   align-items: center;
+}
+
+/* ── Random tab ─────────────────────────────────────────────────────────────
+ * The only tab whose answer is "nothing to do", and therefore the only one that could be mistaken
+ * for a panel that failed to load: it was one grey line of helper text in a 220px box. Saying what
+ * the server is going to do — and giving the set, the one thing there *is* to decide, a row of its
+ * own — makes it read as a choice that landed rather than an empty screen.
+ */
+.randomCard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  text-align: center;
+  padding: var(--space-3);
+  border: 1px dashed rgba(255, 255, 255, 0.14);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.randomDie {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.randomTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.randomBody {
+  margin: 0;
+  max-width: 42ch;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.randomSetRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  align-self: stretch;
+  margin-top: var(--space-1);
+  padding-top: var(--space-3);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .nameInput {

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -179,7 +179,22 @@ export function DeckPicker({
         : (tabs[0] ?? 'paste')
   const [uncontrolledTab, setUncontrolledTab] = useState<Tab>(() => initialTab)
   const tab = controlledTab ?? uncontrolledTab
+  /**
+   * Whether landing on Random was a *placeholder* rather than a decision.
+   *
+   * The deck library hydrates asynchronously, so on the first render `decks` is always empty and
+   * {@link initialTab} falls through to `random` — the picker's way of showing something rather than
+   * an empty "My Decks". That placeholder is replaced by `saved` as soon as the list arrives.
+   *
+   * Random asked for *from outside* is the opposite: the landing wizard's "Random pool" and the
+   * cross-kind recreate both hand the tab in through {@link DeckPickerProps.tab}, having already
+   * promised the player a rolled pool. Before this the two were indistinguishable, so
+   * "A friend → Random pool → Create lobby" opened a lobby sitting on My Decks — the picker
+   * overwrote the answer the wizard had just collected.
+   */
+  const randomIsPlaceholder = useRef(controlledTab === undefined)
   const setTab = useCallback((next: Tab) => {
+    randomIsPlaceholder.current = false
     setUncontrolledTab(next)
     onTabChange?.(next)
   }, [onTabChange])
@@ -210,11 +225,12 @@ export function DeckPicker({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Move off `random` to `saved` once decks are hydrated, so users land on their own list. Keyed
-  // on `decks.length`, so this only fires as the deck list arrives — a user who picks Random later
-  // stays on it.
+  // Replace the placeholder Random tab with `saved` once decks are hydrated, so users land on their
+  // own list. Keyed on `decks.length`, so this only fires as the deck list arrives — a user who
+  // picks Random later stays on it, and so does a Random the caller asked for
+  // (see `randomIsPlaceholder`).
   useEffect(() => {
-    if (decks.length > 0 && tab === 'random' && showSaved) {
+    if (randomIsPlaceholder.current && decks.length > 0 && tab === 'random' && showSaved) {
       setTab('saved')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -504,39 +520,51 @@ export function DeckPicker({
 
         {tab === 'random' && (
           <>
-            {availableSets.length > 0 && (() => {
-              const selectedSet = randomSetCode
-                ? availableSets.find((s) => s.code === randomSetCode) ?? null
-                : null
-              return (
-                <div className={styles.actionsRow}>
-                  <label className={styles.helperText} style={{ flexShrink: 0 }}>Set</label>
-                  <span
-                    className={`${lobbyStyles.setChip} ${selectedSet?.partial ? lobbyStyles.setChipPartial : ''}`}
-                    title={selectedSet?.name ?? 'A random set is rolled when the game starts'}
-                  >
-                    {selectedSet ? (
-                      <SetIcon code={selectedSet.code} className={lobbyStyles.setChipIcon} />
-                    ) : (
-                      <span className={lobbyStyles.setChipIcon} aria-hidden>🎲</span>
-                    )}
-                    <span className={lobbyStyles.setChipName}>{selectedSet?.name ?? 'Random Set'}</span>
-                  </span>
-                  <button
-                    type="button"
-                    className={lobbyStyles.addSetsButton}
-                    onClick={() => setShowSetPicker(true)}
-                    disabled={disabled}
-                    style={{ marginLeft: 'auto' }}
-                  >
-                    Choose set
-                  </button>
-                </div>
-              )
-            })()}
-            <p className={styles.helperText}>
-              The server will generate a random sealed pool deck when the game starts.
-            </p>
+            {/* The one tab whose answer is "nothing to do", which is exactly why it has to say so.
+                It used to be a single grey line in a 220px box — indistinguishable from a panel
+                that had failed to load, and the least convincing possible landing place for
+                someone who has just answered "Random pool" in the wizard. */}
+            <div className={styles.randomCard} data-testid="random-pool-panel">
+              <span className={styles.randomDie} aria-hidden>🎲</span>
+              <h3 className={styles.randomTitle}>The server builds your deck</h3>
+              <p className={styles.randomBody}>
+                Eight boosters from one set, auto-built into a 40-card deck the moment the game
+                starts. Nothing to pick, nothing to submit — just ready up.
+              </p>
+              <p className={styles.randomBody}>
+                This covers your seat only. Your opponent can still bring a deck of their own.
+              </p>
+              {availableSets.length > 0 && (() => {
+                const selectedSet = randomSetCode
+                  ? availableSets.find((s) => s.code === randomSetCode) ?? null
+                  : null
+                return (
+                  <div className={styles.randomSetRow}>
+                    <label className={styles.helperText} style={{ flexShrink: 0 }}>Set</label>
+                    <span
+                      className={`${lobbyStyles.setChip} ${selectedSet?.partial ? lobbyStyles.setChipPartial : ''}`}
+                      title={selectedSet?.name ?? 'A random set is rolled when the game starts'}
+                    >
+                      {selectedSet ? (
+                        <SetIcon code={selectedSet.code} className={lobbyStyles.setChipIcon} />
+                      ) : (
+                        <span className={lobbyStyles.setChipIcon} aria-hidden>🎲</span>
+                      )}
+                      <span className={lobbyStyles.setChipName}>{selectedSet?.name ?? 'Random Set'}</span>
+                    </span>
+                    <button
+                      type="button"
+                      className={lobbyStyles.addSetsButton}
+                      onClick={() => setShowSetPicker(true)}
+                      disabled={disabled}
+                      style={{ marginLeft: 'auto' }}
+                    >
+                      Choose set
+                    </button>
+                  </div>
+                )
+              })()}
+            </div>
             {showSetPicker && (
               <SetPickerModal
                 sets={availableSets}

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -38,7 +38,7 @@
      1120px, where a basis would be read as a height. */
   flex: 0 1 auto;
   width: 100%;
-  max-width: var(--landing-card-w);
+  max-width: var(--screen-card-w);
   min-width: 0;
   box-sizing: border-box;
   display: flex;
@@ -119,7 +119,6 @@
  */
 .landingLayout {
   --landing-rail-w: 320px;
-  --landing-card-w: 756px;
   margin: auto 0;
   width: 100%;
   display: flex;
@@ -249,9 +248,11 @@
   }
 }
 
+/* Same width as the landing card it replaces — see `--screen-card-w`. The two are consecutive
+   screens, so a different cap on each read as the page reflowing rather than as a new screen. */
 .lobbyContent {
   width: 100%;
-  max-width: 560px;
+  max-width: var(--screen-card-w);
   margin: auto 0;
   display: flex;
   flex-direction: column;
@@ -704,7 +705,7 @@
 
 @media (max-width: 1120px) {
   .sidePanelStack {
-    width: min(var(--landing-card-w), 100%);
+    width: min(var(--screen-card-w), 100%);
     max-height: none;
   }
 }

--- a/web-client/src/styles/variables.css
+++ b/web-client/src/styles/variables.css
@@ -179,6 +179,15 @@
   --font-weight-bold: 700;
 
   /* =========================================================================
+   * Layout
+   * ========================================================================= */
+  /* The centred glass card every pre-game screen sits in — the landing screen and the lobby.
+   * Shared rather than per-screen because those two are consecutive: the lobby capped itself at
+   * 560px against the landing's 756, so creating a lobby visibly narrowed the card you were
+   * already looking at, for no reason a player could name. */
+  --screen-card-w: 756px;
+
+  /* =========================================================================
    * Border Radius
    * ========================================================================= */
   --radius-sm: 4px;


### PR DESCRIPTION
## The bug

**A friend → Random pool → Create lobby** opened a lobby sitting on **My Decks**, with the Cards axis reading *Bring a deck*. Same for **Just me → Random pool**. The wizard collected the answer and the lobby threw it away.

`DeckPicker` defaults to its Random tab when the deck library hasn't hydrated yet — on the first render `decks` is always empty, so there is nothing else to show — and moves to `saved` once the list arrives. That fallback couldn't tell itself apart from a Random tab the *caller* had asked for, so it overwrote the wizard's promise for anyone with at least one saved deck.

The fix names the distinction: a Random the picker chose for itself is a **placeholder** and still gets replaced; a Random handed in through the `tab` prop — the landing wizard, and `useLobbyCommands.recreate` — is a **decision** and stays.

## What else the answer landing exposed

- **The subtitle branched on `vsAi` alone**, so a random-pool lobby opened telling the player to *"Pick a deck and ready up"* — the one instruction that answer had just made obsolete. It follows the Cards axis now; Random and Momir both say there is nothing to prepare.
- **The Random tab was one grey line of helper text in a 220px box**, indistinguishable from a panel that had failed to load. It now states what the server will do (eight boosters, auto-built into a 40-card deck) and gives the set — the one thing there *is* to decide — a row of its own.

## Lobby width

Separately, and asked for in review: `.lobbyContent` capped itself at **560px** against the landing card's **756px**, so creating a lobby visibly narrowed the card you were already looking at. Both now read one `--screen-card-w` token. `DeckPicker` drops its own 540px cap, which was a second and narrower answer to the same question — the deck gallery gets a third column out of it.

## Before / after

Same walk in both, at 1512px with three saved decks. Left: today. Right: this branch.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/random-pool-lobby-flow-screenshots/random-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/random-pool-lobby-flow-screenshots/random-after.png) |

The landing card it now matches, and My Decks in the wider card:

| Landing | Lobby → My Decks |
|---|---|
| ![landing](https://raw.githubusercontent.com/wingedsheep/argentum-engine/random-pool-lobby-flow-screenshots/landing.png) | ![my decks](https://raw.githubusercontent.com/wingedsheep/argentum-engine/random-pool-lobby-flow-screenshots/mydecks.png) |

*(`random-pool-lobby-flow-screenshots` is a throwaway branch — delete it when this merges.)*

## Verification

`npm run typecheck`, `npx vitest run` (261 pass) and `npm run build` are green. Driven against a real server + dev client with Playwright:

| Walk | Result |
|---|---|
| `A friend → Random pool → Create lobby` | tab **Random**, axis **Random pool**, seat **Deck: Random Pool** |
| `Just me → Random pool → Start playing` | tab **Random**, axis **Random pool**, subtitle *"…Ready up and the AI starts."* |
| Joiner with saved decks, no tab requested | tab **My Decks** — the placeholder rule still fires |
| Host readies on the rolled pool | `✓ Ready · Random Pool` / `Deck: Random Pool` |
| Group → Sealed → Bracket | tournament lobby renders clean at 756px |
| Card widths | landing 756 / lobby 756 (was 756 / 560) |

## Not fixed here

A player who **joins** a lobby is silently submitted as *Random Pool* — the placeholder tab emits its empty deck list before moving to My Decks, so their seat reads "Deck: Random Pool" while the picker shows an empty My Decks and Ready is enabled. Confirmed pre-existing (reproduces identically on `main`), and closing it means deciding whether that zero-friction ready is a feature or a lie. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)