### PR TITLE
Add five more Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AncientVendetta.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AncientVendetta.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.namedFromVariable
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.OptionType
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ancient Vendetta — Aetherdrift #75
+ * {3}{B} · Sorcery
+ *
+ * Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards
+ * with that name and exile them. Then that player shuffles.
+ *
+ * Lobotomy's shape with two differences that matter:
+ *
+ *  - The name is **typed, not picked** — [OptionType.CARD_NAME] (Desperate Research's
+ *    [Effects.ChooseCardName]) rather than Lobotomy's "reveal their hand, then choose a card from
+ *    it". You are naming blind, so this can whiff entirely.
+ *  - It exiles **up to four**, not all, so the gathered matches go through a `chooseUpTo(4)`
+ *    selection. Four is a ceiling, not a requirement — the controller may exile fewer (or none),
+ *    which matters when exiling would turn on an opponent's graveyard-hate or escape payoff.
+ *
+ * The name is chosen on resolution, not as the spell is cast: the printed text is an ordinary
+ * effect, so the opponent sees the spell on the stack before the name exists.
+ *
+ * The search spans a hidden zone (hand and library both), so the selection is a private look for
+ * the controller; the shuffle afterwards is what stops it from also being a free library-order
+ * read.
+ */
+val AncientVendetta = card("Ancient Vendetta") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose a card name. Search target opponent's graveyard, hand, and library for " +
+        "up to four cards with that name and exile them. Then that player shuffles."
+
+    spell {
+        target("opponent", Targets.Opponent)
+        effect = Effects.Pipeline {
+            // 1. Choose a card name.
+            val chosenName = chooseOption(
+                OptionType.CARD_NAME,
+                prompt = "Choose a card name",
+                name = "chosenName"
+            )
+            // 2. Search that opponent's graveyard, hand, and library for cards with that name.
+            val matches = gather(
+                CardSource.FromMultipleZones(
+                    zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                    player = Player.ContextPlayer(0),
+                    filter = GameObjectFilter.Any.namedFromVariable(chosenName.key)
+                ),
+                name = "matches"
+            )
+            // 3. Up to four of them — a ceiling, not a requirement.
+            val toExile = chooseUpTo(
+                4, from = matches,
+                prompt = "Exile up to four cards with the chosen name",
+                name = "toExile"
+            )
+            // 4. Exile them.
+            exile(toExile, owner = Player.ContextPlayer(0))
+            // 5. Then that player shuffles.
+            run(ShuffleLibraryEffect(target = EffectTarget.ContextTarget(0)))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Tianxing Xu"
+        flavorText = "\"Make peace with your end, for not even your legacy will remain.\"\n—Zahur"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg?1783907900"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CryptcallerChariot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CryptcallerChariot.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cryptcaller Chariot — Aetherdrift #80
+ * {3}{B} · Artifact — Vehicle · 5/5
+ *
+ * Menace
+ * Whenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.
+ * Crew 2
+ *
+ * Batch-worded discard payoff (CR 603.2c), so it uses [Triggers.YouDiscardOneOrMore] — one trigger
+ * per discard *event* however many cards it held — and reads the batch size back through
+ * [ContextPropertyKey.TRIGGER_DISCARD_COUNT] for "that many". Discarding three cards to a single
+ * effect makes three Zombies; three separate discards make one each. Same shape as its set-mates
+ * Marauding Mako and Magmakin Artillerist.
+ *
+ * The Zombies enter tapped, so they can't crew the Chariot the turn they arrive — the card wants
+ * you to crew first and discard after.
+ */
+val CryptcallerChariot = card("Cryptcaller Chariot") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Menace\n" +
+        "Whenever you discard one or more cards, create that many tapped 2/2 black Zombie " +
+        "creature tokens.\n" +
+        "Crew 2"
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscardOneOrMore
+        effect = Effects.CreateToken(
+            count = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DISCARD_COUNT),
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            tapped = true,
+            imageUri = "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1783907681",
+        )
+        description = "Whenever you discard one or more cards, create that many tapped 2/2 black " +
+            "Zombie creature tokens."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "80"
+        artist = "Aaron Miller"
+        flavorText = "\"They too deserve to witness Amonkhet's rebirth.\"\n—Zahur"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg?1783907897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OildeepGearhulk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OildeepGearhulk.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Oildeep Gearhulk — Aetherdrift #215
+ * {U}{U}{B}{B} · Artifact Creature — Construct · 4/4
+ *
+ * Lifelink, ward {1}
+ * When this creature enters, look at target player's hand. You may choose a card from it. If you
+ * do, that player discards that card, then draws a card.
+ *
+ * The Duress pipeline with three deliberate deviations from its set-mate Gastal Raider:
+ *
+ *  - It **looks**, it doesn't reveal ([LookAtTargetHandEffect], not `RevealHandEffect`) — only the
+ *    Gearhulk's controller sees the hand, so the rest of the table learns nothing.
+ *  - It hits **target player**, not target opponent — you may legally point it at yourself, which
+ *    turns it into a rummage.
+ *  - "You may choose" is [SelectionMode.ChooseUpTo] 1, so declining is expressible, and the
+ *    discard-then-draw is wrapped in a [ConditionalOnCollectionEffect] on the selection so the
+ *    "if you do" rider holds: no card chosen means no discard *and* no draw. An empty hand takes
+ *    the same branch.
+ *
+ * The draw is the *target player's*, not yours — [Effects.DrawCards] is aimed at the same target,
+ * so the Gearhulk trades a card rather than stripping one. The discard is a real discard
+ * ([MoveType.Discard]), so discard-matters triggers see it.
+ */
+val OildeepGearhulk = card("Oildeep Gearhulk") {
+    manaCost = "{U}{U}{B}{B}"
+    colorIdentity = "UB"
+    typeLine = "Artifact Creature — Construct"
+    power = 4
+    toughness = 4
+    oracleText = "Lifelink, ward {1}\n" +
+        "When this creature enters, look at target player's hand. You may choose a card from it. " +
+        "If you do, that player discards that card, then draws a card."
+
+    keywords(Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{1}")))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            LookAtTargetHandEffect(player),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                storeAs = "targetHand"
+            ),
+            SelectFromCollectionEffect(
+                from = "targetHand",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "chosenCard",
+                prompt = "You may choose a card for that player to discard",
+                alwaysPrompt = true,
+                showAllCards = true
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "chosenCard",
+                ifNotEmpty = Effects.Composite(
+                    MoveCollectionEffect(
+                        from = "chosenCard",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                        moveType = MoveType.Discard
+                    ),
+                    Effects.DrawCards(1, player)
+                )
+            )
+        )
+        description = "When this creature enters, look at target player's hand. You may choose a " +
+            "card from it. If you do, that player discards that card, then draws a card."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "215"
+        artist = "Artur Nakhodkin"
+        flavorText = "Oil-actuated inventions raised eyebrows after the Invasion, but no one could " +
+            "argue against the efficacy of the design."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg?1783907855"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PerilousSnare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PerilousSnare.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Perilous Snare — Aetherdrift #23
+ * {2}{W} · Artifact
+ *
+ * Start your engines!
+ * When this artifact enters, exile target nonland permanent an opponent controls until this
+ * artifact leaves the battlefield.
+ * Max speed — {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as
+ * a sorcery.
+ *
+ * An Oblivion Ring on the exile side: [Effects.ExileUntilLeaves] parks the permanent in the
+ * source's linked-exile pile, and the paired leaves-the-battlefield trigger returns it under its
+ * *owner's* control (CR 610.3) — so bouncing the Snare in response to its own ETB trigger still
+ * gives the card back.
+ *
+ * The second ability lives in a [maxSpeed] block, which folds "your speed is 4" into the ability's
+ * activation condition rather than checking it once — dropping out of max speed turns the ability
+ * off. `TimingRule.SorcerySpeed` carries the "Activate only as a sorcery" rider.
+ */
+val PerilousSnare = card("Perilous Snare") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "When this artifact enters, exile target nonland permanent an opponent controls until this " +
+        "artifact leaves the battlefield.\n" +
+        "Max speed — {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate " +
+        "only as a sorcery."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target(
+            "exiled",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.NonlandPermanent.opponentControls()))
+        )
+        effect = Effects.ExileUntilLeaves(exiled)
+        description = "When this artifact enters, exile target nonland permanent an opponent " +
+            "controls until this artifact leaves the battlefield."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Tap
+            val boosted = target(
+                "boosted",
+                TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle.youControl()))
+            )
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, boosted)
+            timing = TimingRule.SorcerySpeed
+            description = "Put a +1/+1 counter on target creature or Vehicle you control."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "23"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg?1783907916"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WaxenShapethief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WaxenShapethief.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Waxen Shapethief — Aetherdrift #74
+ * {3}{U} · Creature — Shapeshifter · 0/0
+ *
+ * Flash
+ * You may have this creature enter as a copy of an artifact or creature you control.
+ * Cycling {2}
+ *
+ * A self-only clone: the copy pool is narrowed to permanents **you** control (CR 707.2), so it
+ * duplicates your own best artifact or creature rather than stealing a stat line from across the
+ * table. `optional = true` keeps the "you may" — declining leaves a printed 0/0 that dies to state-
+ * based actions immediately, which is the card's real downside when you have nothing worth copying.
+ *
+ * Flash plus a copy of a creature you already control means the copy's own enters-the-battlefield
+ * triggers fire at instant speed. Cycling is the escape hatch for the same empty board.
+ */
+val WaxenShapethief = card("Waxen Shapethief") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shapeshifter"
+    power = 0
+    toughness = 0
+    oracleText = "Flash\n" +
+        "You may have this creature enter as a copy of an artifact or creature you control.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.FLASH)
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            copyFilter = GameObjectFilter.CreatureOrArtifact.youControl(),
+        )
+    )
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "74"
+        artist = "Helge C. Balzer"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg?1783907899"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -507,6 +507,99 @@
     "colorIdentityOverride": []
 }
 
