### PR TITLE
Add "put into a graveyard this turn" filter support, and Abyssal Harvester

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2959,19 +2959,24 @@ work for abilities-on-stack (which carry no `CardComponent`).
   was cast for its warp cost (CR 702.185). Pair with
   `Conditions.TargetMatchesFilter(GameObjectFilter.Creature.castForWarp(), …)` to
   branch on whether a target was warp-cast (e.g., Full Bore).
-- `PutIntoGraveyardFromBattlefieldThisTurn` (filter builder
-  `putIntoGraveyardFromBattlefieldThisTurn()`) — card currently in a graveyard whose most
-  recent arrival there was from the battlefield during the current turn. Backed by the
-  per-entity `PutIntoGraveyardFromBattlefieldThisTurnMarker` data-object component, set by
-  `ZoneTransitionService` on every battlefield→graveyard move and stripped when the card
-  leaves the graveyard (so a later mill or exile→graveyard arrival doesn't falsely match).
-  The marker carries no turn number — `BeginningPhaseManager` wipes it from every entity
-  at each turn's untap step, which is what gives the predicate MTG-correct per-turn
-  semantics (the engine's `state.turnNumber` increments per round, not per active player,
-  so a turn-number comparison would be wrong in multiplayer). Used by Samwise the
-  Stouthearted and Lobelia Sackville-Baggins (LTR) — pair with `GameObjectFilter.Permanent`
-  or `Creature` on a graveyard-zone `TargetFilter`. False in battlefield-projection / untap /
-  trigger-gating contexts (the marker only lives on graveyard cards).
+- `PutIntoGraveyardThisTurn` (filter builder `putIntoGraveyardThisTurn()`) and
+  `PutIntoGraveyardFromBattlefieldThisTurn` (filter builder
+  `putIntoGraveyardFromBattlefieldThisTurn()`) — card currently in a graveyard that was put
+  there during the current turn; the second additionally requires that the arrival was from
+  the battlefield. Both read one per-entity `PutIntoGraveyardThisTurnComponent`, whose
+  `fromBattlefield` flag is the only difference between them, so the "from the battlefield"
+  refinement can never drift from the general case. `ZoneTransitionService` stamps the
+  component on *every* graveyard arrival (a mill, a discard, a countered spell, a death) and
+  strips it when the card leaves the graveyard, so a later arrival by a different route
+  doesn't carry the earlier claim. The component carries no turn number —
+  `BeginningPhaseManager` wipes it from every entity at each turn's untap step, which is what
+  gives both predicates MTG-correct per-turn semantics (the engine's `state.turnNumber`
+  increments per round, not per active player, so a turn-number comparison would be wrong in
+  multiplayer). Used by Abyssal Harvester (FDN) and by Samwise the Stouthearted / Lobelia
+  Sackville-Baggins (LTR) respectively — pair with `GameObjectFilter.Creature` or `Permanent`
+  on a graveyard-zone `TargetFilter`. Both are false in battlefield-projection / untap /
+  trigger-gating contexts (the component only lives on graveyard cards). Note that a card the
+  *scenario builder* plants in a graveyard was never "put there" and so matches neither.
 - `BlockedOrWasBlockedByLegendaryThisTurn` (filter builder
   `blockedOrWasBlockedByLegendaryThisTurn()`) — creature that, at some point during the current
   turn, blocked or was blocked by a legendary creature. Backed by the per-creature

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -837,6 +837,15 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn
     )
 
