### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshPartyCrasher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshPartyCrasher.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ash, Party Crasher
+ * {R}{W}
+ * Legendary Creature — Human Peasant
+ * 2/2
+ *
+ * Haste
+ * Celebration — Whenever Ash attacks, if two or more nonland permanents entered the battlefield
+ * under your control this turn, put a +1/+1 counter on Ash.
+ *
+ * The triggered half of the Celebration ability word (CR 207.2c — italic flavor, no rules meaning),
+ * the [BelligerentOfTheBall] shape bound to an attack instead of the begin-combat step: an
+ * intervening-'if' clause (CR 603.4), so [Conditions.Celebration] is checked both when attackers are
+ * declared and again as the ability resolves.
+ *
+ * Untargeted — "put a +1/+1 counter on Ash" refers to the source itself, hence
+ * [EffectTarget.Self] rather than a target requirement. Ash's own haste means it can attack the turn
+ * it lands, and Ash itself is a nonland permanent that entered this turn, so one more permanent
+ * (a token, a second creature) already turns the counter on.
+ */
+val AshPartyCrasher = card("Ash, Party Crasher") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Peasant"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "Celebration — Whenever Ash attacks, if two or more nonland permanents entered the " +
+        "battlefield under your control this turn, put a +1/+1 counter on Ash."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.Celebration
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever Ash attacks, if two or more nonland permanents entered the " +
+            "battlefield under your control this turn, put a +1/+1 counter on Ash."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Jason Rainville"
+        flavorText = "\"Get up and dance! Let your feet thunder like forgehammers!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg?1783915073"
+
+        ruling(
+            "2023-09-01",
+            "Celebration abilities only care if two or more nonland permanents entered the " +
+                "battlefield under your control in a turn. They won't get more powerful if more " +
+                "than two permanents entered the battlefield under your control in a turn."
+        )
+        ruling(
+            "2023-09-01",
+            "The permanents that entered the battlefield don't need to remain on the battlefield " +
+                "or under your control. Celebration abilities are checking for past events, not " +
+                "the current game state."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BespokeBattlegarb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BespokeBattlegarb.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bespoke Battlegarb
+ * {1}{R}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+0.
+ * Celebration — At the beginning of combat on your turn, if two or more nonland permanents entered
+ * the battlefield under your control this turn, attach this Equipment to up to one target creature
+ * you control.
+ * Equip {2}
+ *
+ * The Celebration trigger (CR 207.2c — italic flavor, no rules meaning) is an intervening-'if'
+ * clause (CR 603.4) on [Conditions.Celebration], checked when the begin-combat step starts and
+ * again on resolution. It is a *free* attach — no equip cost, no sorcery-speed restriction — so the
+ * Battlegarb re-suits itself every combat in a turn that celebrates.
+ *
+ * "Up to one target" is an optional target ([TargetCreature] with `optional = true`), the same shape
+ * as [LordSkitterSewerKing]'s exile: choosing no target leaves the Equipment where it is, which
+ * matters because [Effects.AttachEquipment] would otherwise force a move off the creature it is
+ * already on. Re-picking the current host is legal and a no-op (the executor suppresses the
+ * "becomes attached" event when the host doesn't change, CR 603.2e).
+ *
+ * The printed [equipAbility] stays alongside it, so the Battlegarb is still equippable by hand at
+ * sorcery speed on a turn that doesn't celebrate.
+ */
+val BespokeBattlegarb = card("Bespoke Battlegarb") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\n" +
+        "Celebration — At the beginning of combat on your turn, if two or more nonland permanents " +
+        "entered the battlefield under your control this turn, attach this Equipment to up to one " +
+        "target creature you control.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(2, 0, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.Celebration
+        val creature = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.AttachEquipment(creature)
+        description = "At the beginning of combat on your turn, if two or more nonland permanents " +
+            "entered the battlefield under your control this turn, attach this Equipment to up to " +
+            "one target creature you control."
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg?1783915097"
+
+        ruling(
+            "2023-09-01",
+            "Some celebration abilities trigger at specific parts of the turn and check whether " +
+                "two or more nonland permanents entered the battlefield under your control " +
+                "already in that turn."
+        )
+        ruling(
+            "2023-09-01",
+            "The permanents that entered the battlefield don't need to remain on the battlefield " +
+                "or under your control. Celebration abilities are checking for past events, not " +
+                "the current game state."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GretaSweettoothScourge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GretaSweettoothScourge.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Greta, Sweettooth Scourge
+ * {1}{B}{G}
+ * Legendary Creature — Human Warrior
+ * 3/3
+ *
+ * When Greta enters, create a Food token.
+ * {G}, Sacrifice a Food: Put a +1/+1 counter on target creature. Activate only as a sorcery.
+ * {1}{B}, Sacrifice a Food: You draw a card and you lose 1 life.
+ *
+ * Three abilities over existing primitives; the only thing worth naming is the Food cost filter.
+ * "Sacrifice a Food" means any Food *artifact*, not just a Food token (2024-11-08 ruling), so the
+ * cost matches on the Food subtype the way [SweettoothWitch] does — Tough Cookie (an Artifact
+ * Creature — Food Golem) is legal fodder. The engine's cost payment already forbids spending one
+ * Food on two costs.
+ *
+ * The counter ability targets *any* creature, not just yours ([Targets.Creature]), and carries
+ * [TimingRule.SorcerySpeed] for "Activate only as a sorcery." The draw ability has no such
+ * restriction and no target — the life loss is the controller's, hence [EffectTarget.Controller]
+ * rather than the `LoseLife` default of a target opponent.
+ */
+val GretaSweettoothScourge = card("Greta, Sweettooth Scourge") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "When Greta enters, create a Food token. (It's an artifact with \"{2}, {T}, " +
+        "Sacrifice this token: You gain 3 life.\")\n" +
+        "{G}, Sacrifice a Food: Put a +1/+1 counter on target creature. Activate only as a sorcery.\n" +
+        "{1}{B}, Sacrifice a Food: You draw a card and you lose 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.Sacrifice(GameObjectFilter.Any.withSubtype("Food")),
+        )
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "Put a +1/+1 counter on target creature. Activate only as a sorcery."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.Sacrifice(GameObjectFilter.Any.withSubtype("Food")),
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.LoseLife(1, EffectTarget.Controller),
+        )
+        description = "You draw a card and you lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg?1783915071"
+
+        ruling(
+            "2024-11-08",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact " +
+                "token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food " +
+                "Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+        )
+        ruling(
+            "2024-11-08",
+            "Food is an artifact type. Even though it appears on some creatures, it's never a " +
+                "creature type."
+        )
+        ruling(
+            "2024-11-08",
+            "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a " +
+                "Food token to activate its own ability and also to activate this ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RagingBattleMouse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RagingBattleMouse.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Raging Battle Mouse
+ * {1}{R}
+ * Creature — Mouse
+ * 2/1
+ *
+ * The second spell you cast each turn costs {1} less to cast.
+ * Celebration — At the beginning of combat on your turn, if two or more nonland permanents entered
+ * the battlefield under your control this turn, target creature you control gets +1/+1 until end
+ * of turn.
+ *
+ * Two independent abilities:
+ *
+ * 1. The cost reduction is the [UthrosPsionicist][com.wingedsheep.mtg.sets.definitions.eoe.cards.UthrosPsionicist]
+ *    shape — [CostGating.NthOfTypePerTurn] with `n = 2` over an untyped
+ *    [SpellCostTarget.YouCast], which counts the spell currently being cast. Being a static ability
+ *    of a permanent it only functions on the battlefield, so the Mouse can never discount itself
+ *    even when it *is* your second spell (2023-09-01 ruling), and [CostModification.ReduceGeneric]
+ *    touches only the generic component of the cost.
+ *
+ * 2. The Celebration trigger is exactly [BelligerentOfTheBall]'s: an intervening-'if' clause
+ *    (CR 603.4) on [Conditions.Celebration], checked when the begin-combat step starts and again on
+ *    resolution. The pump can target the Mouse itself.
+ */
+val RagingBattleMouse = card("Raging Battle Mouse") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Mouse"
+    power = 2
+    toughness = 1
+    oracleText = "The second spell you cast each turn costs {1} less to cast.\n" +
+        "Celebration — At the beginning of combat on your turn, if two or more nonland permanents " +
+        "entered the battlefield under your control this turn, target creature you control gets " +
+        "+1/+1 until end of turn."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.NthOfTypePerTurn(2),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.Celebration
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(power = 1, toughness = 1, target = creature)
+        description = "At the beginning of combat on your turn, if two or more nonland permanents " +
+            "entered the battlefield under your control this turn, target creature you control " +
+            "gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "143"
+        artist = "Rudy Siswanto"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg?1783915090"
+
+        ruling(
+            "2023-09-01",
+            "Spells that were cast before Raging Battle Mouse entered the battlefield count. If " +
+                "Raging Battle Mouse was the first spell you cast this turn, the next spell you " +
+                "cast this turn is your second spell."
+        )
+        ruling(
+            "2023-09-01",
+            "Raging Battle Mouse can't reduce its own cost, even if it's the second spell you cast " +
+                "in a turn."
+        )
+        ruling(
+            "2023-09-01",
+            "Raging Battle Mouse's cost-reduction ability can't reduce the amount of colored mana " +
+                "you pay for a spell. It reduces only the generic mana component of that cost."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SyrArmontTheRedeemer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SyrArmontTheRedeemer.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Syr Armont, the Redeemer
+ * {3}{G}{W}
+ * Legendary Creature — Human Knight
+ * 4/4
+ *
+ * When Syr Armont enters, create a Monster Role token attached to another target creature you
+ * control. (If you control another Role on it, put that one into the graveyard. Enchanted creature
+ * gets +1/+1 and has trample.)
+ * Enchanted creatures you control get +1/+1.
+ *
+ * Two halves that feed each other, both on existing primitives:
+ *
+ * 1. The ETB is [RedtoothGenealogist]'s exactly, with the Monster Role instead of the Royal one —
+ *    "another target creature you control" is [Targets.OtherCreatureYouControl], so Syr Armont
+ *    can't crown himself, and with no other creature the trigger has no legal target and leaves the
+ *    stack. The one-Role-per-creature state-based action lives behind [Effects.CreateRoleToken].
+ *
+ * 2. The anthem is [ATaleForTheAges]'s group static, at +1/+1 instead of +2/+2: "enchanted" is
+ *    *has an Aura attached*, and Role tokens are Auras (CR 113.2c), so the Role Syr Armont hands out
+ *    is itself worth another +1/+1 on top of the Role's own bonus. Unlike A Tale for the Ages this
+ *    anthem *can* pump its own source — Syr Armont is a creature you control, so an Aura on him
+ *    turns it on for himself too.
+ */
+val SyrArmontTheRedeemer = card("Syr Armont, the Redeemer") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 4
+    toughness = 4
+    oracleText = "When Syr Armont enters, create a Monster Role token attached to another target " +
+        "creature you control. (If you control another Role on it, put that one into the " +
+        "graveyard. Enchanted creature gets +1/+1 and has trample.)\n" +
+        "Enchanted creatures you control get +1/+1."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("another target creature you control", Targets.OtherCreatureYouControl)
+        effect = Effects.CreateRoleToken("Monster Role", creature)
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().enchanted()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg?1783915070"
+
+        ruling(
+            "2023-09-01",
+            "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and " +
+                "the enchant creature ability."
+        )
+        ruling(
+            "2023-09-01",
+            "If a permanent has more than one Role attached to it controlled by the same player, " +
+                "each of those Roles except the one with the most recent timestamp is put into its " +
+                "owner's graveyard. This is a state-based action."
+        )
+        ruling(
+            "2023-09-01",
+            "Some spells and abilities that create Role tokens require targets. If each target " +
+                "chosen is an illegal target as that spell or ability tries to resolve, it won't " +
+                "resolve. The Role token won't be created."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -433,6 +433,70 @@
     ]
 }
 
+// Ash, Party Crasher
+{
+    "name": "Ash, Party Crasher",
+    "manaCost": "{R}{W}",
+    "typeLine": "Legendary Creature — Human Peasant",
+    "oracleText": "Haste\nCelebration — Whenever Ash attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Ash.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "Whenever Ash attacks, if two or more nonland permanents entered the battlefield under your control this turn, put a +1/+1 counter on Ash."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "flavorText": "\"Get up and dance! Let your feet thunder like forgehammers!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d51e6610-25b6-4d8e-92d7-c50a2ff844ff.jpg?1783915073",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Celebration abilities only care if two or more nonland permanents entered the battlefield under your control in a turn. They won't get more powerful if more than two permanents entered the battlefield under your control in a turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "The permanents that entered the battlefield don't need to remain on the battlefield or under your control. Celebration abilities are checking for past events, not the current game state."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Ashiok's Reaper
 {
     "name": "Ashiok's Reaper",
@@ -829,6 +893,111 @@
                 ]
             }
         }
+    ]
+}
+
+// Bespoke Battlegarb
+{
+    "name": "Bespoke Battlegarb",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nCelebration — At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, attach this Equipment to up to one target creature you control.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "up to one target creature you control"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, attach this Equipment to up to one target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a28ecd59-9166-473c-bafc-cb3c54c21388.jpg?1783915097",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Some celebration abilities trigger at specific parts of the turn and check whether two or more nonland permanents entered the battlefield under your control already in that turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "The permanents that entered the battlefield don't need to remain on the battlefield or under your control. Celebration abilities are checking for past events, not the current game state."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3851,6 +4020,144 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Greta, Sweettooth Scourge
+{
+    "name": "Greta, Sweettooth Scourge",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "When Greta enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{G}, Sacrifice a Food: Put a +1/+1 counter on target creature. Activate only as a sorcery.\n{1}{B}, Sacrifice a Food: You draw a card and you lose 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "Food"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put a +1/+1 counter on target creature. Activate only as a sorcery."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "Food"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "descriptionOverride": "You draw a card and you lose 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cfd365e-34d1-4224-b925-119000311934.jpg?1783915071",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token. For example, you can sacrifice Tough Cookie (an Artifact Creature — Food Golem) to activate an ability with \"Sacrifice a Food\" in its cost."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food token to activate its own ability and also to activate this ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -6956,6 +7263,106 @@
     ]
 }
 