+// Ancient Vendetta
+{
+    "name": "Ancient Vendetta",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose a card name. Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. Then that player shuffles.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ChooseOption",
+                    "optionType": "CARD_NAME",
+                    "storeAs": "chosenName",
+                    "prompt": "Choose a card name"
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromMultipleZones",
+                        "zones": [
+                            "Graveyard",
+                            "Hand",
+                            "Library"
+                        ],
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        },
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "NameEqualsChosen",
+                                    "variableName": "chosenName"
+                                }
+                            ]
+                        }
+                    },
+                    "storeAs": "matches"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "matches",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeSelected": "toExile",
+                    "prompt": "Exile up to four cards with the chosen name"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toExile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    }
+                },
+                {
+                    "type": "ShuffleLibrary",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Tianxing Xu",
+        "flavorText": "\"Make peace with your end, for not even your legacy will remain.\"\n—Zahur",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/230301f2-f288-4b13-9f62-e649ad8357bb.jpg?1783907900"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Apocalypse Runner
 {
     "name": "Apocalypse Runner",
@@ -2259,6 +2352,69 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Cryptcaller Chariot
+{
+    "name": "Cryptcaller Chariot",
+    "manaCost": "{3}{B}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Menace\nWhenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens.\nCrew 2",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "MENACE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "batch": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DISCARD_COUNT"
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1783907681",
+                    "tapped": true
+                },
+                "descriptionOverride": "Whenever you discard one or more cards, create that many tapped 2/2 black Zombie creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "RARE",
+        "artist": "Aaron Miller",
+        "flavorText": "\"They too deserve to witness Amonkhet's rebirth.\"\n—Zahur",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0c8259c-055e-4bff-b945-c0ecb057a8f0.jpg?1783907897"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -6820,6 +6976,130 @@
     ]
 }
 
