### PR TITLE
Let the host choose the AI opponent's deck, and apply the format to it

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -68,6 +68,29 @@ class SealedDeckGenerator(
     }
 
     /**
+     * Generates a sealed deck from 8 boosters spread evenly across [setCodes].
+     *
+     * The multi-set flavour of [generate]: [BoosterGenerator.generateSealedPool] already knows how
+     * to split a booster count across sets, so this only has to pick which set's ratings tables the
+     * autobuilder loads — the first one, since Draftsim's tables are per-set and a mixed pool has no
+     * single home set. Sets without a ratings file fall back to the scorer's rarity ladder anyway.
+     *
+     * @param setCodes the sets to open boosters from; a single-element list behaves exactly like
+     *        [generate].
+     * @return A map of card name (or "Name#SetCode-CollectorNumber" for lands) to count
+     */
+    fun generate(setCodes: List<String>): Map<String, Int> {
+        require(setCodes.isNotEmpty()) { "At least one set code is required" }
+        if (setCodes.size == 1) return generate(setCodes.first())
+        setCodes.forEach { requireNotNull(boosterGenerator.availableSets[it]) { "Unknown set code: $it" } }
+
+        val pool = boosterGenerator.generateSealedPool(setCodes, boosterCount = 8)
+        val deck = buildSealedDeck(pool, setCodes.first())
+
+        return BoosterGenerator.withBasicLandArt(deck, boosterGenerator.getBasicLands(setCodes))
+    }
+
+    /**
      * Builds a sealed deck from [pool] with the Draftsim autobuilder, scoped to [setCode] so it loads
      * that set's ratings/removal/archetype tables. Sets without a Draftsim ratings file still build
      * (the scorer falls back to a rarity ladder). Falls back to [buildHeuristicSealedDeck] only if

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.model.CardDefinition
+import org.slf4j.LoggerFactory
+
+/**
+ * Builds a 60-card constructed deck that is legal in a given [DeckFormat].
+ *
+ * This is the constructed counterpart to [com.wingedsheep.ai.engine.SealedDeckGenerator]: where
+ * that one opens boosters and autobuilds a 40-card limited deck, this one draws from a *constructed*
+ * card pool — every card the format allows — and hands it to [RandomDeckGenerator] for the
+ * two-colour, mana-curve-aware 60-card build (24 lands, up to 4 copies of a card).
+ *
+ * It exists because the AI seat used to play a limited deck no matter what the lobby asked for. A
+ * Pauper lobby validates the human's deck down to commons and then sat them across from a sealed
+ * pool full of rares; the format restriction only ever applied to one side of the table.
+ *
+ * **Per-card legality is the whole of the filter.** [CardDefinition.legalFormats] is Scryfall-sourced
+ * and already accounts for bans and set legality, so "is this card allowed in Pauper" needs no
+ * rarity check here. Structural rules on top of that (singleton, 100 cards, a commander in the
+ * command zone) are *not* modelled: commander-shape formats are rejected outright rather than
+ * approximated — see [generate].
+ */
+class ConstructedDeckGenerator(
+    private val boosterGenerator: BoosterGenerator,
+    private val cardRegistry: CardRegistry,
+) {
+    /**
+     * Builds a format-legal deck from the cards printed in [setCodes].
+     *
+     * @param setCodes sets to draw from. Empty means "every set" — the full format-legal pool.
+     * @param format the constructed format the deck must be legal in.
+     * @throws IllegalArgumentException if [format] is commander-shaped (see class doc), or if the
+     *         legal pool is too thin to build from.
+     */
+    fun generate(setCodes: List<String>, format: DeckFormat): Map<String, Int> {
+        require(!format.isCommanderShape) {
+            "Commander-shape formats need a designated commander and singleton rules; " +
+                "ConstructedDeckGenerator only builds the 60-card constructed shape."
+        }
+
+        val pool = legalPool(setCodes, format)
+        require(pool.isNotEmpty()) {
+            "No ${format.displayName}-legal cards available" +
+                if (setCodes.isEmpty()) "" else " in ${setCodes.joinToString(", ")}"
+        }
+
+        // Basic lands come from the chosen sets so the deck's art matches the pool it was built
+        // from; an all-sets build falls back to whatever the generator has registered.
+        val basics = if (setCodes.isEmpty()) {
+            boosterGenerator.availableSets.values.firstOrNull()?.basicLands.orEmpty()
+        } else {
+            boosterGenerator.getBasicLands(setCodes).values.toList()
+        }
+
+        logger.info(
+            "Building a {} deck from {} legal cards ({})",
+            format.displayName,
+            pool.size,
+            if (setCodes.isEmpty()) "all sets" else setCodes.joinToString(", "),
+        )
+        return RandomDeckGenerator(
+            cardPool = pool,
+            basicLandVariants = basics,
+            setCodes = setCodes,
+        ).generate()
+    }
+
+    /** Convenience overload: build from the whole format-legal card base. */
+    fun generate(format: DeckFormat): Map<String, Int> = generate(emptyList(), format)
+
+    /**
+     * Every card legal in [format], scoped to [setCodes] when non-empty.
+     *
+     * Set scoping reads [BoosterGenerator.SetConfig.cards] *and* resolves the set's reprint
+     * [BoosterGenerator.SetConfig.printings] rows through the registry: a reprint's canonical
+     * `CardDefinition` lives in its earliest printing's set, so a set that is mostly reprints
+     * (a core set, a precon set) would otherwise look almost empty.
+     */
+    private fun legalPool(setCodes: List<String>, format: DeckFormat): List<CardDefinition> {
+        val candidates = if (setCodes.isEmpty()) {
+            cardRegistry.allCardNames().mapNotNull { cardRegistry.getCard(it) }
+        } else {
+            setCodes.flatMap { setCode ->
+                val config = boosterGenerator.availableSets[setCode]
+                    ?: throw IllegalArgumentException("Unknown set code: $setCode")
+                config.cards + config.printings.mapNotNull { cardRegistry.getCard(it.name) }
+            }
+        }
+        return candidates
+            .distinctBy { it.name }
+            // An empty `legalFormats` means we have no Scryfall legality data for the card at all
+            // (custom//unreleased content). Excluding it keeps the deck honestly format-legal
+            // rather than silently smuggling unknowns in.
+            .filter { format in it.legalFormats }
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(ConstructedDeckGenerator::class.java)
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/RandomDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/RandomDeckGenerator.kt
@@ -82,14 +82,28 @@ class RandomDeckGenerator(
     }
 
     /**
-     * Picks 1-2 colors randomly.
+     * Picks 1-2 colors randomly, **from the colours the pool actually contains**.
+     *
+     * Sampling all five would be wrong for any pool narrower than the whole card base: a mono-green
+     * pool asked for a White/Blue deck yields zero matching spells and [selectSpellsWithCurve]
+     * throws. That is not hypothetical — it is the normal case for
+     * [ConstructedDeckGenerator], whose pool is one format's legal cards, sometimes scoped to a
+     * single set on top of that.
+     *
+     * A pool of nothing but colorless cards returns the empty set; [cardMatchesColors] admits every
+     * colorless card, and [calculateLandCounts] has its own empty-colour branch.
      */
     private fun pickColors(): Set<Color> {
-        val allColors = Color.entries.toList()
-        val shuffled = allColors.shuffled(random)
+        val available = cardPool.asSequence()
+            .filter { !it.isLand }
+            .flatMap { it.colors.asSequence() }
+            .distinct()
+            .toList()
+        if (available.isEmpty()) return emptySet()
 
-        // 40% chance of mono-color, 60% chance of two colors
-        return if (random.nextFloat() < 0.4f) {
+        val shuffled = available.shuffled(random)
+        // 40% chance of mono-color, 60% chance of two colors — the second only if one exists.
+        return if (random.nextFloat() < 0.4f || shuffled.size < 2) {
             setOf(shuffled.first())
         } else {
             setOf(shuffled[0], shuffled[1])
@@ -201,6 +215,11 @@ class RandomDeckGenerator(
      * Returns a map of land type name to count needed.
      */
     private fun calculateLandCounts(spells: List<CardDefinition>, colors: Set<Color>): Map<String, Int> {
+        // An all-colorless pool (see `pickColors`) has no colour to weight by. Generic costs still
+        // need lands, so give it one basic type rather than dividing by zero.
+        if (colors.isEmpty()) {
+            return mapOf(COLOR_TO_LAND.getValue(Color.entries.random(random)) to LAND_COUNT)
+        }
         if (colors.size == 1) {
             // Mono-color: all lands of that color
             val landName = COLOR_TO_LAND[colors.first()]!!

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGeneratorTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.assertions.withClue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * The AI seat's constructed build.
+ *
+ * The bug this closes: a quick lobby's deck-format restriction only ever applied to the *human's*
+ * deck. A Pauper lobby validated your list down to commons and then sat you across from a sealed
+ * pool full of rares. These tests pin the two properties that fixes it — the deck is built to the
+ * constructed shape, and every card in it is legal in the requested format — plus the explicit
+ * refusal to fake a Commander deck.
+ */
+class ConstructedDeckGeneratorTest : FunSpec({
+
+    fun card(
+        name: String,
+        cost: String,
+        rarity: Rarity,
+        formats: Set<DeckFormat>,
+    ): CardDefinition = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse(cost),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity),
+    ).copy(legalFormats = formats)
+
+    /**
+     * A mono-green pool spread across the curve, with a rarity split that matters: commons are
+     * Pauper-legal, rares are not. Everything is Modern-legal, so "Modern" means "the whole pool".
+     */
+    fun pool(prefix: String): List<CardDefinition> =
+        (1..12).flatMap { i ->
+            val cmc = (i % 5) + 1
+            listOf(
+                card("$prefix Common $i", "{${cmc - 1}}{G}", Rarity.COMMON, setOf(DeckFormat.PAUPER, DeckFormat.MODERN)),
+                card("$prefix Rare $i", "{${cmc - 1}}{G}", Rarity.RARE, setOf(DeckFormat.MODERN)),
+            )
+        }
+
+    fun basics(): List<CardDefinition> = listOf(
+        CardDefinition.basicLand("Forest", Subtype.FOREST, ScryfallMetadata(collectorNumber = "300")),
+    )
+
+    fun generatorOver(vararg sets: Pair<String, List<CardDefinition>>): ConstructedDeckGenerator {
+        val configs = sets.associate { (code, cards) ->
+            code to BoosterGenerator.SetConfig(
+                setCode = code,
+                setName = "Set $code",
+                cards = cards,
+                basicLands = basics(),
+            )
+        }
+        val registry = CardRegistry()
+        sets.forEach { (_, cards) -> registry.register(cards) }
+        registry.register(basics())
+        return ConstructedDeckGenerator(BoosterGenerator(configs), registry)
+    }
+
+    test("builds a 60-card deck from the chosen sets") {
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        val deck = gen.generate(listOf("AAA"), DeckFormat.MODERN)
+
+        deck.values.sum() shouldBe RandomDeckGenerator.DECK_SIZE
+    }
+
+    test("only uses cards legal in the requested format") {
+        // The whole point: a Pauper build must not reach for the rares sharing the set.
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        val deck = gen.generate(listOf("AAA"), DeckFormat.PAUPER)
+
+        val nonBasics = deck.keys.filterNot { it.startsWith("Forest") }
+        nonBasics.shouldNotBeEmpty()
+        nonBasics.forEach { name ->
+            withClue("$name is not Pauper-legal but was put in a Pauper deck") {
+                name.contains("Common") shouldBe true
+            }
+        }
+    }
+
+    test("scopes the pool to the chosen sets") {
+        val gen = generatorOver("AAA" to pool("AAA"), "BBB" to pool("BBB"))
+
+        val deck = gen.generate(listOf("BBB"), DeckFormat.MODERN)
+
+        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+    }
+
+    test("an empty set list draws on the whole registered card base") {
+        val gen = generatorOver("AAA" to pool("AAA"), "BBB" to pool("BBB"))
+
+        val deck = gen.generate(emptyList(), DeckFormat.MODERN)
+
+        deck.values.sum() shouldBe RandomDeckGenerator.DECK_SIZE
+    }
+
+    test("resolves a set's reprint rows through the registry") {
+        // A set whose own `cards` are empty but which reprints AAA's pool: without the printings
+        // lookup its legal pool would look empty and the build would fail.
+        val aaa = pool("AAA")
+        val registry = CardRegistry()
+        registry.register(aaa)
+        registry.register(basics())
+        val gen = ConstructedDeckGenerator(
+            BoosterGenerator(
+                mapOf(
+                    "AAA" to BoosterGenerator.SetConfig("AAA", "Set AAA", aaa, basics()),
+                    "RPT" to BoosterGenerator.SetConfig(
+                        setCode = "RPT",
+                        setName = "Reprint Set",
+                        cards = emptyList(),
+                        basicLands = basics(),
+                        printings = aaa.mapIndexed { i, c ->
+                            Printing(
+                                oracleId = "oracle-$i",
+                                name = c.name,
+                                setCode = "RPT",
+                                collectorNumber = i.toString(),
+                            )
+                        },
+                    ),
+                )
+            ),
+            registry,
+        )
+
+        gen.generate(listOf("RPT"), DeckFormat.MODERN).values.sum() shouldBe RandomDeckGenerator.DECK_SIZE
+    }
+
+    test("refuses commander-shape formats rather than faking one") {
+        // Commander needs a designated commander, singleton construction and a colour-identity
+        // constraint — none of which this builder models. AiDeckResolver relies on the throw to
+        // fall back to a limited deck instead of seating an illegal 60-card pile.
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        listOf(DeckFormat.COMMANDER, DeckFormat.BRAWL, DeckFormat.STANDARD_BRAWL).forEach { format ->
+            shouldThrow<IllegalArgumentException> { gen.generate(listOf("AAA"), format) }
+        }
+    }
+
+    test("refuses a format with no legal cards rather than building an illegal deck") {
+        // Nothing in the pool is Standard-legal. Failing here is what lets the resolver fall back.
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        shouldThrow<IllegalArgumentException> { gen.generate(listOf("AAA"), DeckFormat.STANDARD) }
+    }
+
+    test("rejects an unknown set code") {
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        shouldThrow<IllegalArgumentException> { gen.generate(listOf("NOPE"), DeckFormat.MODERN) }
+    }
+
+    test("keeps a playable land count") {
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        val deck = gen.generate(listOf("AAA"), DeckFormat.MODERN)
+
+        val lands = deck.entries.filter { it.key.startsWith("Forest") }.sumOf { it.value }
+        lands shouldBe RandomDeckGenerator.LAND_COUNT
+    }
+
+    test("never exceeds the four-copy limit") {
+        val gen = generatorOver("AAA" to pool("AAA"))
+
+        val deck = gen.generate(listOf("AAA"), DeckFormat.MODERN)
+
+        deck.filterKeys { !it.startsWith("Forest") }.values.forEach {
+            (it <= RandomDeckGenerator.MAX_COPIES) shouldBe true
+        }
+    }
+})

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiDeckResolver.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiDeckResolver.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
+import com.wingedsheep.gameserver.lobby.AiDeckSpec
+import com.wingedsheep.sdk.core.DeckFormat
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Turns the host's [AiDeckSpec] into the decklist the AI seat actually plays.
+ *
+ * This is the one place that knows how the two axes interact — *what the host asked for* and
+ * *what the lobby's format allows* — so neither the lobby handler nor
+ * [AiGameManager] has to. The matrix it implements:
+ *
+ * |                | no format / limited lobby   | constructed format (Standard, Pauper, …) |
+ * |----------------|-----------------------------|------------------------------------------|
+ * | [AiDeckSpec.Auto]  | sealed pool, human's set | 60-card legal deck, whole card base      |
+ * | [AiDeckSpec.Sets]  | sealed pool, chosen sets | 60-card legal deck, chosen sets          |
+ * | [AiDeckSpec.Fixed] | the submitted list       | the submitted list (validated on submit) |
+ *
+ * **Commander-shape formats are a known gap.** Commander / Brawl / Standard Brawl need a
+ * designated commander in the command zone, singleton construction and a colour-identity
+ * constraint over the whole deck — none of which the heuristic builders model. Rather than ship an
+ * illegal 100-card approximation, those lobbies fall through to the limited path and the client
+ * says so on the AI panel. A host who wants a real Commander opponent can still pick [AiDeckSpec.Fixed]
+ * and hand the AI a real Commander decklist.
+ */
+@Component
+class AiDeckResolver(
+    private val sealedDeckGenerator: SealedDeckGenerator,
+    private val constructedDeckGenerator: ConstructedDeckGenerator,
+) {
+    private val logger = LoggerFactory.getLogger(AiDeckResolver::class.java)
+
+    /**
+     * @param spec what the host chose for the AI seat.
+     * @param format the lobby's deck-format restriction, or null for none.
+     * @param fallbackSetCode the set the lobby already resolved for its random pools — used by
+     *        [AiDeckSpec.Auto] on the limited path so the AI and the human open the same set.
+     */
+    fun resolve(spec: AiDeckSpec, format: DeckFormat?, fallbackSetCode: String): Map<String, Int> {
+        // A fixed list is the host's explicit answer and was validated against the format when it
+        // was submitted; nothing left to decide.
+        if (spec is AiDeckSpec.Fixed) return spec.deckList
+
+        // An empty set selection means the host cleared the picker rather than that they want an
+        // empty pool — treat it as Auto instead of failing the game start.
+        val setCodes = (spec as? AiDeckSpec.Sets)?.setCodes?.filter { it.isNotBlank() }.orEmpty()
+
+        if (format != null && !format.isCommanderShape) {
+            // Constructed lobby: build to the format so both sides of the table play under the
+            // same restriction. Falls back to the limited path if the legal pool is unusably thin
+            // (a narrow format crossed with a narrow set selection) — a limited deck the AI can
+            // actually play beats failing the game start.
+            val built = runCatching { constructedDeckGenerator.generate(setCodes, format) }
+                .onFailure { error ->
+                    logger.warn(
+                        "Constructed AI deck for {} ({}) failed; falling back to a sealed pool",
+                        format.displayName,
+                        if (setCodes.isEmpty()) "all sets" else setCodes.joinToString(", "),
+                        error,
+                    )
+                }
+                .getOrNull()
+            if (built != null) return built
+        } else if (format != null) {
+            logger.info(
+                "Lobby format {} is commander-shaped; the AI seat falls back to a limited deck",
+                format.displayName,
+            )
+        }
+
+        return if (setCodes.isEmpty()) {
+            sealedDeckGenerator.generate(fallbackSetCode)
+        } else {
+            sealedDeckGenerator.generate(setCodes)
+        }
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.config
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
 import com.wingedsheep.ai.engine.deck.RandomDeckGenerator
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.engine.registry.CardRegistry
@@ -99,6 +100,17 @@ class GameBeansConfig(
     @Bean
     fun sealedDeckGenerator(boosterGenerator: BoosterGenerator): SealedDeckGenerator =
         SealedDeckGenerator(boosterGenerator)
+
+    /**
+     * Builds format-legal 60-card decks for the AI seat. Needs the registry as well as the booster
+     * generator: a set's reprints are name-only [com.wingedsheep.sdk.model.Printing] rows whose
+     * canonical definition lives in an earlier set.
+     */
+    @Bean
+    fun constructedDeckGenerator(
+        boosterGenerator: BoosterGenerator,
+        cardRegistry: CardRegistry,
+    ): ConstructedDeckGenerator = ConstructedDeckGenerator(boosterGenerator, cardRegistry)
 
     @Bean
     fun randomDeckGenerator(): RandomDeckGenerator {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -1,9 +1,12 @@
 package com.wingedsheep.gameserver.handler
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.gameserver.ai.AiDeckResolver
 import com.wingedsheep.gameserver.ai.AiGameManager
 import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.gameserver.deck.DeckValidator
+import com.wingedsheep.gameserver.lobby.AiDeckSpec
+import com.wingedsheep.gameserver.lobby.AiDeckSpecView
 import com.wingedsheep.gameserver.lobby.MomirBasicSetup
 import com.wingedsheep.gameserver.lobby.QuickGameLobby
 import com.wingedsheep.gameserver.lobby.QuickGameLobbyPlayer
@@ -54,6 +57,8 @@ class QuickGameLobbyHandler(
     private val deckGenerator: SealedDeckGenerator,
     private val gameProperties: GameProperties,
     private val aiGameManager: AiGameManager,
+    private val aiDeckResolver: AiDeckResolver,
+    private val boosterGenerator: com.wingedsheep.engine.limited.BoosterGenerator,
     private val gamePlayHandler: GamePlayHandler,
 ) {
     private val logger = LoggerFactory.getLogger(QuickGameLobbyHandler::class.java)
@@ -76,7 +81,66 @@ class QuickGameLobbyHandler(
             is ClientMessage.SetQuickGameLobbyPublic -> handleSetPublic(session, message)
             is ClientMessage.SetQuickGameLobbyRanked -> handleSetRanked(session, message)
             is ClientMessage.SetQuickGameLobbyFormat -> handleSetFormat(session, message)
+            is ClientMessage.SetQuickGameAiDeck -> handleSetAiDeck(session, message)
             else -> {}
+        }
+    }
+
+    /**
+     * Host picks what the AI opponent plays (see [AiDeckSpec]).
+     *
+     * A [AiDeckSpec.Fixed] list is validated here, against the lobby's current format, so an
+     * illegal choice is refused at the point the host makes it rather than silently seating an
+     * illegal deck. [AiDeckSpec.Sets] only checks that the codes exist — whether the resulting pool
+     * can carry a deck is the resolver's problem at game start, and it falls back rather than fails.
+     */
+    private fun handleSetAiDeck(session: WebSocketSession, message: ClientMessage.SetQuickGameAiDeck) {
+        val playerSession = sessionRegistry.getPlayerSession(session.id) ?: run {
+            sender.sendError(session, ErrorCode.NOT_CONNECTED, "Not connected"); return
+        }
+        val lobby = lobbyRepository.findContainingPlayer(playerSession.playerId) ?: run {
+            sender.sendError(session, ErrorCode.GAME_NOT_FOUND, "Not in a lobby"); return
+        }
+        lobbyRepository.withLock(lobby.lobbyId) { current ->
+            if (current == null) return@withLock
+            if (!current.vsAi) {
+                sender.sendError(session, ErrorCode.INVALID_ACTION, "This lobby has no AI opponent")
+                return@withLock
+            }
+            val host = current.players.firstOrNull { !it.isAi }
+            if (host?.playerId != playerSession.playerId) {
+                sender.sendError(session, ErrorCode.INVALID_ACTION, "Only the host can choose the AI's deck")
+                return@withLock
+            }
+            when (val spec = message.spec) {
+                is AiDeckSpec.Fixed -> {
+                    if (spec.deckList.isEmpty()) {
+                        sender.sendError(session, ErrorCode.INVALID_ACTION, "The AI's deck is empty")
+                        return@withLock
+                    }
+                    val result = deckValidator.validate(spec.deckList, current.format)
+                    if (!result.valid) {
+                        val reason = result.errors.firstOrNull()?.message ?: "Deck is not legal"
+                        sender.sendError(session, ErrorCode.INVALID_ACTION, "AI deck rejected: $reason")
+                        return@withLock
+                    }
+                }
+                is AiDeckSpec.Sets -> {
+                    val unknown = spec.setCodes.filterNot { it in boosterGenerator.availableSets }
+                    if (unknown.isNotEmpty()) {
+                        sender.sendError(
+                            session,
+                            ErrorCode.INVALID_ACTION,
+                            "Unknown set${if (unknown.size > 1) "s" else ""}: ${unknown.joinToString(", ")}",
+                        )
+                        return@withLock
+                    }
+                }
+                is AiDeckSpec.Auto -> {}
+            }
+            if (current.aiDeckSpec == message.spec) return@withLock
+            current.aiDeckSpec = message.spec
+            broadcastState(current)
         }
     }
 
@@ -110,6 +174,19 @@ class QuickGameLobbyHandler(
                     if (deck.isEmpty()) continue // Random pool — format restriction doesn't apply.
                     val result = deckValidator.validate(deck, message.format)
                     if (!result.valid) player.ready = false
+                }
+                // Same rule for the AI's hand-picked deck, except the AI has no ready flag to
+                // clear: an illegal list is dropped back to Auto, which always builds something
+                // legal for the new format. The host sees the seat's label change.
+                val aiSpec = current.aiDeckSpec
+                if (aiSpec is AiDeckSpec.Fixed && !deckValidator.validate(aiSpec.deckList, message.format).valid) {
+                    logger.info(
+                        "Lobby {}: AI deck '{}' is not legal in {}; reverting the AI to Auto",
+                        current.lobbyId,
+                        aiSpec.label,
+                        message.format?.displayName ?: "no format",
+                    )
+                    current.aiDeckSpec = AiDeckSpec.Auto
                 }
             }
             broadcastState(current)
@@ -523,7 +600,15 @@ class QuickGameLobbyHandler(
 
         if (lobby.vsAi) {
             // AI is added by AiGameManager. For Momir Basic it plays the same fixed 60-basic deck
-            // as the human; otherwise it generates its own random sealed deck for the chosen set.
+            // as the human; otherwise the host's AiDeckSpec decides — a hand-picked list, a build
+            // from chosen sets, or the Auto default that mirrors the human's set (and honours a
+            // constructed format restriction). Resolved here rather than inside AiGameManager so
+            // the deck-source policy lives next to the lobby state that configures it.
+            val aiDeck = if (lobby.momirBasic) {
+                MomirBasicSetup.fixedBasicDeck
+            } else {
+                aiDeckResolver.resolve(lobby.aiDeckSpec, lobby.format, aiSetCode)
+            }
             aiGameManager.createAiOpponent(
                 gameSession = gameSession,
                 setCode = aiSetCode,
@@ -531,7 +616,7 @@ class QuickGameLobbyHandler(
                 onMulliganKeep = { id -> gamePlayHandler.handleAiMulliganKeep(gameSession, id) },
                 onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
                 onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) },
-                deckOverride = if (lobby.momirBasic) MomirBasicSetup.fixedBasicDeck else null,
+                deckOverride = aiDeck,
             )
         }
 
@@ -581,6 +666,7 @@ class QuickGameLobbyHandler(
             maxPlayers = lobby.maxPlayers,
             ranked = lobby.ranked,
             rankedEligible = lobby.rankedEligible,
+            aiDeck = if (lobby.vsAi) AiDeckSpecView.of(lobby.aiDeckSpec) else null,
         )
         sender.send(session, msg)
     }
@@ -621,6 +707,7 @@ class QuickGameLobbyHandler(
                 maxPlayers = lobby.maxPlayers,
                 ranked = lobby.ranked,
                 rankedEligible = lobby.rankedEligible,
+                aiDeck = if (lobby.vsAi) AiDeckSpecView.of(lobby.aiDeckSpec) else null,
             )
             sender.send(ws, msg)
         }
@@ -659,6 +746,9 @@ class QuickGameLobbyHandler(
         // as "deck selected" and shows a fixed label rather than the deck-picker states.
         val label = when {
             lobby.momirBasic -> "Momir Basic (${MomirBasicSetup.COPIES_PER_BASIC * MomirBasicSetup.BASIC_LAND_NAMES.size} lands)"
+            // The AI seat holds no deck list of its own — it plays whatever the host's
+            // `aiDeckSpec` resolves to at game start — so it labels from the spec instead.
+            isAi -> aiDeckLabel(lobby)
             deckList == null -> "Choosing…"
             deckList!!.isEmpty() -> if (setCode != null) "Random Pool ($setCode)" else "Random Pool"
             else -> "Custom ($total)"
@@ -674,5 +764,17 @@ class QuickGameLobbyHandler(
             setCode = setCode,
             teamIndex = lobby.teamIndexOf(seatIndex),
         )
+    }
+
+    /** Player-list label for the AI seat, describing what the host chose for it. */
+    private fun aiDeckLabel(lobby: QuickGameLobby): String = when (val spec = lobby.aiDeckSpec) {
+        is AiDeckSpec.Auto -> if (lobby.format != null && !lobby.format!!.isCommanderShape) {
+            "Auto (${lobby.format!!.displayName})"
+        } else {
+            "Auto (sealed)"
+        }
+        is AiDeckSpec.Sets ->
+            if (spec.setCodes.isEmpty()) "Auto (sealed)" else "Built from ${spec.setCodes.joinToString(", ")}"
+        is AiDeckSpec.Fixed -> "${spec.label} (${spec.deckList.values.sum()})"
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.gameserver.lobby
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * What the AI seat in a quick-game lobby should play.
+ *
+ * Before this the answer was always "a 40-card sealed deck from whatever set the human picked",
+ * decided at game start and not configurable at all. This is the host's answer to the same
+ * question, held on [QuickGameLobby.aiDeckSpec] and resolved into an actual deck list by
+ * [com.wingedsheep.gameserver.ai.AiDeckResolver] when the game starts.
+ *
+ * Three variants rather than the four sources the UI offers, deliberately: "an example deck",
+ * "one of my saved decks" and "a decklist I pasted" all reduce to a list of card names on the
+ * client, exactly as they already do for the *human's* deck submission. Only [Fixed] crosses the
+ * wire for all three, so adding a fourth way to arrive at a decklist needs no server change.
+ *
+ * Resolution is deferred to game start (rather than resolved eagerly on selection) so that
+ * changing the lobby's format re-rolls the AI's deck under the new restriction, and so a
+ * generated deck is as fresh as the human's own random pool.
+ */
+@Serializable
+sealed interface AiDeckSpec {
+
+    /**
+     * The historical behaviour: the server picks for you. A generated deck mirroring the human's
+     * set for limited-shaped lobbies, or a format-legal constructed deck when the lobby carries a
+     * deck-format restriction.
+     */
+    @Serializable
+    @SerialName("auto")
+    data object Auto : AiDeckSpec
+
+    /**
+     * Build the AI a deck from [setCodes], using the same heuristics as the Auto path but with the
+     * card pool pinned to the host's choice — "give me something out of Onslaught block".
+     *
+     * Empty is treated as [Auto] by the resolver rather than rejected, so a host who clears every
+     * set gets the default instead of a failed game start.
+     */
+    @Serializable
+    @SerialName("sets")
+    data class Sets(val setCodes: List<String>) : AiDeckSpec
+
+    /**
+     * Play this exact decklist. Covers the example decks, the host's saved decks and a pasted list.
+     *
+     * [label] is what the lobby shows next to the AI seat ("Mono-Red Burn"); it is display-only and
+     * never round-trips into the engine.
+     */
+    @Serializable
+    @SerialName("deck")
+    data class Fixed(
+        val deckList: Map<String, Int>,
+        val label: String = "Custom",
+    ) : AiDeckSpec
+}
+
+/**
+ * The lobby-broadcast projection of an [AiDeckSpec].
+ *
+ * Deliberately *not* the spec itself: [AiDeckSpec.Fixed] carries a full decklist, and the lobby
+ * state is re-broadcast on every change (deck submitted, ready toggled, format changed). Echoing a
+ * 60-card map back on each of those is pure waste when the only thing the UI renders is a label and
+ * a card count. The host's own selection lives in client state; this is what re-hydrates it after a
+ * reconnect.
+ */
+@Serializable
+data class AiDeckSpecView(
+    /** Discriminator matching the [AiDeckSpec] variants: `auto`, `sets` or `deck`. */
+    val kind: String,
+    /** Chosen sets, for [AiDeckSpec.Sets]; empty otherwise. */
+    val setCodes: List<String> = emptyList(),
+    /** Display label for [AiDeckSpec.Fixed]; null otherwise. */
+    val label: String? = null,
+    /** Card count for [AiDeckSpec.Fixed]; 0 otherwise. */
+    val cardCount: Int = 0,
+) {
+    companion object {
+        fun of(spec: AiDeckSpec): AiDeckSpecView = when (spec) {
+            is AiDeckSpec.Auto -> AiDeckSpecView(kind = "auto")
+            is AiDeckSpec.Sets -> AiDeckSpecView(kind = "sets", setCodes = spec.setCodes)
+            is AiDeckSpec.Fixed -> AiDeckSpecView(
+                kind = "deck",
+                label = spec.label,
+                cardCount = spec.deckList.values.sum(),
+            )
+        }
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
@@ -52,6 +52,15 @@ class QuickGameLobby(
 ) {
     val players: MutableList<QuickGameLobbyPlayer> = mutableListOf()
 
+    /**
+     * What the AI seat plays, when [vsAi]. Host-controlled from the lobby's AI panel and resolved
+     * into a decklist at game start by [com.wingedsheep.gameserver.ai.AiDeckResolver] — deferred so
+     * that changing [format] re-rolls the AI's deck under the new restriction. Ignored entirely in
+     * a human-only lobby, and overridden by [momirBasic] (every seat plays the fixed 60 basics).
+     */
+    @Volatile
+    var aiDeckSpec: AiDeckSpec = AiDeckSpec.Auto
+
     @Volatile
     var started: Boolean = false
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -499,6 +499,21 @@ sealed interface ClientMessage {
         val ranked: Boolean = false,
     ) : ClientMessage
 
+    /**
+     * Choose what the AI opponent plays. Host-only, and only meaningful in a `vsAi` lobby.
+     *
+     * The spec is stored on the lobby and resolved into a decklist at game start, so re-sending it
+     * is cheap and changing the lobby format afterwards still applies. A
+     * [com.wingedsheep.gameserver.lobby.AiDeckSpec.Fixed] list is validated against the lobby's
+     * format on arrival and rejected outright if it doesn't pass — the host finds out here rather
+     * than at game start.
+     */
+    @Serializable
+    @SerialName("setQuickGameAiDeck")
+    data class SetQuickGameAiDeck(
+        val spec: com.wingedsheep.gameserver.lobby.AiDeckSpec,
+    ) : ClientMessage
+
     /** Join an existing quick-game lobby by its short code. */
     @Serializable
     @SerialName("joinQuickGameLobby")

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -1108,6 +1108,11 @@ sealed interface ServerMessage {
         val ranked: Boolean = false,
         /** Whether ranked is even offered for this lobby: a standard 1v1 human-vs-human lobby. */
         val rankedEligible: Boolean = false,
+        /**
+         * What the AI seat will play, when [vsAi]. A summary rather than the spec itself — the
+         * decklist behind a "deck" choice never rides the lobby broadcast. Null in a human lobby.
+         */
+        val aiDeck: com.wingedsheep.gameserver.lobby.AiDeckSpecView? = null,
     ) : ServerMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/websocket/GameWebSocketHandler.kt
@@ -139,6 +139,7 @@ class GameWebSocketHandler(
                 is ClientMessage.SetQuickGameLobbySetCode,
                 is ClientMessage.SetQuickGameLobbyPublic,
                 is ClientMessage.SetQuickGameLobbyRanked,
+                is ClientMessage.SetQuickGameAiDeck,
                 is ClientMessage.SetQuickGameLobbyFormat -> quickGameLobbyHandler.handle(session, clientMessage)
             }
         } catch (e: Exception) {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiDeckResolverTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/AiDeckResolverTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
+import com.wingedsheep.ai.engine.deck.RandomDeckGenerator
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.gameserver.lobby.AiDeckSpec
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The policy matrix behind "what does the AI play" — what the host asked for crossed with what the
+ * lobby's format allows.
+ *
+ * The behaviour under test is the one the feature exists for: a lobby's deck-format restriction
+ * used to apply to the human's deck only, so a Pauper or Standard lobby seated a 40-card sealed
+ * pool opposite a validated constructed deck. Each case here pins one cell of the matrix, including
+ * the two deliberate fallbacks (commander-shape formats, and a legal pool too thin to build from).
+ */
+class AiDeckResolverTest : FunSpec({
+
+    fun card(name: String, cost: String, rarity: Rarity, formats: Set<DeckFormat>) =
+        CardDefinition.creature(
+            name = name,
+            manaCost = ManaCost.parse(cost),
+            subtypes = emptySet(),
+            power = 2,
+            toughness = 2,
+            metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity),
+        ).copy(legalFormats = formats)
+
+    /**
+     * Deep enough to open 8 boosters without exhausting a rarity, and past the 200-card standalone
+     * threshold `randomSetCode()` enforces. Commons are Pauper-legal; rares are Modern-only, so a
+     * Pauper build has to leave them behind.
+     */
+    fun pool(prefix: String): List<CardDefinition> =
+        (1..200).map {
+            card("$prefix Common $it", "{${it % 5}}{G}", Rarity.COMMON, setOf(DeckFormat.PAUPER, DeckFormat.MODERN))
+        } + (1..40).map {
+            card("$prefix Uncommon $it", "{${it % 5}}{G}", Rarity.UNCOMMON, setOf(DeckFormat.PAUPER, DeckFormat.MODERN))
+        } + (1..20).map {
+            card("$prefix Rare $it", "{${it % 5}}{G}", Rarity.RARE, setOf(DeckFormat.MODERN))
+        }
+
+    val basics = listOf(
+        CardDefinition.basicLand("Forest", Subtype.FOREST, ScryfallMetadata(collectorNumber = "300")),
+    )
+
+    fun resolver(): AiDeckResolver {
+        val configs = listOf("AAA", "BBB").associateWith { code ->
+            BoosterGenerator.SetConfig(
+                setCode = code,
+                setName = "Set $code",
+                cards = pool(code),
+                basicLands = basics,
+            )
+        }
+        val booster = BoosterGenerator(configs)
+        val registry = CardRegistry()
+        configs.values.forEach { registry.register(it.cards) }
+        registry.register(basics)
+        return AiDeckResolver(SealedDeckGenerator(booster), ConstructedDeckGenerator(booster, registry))
+    }
+
+    val sealedSize = 40
+    val constructedSize = RandomDeckGenerator.DECK_SIZE
+
+    test("Auto with no format opens a sealed pool from the lobby's set") {
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = null, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe sealedSize
+    }
+
+    test("Auto under a constructed format builds to that format instead") {
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.MODERN, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe constructedSize
+    }
+
+    test("Auto under Pauper uses only Pauper-legal cards") {
+        // The regression this feature closes: the AI's deck must respect the same restriction the
+        // human's deck was validated against.
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.PAUPER, fallbackSetCode = "AAA")
+
+        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.contains("Rare") shouldBe false }
+    }
+
+    test("Sets pins the sealed pool to the chosen sets") {
+        val deck = resolver().resolve(AiDeckSpec.Sets(listOf("BBB")), format = null, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe sealedSize
+        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+    }
+
+    test("Sets under a constructed format builds to the format from those sets") {
+        val deck = resolver()
+            .resolve(AiDeckSpec.Sets(listOf("BBB")), format = DeckFormat.MODERN, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe constructedSize
+        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+    }
+
+    test("an empty set selection falls back to Auto rather than failing the game start") {
+        val deck = resolver().resolve(AiDeckSpec.Sets(emptyList()), format = null, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe sealedSize
+    }
+
+    test("Fixed plays the submitted list verbatim, whatever the format") {
+        val list = mapOf("Anything" to 4, "Forest" to 56)
+
+        resolver().resolve(AiDeckSpec.Fixed(list), format = null, fallbackSetCode = "AAA") shouldBe list
+        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.PAUPER, "AAA") shouldBe list
+        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.COMMANDER, "AAA") shouldBe list
+    }
+
+    test("a commander-shape format falls back to a limited deck instead of an illegal 60") {
+        // Known gap: the builders can't construct a commander deck (singleton, 100 cards, a
+        // commander in the command zone). Falling back beats seating something illegal.
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.COMMANDER, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe sealedSize
+    }
+
+    test("a format with no legal cards falls back to a limited deck") {
+        // Nothing in the synthetic pool is Standard-legal, so the constructed build throws and the
+        // resolver has to recover rather than propagate.
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.STANDARD, fallbackSetCode = "AAA")
+
+        deck.values.sum() shouldBe sealedSize
+    }
+
+    test("successive Auto resolutions are not identical decks") {
+        // Each game start re-rolls; a cached deck would make every AI game the same match.
+        val resolver = resolver()
+        val decks = (1..8).map { resolver.resolve(AiDeckSpec.Auto, null, "AAA") }
+
+        decks.distinct().size shouldNotBe 1
+    }
+})

--- a/web-client/src/components/lobby/AiOpponentPanel.tsx
+++ b/web-client/src/components/lobby/AiOpponentPanel.tsx
@@ -13,6 +13,13 @@
  *     Its `saved` / `examples` / `paste` tabs are three ways to arrive at a decklist, so all three
  *     collapse into one `deck` spec on the wire; the `random` tab is omitted because that is what
  *     "From sets" already is.
+ *
+ * Rendered as **two pieces** by `LobbyScreen`, sharing only the selected source:
+ * {@link AiOpponentRow} is a settings row inside the settings panel, and {@link AiDeckSection} is
+ * the "Pick a deck" picker, which sits *outside* that panel. The panel is itself a scroll
+ * container (`max-height: min(62vh, 640px); overflow: auto`), and the deck picker scrolls too, so
+ * nesting them put a scrollable inside a scrollable — two competing wheel targets over one control.
+ * Your own deck picker already lives outside the panel for the same reason; this just matches it.
  */
 import { useCallback, useRef, useState } from 'react'
 import { useGameStore } from '@/store/gameStore'
@@ -27,33 +34,40 @@ type Source = 'auto' | 'sets' | 'deck'
 /** Commander-shape formats the AI builders can't construct for — see `AiDeckResolver`. */
 const COMMANDER_SHAPES = ['COMMANDER', 'BRAWL', 'STANDARD_BRAWL']
 
-export function AiOpponentPanel({
+export type AiDeckSource = Source
+
+/** Which source a lobby should start on, given the server's summary of the current choice. */
+export function initialAiSource(aiDeck: AiDeckSpecView | null | undefined): Source {
+  return (aiDeck?.kind as Source | undefined) ?? 'auto'
+}
+
+export function AiOpponentRow({
   aiDeck,
   format,
   disabled,
+  source,
+  onSourceChange,
 }: {
-  /** The server's summary of the current choice; re-hydrates the panel after a reconnect. */
+  /** The server's summary of the current choice; re-hydrates the row after a reconnect. */
   aiDeck: AiDeckSpecView | null
   /** The lobby's deck-format restriction, upper-case, or null. */
   format: string | null
   /** True once the host has readied up — the choice is locked in at that point. */
   disabled: boolean
+  /** Selected source. Lifted to `LobbyScreen` so it can place {@link AiDeckSection} outside. */
+  source: Source
+  onSourceChange: (source: Source) => void
 }) {
   const setAiDeck = useGameStore((s) => s.setQuickGameAiDeck)
   const availableSets = useGameStore((s) => s.availableSets)
 
-  // Source follows the server's summary, so a reconnect or a format-triggered revert to Auto
-  // (see `QuickGameLobbyHandler.handleSetFormat`) moves the panel rather than leaving it lying
-  // about which source is live.
-  const [source, setSource] = useState<Source>((aiDeck?.kind as Source | undefined) ?? 'auto')
   const [setCodes, setSetCodes] = useState<readonly string[]>(aiDeck?.setCodes ?? [])
   const [showSetPicker, setShowSetPicker] = useState(false)
-  const lastDeckKeyRef = useRef<string | null>(null)
 
   const isCommanderShape = format !== null && COMMANDER_SHAPES.includes(format)
 
   const pick = (next: Source) => {
-    setSource(next)
+    onSourceChange(next)
     // Auto is complete the moment it's picked. The other two need a selection first, so they only
     // send once the host has actually chosen sets / a deck — otherwise clicking the tab would
     // submit an empty spec the server has to reject.
@@ -75,35 +89,25 @@ export function AiOpponentPanel({
     if (chosen) toggleSet(chosen.code)
   }
 
-  // Deduped like the human picker's submission path: DeckPicker re-emits its current deck on every
-  // render, and each send costs a lobby broadcast.
-  const handleDeckChange = useCallback(
-    (deckList: Record<string, number>) => {
-      const total = Object.values(deckList).reduce((a, b) => a + b, 0)
-      if (total === 0) return
-      const key = Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')
-      if (key === lastDeckKeyRef.current) return
-      lastDeckKeyRef.current = key
-      setAiDeck({ type: 'deck', deckList, label: 'Chosen deck' } satisfies AiDeckSpec)
-    },
-    [setAiDeck],
+  const sourceButtons = (
+    <div className={styles.settingsButtons}>
+      <SourceButton active={source === 'auto'} disabled={disabled} onClick={() => pick('auto')}>
+        Auto
+      </SourceButton>
+      <SourceButton active={source === 'sets'} disabled={disabled} onClick={() => pick('sets')}>
+        From sets
+      </SourceButton>
+      <SourceButton active={source === 'deck'} disabled={disabled} onClick={() => pick('deck')}>
+        Pick a deck
+      </SourceButton>
+    </div>
   )
 
   return (
     <div className={styles.settingsRow} data-testid="ai-opponent-panel">
       <span className={styles.settingsLabel}>AI deck</span>
       <div className={styles.variantGroup}>
-        <div className={styles.settingsButtons}>
-          <SourceButton active={source === 'auto'} disabled={disabled} onClick={() => pick('auto')}>
-            Auto
-          </SourceButton>
-          <SourceButton active={source === 'sets'} disabled={disabled} onClick={() => pick('sets')}>
-            From sets
-          </SourceButton>
-          <SourceButton active={source === 'deck'} disabled={disabled} onClick={() => pick('deck')}>
-            Pick a deck
-          </SourceButton>
-        </div>
+        {sourceButtons}
 
         {source === 'auto' && (
           <div className={styles.variantCaption}>
@@ -158,21 +162,6 @@ export function AiOpponentPanel({
           </>
         )}
 
-        {source === 'deck' && (
-          <>
-            <DeckPicker
-              onDeckChange={handleDeckChange}
-              availableSets={availableSets}
-              disabled={disabled}
-              format={format}
-              tabs={['saved', 'examples', 'paste']}
-            />
-            <div className={styles.variantCaption}>
-              The AI plays this exact list. It is checked against the lobby format, and reverts to
-              Auto if you later switch to a format it isn’t legal in.
-            </div>
-          </>
-        )}
       </div>
 
       {showSetPicker && (
@@ -209,5 +198,59 @@ function SourceButton({
     >
       {children}
     </button>
+  )
+}
+
+/**
+ * The "Pick a deck" picker for the AI seat, rendered *outside* the lobby's settings panel.
+ *
+ * Outside, because the settings panel is a scroll container and so is the deck picker — nesting
+ * them gives one control two competing wheel targets. Your own picker is a sibling of the panel
+ * for the same reason, which makes this the consistent placement rather than a special case.
+ *
+ * That does put two identical-looking pickers on one screen, so the heading carries the whole
+ * burden of telling them apart and is deliberately blunt about whose deck this is.
+ */
+export function AiDeckSection({
+  format,
+  disabled,
+}: {
+  format: string | null
+  disabled: boolean
+}) {
+  const setAiDeck = useGameStore((s) => s.setQuickGameAiDeck)
+  const availableSets = useGameStore((s) => s.availableSets)
+  const lastDeckKeyRef = useRef<string | null>(null)
+
+  // Deduped like the human picker's submission path: DeckPicker re-emits its current deck on every
+  // render, and each send costs a lobby broadcast.
+  const handleDeckChange = useCallback(
+    (deckList: Record<string, number>) => {
+      const total = Object.values(deckList).reduce((a, b) => a + b, 0)
+      if (total === 0) return
+      const key = Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')
+      if (key === lastDeckKeyRef.current) return
+      lastDeckKeyRef.current = key
+      setAiDeck({ type: 'deck', deckList, label: 'Chosen deck' } satisfies AiDeckSpec)
+    },
+    [setAiDeck],
+  )
+
+  return (
+    <div className={styles.aiDeckSection} data-testid="ai-deck-section">
+      <div className={styles.aiDeckSectionHeader}>
+        <span className={styles.aiDeckSectionTitle}>The AI opponent’s deck</span>
+        <span className={styles.aiDeckSectionHint}>
+          Not your own — yours is below. Checked against the lobby format.
+        </span>
+      </div>
+      <DeckPicker
+        onDeckChange={handleDeckChange}
+        availableSets={availableSets}
+        disabled={disabled}
+        format={format}
+        tabs={['saved', 'examples', 'paste']}
+      />
+    </div>
   )
 }

--- a/web-client/src/components/lobby/AiOpponentPanel.tsx
+++ b/web-client/src/components/lobby/AiOpponentPanel.tsx
@@ -1,0 +1,213 @@
+/**
+ * The AI seat's deck, as a thing the host can actually choose.
+ *
+ * Before this the answer was fixed and invisible: the AI always played a 40-card sealed pool
+ * opened from whatever set *you* had picked, and nothing in the lobby said so. Two consequences
+ * this panel exists to fix — you couldn't test a matchup against a specific list, and a lobby with
+ * a deck-format restriction applied it to one side of the table only.
+ *
+ * Three sources, matching `AiDeckSpec` on the server:
+ *   - **Auto** — the server decides, honouring the lobby format.
+ *   - **From sets** — same builders, card pool pinned to sets you choose (multi-select).
+ *   - **Pick a deck** — an exact list, via the same {@link DeckPicker} you use for your own deck.
+ *     Its `saved` / `examples` / `paste` tabs are three ways to arrive at a decklist, so all three
+ *     collapse into one `deck` spec on the wire; the `random` tab is omitted because that is what
+ *     "From sets" already is.
+ */
+import { useCallback, useRef, useState } from 'react'
+import { useGameStore } from '@/store/gameStore'
+import type { AiDeckSpec, AiDeckSpecView, AvailableSet } from '@/types'
+import { DeckPicker } from '../ui/DeckPicker'
+import { SetIcon } from '../ui/SetIcon'
+import { SetPickerModal } from '../ui/SetPickerModal'
+import styles from '../ui/GameUI.module.css'
+
+type Source = 'auto' | 'sets' | 'deck'
+
+/** Commander-shape formats the AI builders can't construct for — see `AiDeckResolver`. */
+const COMMANDER_SHAPES = ['COMMANDER', 'BRAWL', 'STANDARD_BRAWL']
+
+export function AiOpponentPanel({
+  aiDeck,
+  format,
+  disabled,
+}: {
+  /** The server's summary of the current choice; re-hydrates the panel after a reconnect. */
+  aiDeck: AiDeckSpecView | null
+  /** The lobby's deck-format restriction, upper-case, or null. */
+  format: string | null
+  /** True once the host has readied up — the choice is locked in at that point. */
+  disabled: boolean
+}) {
+  const setAiDeck = useGameStore((s) => s.setQuickGameAiDeck)
+  const availableSets = useGameStore((s) => s.availableSets)
+
+  // Source follows the server's summary, so a reconnect or a format-triggered revert to Auto
+  // (see `QuickGameLobbyHandler.handleSetFormat`) moves the panel rather than leaving it lying
+  // about which source is live.
+  const [source, setSource] = useState<Source>((aiDeck?.kind as Source | undefined) ?? 'auto')
+  const [setCodes, setSetCodes] = useState<readonly string[]>(aiDeck?.setCodes ?? [])
+  const [showSetPicker, setShowSetPicker] = useState(false)
+  const lastDeckKeyRef = useRef<string | null>(null)
+
+  const isCommanderShape = format !== null && COMMANDER_SHAPES.includes(format)
+
+  const pick = (next: Source) => {
+    setSource(next)
+    // Auto is complete the moment it's picked. The other two need a selection first, so they only
+    // send once the host has actually chosen sets / a deck — otherwise clicking the tab would
+    // submit an empty spec the server has to reject.
+    if (next === 'auto') setAiDeck({ type: 'auto' })
+    else if (next === 'sets' && setCodes.length > 0) setAiDeck({ type: 'sets', setCodes })
+  }
+
+  const toggleSet = (code: string) => {
+    const next = setCodes.includes(code) ? setCodes.filter((c) => c !== code) : [...setCodes, code]
+    setSetCodes(next)
+    // An empty selection is the server's "treat as Auto", so send it rather than going quiet —
+    // clearing the last chip should visibly fall back, not silently keep the old pool.
+    setAiDeck({ type: 'sets', setCodes: next })
+  }
+
+  const addRandomSet = () => {
+    const candidates = availableSets.filter((s: AvailableSet) => !s.extensionSet && !setCodes.includes(s.code))
+    const chosen = candidates[Math.floor(Math.random() * candidates.length)]
+    if (chosen) toggleSet(chosen.code)
+  }
+
+  // Deduped like the human picker's submission path: DeckPicker re-emits its current deck on every
+  // render, and each send costs a lobby broadcast.
+  const handleDeckChange = useCallback(
+    (deckList: Record<string, number>) => {
+      const total = Object.values(deckList).reduce((a, b) => a + b, 0)
+      if (total === 0) return
+      const key = Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')
+      if (key === lastDeckKeyRef.current) return
+      lastDeckKeyRef.current = key
+      setAiDeck({ type: 'deck', deckList, label: 'Chosen deck' } satisfies AiDeckSpec)
+    },
+    [setAiDeck],
+  )
+
+  return (
+    <div className={styles.settingsRow} data-testid="ai-opponent-panel">
+      <span className={styles.settingsLabel}>AI deck</span>
+      <div className={styles.variantGroup}>
+        <div className={styles.settingsButtons}>
+          <SourceButton active={source === 'auto'} disabled={disabled} onClick={() => pick('auto')}>
+            Auto
+          </SourceButton>
+          <SourceButton active={source === 'sets'} disabled={disabled} onClick={() => pick('sets')}>
+            From sets
+          </SourceButton>
+          <SourceButton active={source === 'deck'} disabled={disabled} onClick={() => pick('deck')}>
+            Pick a deck
+          </SourceButton>
+        </div>
+
+        {source === 'auto' && (
+          <div className={styles.variantCaption}>
+            {isCommanderShape
+              ? `The AI can't build a ${format === 'COMMANDER' ? 'Commander' : 'Brawl'} deck yet, so it plays a 40-card sealed deck. Use “Pick a deck” to give it a real one.`
+              : format
+                ? `The server builds the AI a 60-card ${format.replace('_', ' ').toLowerCase()}-legal deck.`
+                : 'The server opens eight boosters from your set and auto-builds the AI a 40-card deck.'}
+          </div>
+        )}
+
+        {source === 'sets' && (
+          <>
+            <div className={styles.setChips}>
+              {setCodes.map((code) => {
+                const set = availableSets.find((s: AvailableSet) => s.code === code)
+                return (
+                  <span key={code} className={`${styles.setChip} ${set?.partial ? styles.setChipPartial : ''}`}>
+                    <SetIcon code={code} className={styles.setChipIcon} />
+                    <span className={styles.setChipName}>{set?.name ?? code}</span>
+                    {!disabled && (
+                      <button
+                        type="button"
+                        className={styles.setChipRemove}
+                        onClick={() => toggleSet(code)}
+                        aria-label={`Remove ${set?.name ?? code}`}
+                      >
+                        ×
+                      </button>
+                    )}
+                  </span>
+                )
+              })}
+              <button
+                type="button"
+                className={styles.addSetsButton}
+                onClick={() => setShowSetPicker(true)}
+                disabled={disabled}
+              >
+                {setCodes.length === 0 ? 'Choose sets' : '+ Add'}
+              </button>
+            </div>
+            <div className={styles.variantCaption}>
+              {setCodes.length === 0
+                ? 'Pick one or more sets — until you do, the AI falls back to Auto.'
+                : isCommanderShape
+                  ? 'Commander decks aren’t buildable yet, so the AI opens a sealed pool from these sets.'
+                  : format
+                    ? `Only ${format.replace('_', ' ').toLowerCase()}-legal cards from these sets are used.`
+                    : 'Eight boosters are opened across these sets and auto-built into a deck.'}
+            </div>
+          </>
+        )}
+
+        {source === 'deck' && (
+          <>
+            <DeckPicker
+              onDeckChange={handleDeckChange}
+              availableSets={availableSets}
+              disabled={disabled}
+              format={format}
+              tabs={['saved', 'examples', 'paste']}
+            />
+            <div className={styles.variantCaption}>
+              The AI plays this exact list. It is checked against the lobby format, and reverts to
+              Auto if you later switch to a format it isn’t legal in.
+            </div>
+          </>
+        )}
+      </div>
+
+      {showSetPicker && (
+        <SetPickerModal
+          sets={availableSets}
+          selectedCodes={setCodes}
+          onToggleSet={toggleSet}
+          onClose={() => setShowSetPicker(false)}
+          onSelectRandom={addRandomSet}
+          title="Sets for the AI's deck"
+        />
+      )}
+    </div>
+  )
+}
+
+function SourceButton({
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  active: boolean
+  disabled: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`${styles.settingsButton} ${active ? styles.settingsButtonActive : ''}`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -27,7 +27,7 @@ import { DeckPicker, type DeckPickerTab } from '../ui/DeckPicker'
 import { FullscreenButton } from '../ui/FullscreenButton'
 import { JoinQrModal } from '../ui/JoinQrModal'
 import { SettingsLabel } from '../ui/SettingsLabel'
-import { AiOpponentPanel } from './AiOpponentPanel'
+import { AiDeckSection, AiOpponentRow, initialAiSource, type AiDeckSource } from './AiOpponentPanel'
 import { LobbyAxes } from './LobbyAxes'
 import { LobbyAxisSummary } from './LobbyAxisSummary'
 import { TeamChip, TournamentLobbySettings } from './TournamentLobbySettings'
@@ -50,6 +50,9 @@ export function LobbyScreen() {
   // promise a Random pool from outside any mounted lobby screen. See `pendingDeckTab.ts`.
   const [deckTab, setDeckTab] = useState<DeckPickerTab | undefined>(takePendingDeckTab)
   const [copied, setCopied] = useState(false)
+  // Which source the AI-deck control is on. Lifted out of `AiOpponentRow` because its "Pick a
+  // deck" picker renders outside the settings panel the row lives in (see `AiDeckSection`).
+  const [aiSource, setAiSource] = useState<AiDeckSource>(() => initialAiSource(quickLobby?.aiDeck))
   const [pendingRecreate, setPendingRecreate] = useState<RecreateSpec | null>(null)
 
   const view: UnifiedLobbyView | null = quickLobby
@@ -169,10 +172,12 @@ export function LobbyScreen() {
             {/* Only a quick vs-AI lobby has an AI seat whose deck is the host's to choose.
                 Momir Basic hands every seat the same fixed 60 basics, so there is nothing to pick. */}
             {view.kind === 'QUICK' && quickLobby?.vsAi && !isMomir && (
-              <AiOpponentPanel
+              <AiOpponentRow
                 aiDeck={quickLobby.aiDeck ?? null}
                 format={quickLobby.format ?? null}
                 disabled={view.you?.tone === 'ready'}
+                source={aiSource}
+                onSourceChange={setAiSource}
               />
             )}
 
@@ -188,6 +193,12 @@ export function LobbyScreen() {
         {view.kind === 'TOURNAMENT' && lobbyState && view.isWaiting &&
           lobbyState.settings.format === 'PREMADE_DECKS' && (
             <PremadeDeckPickerPanel lobbyState={lobbyState} playerId={playerId} />
+        )}
+        {view.kind === 'QUICK' && quickLobby?.vsAi && !isMomir && aiSource === 'deck' && (
+          <AiDeckSection
+            format={quickLobby.format ?? null}
+            disabled={view.you?.tone === 'ready'}
+          />
         )}
         {view.kind === 'QUICK' && quickLobby && !isMomir && (
           <QuickGameDeckPicker

--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -27,6 +27,7 @@ import { DeckPicker, type DeckPickerTab } from '../ui/DeckPicker'
 import { FullscreenButton } from '../ui/FullscreenButton'
 import { JoinQrModal } from '../ui/JoinQrModal'
 import { SettingsLabel } from '../ui/SettingsLabel'
+import { AiOpponentPanel } from './AiOpponentPanel'
 import { LobbyAxes } from './LobbyAxes'
 import { LobbyAxisSummary } from './LobbyAxisSummary'
 import { TeamChip, TournamentLobbySettings } from './TournamentLobbySettings'
@@ -163,6 +164,16 @@ export function LobbyScreen() {
                 </button>
               </div>
             </div>
+            )}
+
+            {/* Only a quick vs-AI lobby has an AI seat whose deck is the host's to choose.
+                Momir Basic hands every seat the same fixed 60 basics, so there is nothing to pick. */}
+            {view.kind === 'QUICK' && quickLobby?.vsAi && !isMomir && (
+              <AiOpponentPanel
+                aiDeck={quickLobby.aiDeck ?? null}
+                format={quickLobby.format ?? null}
+                disabled={view.you?.tone === 'ready'}
+              />
             )}
 
             {lobbyState && view.kind === 'TOURNAMENT' && (

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1084,10 +1084,12 @@
   background-color: var(--bg-panel-light);
   border: 1px solid var(--border-light);
   border-radius: var(--radius-xl);
-  /* Stable height: the panel never grows past this — extra rows scroll inside it instead of
-     resizing (and re-centering) the whole lobby as sets/boosters are added. */
-  max-height: min(62vh, 640px);
-  overflow: hidden auto;
+  /* Deliberately *not* a scroll container. It used to cap at `min(62vh, 640px)` and scroll
+     internally, to keep the lobby from re-centering as sets/boosters were added — but that put a
+     second scrollbar on the screen for the half of the lobby above Players, and a third once a
+     row's own control scrolled (the booster-count steppers, the AI seat's deck picker). Wheeling
+     over the settings then hit whichever container the pointer happened to be inside.
+     `.lobbyOverlay` is the one scroll container now; the panel grows and the page absorbs it. */
 }
 
 /* Wraps on purpose. Without it the row is one unbreakable line, so an oversized control group
@@ -1116,10 +1118,34 @@
   font-size: var(--font-sm);
 }
 
-.settingsLabelWithHelp {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
+/* The AI seat's deck picker, a sibling of the settings panel rather than a row inside it — the
+   panel scrolls and so does the picker, and one control should not sit under two scroll contexts.
+   Two visually identical pickers end up on screen (the AI's and your own), so the header is what
+   distinguishes them and is styled to be read first. */
+.aiDeckSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-self: stretch;
+}
+
+.aiDeckSectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.aiDeckSectionTitle {
+  color: var(--text-primary);
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+
+.aiDeckSectionHint {
+  color: var(--text-disabled);
+  font-size: var(--font-xs);
 }
 
 /* A sub-option of the row above it (Cards → Sealed/Draft shape, Cards → deck legality). Indented
@@ -1335,9 +1361,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  /* Cap the per-set stepper list so picking more sets scrolls here instead of growing the row. */
-  max-height: 216px;
-  overflow-y: auto;
+  /* Not capped: this list used to scroll at 216px so picking more sets wouldn't grow the row, but
+     the row sat inside the settings panel, which scrolled too. Now that the panel doesn't, the
+     list grows and the page absorbs it — one scrollbar for the whole lobby. */
 }
 
 .boosterDistributionRow {

--- a/web-client/src/store/slices/quickGameLobbySlice.ts
+++ b/web-client/src/store/slices/quickGameLobbySlice.ts
@@ -8,7 +8,7 @@
  * model — every state change comes from the server as a fresh `quickGameLobbyState` message,
  * so we just store and re-render.
  */
-import type { DeckFormat, QuickGameLobbyStateMessage } from '@/types'
+import type { AiDeckSpec, DeckFormat, QuickGameLobbyStateMessage } from '@/types'
 import {
   createCreateQuickGameLobbyMessage,
   createJoinQuickGameLobbyMessage,
@@ -19,6 +19,7 @@ import {
   createSetQuickGameLobbyPublicMessage,
   createSetQuickGameLobbyRankedMessage,
   createSetQuickGameLobbyFormatMessage,
+  createSetQuickGameAiDeckMessage,
 } from '@/types'
 import type { SliceCreator } from './types'
 import { getWebSocket } from './shared'
@@ -44,6 +45,8 @@ export interface QuickGameLobbySliceActions {
   setQuickGameLobbyPublic: (isPublic: boolean) => void
   setQuickGameLobbyRanked: (ranked: boolean) => void
   setQuickGameLobbyFormat: (format: DeckFormat | null, momirBasic?: boolean) => void
+  /** Host-only: choose what the AI opponent plays. No-op in a human lobby (server rejects). */
+  setQuickGameAiDeck: (spec: AiDeckSpec) => void
 }
 
 export type QuickGameLobbySlice = QuickGameLobbySliceState & QuickGameLobbySliceActions
@@ -86,5 +89,9 @@ export const createQuickGameLobbySlice: SliceCreator<QuickGameLobbySlice> = (set
 
   setQuickGameLobbyFormat: (format, momirBasic) => {
     getWebSocket()?.send(createSetQuickGameLobbyFormatMessage(format, momirBasic))
+  },
+
+  setQuickGameAiDeck: (spec) => {
+    getWebSocket()?.send(createSetQuickGameAiDeckMessage(spec))
   },
 })

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -33,6 +33,7 @@ import type {
   Step,
   AvailableSet,
   QuickGameLobbyStateMessage,
+  AiDeckSpec,
   DeckFormat,
   YieldKind,
 } from '@/types'
@@ -930,6 +931,8 @@ export type GameStore = {
   setQuickGameLobbyPublic: (isPublic: boolean) => void
   setQuickGameLobbyRanked: (ranked: boolean) => void
   setQuickGameLobbyFormat: (format: DeckFormat | null, momirBasic?: boolean) => void
+  /** Host-only: choose what the AI opponent plays (auto / built from sets / an exact list). */
+  setQuickGameAiDeck: (spec: AiDeckSpec) => void
 
   // Draft slice
   deckBuildingState: DeckBuildingState | null

--- a/web-client/src/types/index.ts
+++ b/web-client/src/types/index.ts
@@ -315,6 +315,9 @@ export type {
   QuickGameLobbyPlayerView,
   QuickGameLobbyStateMessage,
   QuickGameLobbyClosedMessage,
+  AiDeckSpec,
+  AiDeckSpecView,
+  SetQuickGameAiDeckMessage,
   CreateQuickGameLobbyMessage,
   JoinQuickGameLobbyMessage,
   LeaveQuickGameLobbyMessage,
@@ -434,6 +437,7 @@ export {
   createSetQuickGameLobbyPublicMessage,
   createSetQuickGameLobbyRankedMessage,
   createSetQuickGameLobbyFormatMessage,
+  createSetQuickGameAiDeckMessage,
   isQuickGameLobbyStateMessage,
   isQuickGameLobbyClosedMessage,
 } from './messages'

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1859,6 +1859,7 @@ export type ClientMessage =
   | SetQuickGameLobbySetCodeMessage
   | SetQuickGameLobbyPublicMessage
   | SetQuickGameLobbyRankedMessage
+  | SetQuickGameAiDeckMessage
   | SetQuickGameLobbyFormatMessage
 
 /**
@@ -2732,6 +2733,37 @@ export interface QuickGameLobbyStateMessage {
   readonly ranked?: boolean
   /** Whether ranked is offered for this lobby: a standard 1v1 human-vs-human lobby. */
   readonly rankedEligible?: boolean
+  /** What the AI seat will play. Present only in a vs-AI lobby. See [AiDeckSpecView]. */
+  readonly aiDeck?: AiDeckSpecView | null
+}
+
+/**
+ * What the host has chosen for the AI opponent's deck.
+ *
+ * `auto` — the server picks: a sealed pool mirroring your set, or a format-legal constructed deck
+ * when the lobby carries a deck-format restriction.
+ * `sets` — the server builds the AI a deck from [setCodes].
+ * `deck` — the AI plays an exact list the host supplied (example deck / saved deck / pasted).
+ */
+export type AiDeckSpec =
+  | { readonly type: 'auto' }
+  | { readonly type: 'sets'; readonly setCodes: readonly string[] }
+  | { readonly type: 'deck'; readonly deckList: Record<string, number>; readonly label?: string }
+
+/**
+ * The lobby-broadcast summary of an [AiDeckSpec]. The decklist behind a `deck` choice never rides
+ * the lobby broadcast — only its label and card count — so this is a summary, not the spec.
+ */
+export interface AiDeckSpecView {
+  readonly kind: 'auto' | 'sets' | 'deck'
+  readonly setCodes?: readonly string[]
+  readonly label?: string | null
+  readonly cardCount?: number
+}
+
+export interface SetQuickGameAiDeckMessage {
+  readonly type: 'setQuickGameAiDeck'
+  readonly spec: AiDeckSpec
 }
 
 export interface QuickGameLobbyClosedMessage {
@@ -2880,6 +2912,9 @@ export function createSetQuickGameLobbySetCodeMessage(setCode: string | null): S
 }
 export function createSetQuickGameLobbyPublicMessage(isPublic: boolean): SetQuickGameLobbyPublicMessage {
   return { type: 'setQuickGameLobbyPublic', isPublic }
+}
+export function createSetQuickGameAiDeckMessage(spec: AiDeckSpec): SetQuickGameAiDeckMessage {
+  return { type: 'setQuickGameAiDeck', spec }
 }
 export function createSetQuickGameLobbyRankedMessage(ranked: boolean): SetQuickGameLobbyRankedMessage {
   return { type: 'setQuickGameLobbyRanked', ranked }


### PR DESCRIPTION
The quick-game AI seat always played a 40-card sealed pool opened from whatever set the human picked — decided at game start (`AiGameManager.kt:245`) and configurable nowhere. Two consequences:

1. You couldn't test a matchup against a specific list.
2. **A lobby's deck-format restriction applied to one side of the table only.** `lobby.format` was never passed to the AI deck path, so a Pauper lobby validated your deck down to commons and then sat you across from a sealed pool full of rares. Commander was worse: you played 100-card singleton, the AI played a 40-card sealed pile.

## What this adds

A host-controlled **AI deck** row in the quick lobby, with four sources:

| Source | Behaviour |
|---|---|
| **Auto** | Server decides — sealed mirroring your set, or a format-legal constructed deck |
| **From sets** | Same builders, card pool pinned to sets you multi-select |
| **Pick a deck** | An exact list, via the same `DeckPicker` you use (saved / examples / paste) |

On the wire that's three variants — `AiDeckSpec.Auto | Sets | Fixed`. The three deck tabs all reduce to a decklist client-side exactly as the human's own submission does, so they share `Fixed`, and a fourth route to a decklist needs no server change.

Resolution is deferred to game start (`AiDeckResolver`) rather than done at selection time, so changing the lobby format re-rolls the AI's deck under the new restriction. A `Fixed` list that stops being legal reverts to Auto and the seat label says so.

## Format support

`ConstructedDeckGenerator` (new, `ai` module) builds a 60-card deck from the format's legal pool via the previously-unwired `RandomDeckGenerator`. Per-card `legalFormats` is Scryfall-sourced and already accounts for bans and set legality, so that filter is the whole of it.

**Drive-by fix:** `RandomDeckGenerator.pickColors` sampled from all five colours regardless of the pool, so a narrow pool — which one format crossed with one set always is — frequently yielded zero matching spells and threw. It now samples only colours the pool contains. Nothing in `main` called this class, so the bug was latent; without the fix the constructed path would have silently fallen back to sealed much of the time.

## Known gap: commander-shape formats

Commander / Brawl / Standard Brawl need a designated commander, singleton construction and a colour-identity constraint over the whole deck — none of which the heuristic builders model. Rather than ship an illegal 100-card approximation, `ConstructedDeckGenerator` refuses, `AiDeckResolver` falls back to a limited deck, and the panel says so outright. **"Pick a deck" is the escape hatch** — you can hand the AI a real Commander list today.

## Screenshots

Default state, and the format-aware caption under Pauper (note the AI seat: `✓ Ready · Auto (Pauper)`):

![AI deck row, default](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ai-opponent-deck-choice-screenshots/06-ai-panel-auto.png)

![Pauper lobby](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ai-opponent-deck-choice-screenshots/11-pauper-auto.png)

"From sets" with chips, and the multi-select picker behind it:

![From sets](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ai-opponent-deck-choice-screenshots/07-ai-panel-sets.png)

![Set picker](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ai-opponent-deck-choice-screenshots/08-set-picker.png)

The commander-shape gap, stated in the UI rather than silently approximated:

![Commander gap](https://raw.githubusercontent.com/wingedsheep/argentum-engine/ai-opponent-deck-choice-screenshots/12-commander-gap.png)

The `ai-opponent-deck-choice-screenshots` branch is throwaway — images are hosted there so they stay out of this diff.

## Testing

- `just build` green; `just test-ai` green; web-client `typecheck` + `build` clean
- **`ConstructedDeckGeneratorTest`** (10 cases) — 60-card shape, Pauper excludes the rares sharing the set, set scoping, reprint-row resolution through the registry, commander refusal, land count, 4-copy cap
- **`AiDeckResolverTest`** (10 cases) — every cell of the matrix, including both deliberate fallbacks and "successive Auto resolutions differ"
- Drove the running app end to end: selecting BLB + EOE flipped the AI seat to `✓ Ready · Built from BLB, EOE`; Pauper produced the 60-card caption and `Auto (Pauper)`; Commander showed the gap copy; and a full game started and reached mulligan with a sets-configured AI deck

No engine/rules surface is touched, and no card-SDK vocabulary is added, so `card-sdk-language-reference.md` doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