+// Raging Battle Mouse
+{
+    "name": "Raging Battle Mouse",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Mouse",
+    "oracleText": "The second spell you cast each turn costs {1} less to cast.\nCelebration — At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, if two or more nonland permanents entered the battlefield under your control this turn, target creature you control gets +1/+1 until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {}
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "NthOfTypePerTurn",
+                    "n": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "RARE",
+        "artist": "Rudy Siswanto",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d0ab162-540e-4999-902c-9dacd6687aca.jpg?1783915090",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Spells that were cast before Raging Battle Mouse entered the battlefield count. If Raging Battle Mouse was the first spell you cast this turn, the next spell you cast this turn is your second spell."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Raging Battle Mouse can't reduce its own cost, even if it's the second spell you cast in a turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Raging Battle Mouse's cost-reduction ability can't reduce the amount of colored mana you pay for a spell. It reduces only the generic mana component of that cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rankle's Prank
 {
     "name": "Rankle's Prank",
@@ -9802,6 +10209,87 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Syr Armont, the Redeemer
+{
+    "name": "Syr Armont, the Redeemer",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "When Syr Armont enters, create a Monster Role token attached to another target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)\nEnchanted creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Monster Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature you control"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsEnchanted"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85050609-baf0-430a-ab33-83a6ea6d4741.jpg?1783915070",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Roles are colorless enchantment tokens. Each one has the Aura and Role subtypes and the enchant creature ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some spells and abilities that create Role tokens require targets. If each target chosen is an illegal target as that spell or ability tries to resolve, it won't resolve. The Role token won't be created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BespokeBattlegarbScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BespokeBattlegarbScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
+import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bespoke Battlegarb (Wilds of Eldraine) — the Celebration *free attach* trigger.
+ *
+ * "Celebration — At the beginning of combat on your turn, if two or more nonland permanents entered
+ * the battlefield under your control this turn, attach this Equipment to **up to one** target
+ * creature you control."
+ *
+ * The intervening-'if' half is already pinned generically by [CelebrationScenarioTest]; what is
+ * card-specific here is the *optional* target on an attach effect. "Up to one target" means the
+ * ability must resolve cleanly when the controller declines — the Equipment simply stays where it
+ * is — and that path is the one an attach effect could plausibly get wrong, since attaching with no
+ * target has nothing to attach to.
+ */
+class BespokeBattlegarbScenarioTest : ScenarioTestBase() {
+
+    private fun attachedHost(game: TestGame, equipmentId: EntityId): EntityId? =
+        game.state.getEntity(equipmentId)?.get<AttachedToComponent>()?.targetId
+
+    /** Overwrite the entry log wholesale — the cheapest way to switch Celebration on. */
+    private fun celebrate(game: TestGame, playerId: EntityId) {
+        game.state = game.state.updateEntity(playerId) { container ->
+            container.with(
+                PermanentsEnteredUnderControlThisTurnComponent(
+                    (0..1).map { EnteredPermanentRecord(EntityId.of("entry-$it"), setOf(CardType.CREATURE)) }
+                )
+            )
+        }
+    }
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Beast",
+                manaCost = ManaCost.parse("{G}"),
+                subtypes = setOf(Subtype.BEAST),
+                power = 1,
+                toughness = 1
+            )
+        )
+
+        context("Bespoke Battlegarb — Celebration attach") {
+
+            test("attaches to the chosen creature and grants +2/+0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bespoke Battlegarb")
+                    .withCardOnBattlefield(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                celebrate(game, game.player1Id)
+
+                val battlegarb = game.findPermanent("Bespoke Battlegarb")!!
+                val beast = game.findPermanent("Test Beast")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(beast))
+                game.resolveStack()
+
+                attachedHost(game, battlegarb) shouldBe beast
+                withClue("the equipped creature gets +2/+0") {
+                    game.state.projectedState.getPower(beast) shouldBe 3
+                    game.state.projectedState.getToughness(beast) shouldBe 1
+                }
+            }
+
+            test("declining the optional target resolves cleanly and attaches nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bespoke Battlegarb")
+                    .withCardOnBattlefield(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                celebrate(game, game.player1Id)
+
+                val battlegarb = game.findPermanent("Bespoke Battlegarb")!!
+                val beast = game.findPermanent("Test Beast")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.skipTargets()
+                game.resolveStack()
+
+                withClue("no target chosen — the Equipment stays unattached") {
+                    attachedHost(game, battlegarb) shouldBe null
+                    game.state.projectedState.getPower(beast) shouldBe 1
+                }
+            }
+
+            test("does not trigger when fewer than two nonland permanents entered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bespoke Battlegarb")
+                    .withCardOnBattlefield(1, "Test Beast")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val battlegarb = game.findPermanent("Bespoke Battlegarb")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                withClue("the intervening-'if' fails at trigger time, so nothing asks for a target") {
+                    game.state.pendingDecision shouldBe null
+                }
+                game.resolveStack()
+                attachedHost(game, battlegarb) shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five WOE cards, all composed from existing SDK primitives — no new effect, trigger, or condition types, so `docs/card-sdk-language-reference.md` needs no update.

| # | Card | Shape |
|---|---|---|
| 201 | **Ash, Party Crasher** | Haste + Celebration attack trigger (intervening-'if', CR 603.4) → `AddCounters(+1/+1, Self)` |
| 143 | **Raging Battle Mouse** | `CostGating.NthOfTypePerTurn(2)` for "the second spell you cast each turn costs {1} less", plus the Celebration begin-combat pump |
| 122 | **Bespoke Battlegarb** | Equipment; Celebration free-attach on an **optional** target, alongside the printed `equipAbility("{2}")` |
| 205 | **Greta, Sweettooth Scourge** | Food ETB + two "Sacrifice a Food" abilities (one sorcery-speed) |
| 214 | **Syr Armont, the Redeemer** | Monster Role ETB on another creature you control + A Tale for the Ages' enchanted-creature anthem at +1/+1 |

Notes worth a reviewer's eye:

- **"Sacrifice a Food"** matches the Food *subtype*, not token-ness — Tough Cookie (Artifact Creature — Food Golem) is legal fodder (2024-11-08 ruling). Same filter Sweettooth Witch already uses.
- **Syr Armont's anthem** stacks with the Role it hands out: Roles are Auras (CR 113.2c), so the Monster Role's own +1/+1 and the anthem's +1/+1 both apply. Unlike A Tale for the Ages, this one can pump its own source.
- **Raging Battle Mouse can't discount itself** — the reduction is a static ability of a permanent, so it only functions on the battlefield (2023-09-01 ruling). Falls out of the existing gating, no special-casing.

## Tests

`BespokeBattlegarbScenarioTest` covers the attach trigger's three paths — target chosen, target declined, Celebration off. "Up to one target" on an attach effect is the one place these five could plausibly resolve wrong (`AttachEquipmentExecutor` errors on an unresolvable target), so it's pinned; the other four are covered by the snapshot and lint nets.

Verified: `just build` green, `just check-card-printing` clean for all five (WOE is the earliest real printing in every case), and each card re-checked field-by-field against Scryfall (mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor, image URI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)