+// Oildeep Gearhulk
+{
+    "name": "Oildeep Gearhulk",
+    "manaCost": "{U}{U}{B}{B}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Lifelink, ward {1}\nWhen this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LookAtTargetHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "targetHand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "targetHand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "chosenCard",
+                            "prompt": "You may choose a card for that player to discard",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "chosenCard",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "chosenCard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "moveType": "Discard"
+                                    },
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target player"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "MYTHIC",
+        "artist": "Artur Nakhodkin",
+        "flavorText": "Oil-actuated inventions raised eyebrows after the Invasion, but no one could argue against the efficacy of the design.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5e2d09e-b9f5-4a0d-96d3-984b5c2c387d.jpg?1783907855"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Ooze Patrol
 {
     "name": "Ooze Patrol",
@@ -7056,6 +7336,119 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Perilous Snare
+{
+    "name": "Perilous Snare",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield.\nMax speed — {T}: Put a +1/+1 counter on target creature or Vehicle you control. Activate only as a sorcery.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "exiled"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:opponent"
+                    },
+                    "id": "exiled"
+                },
+                "descriptionOverride": "When this artifact enters, exile target nonland permanent an opponent controls until this artifact leaves the battlefield."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "boosted"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|Vehicle ctrl:you"
+                        },
+                        "id": "boosted"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — Put a +1/+1 counter on target creature or Vehicle you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "RARE",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/47f7e468-2196-4960-a612-37ab326e2a17.jpg?1783907916"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -10660,6 +11053,55 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Waxen Shapethief
+{
+    "name": "Waxen Shapethief",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Flash\nYou may have this creature enter as a copy of an artifact or creature you control.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "copyFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Or",
+                            "predicates": [
+                                "IsCreature",
+                                "IsArtifact"
+                            ]
+                        }
+                    ],
+                    "controllerPredicate": "ControlledByYou"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "RARE",
+        "artist": "Helge C. Balzer",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/412aaa30-b9cd-4cf8-beb8-1c1229667b31.jpg?1783907899"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five more Aetherdrift cards, taking DFT from 179 to 184 implemented. All five are DFT-canonical (Scryfall shows no earlier real-expansion printing), and all compose existing SDK primitives — **no new engine vocabulary, no executor changes**.