+    /**
+     * Must currently be in a graveyard *and* have been put there during the current turn,
+     * from any zone. The zone-agnostic sibling of [putIntoGraveyardFromBattlefieldThisTurn],
+     * used by FDN's Abyssal Harvester. See [StatePredicate.PutIntoGraveyardThisTurn].
+     */
+    fun putIntoGraveyardThisTurn() = copy(
+        statePredicates = statePredicates + StatePredicate.PutIntoGraveyardThisTurn
+    )
+
     /** Must be saddled (CR 702.171b) */
     fun saddled() = copy(
         statePredicates = statePredicates + StatePredicate.IsSaddled

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -246,19 +246,42 @@ sealed interface StatePredicate {
     }
 
     /**
+     * This card is currently in a graveyard *and* was put there during the current turn,
+     * from any zone — the battlefield, but equally the library (mill), the hand (discard),
+     * or the stack (a countered or resolved spell). Used as a target predicate on
+     * graveyard-zone filters:
+     *
+     *  - Abyssal Harvester (FDN): "target creature card from a graveyard that was put
+     *    there this turn".
+     *
+     * The zone-restricted sibling is [PutIntoGraveyardFromBattlefieldThisTurn]; both read
+     * the same `PutIntoGraveyardThisTurnComponent` (see that predicate's doc for the
+     * component's lifecycle), this one ignoring its `fromBattlefield` flag.
+     *
+     * Pair with `CardPredicate.IsCreature` (or any other card-predicate constraint) to
+     * express the full Abyssal Harvester filter.
+     */
+    @SerialName("PutIntoGraveyardThisTurn")
+    @Serializable
+    data object PutIntoGraveyardThisTurn : History {
+        override val description: String = "put into a graveyard this turn"
+    }
+
+    /**
      * This card is currently in a graveyard *and* was put there from the battlefield
-     * during the current turn. Used as a target predicate on graveyard-zone filters:
+     * during the current turn. The zone-restricted sibling of [PutIntoGraveyardThisTurn].
+     * Used as a target predicate on graveyard-zone filters:
      *
      *  - Samwise the Stouthearted (LTR): "target permanent card in your graveyard
      *    that was put there from the battlefield this turn"
      *  - Lobelia Sackville-Baggins (LTR): same predicate on an opponent's graveyard.
      *
-     * Backed by the `PutIntoGraveyardFromBattlefieldThisTurnMarker` data-object
-     * component on the card entity. The marker is set by `ZoneTransitionService`
-     * whenever a card moves battlefield → graveyard, and stripped when it leaves the
-     * graveyard so a later arrival from a different zone (mill, exile → graveyard)
-     * does not falsely match. The marker carries no turn number — `BeginningPhaseManager`
-     * wipes it from every entity during the untap step of each turn, giving the predicate
+     * Backed by the `PutIntoGraveyardThisTurnComponent` on the card entity, whose
+     * `fromBattlefield` flag this predicate additionally requires. The component is set by
+     * `ZoneTransitionService` on every arrival in a graveyard, and stripped when the card
+     * leaves the graveyard so a later arrival by a different route does not carry the
+     * earlier "from battlefield" claim. It carries no turn number — `BeginningPhaseManager`
+     * wipes it from every entity during the untap step of each turn, giving both predicates
      * MTG-correct per-turn semantics independent of the engine's per-round `state.turnNumber`.
      *
      * Pair with `CardPredicate.IsPermanent` (or any other card-predicate constraint)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AbyssalHarvester.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AbyssalHarvester.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Abyssal Harvester
+ * {1}{B}{B}
+ * Creature — Demon Warlock
+ * 3/2
+ *
+ * {T}: Exile target creature card from a graveyard that was put there this turn. Create a
+ * token that's a copy of it, except it's a Nightmare in addition to its other types. Then
+ * exile all other Nightmare tokens you control.
+ *
+ * Modeling notes:
+ *  - "put there this turn" is `StatePredicate.PutIntoGraveyardThisTurn` (`.putIntoGraveyardThisTurn()`),
+ *    the zone-agnostic sibling of the LTR Samwise / Lobelia predicate: a card milled, discarded,
+ *    or countered into a graveyard qualifies just as much as one that died. Any player's
+ *    graveyard is fair game ("a graveyard", not "your graveyard"), so no owner constraint.
+ *  - The token copies the *exiled* card (CR 707.2: copiable values are the card's printed
+ *    characteristics), read off the target after it lands in exile — the same
+ *    exile-then-read-it shape Lobelia Sackville-Baggins uses. CR 400.7j lets the later part
+ *    of the same effect find the object the card became in the public zone it moved to.
+ *  - "Nightmare in addition to its other types" is `addedSubtypes` (unions) rather than
+ *    `overrideSubtypes` (replaces).
+ *  - "all *other* Nightmare tokens you control" is snapshotted with the opening `gather`,
+ *    before the new token exists. Nothing else can create a Nightmare token between the two
+ *    steps of one resolution, so the snapshot is exactly "every Nightmare token except the
+ *    one this ability just made" — no exclusion step needed.
+ */
+val AbyssalHarvester = card("Abyssal Harvester") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "{T}: Exile target creature card from a graveyard that was put there this " +
+        "turn. Create a token that's a copy of it, except it's a Nightmare in addition to " +
+        "its other types. Then exile all other Nightmare tokens you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val harvested = target(
+            "creature card in a graveyard that was put there this turn",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.putIntoGraveyardThisTurn(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Pipeline {
+            // Snapshot the Nightmare tokens that exist *before* the copy is created; those are
+            // the "other" ones the last clause exiles.
+            val previousNightmares = gather(
+                GameObjectFilter.Permanent.token().withSubtype(Subtype.NIGHTMARE).youControl()
+            )
+            run(Effects.Move(harvested, Zone.EXILE, fromZone = Zone.GRAVEYARD))
+            run(
+                Effects.CreateTokenCopyOfTarget(
+                    target = harvested,
+                    addedSubtypes = setOf(Subtype.NIGHTMARE)
+                )
+            )
+            exile(previousNightmares)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Diana Franco"
+        flavorText = "\"Till the soil, spare no soul. / Neath the darkness, nightmares grow.\"\n—Children's nursery rhyme"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1,3 +1,90 @@
+// Abyssal Harvester
+{
+    "name": "Abyssal Harvester",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Demon Warlock",
+    "oracleText": "{T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "permanent token Nightmare ctrl:you"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature card in a graveyard that was put there this turn"
+                            },
+                            "destination": "Exile",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature card in a graveyard that was put there this turn"
+                            },
+                            "addedSubtypes": [
+                                "Nightmare"
+                            ]
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "PutIntoGraveyardThisTurn"
+                                ]
+                            },
+                            "zone": "Graveyard"
+                        },
+                        "id": "creature card in a graveyard that was put there this turn"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "RARE",
+        "artist": "Diana Franco",
+        "flavorText": "\"Till the soil, spare no soul. / Neath the darkness, nightmares grow.\"\n—Children's nursery rhyme",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2e0f538-5825-47e9-883c-3ec6fd5b25ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Alesha, Who Laughs at Fate
 {
     "name": "Alesha, Who Laughs at Fate",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -195,6 +195,14 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // (Giant Beaver) -> GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn().
     supported("SaddledPermanentThisTurn", "filter: a creature that saddled this permanent this turn (crewedOrSaddledSourceThisTurn)")
     supported("CrewedPermanentThisTurn", "filter: a creature that crewed this permanent this turn (crewedOrSaddledSourceThisTurn)")
+    // Graveyard-arrival filters, both backed by the one PutIntoGraveyardThisTurnComponent stamp:
+    // "…that was put there this turn" (Abyssal Harvester) reads the stamp, the battlefield-only
+    // variant (Samwise the Stouthearted, Lobelia Sackville-Baggins) also requires its
+    // fromBattlefield flag. The remaining sibling tags (…FromLibraryThisTurn,
+    // …FromAnywhereOtherThanTheBattlefieldThisTurn) would each need the stamp to carry the origin
+    // zone rather than a boolean, so they stay unmapped.
+    supported("WasPutIntoGraveyardFromAnywhereThisTurn", "filter: a card put into a graveyard this turn, from any zone (putIntoGraveyardThisTurn)")
+    supported("WasPutIntoGraveyardFromTheBattlefieldThisTurn", "filter: a card put into a graveyard from the battlefield this turn (putIntoGraveyardFromBattlefieldThisTurn)")
 
     // Costs.
     supported("PayMana", "cost: pay mana (universal)")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -262,16 +262,16 @@ class BeginningPhaseManager(
             newState = newState.updateEntity(entityId) { it.without<EnteredThisTurnComponent>() }
         }
 
-        // Wipe "put into graveyard from battlefield this turn" markers on every turn
-        // boundary so the predicate (Samwise, Lobelia — LTR) matches only cards that
-        // arrived in a graveyard this turn, not last turn. Scans all entities (the
+        // Wipe "put into a graveyard this turn" markers on every turn boundary so the
+        // predicates (Abyssal Harvester — FDN; Samwise, Lobelia — LTR) match only cards
+        // that arrived in a graveyard this turn, not last turn. Scans all entities (the
         // marker lives on graveyard cards, not battlefield permanents).
         val stampedThisTurn = newState.entities.filter { (_, container) ->
-            container.has<com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker>()
+            container.has<com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent>()
         }.keys
         for (entityId in stampedThisTurn) {
             newState = newState.updateEntity(entityId) {
-                it.without<com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker>()
+                it.without<com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent>()
             }
         }
 
@@ -424,7 +424,8 @@ class BeginningPhaseManager(
         predicate: StatePredicate,
         container: ComponentContainer
     ): Boolean = when (predicate) {
-        // Graveyard-only predicate; untap filters never see a card with the marker.
+        // Graveyard-only predicates; untap filters never see a card with the marker.
+        StatePredicate.PutIntoGraveyardThisTurn -> false
         StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
         // No granter context in untap filtering — granter-relative exclusion is resolution-time only.
         StatePredicate.IsGrantingPermanent -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -369,7 +369,7 @@ val engineSerializersModule = SerializersModule {
         subclass(RoomComponent::class)
         subclass(CantBeCounteredComponent::class)
         subclass(com.wingedsheep.engine.state.components.identity.CantBeCopiedComponent::class)
-        subclass(PutIntoGraveyardFromBattlefieldThisTurnMarker::class)
+        subclass(PutIntoGraveyardThisTurnComponent::class)
         subclass(EmblemSourceComponent::class)
         subclass(CommanderComponent::class)
         subclass(RingBearerComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1768,7 +1768,8 @@ class TriggerMatcher(
             val entity = state.getEntity(entityId) ?: return false
             entity.has<FaceDownComponent>()
         }
-        // Graveyard-zone-only predicate; trigger gating never sees a stamped entity here.
+        // Graveyard-zone-only predicates; trigger gating never sees a stamped entity here.
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.PutIntoGraveyardThisTurn -> false
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
         // No granter context in trigger gating — granter-relative exclusion is resolution-time only.
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsGrantingPermanent -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -30,7 +30,7 @@ import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
-import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
+import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
@@ -1095,15 +1095,20 @@ class PredicateEvaluator {
                 container.has<BlockedThisCombatComponent>()
             }
 
-            // "Put there from the battlefield this turn" filter for graveyard-zone targets
-            // (Samwise the Stouthearted, Lobelia Sackville-Baggins — LTR). Reads the marker
-            // set by ZoneTransitionService on battlefield→graveyard moves. The marker is
-            // stripped when the card leaves the graveyard (so a later mill→graveyard or
-            // exile→graveyard arrival doesn't falsely match) AND at the start of every
-            // turn by BeginningPhaseManager (so the "this turn" window matches MTG's
+            // "Put there this turn" filter for graveyard-zone targets (Abyssal Harvester — FDN).
+            // Reads the marker ZoneTransitionService stamps on every graveyard arrival,
+            // regardless of the zone it came from. The marker is stripped when the card leaves
+            // the graveyard (so it can't outlive the arrival it describes) AND at the start of
+            // every turn by BeginningPhaseManager (so the "this turn" window matches MTG's
             // per-turn semantics, not the engine's per-round turn counter).
+            StatePredicate.PutIntoGraveyardThisTurn -> {
+                container.has<PutIntoGraveyardThisTurnComponent>()
+            }
+
+            // The zone-restricted sibling: same marker, but the arrival must have been from
+            // the battlefield (Samwise the Stouthearted, Lobelia Sackville-Baggins — LTR).
             StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> {
-                container.has<PutIntoGraveyardFromBattlefieldThisTurnMarker>()
+                container.get<PutIntoGraveyardThisTurnComponent>()?.fromBattlefield == true
             }
 
             // "Blocked or was blocked by a legendary creature this turn" (You Cannot Pass! — LTR).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -16,7 +16,7 @@ import com.wingedsheep.engine.state.components.identity.CommanderComponent
 import com.wingedsheep.engine.state.components.identity.CommanderZoneChoiceAskedComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
-import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
+import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.ManifestedComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -629,24 +629,24 @@ object ZoneTransitionService {
             }
         }
 
-        // 8b3. Stamp "put into graveyard from battlefield this turn" on the card entity
-        // (Samwise the Stouthearted / Lobelia Sackville-Baggins, LTR). Overwrites any
-        // previous stamp so a card that bounces battlefield→graveyard twice in one turn
-        // still matches; a graveyard arrival via a different path (mill, exile→graveyard)
-        // doesn't trigger this branch, so it can't falsely match.
-        if (leavingBattlefield && actualDestZone == Zone.GRAVEYARD) {
+        // 8b3. Stamp "put into a graveyard this turn" on the card entity, recording whether
+        // the arrival came from the battlefield. Backs Abyssal Harvester (FDN, any origin
+        // zone) and Samwise the Stouthearted / Lobelia Sackville-Baggins (LTR, battlefield
+        // only). Overwrites any previous stamp so a card that bounces into a graveyard twice
+        // in one turn records its most recent origin.
+        if (actualDestZone == Zone.GRAVEYARD && fromZone != Zone.GRAVEYARD) {
             newState = newState.updateEntity(entityId) { c ->
-                c.with(PutIntoGraveyardFromBattlefieldThisTurnMarker)
+                c.with(PutIntoGraveyardThisTurnComponent(fromBattlefield = leavingBattlefield))
             }
         }
 
         // 8c. Track cards leaving the graveyard
         if (fromZone == Zone.GRAVEYARD) {
-            // Strip the "from battlefield this turn" stamp — the card is no longer in a
-            // graveyard, so the predicate must not carry over to a later graveyard
-            // arrival via a different path.
+            // Strip the "put into a graveyard this turn" stamp — the card is no longer in a
+            // graveyard, so neither predicate may carry over to a later graveyard arrival
+            // via a different path.
             newState = newState.updateEntity(entityId) { c ->
-                c.without<PutIntoGraveyardFromBattlefieldThisTurnMarker>()
+                c.without<PutIntoGraveyardThisTurnComponent>()
             }
             newState = newState.updateEntity(ownerId) { playerContainer ->
                 val existing = playerContainer.get<CardsLeftGraveyardThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -457,10 +457,11 @@ internal class AffectsFilterResolver {
             container.has<AttackedThisCombatComponent>()
         StatePredicate.BlockedThisCombat ->
             container.has<BlockedThisCombatComponent>()
-        // Graveyard-zone-only predicate (Samwise/Lobelia). Battlefield projection
-        // never sees a card whose stamp would match — every battlefield permanent
+        // Graveyard-zone-only predicates (Abyssal Harvester; Samwise/Lobelia). Battlefield
+        // projection never sees a card whose stamp would match — every battlefield permanent
         // has had its from-graveyard marker stripped on battlefield entry — so the
         // projection answer is unconditionally false here.
+        StatePredicate.PutIntoGraveyardThisTurn -> false
         StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn -> false
         StatePredicate.BlockedOrWasBlockedByLegendaryThisTurn ->
             container.has<com.wingedsheep.engine.state.components.combat.BlockedOrWasBlockedByLegendaryThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
@@ -167,18 +167,28 @@ data object CantBeCounteredComponent : Component
 data object CantBeCopiedComponent : Component
 
 /**
- * Marker: this card entered a graveyard *from the battlefield* during the current turn.
+ * Marker: this card entered a graveyard during the current turn, recording whether it came
+ * from the battlefield.
  *
  * "Current turn" follows MTG turn boundaries — a new turn begins whenever a player starts
  * their turn (BeginningPhaseManager wipes the marker from every entity at the untap step
- * of every turn). The marker is set by `ZoneTransitionService` whenever a card moves
- * battlefield → graveyard, and stripped when the card leaves the graveyard so a later
- * arrival via a different path (mill, exile → graveyard, hand → graveyard) does not
- * carry the "from battlefield" claim.
+ * of every turn). The marker is set by `ZoneTransitionService` on every arrival in a
+ * graveyard, and stripped when the card leaves the graveyard so a later arrival via a
+ * different path does not carry the earlier claim.
  *
- * Backs `StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn` (LTR — Samwise the
- * Stouthearted's "permanent card in your graveyard that was put there from the
- * battlefield this turn" and Lobelia Sackville-Baggins's analogous exile target).
+ * Backs two predicates, so the "from battlefield" refinement stays a flag on one stamp
+ * rather than two markers that can drift apart:
+ *  - `StatePredicate.PutIntoGraveyardThisTurn` — marker present, [fromBattlefield] ignored
+ *    (FDN — Abyssal Harvester's "creature card from a graveyard that was put there this turn").
+ *  - `StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn` — marker present *and*
+ *    [fromBattlefield] (LTR — Samwise the Stouthearted's "permanent card in your graveyard
+ *    that was put there from the battlefield this turn" and Lobelia Sackville-Baggins's
+ *    analogous exile target).
+ *
+ * @property fromBattlefield true when the graveyard arrival was a battlefield → graveyard
+ *   move; false for mill, discard, a countered or resolved spell, or exile → graveyard.
  */
 @Serializable
-data object PutIntoGraveyardFromBattlefieldThisTurnMarker : Component
+data class PutIntoGraveyardThisTurnComponent(
+    val fromBattlefield: Boolean
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbyssalHarvesterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbyssalHarvesterScenarioTest.kt
@@ -1,0 +1,206 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Abyssal Harvester (FDN #54).
+ *
+ * "{1}{B}{B} Creature — Demon Warlock 3/2
+ *  {T}: Exile target creature card from a graveyard that was put there this turn. Create a
+ *  token that's a copy of it, except it's a Nightmare in addition to its other types. Then
+ *  exile all other Nightmare tokens you control."
+ *
+ * The "put there this turn" half is `StatePredicate.PutIntoGraveyardThisTurn` — see
+ * [PutIntoGraveyardThisTurnTest] for the predicate's own rules coverage.
+ */
+class AbyssalHarvesterScenarioTest : ScenarioTestBase() {
+
+    init {
+        val harvesterAbilityId by lazy {
+            cardRegistry.getCard("Abyssal Harvester")!!.script.activatedAbilities.single().id
+        }
+
+        context("Abyssal Harvester") {
+
+            /**
+             * Move a card the builder planted in a graveyard out and back in through
+             * [ZoneTransitionService], so it carries a genuine "put into a graveyard this turn"
+             * stamp. The builder's `withCardInGraveyard` writes the zone directly and therefore
+             * never stamps — which is exactly the distinction the ability cares about.
+             */
+            fun ScenarioTestBase.TestGame.landInGraveyardThisTurn(cardId: EntityId) {
+                state = ZoneTransitionService.moveToZone(state, cardId, Zone.HAND).state
+                state = ZoneTransitionService.moveToZone(state, cardId, Zone.GRAVEYARD).state
+            }
+
+            test("exiles the targeted card and leaves a Nightmare token copy behind") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Abyssal Harvester")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearCard = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+                game.landInGraveyardThisTurn(bearCard)
+
+                val harvester = game.findPermanent("Abyssal Harvester")!!
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = harvesterAbilityId,
+                        targets = listOf(
+                            ChosenTarget.Card(bearCard, game.player2Id, Zone.GRAVEYARD)
+                        )
+                    )
+                )
+                withClue("Activating Abyssal Harvester should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the targeted card is exiled") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+
+                val token = game.findPermanent("Grizzly Bears")
+                token shouldNotBe null
+                val tokenContainer = game.state.getEntity(token!!)!!
+                withClue("the copy is a token") {
+                    tokenContainer.has<TokenComponent>() shouldBe true
+                }
+                val typeLine = tokenContainer.get<CardComponent>()!!.typeLine
+                withClue("Nightmare is added in addition to the copied types: $typeLine") {
+                    typeLine.subtypes.contains(Subtype.NIGHTMARE) shouldBe true
+                    typeLine.subtypes.contains(Subtype("Bear")) shouldBe true
+                }
+                withClue("the token copies the card's printed P/T (Grizzly Bears is 2/2)") {
+                    game.state.projectedState.getPower(token) shouldBe 2
+                    game.state.projectedState.getToughness(token) shouldBe 2
+                }
+                withClue("the token is controlled by the activating player, not the card's owner") {
+                    game.state.projectedState.getController(token) shouldBe game.player1Id
+                }
+            }
+
+            test("a second activation exiles the Nightmare token the first one made") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Abyssal Harvester")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val harvester = game.findPermanent("Abyssal Harvester")!!
+                val abilityId = harvesterAbilityId
+
+                val bearCard = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+                game.landInGraveyardThisTurn(bearCard)
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Card(bearCard, game.player2Id, Zone.GRAVEYARD))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+
+                // Untap the Harvester so it can be activated again this turn.
+                game.state = game.state.updateEntity(harvester) { it.without<TappedComponent>() }
+
+                val giantCard = game.findCardsInGraveyard(2, "Hill Giant").single()
+                game.landInGraveyardThisTurn(giantCard)
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Card(giantCard, game.player2Id, Zone.GRAVEYARD))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the new Nightmare token stays") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+                withClue("the previous Nightmare token is exiled by 'all other Nightmare tokens'") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a card already sitting in a graveyard is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Abyssal Harvester")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // No landInGraveyardThisTurn call — the card was never *put there* this turn.
+                val bearCard = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+                val harvester = game.findPermanent("Abyssal Harvester")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = harvesterAbilityId,
+                        targets = listOf(ChosenTarget.Card(bearCard, game.player2Id, Zone.GRAVEYARD))
+                    )
+                )
+                withClue("the ability should be rejected for an illegal target") {
+                    result.error shouldNotBe null
+                }
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            }
+
+            test("a noncreature card put into a graveyard this turn is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Abyssal Harvester")
+                    .withCardInGraveyard(2, "Shock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shockCard = game.findCardsInGraveyard(2, "Shock").single()
+                game.landInGraveyardThisTurn(shockCard)
+
+                val harvester = game.findPermanent("Abyssal Harvester")!!
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = harvesterAbilityId,
+                        targets = listOf(ChosenTarget.Card(shockCard, game.player2Id, Zone.GRAVEYARD))
+                    )
+                )
+                withClue("only creature cards qualify") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PutIntoGraveyardFromBattlefieldThisTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PutIntoGraveyardFromBattlefieldThisTurnTest.kt
@@ -1,7 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.handlers.PredicateEvaluator
-import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardFromBattlefieldThisTurnMarker
+import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -19,9 +19,10 @@ import io.kotest.matchers.shouldBe
  * was put there from the battlefield this turn") and Lobelia Sackville-Baggins
  * (analogous against an opponent's graveyard).
  *
- * The marker is set on the card entity by `ZoneTransitionService` whenever it moves
- * battlefield → graveyard, and stripped when it leaves the graveyard so a later arrival
- * via mill or exile → graveyard doesn't falsely match. It carries no turn number —
+ * The marker is set on the card entity by `ZoneTransitionService` on every graveyard
+ * arrival and records whether that arrival came from the battlefield; this predicate
+ * requires that flag. It is stripped when the card leaves the graveyard, so a later
+ * arrival via mill or exile → graveyard doesn't falsely match. It carries no turn number —
  * `BeginningPhaseManager` wipes it from every entity during the untap step of each turn,
  * which is what gives the predicate MTG-correct per-turn semantics.
  */
@@ -79,8 +80,10 @@ class PutIntoGraveyardFromBattlefieldThisTurnTest : FunSpec({
         // battlefield, so the marker should never be set.
         val deadBear = driver.putCardInGraveyard(player, "Grizzly Bears")
         driver.matches(deadBear) shouldBe false
-        driver.state.getEntity(deadBear)
-            ?.get<PutIntoGraveyardFromBattlefieldThisTurnMarker>() shouldBe null
+        // The marker may be present (the card did arrive in a graveyard this turn), but it
+        // must not claim a battlefield origin.
+        (driver.state.getEntity(deadBear)
+            ?.get<PutIntoGraveyardThisTurnComponent>()?.fromBattlefield ?: false) shouldBe false
     }
 
     test("marker is stripped when the card leaves the graveyard") {
@@ -104,7 +107,7 @@ class PutIntoGraveyardFromBattlefieldThisTurnTest : FunSpec({
         )
         driver.replaceState(moveToExile.state)
         driver.state.getEntity(bear)
-            ?.get<PutIntoGraveyardFromBattlefieldThisTurnMarker>() shouldBe null
+            ?.get<PutIntoGraveyardThisTurnComponent>() shouldBe null
         driver.matches(bear) shouldBe false
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PutIntoGraveyardThisTurnTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PutIntoGraveyardThisTurnTest.kt
@@ -1,0 +1,205 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for `StatePredicate.PutIntoGraveyardThisTurn`, the zone-agnostic graveyard filter
+ * behind FDN's Abyssal Harvester ("target creature card from a graveyard that was put there
+ * this turn").
+ *
+ * It is the sibling of `PutIntoGraveyardFromBattlefieldThisTurn` (Samwise / Lobelia, LTR) and
+ * reads the same `PutIntoGraveyardThisTurnComponent`, ignoring its `fromBattlefield` flag —
+ * so a milled, discarded, or countered card qualifies where the LTR predicate does not. The
+ * marker is stripped when the card leaves the graveyard and wiped by `BeginningPhaseManager`
+ * at the untap step of every turn, which is what gives the "this turn" window MTG-correct
+ * per-turn semantics rather than the engine's per-round turn counter.
+ */
+class PutIntoGraveyardThisTurnTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of(
+                "Forest" to 10,
+                "Swamp" to 10,
+                "Grizzly Bears" to 20
+            ),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.matchesAnyOrigin(entityId: EntityId): Boolean =
+        PredicateEvaluator().matchesStatePredicate(
+            state = state,
+            entityId = entityId,
+            predicate = StatePredicate.PutIntoGraveyardThisTurn,
+            context = null
+        )
+
+    fun GameTestDriver.matchesFromBattlefield(entityId: EntityId): Boolean =
+        PredicateEvaluator().matchesStatePredicate(
+            state = state,
+            entityId = entityId,
+            predicate = StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn,
+            context = null
+        )
+
+    test("a creature destroyed this turn matches — as it does for the battlefield-only sibling") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 1)
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.castSpellWithTargets(
+            player,
+            doomBlade,
+            listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(victim))
+        )
+        driver.bothPass()
+
+        driver.matchesAnyOrigin(victim) shouldBe true
+        driver.matchesFromBattlefield(victim) shouldBe true
+        driver.state.getEntity(victim)
+            ?.get<PutIntoGraveyardThisTurnComponent>()?.fromBattlefield shouldBe true
+    }
+
+    test("a card milled from library into the graveyard matches, but not as 'from battlefield'") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Grizzly Bears")
+        val toLibrary = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = card,
+            destinationZone = Zone.LIBRARY
+        )
+        driver.replaceState(toLibrary.state)
+        val toGraveyard = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = card,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(toGraveyard.state)
+
+        // This is the whole point of the new predicate: the LTR one says no, this one says yes.
+        driver.matchesAnyOrigin(card) shouldBe true
+        driver.matchesFromBattlefield(card) shouldBe false
+        driver.state.getEntity(card)
+            ?.get<PutIntoGraveyardThisTurnComponent>()?.fromBattlefield shouldBe false
+    }
+
+    test("a card discarded from hand into the graveyard matches") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Grizzly Bears")
+        val toGraveyard = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = card,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(toGraveyard.state)
+
+        driver.matchesAnyOrigin(card) shouldBe true
+        driver.matchesFromBattlefield(card) shouldBe false
+    }
+
+    test("a card that was already in a graveyard when play began does not match") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // putCardInGraveyard writes the zone directly rather than going through
+        // ZoneTransitionService — nothing "put it there", so there is no arrival to report.
+        val planted = driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.matchesAnyOrigin(planted) shouldBe false
+        driver.matchesFromBattlefield(planted) shouldBe false
+    }
+
+    test("marker is stripped when the card leaves the graveyard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val toGraveyard = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = bear,
+            destinationZone = Zone.GRAVEYARD
+        )
+        driver.replaceState(toGraveyard.state)
+        driver.matchesAnyOrigin(bear) shouldBe true
+
+        val toExile = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+            state = driver.state,
+            entityId = bear,
+            destinationZone = Zone.EXILE
+        )
+        driver.replaceState(toExile.state)
+        driver.state.getEntity(bear)
+            ?.get<PutIntoGraveyardThisTurnComponent>() shouldBe null
+        driver.matchesAnyOrigin(bear) shouldBe false
+    }
+
+    test("a battlefield arrival overwrites an earlier non-battlefield one for the same card") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Hand → graveyard (not from the battlefield), then graveyard → battlefield → graveyard.
+        val bear = driver.putCardInHand(player, "Grizzly Bears")
+        fun move(dest: Zone) {
+            driver.replaceState(
+                com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                    state = driver.state, entityId = bear, destinationZone = dest
+                ).state
+            )
+        }
+        move(Zone.GRAVEYARD)
+        driver.matchesFromBattlefield(bear) shouldBe false
+
+        move(Zone.BATTLEFIELD)
+        move(Zone.GRAVEYARD)
+        driver.matchesAnyOrigin(bear) shouldBe true
+        driver.matchesFromBattlefield(bear) shouldBe true
+    }
+
+    test("a card put into a graveyard last turn does not match on a later turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.giveColorlessMana(player, 1)
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.castSpellWithTargets(
+            player,
+            doomBlade,
+            listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(victim))
+        )
+        driver.bothPass()
+        driver.matchesAnyOrigin(victim) shouldBe true
+
+        driver.passPriorityUntil(Step.END, maxPasses = 200)
+        driver.bothPass()
+        driver.activePlayer shouldBe opponent
+        // New turn → BeginningPhaseManager wiped the marker during the untap step.
+        driver.matchesAnyOrigin(victim) shouldBe false
+    }
+})