| Card | Cost | What it needed |
|---|---|---|
| Cryptcaller Chariot | `{3}{B}` | Batch discard trigger (CR 603.2c) → dynamic token count |
| Waxen Shapethief | `{3}{U}` | `EntersAsCopy` with a controller-scoped copy pool |
| Perilous Snare | `{2}{W}` | `ExileUntilLeaves` + `maxSpeed` activated ability |
| Oildeep Gearhulk | `{U}{U}{B}{B}` | Look-at-hand → optional discard → conditional draw |
| Ancient Vendetta | `{3}{B}` | Named-card multi-zone search with an "up to four" ceiling |

## Notes on the modelling

**Cryptcaller Chariot** — the payoff is batch-worded, so it uses `Triggers.YouDiscardOneOrMore` and reads the batch size back through `ContextPropertyKey.TRIGGER_DISCARD_COUNT`. Discarding three cards to one effect makes three Zombies; three separate discards make one each. Same shape as its set-mates Marauding Mako and Magmakin Artillerist. Tokens enter tapped, so they can't crew the Chariot the turn they arrive.

**Waxen Shapethief** — `copyFilter = GameObjectFilter.CreatureOrArtifact.youControl()` narrows the pool to your own board (CR 707.2). `optional = true` keeps the "you may" — declining leaves a printed 0/0 that dies to state-based actions, which is the card's real downside.

**Perilous Snare** — the ETB is paired with a leaves-the-battlefield trigger returning the card under its *owner's* control (CR 610.3), so bouncing the Snare in response to its own trigger still gives the card back. The tap ability sits in a `maxSpeed` block, which folds the speed check into activation rather than checking it once, plus `TimingRule.SorcerySpeed` for the "activate only as a sorcery" rider.

**Oildeep Gearhulk** — three deliberate deviations from the Duress pipeline its set-mate Gastal Raider uses: it *looks* rather than reveals (`LookAtTargetHandEffect`, so only the controller sees the hand); it hits target **player**, not target opponent (you may legally point it at yourself); and "you may choose" is `ChooseUpTo(1)` with the discard-then-draw wrapped in a `ConditionalOnCollectionEffect` so the "if you do" rider holds — no card chosen means no discard *and* no draw. The draw is the target player's, so the card trades rather than strips.

**Ancient Vendetta** — Lobotomy's multi-zone search, but the name is *typed* (`OptionType.CARD_NAME`, the Desperate Research primitive) rather than picked from a revealed hand, so you name blind and can whiff. `chooseUpTo(4)` makes four a ceiling, not a requirement — relevant when exiling would turn on an opponent's graveyard payoff.

## Scope note

I originally picked **Full Throttle** as the fifth card and dropped it. "At the beginning of each combat this turn" needs a *repeating* step-based delayed trigger; today step-based delayed triggers are always consumed on fire (`TriggerDetector.detectDelayedTriggers`), and the event-based path rejects `StepEvent` outright (`matchesEventForWatchedEntity` falls through to `else -> false`). That's a real engine capability worth adding under `add-feature`, not something to fake inside a card. Ancient Vendetta went in instead.

## Verification

- `just build` green (compile + `CardLintTest` + `FacadeBoundaryTest` + snapshots).
- `just rebless-cards` — the DFT golden diff is **insertions only**, exactly these five card trees; no unrelated card moved.
- `just check-card-printing` ok for all five.
- Re-fetched every card from Scryfall and diffed name / mana cost / type line / P/T / rarity / collector number / artist / oracle text / flavor / image URI field by field: **0 mismatches**. All image URIs return HTTP 200.

No new SDK types, so no scenario tests are required — the snapshot and lint nets cover these. Every decision these cards raise routes to an existing UI component with card precedent (`EntersAsCopy` → in-place battlefield click à la Clever Impersonator; hand selection → the Duress/Gastal Raider overlay; multi-zone selection → the Turtles Forever / Kastral path; card-name entry → Desperate Research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)