### PR DESCRIPTION
Foundations had one implementable card left — **Abyssal Harvester** (FDN #54) — and it was blocked on a filter the engine didn't expose. This adds the capability, then the card.

> {T}: Exile target creature card from a graveyard that was put there this turn. Create a token that's a copy of it, except it's a Nightmare in addition to its other types. Then exile all other Nightmare tokens you control.

## The engine gap

The engine could already ask whether a graveyard card got there *from the battlefield* this turn (`StatePredicate.PutIntoGraveyardFromBattlefieldThisTurn`, behind Samwise the Stouthearted and Lobelia Sackville-Baggins). It could not ask the broader "was put there this turn" — a milled, discarded, or countered card.

Rather than add a second marker that could drift from the first, the existing `PutIntoGraveyardFromBattlefieldThisTurnMarker` data object becomes:

```kotlin
data class PutIntoGraveyardThisTurnComponent(val fromBattlefield: Boolean) : Component
```

`ZoneTransitionService` now stamps it on **every** graveyard arrival, recording where the card came from, and still strips it when the card leaves the graveyard so a later arrival by a different route can't inherit the earlier claim. `BeginningPhaseManager` wipes it at each untap step exactly as before — that, not `state.turnNumber`, is what gives "this turn" MTG-correct per-turn semantics in multiplayer.

Two predicates read the one stamp:

| Predicate | Filter builder | Reads |
|---|---|---|
| `PutIntoGraveyardThisTurn` *(new)* | `.putIntoGraveyardThisTurn()` | component present |
| `PutIntoGraveyardFromBattlefieldThisTurn` | `.putIntoGraveyardFromBattlefieldThisTurn()` | component present **and** `fromBattlefield` |

## The card

No new effect vocabulary was needed. An inline `Effects.Pipeline { }` snapshots the Nightmare tokens that already exist, exiles the targeted card, makes a token copy of it via `CreateTokenCopyOfTarget(addedSubtypes = {Nightmare})` — the executor is zone-agnostic, so it copies the card now sitting in exile (CR 400.7j, the same shape Lobelia uses) — and exiles the snapshot.

Gathering *before* the copy is created is what makes "all **other** Nightmare tokens" fall out without an exclusion step: nothing else can mint a Nightmare token between the two steps of one resolution.

## Tests

- `PutIntoGraveyardThisTurnTest` (7 tests) — mill, discard, and death all match the general predicate; only death matches the battlefield-only one; the stamp is stripped on leaving the graveyard, wiped at the next untap step, and overwritten when a card re-enters a graveyard by a different route.
- `AbyssalHarvesterScenarioTest` (4 tests) — exile + Nightmare token copy with copied P/T, subtypes, and the activating player as controller; a second activation exiling the first token; and rejection of both a card that was already in the graveyard and a noncreature card.
- `PutIntoGraveyardFromBattlefieldThisTurnTest` updated for the new component and still green.

`just build` passes. Foundations' draft set is now **262/262** (the only remaining FDN entry, Carnelian Orb of Dragonkind, is an Extra whose earliest printing is CLB, which isn't scaffolded).

Also registers the two mtgish IR tags these predicates cover — `WasPutIntoGraveyardFromAnywhereThisTurn` and `WasPutIntoGraveyardFromTheBattlefieldThisTurn` — neither of which was mapped before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)