### PR TITLE
Add five Innistrad Remastered cards

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 147 / 272
+**Implemented:** 148 / 272
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -125,7 +125,7 @@
 - [ ] Heron of Hope
 - [x] Heron-Blessed Geist
 - [x] Hiveheart Shaman
-- [ ] Honeymoon Hearse
+- [x] Honeymoon Hearse
 - [x] Honored Heirloom
 - [ ] Hookhand Mariner
 - [x] Hopeful Initiate

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SkirsdagHighPriestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SkirsdagHighPriestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skirsdag High Priest reprint in Commander 2014. Canonical CardDefinition lives in ISD's `cards/`
+ * package (the card's earliest real printing); this file contributes only presentation data.
+ */
+val SkirsdagHighPriestReprint = Printing(
+    oracleId = "c6064c08-e4e0-49f4-9f0b-55cdecf443af",
+    name = "Skirsdag High Priest",
+    setCode = "C14",
+    collectorNumber = "163",
+    scryfallId = "6b5771ae-8c27-40b3-b384-974cd75283fb",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b5771ae-8c27-40b3-b384-974cd75283fb.jpg?1783938839",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CaptivatingVampireReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CaptivatingVampireReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Captivating Vampire reprint in Commander 2017. Canonical CardDefinition lives in M11's `cards/`
+ * package (the card's earliest real printing); this file contributes only presentation data.
+ */
+val CaptivatingVampireReprint = Printing(
+    oracleId = "acd382ee-94fb-4a29-b14e-c2a3c6dde7e0",
+    name = "Captivating Vampire",
+    setCode = "C17",
+    collectorNumber = "104",
+    scryfallId = "1b825bd1-9cbc-45a8-bfbe-fc3e8fdc575e",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b825bd1-9cbc-45a8-bfbe-fc3e8fdc575e.jpg?1783935910",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/MausoleumWanderer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/MausoleumWanderer.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Mausoleum Wanderer
+ * {U}
+ * Creature — Spirit
+ * 1/1
+ *
+ * Flying
+ * Whenever another Spirit you control enters, this creature gets +1/+1 until end of turn.
+ * Sacrifice this creature: Counter target instant or sorcery spell unless its controller pays {X},
+ * where X is this creature's power.
+ *
+ * X reads the source's power through [EntityReference.Source], which resolves with last-known
+ * information (CR 112.7a / 608.2h): the sacrifice-self cost has already moved the Wanderer to the
+ * graveyard by the time the ability resolves, so the engine's pre-sacrifice snapshot supplies the
+ * *pumped* power rather than the printed 1. That is the whole point of the card — flash in a Spirit,
+ * then trade the Wanderer for a bigger tax.
+ */
+val MausoleumWanderer = card("Mausoleum Wanderer") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever another Spirit you control enters, this creature gets +1/+1 until end of turn.\n" +
+        "Sacrifice this creature: Counter target instant or sorcery spell unless its controller " +
+        "pays {X}, where X is this creature's power."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.SPIRIT),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Whenever another Spirit you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        target = Targets.InstantOrSorcerySpell
+        effect = Effects.CounterUnlessDynamicPays(
+            DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power)
+        )
+        description = "Counter target instant or sorcery spell unless its controller pays {X}, " +
+            "where X is this creature's power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "69"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg?1783937494"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CaptivatingVampireReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CaptivatingVampireReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Captivating Vampire reprint in INR. Canonical CardDefinition lives in M11's `cards/` package
+ * (the card's earliest real printing); this file contributes only presentation data.
+ */
+val CaptivatingVampireReprint = Printing(
+    oracleId = "acd382ee-94fb-4a29-b14e-c2a3c6dde7e0",
+    name = "Captivating Vampire",
+    setCode = "INR",
+    collectorNumber = "100",
+    scryfallId = "0f87aadf-7638-4691-b5a5-86f928e98462",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f87aadf-7638-4691-b5a5-86f928e98462.jpg?1783908149",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HoneymoonHearseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HoneymoonHearseReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Honeymoon Hearse reprint in INR. Canonical CardDefinition lives in VOW's `cards/` package
+ * (the card's earliest real printing); this file contributes only presentation data.
+ */
+val HoneymoonHearseReprint = Printing(
+    oracleId = "87925405-072b-49d6-97c0-fc3a13c10d07",
+    name = "Honeymoon Hearse",
+    setCode = "INR",
+    collectorNumber = "159",
+    scryfallId = "41867811-cc23-4841-bb85-2c0146e509fc",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41867811-cc23-4841-bb85-2c0146e509fc.jpg?1783908116",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MausoleumWandererReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MausoleumWandererReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mausoleum Wanderer reprint in INR. Canonical CardDefinition lives in EMN's `cards/` package
+ * (the card's earliest real printing); this file contributes only presentation data.
+ */
+val MausoleumWandererReprint = Printing(
+    oracleId = "1803850e-9499-4bf7-a4d9-6bf655cbe87d",
+    name = "Mausoleum Wanderer",
+    setCode = "INR",
+    collectorNumber = "74",
+    scryfallId = "f47bda42-8eb7-49c5-8f3b-e988e377a7f5",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f47bda42-8eb7-49c5-8f3b-e988e377a7f5.jpg?1783908159",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SkirsdagHighPriestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SkirsdagHighPriestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skirsdag High Priest reprint in INR. Canonical CardDefinition lives in ISD's `cards/` package
+ * (the card's earliest real printing); this file contributes only presentation data.
+ */
+val SkirsdagHighPriestReprint = Printing(
+    oracleId = "c6064c08-e4e0-49f4-9f0b-55cdecf443af",
+    name = "Skirsdag High Priest",
+    setCode = "INR",
+    collectorNumber = "132",
+    scryfallId = "7a329b20-4e6e-45c9-aee0-51fe81dce543",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a329b20-4e6e-45c9-aee0-51fe81dce543.jpg?1783908131",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/UlvenwaldMysteriesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/UlvenwaldMysteriesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ulvenwald Mysteries reprint in INR. Canonical CardDefinition lives in SOI's `cards/` package
+ * (the card's earliest real printing); this file contributes only presentation data.
+ */
+val UlvenwaldMysteriesReprint = Printing(
+    oracleId = "6588ea9a-658f-40d9-a64b-3a418ab81183",
+    name = "Ulvenwald Mysteries",
+    setCode = "INR",
+    collectorNumber = "222",
+    scryfallId = "8a3997f1-5b02-4ca5-a390-fedb5874b575",
+    artist = "Nereida",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a3997f1-5b02-4ca5-a390-fedb5874b575.jpg?1783908087",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkirsdagHighPriest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SkirsdagHighPriest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skirsdag High Priest
+ * {1}{B}
+ * Creature — Human Cleric
+ * 1/2
+ *
+ * Morbid — {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token
+ * with flying. Activate only if a creature died this turn.
+ *
+ * Morbid is an ability word with no rules meaning; the "activate only if" clause is the real
+ * restriction, modeled as [ActivationRestriction.OnlyIfCondition] over
+ * [Conditions.CreatureDiedThisTurn] (any creature, any controller). The tap-two half excludes the
+ * source (`excludeSelf = true`) — the High Priest is already being tapped by the {T} half of the
+ * same cost, so it can't also be one of the two. Per the ISD ruling those two creatures need not
+ * have been under your control since your most recent turn began; only the {T} half is subject to
+ * summoning sickness, which the engine enforces for the tap symbol already.
+ */
+val SkirsdagHighPriest = card("Skirsdag High Priest") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "Morbid — {T}, Tap two untapped creatures you control: Create a 5/5 black Demon " +
+        "creature token with flying. Activate only if a creature died this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.TapPermanents(
+                count = 2,
+                filter = GameObjectFilter.Creature.youControl(),
+                excludeSelf = true
+            )
+        )
+        restrictions = listOf(ActivationRestriction.OnlyIfCondition(Conditions.CreatureDiedThisTurn))
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Demon"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1783940883"
+        )
+        description = "Create a 5/5 black Demon creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "Jason A. Engle"
+        flavorText = "\"Thraben's pleas fall on deaf ears. Ours do not.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg?1783940949"
+
+        ruling(
+            "2020-08-07",
+            "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate its " +
+                "ability aren't required to have been under your control continuously since the " +
+                "beginning of your most recent turn."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkirsdagHighPriestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkirsdagHighPriestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skirsdag High Priest reprint in Jumpstart 2022. Canonical CardDefinition lives in ISD's `cards/`
+ * package (the card's earliest real printing); this file contributes only presentation data.
+ */
+val SkirsdagHighPriestReprint = Printing(
+    oracleId = "c6064c08-e4e0-49f4-9f0b-55cdecf443af",
+    name = "Skirsdag High Priest",
+    setCode = "J22",
+    collectorNumber = "467",
+    scryfallId = "1265ed45-2954-4fca-b13f-5c1afd1ef134",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/1265ed45-2954-4fca-b13f-5c1afd1ef134.jpg?1783918979",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/CaptivatingVampire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/CaptivatingVampire.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Captivating Vampire
+ * {1}{B}{B}
+ * Creature — Vampire
+ * 2/2
+ *
+ * Other Vampire creatures you control get +1/+1.
+ * Tap five untapped Vampires you control: Gain control of target creature. It becomes a Vampire in
+ * addition to its other types.
+ *
+ * The activation cost has no {T} symbol, so Captivating Vampire itself counts as one of the five
+ * (`excludeSelf` stays false) and none of the five need to have been under your control since your
+ * most recent turn began. Both halves of the effect are permanent — the M11 ruling is explicit that
+ * neither the control change nor the added Vampire type has a duration, and both survive Captivating
+ * Vampire leaving the battlefield, so `Duration.Permanent` (the default on both facades) is correct.
+ */
+val CaptivatingVampire = card("Captivating Vampire") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 2
+    oracleText = "Other Vampire creatures you control get +1/+1.\n" +
+        "Tap five untapped Vampires you control: Gain control of target creature. It becomes a " +
+        "Vampire in addition to its other types."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 5,
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE).youControl()
+        )
+        target = Targets.Creature
+        effect = Effects.GainControl(EffectTarget.ContextTarget(0))
+            .then(Effects.AddCreatureType("Vampire", EffectTarget.ContextTarget(0)))
+        description = "Gain control of target creature. It becomes a Vampire in addition to its other types."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "87"
+        artist = "Eric Deschamps"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg?1783941818"
+
+        ruling(
+            "2010-08-15",
+            "Since Captivating Vampire's activated ability doesn't have a tap symbol in its cost, " +
+                "you can tap a Vampire (including Captivating Vampire itself) that hasn't been under " +
+                "your control since your most recent turn began to pay the cost."
+        )
+        ruling(
+            "2010-08-15",
+            "The effect of Captivating Vampire's activated ability has no duration. You retain " +
+                "control of the affected creature until the game ends, the creature leaves the " +
+                "battlefield, or a later effect causes someone else to gain control of it. It doesn't " +
+                "matter whether Captivating Vampire remains on the battlefield. Similarly, the " +
+                "affected creature remains a Vampire in addition to its other types until the game " +
+                "ends, the creature leaves the battlefield, or a later effect changes its types or subtypes."
+        )
+        ruling(
+            "2010-08-15",
+            "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment " +
+                "attached to it."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/UlvenwaldMysteries.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/UlvenwaldMysteries.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Ulvenwald Mysteries
+ * {2}{G}
+ * Enchantment
+ *
+ * Whenever a nontoken creature you control dies, investigate.
+ * Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.
+ *
+ * Both halves are ANY-binding, not OTHER: per the SOI rulings Ulvenwald Mysteries reacts to its own
+ * death if some effect has made it a creature, and a leaves-the-battlefield trigger looks back in
+ * time, so a creature dying *simultaneously* with the enchantment still triggers it.
+ *
+ * The Clue half uses `perPermanent = true` — "Whenever you sacrifice **a** Clue" is a per-object
+ * template (CR 603.2c), so cracking two Clues at once makes two Humans, unlike a batched
+ * "one or more" trigger. It is a triggered ability, not an activated one: the sacrifice has to come
+ * from somewhere else (typically the Clue's own "{2}, Sacrifice this token: Draw a card").
+ */
+val UlvenwaldMysteries = card("Ulvenwald Mysteries") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a nontoken creature you control dies, investigate. (Create a Clue token. " +
+        "It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Investigate()
+        description = "Whenever a nontoken creature you control dies, investigate."
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = EventPattern.PermanentsSacrificedEvent(
+                filter = GameObjectFilter.Artifact.withSubtype("Clue"),
+                perPermanent = true
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human", "Soldier"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg?1783937683"
+        )
+        description = "Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Greg Opalinski"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg?1783937718"
+
+        ruling(
+            "2025-01-24",
+            "If a nontoken creature dies at the same time as Ulvenwald Mysteries leaves the " +
+                "battlefield, the first ability triggers. Similarly, if Ulvenwald Mysteries isn't a " +
+                "token and has become a creature, it dying will cause its own first ability to trigger."
+        )
+        ruling(
+            "2025-01-24",
+            "The last ability is a triggered ability, not an activated ability. It doesn't allow you " +
+                "to sacrifice a Clue whenever you want; rather, you need some other way of sacrificing " +
+                "it, such as the activated ability that Clue tokens have."
+        )
+        ruling(
+            "2025-01-24",
+            "If you sacrifice a Clue as part of casting a spell or activating an ability, the last " +
+                "ability will resolve before that spell or ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HoneymoonHearse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HoneymoonHearse.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Honeymoon Hearse
+ * {2}{R}
+ * Artifact — Vehicle
+ * 5/5
+ *
+ * Trample
+ * Tap two untapped creatures you control: This Vehicle becomes an artifact creature until end of turn.
+ *
+ * A Vehicle with no Crew keyword: the animate ability is written out longhand instead, so the cost is
+ * a flat "tap two creatures" rather than crew's total-power threshold. The effect is the same shape
+ * the engine builds for crew — [Effects.BecomeCreature] on self with the printed base P/T until end
+ * of turn — and no type needs adding, since a Vehicle is already an artifact. Trample is printed on
+ * the card, so it applies for free once the Hearse is a creature.
+ */
+val HoneymoonHearse = card("Honeymoon Hearse") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Trample\n" +
+        "Tap two untapped creatures you control: This Vehicle becomes an artifact creature until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 2, filter = GameObjectFilter.Creature.youControl())
+        effect = Effects.BecomeCreature(EffectTarget.Self, power = 5, toughness = 5)
+        description = "This Vehicle becomes an artifact creature until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Raoul Vitale"
+        flavorText = "A carriage crafted from the finest materials. Horses bred from the finest stock. " +
+            "Skulls taken from the finest foes."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg?1783924835"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1203,6 +1203,83 @@
     "colorIdentityOverride": []
 }
 
+// Mausoleum Wanderer
+{
+    "name": "Mausoleum Wanderer",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever another Spirit you control enters, this creature gets +1/+1 until end of turn.\nSacrifice this creature: Counter target instant or sorcery spell unless its controller pays {X}, where X is this creature's power.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Spirit ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever another Spirit you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Counter",
+                    "condition": {
+                        "type": "CounterCondition.UnlessPaysDynamic",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Source",
+                            "numericProperty": "Power"
+                        }
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "instant|sorcery",
+                            "zone": "Stack"
+                        }
+                    }
+                ],
+                "descriptionOverride": "Counter target instant or sorcery spell unless its controller pays {X}, where X is this creature's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42391fa7-6172-487c-b8aa-d41ab7c64973.jpg?1783937494"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Midnight Scavengers
 {
     "name": "Midnight Scavengers",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -3780,6 +3780,78 @@
     ]
 }
 
+// Skirsdag High Priest
+{
+    "name": "Skirsdag High Priest",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Morbid — {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token with flying. Activate only if a creature died this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "count": 2,
+                                "filter": "creature ctrl:you",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Demon"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1783940883"
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": "CreatureDiedThisTurn"
+                    }
+                ],
+                "descriptionOverride": "Create a 5/5 black Demon creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Thraben's pleas fall on deaf ears. Ours do not.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/09aa6b66-f69b-4f89-b802-e30c247f90e3.jpg?1783940949",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Unlike Skirsdag High Priest itself, the two other creatures you tap to activate its ability aren't required to have been under your control continuously since the beginning of your most recent turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Slayer of the Wicked
 {
     "name": "Slayer of the Wicked",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -35,6 +35,96 @@
     ]
 }
 
+// Captivating Vampire
+{
+    "name": "Captivating Vampire",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Other Vampire creatures you control get +1/+1.\nTap five untapped Vampires you control: Gain control of target creature. It becomes a Vampire in addition to its other types.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 5,
+                        "filter": "creature Vampire ctrl:you"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainControl",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Vampire",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ],
+                "descriptionOverride": "Gain control of target creature. It becomes a Vampire in addition to its other types."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Vampire ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "RARE",
+        "artist": "Eric Deschamps",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f99b0735-cc3c-48dc-a7ad-b7d9eea45e54.jpg?1783941818",
+        "rulings": [
+            {
+                "date": "2010-08-15",
+                "text": "Since Captivating Vampire's activated ability doesn't have a tap symbol in its cost, you can tap a Vampire (including Captivating Vampire itself) that hasn't been under your control since your most recent turn began to pay the cost."
+            },
+            {
+                "date": "2010-08-15",
+                "text": "The effect of Captivating Vampire's activated ability has no duration. You retain control of the affected creature until the game ends, the creature leaves the battlefield, or a later effect causes someone else to gain control of it. It doesn't matter whether Captivating Vampire remains on the battlefield. Similarly, the affected creature remains a Vampire in addition to its other types until the game ends, the creature leaves the battlefield, or a later effect changes its types or subtypes."
+            },
+            {
+                "date": "2010-08-15",
+                "text": "Gaining control of a creature doesn't cause you gain control of any Auras or Equipment attached to it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cultivate
 {
     "name": "Cultivate",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1839,6 +1839,79 @@
     ]
 }
 
+// Ulvenwald Mysteries
+{
+    "name": "Ulvenwald Mysteries",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a nontoken creature you control dies, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "Whenever a nontoken creature you control dies, investigate."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Clue",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human",
+                        "Soldier"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9cbf36e-4044-4f08-9bae-f0dcb2455716.jpg?1783937683"
+                },
+                "descriptionOverride": "Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Opalinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/911a2b5d-7e2d-4358-8e38-cbae7192e4d4.jpg?1783937718",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "If a nontoken creature dies at the same time as Ulvenwald Mysteries leaves the battlefield, the first ability triggers. Similarly, if Ulvenwald Mysteries isn't a token and has become a creature, it dying will cause its own first ability to trigger."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "The last ability is a triggered ability, not an activated ability. It doesn't allow you to sacrifice a Clue whenever you want; rather, you need some other way of sacrificing it, such as the activated ability that Clue tokens have."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If you sacrifice a Clue as part of casting a spell or activating an ability, the last ability will resolve before that spell or ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Uncaged Fury
 {
     "name": "Uncaged Fury",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -4574,6 +4574,58 @@
     ]
 }
 
+// Honeymoon Hearse
+{
+    "name": "Honeymoon Hearse",
+    "manaCost": "{2}{R}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Trample\nTap two untapped creatures you control: This Vehicle becomes an artifact creature until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "creature ctrl:you"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                "descriptionOverride": "This Vehicle becomes an artifact creature until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "flavorText": "A carriage crafted from the finest materials. Horses bred from the finest stock. Skulls taken from the finest foes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04e491a1-b195-45bb-bf06-345eaee30b81.jpg?1783924835"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Honored Heirloom
 {
     "name": "Honored Heirloom",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptivatingVampireScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptivatingVampireScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.m11.cards.CaptivatingVampire
+import com.wingedsheep.mtg.sets.definitions.vow.cards.VoldarenEpicure
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Captivating Vampire (M11) — {1}{B}{B} Creature — Vampire 2/2
+ *
+ * "Other Vampire creatures you control get +1/+1.
+ *  Tap five untapped Vampires you control: Gain control of target creature. It becomes a Vampire in
+ *  addition to its other types."
+ *
+ * The interesting seam is that the two halves feed each other: the stolen creature *becomes* a
+ * Vampire, so it immediately picks up the lord's +1/+1. Both effects are permanent per the M11
+ * rulings, and the cost has no {T} symbol, so Captivating Vampire may be one of the five it taps.
+ */
+class CaptivatingVampireScenarioTest : FunSpec({
+
+    val captivateAbilityId = CaptivatingVampire.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CaptivatingVampire)
+        driver.registerCard(VoldarenEpicure)
+        return driver
+    }
+
+    test("the lord pumps other Vampires you control but not itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val lord = driver.putCreatureOnBattlefield(me, "Captivating Vampire")
+        val myVampire = driver.putCreatureOnBattlefield(me, "Voldaren Epicure")
+        val theirVampire = driver.putCreatureOnBattlefield(opponent, "Voldaren Epicure")
+
+        val projected = driver.state.projectedState
+        projected.getPower(lord) shouldBe 2
+        projected.getToughness(lord) shouldBe 2
+        projected.getPower(myVampire) shouldBe 2
+        projected.getToughness(myVampire) shouldBe 2
+        // "you control" — the opponent's Vampire is untouched.
+        projected.getPower(theirVampire) shouldBe 1
+    }
+
+    test("tapping five Vampires steals a creature, which becomes a Vampire and joins the lord bonus") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val lord = driver.putCreatureOnBattlefield(me, "Captivating Vampire")
+        val fodder = (1..4).map { driver.putCreatureOnBattlefield(me, "Voldaren Epicure") }
+        val prey = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        driver.state.projectedState.getController(prey) shouldBe opponent
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = lord,
+                abilityId = captivateAbilityId,
+                targets = listOf(ChosenTarget.Permanent(prey)),
+                // No {T} in the cost, so the lord itself is one of the five Vampires tapped.
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(lord) + fodder)
+            )
+        )
+        driver.isTapped(lord) shouldBe true
+        fodder.forEach { driver.isTapped(it) shouldBe true }
+
+        driver.bothPass() // the ability resolves
+
+        val projected = driver.state.projectedState
+        projected.getController(prey) shouldBe me
+        projected.hasSubtype(prey, "Vampire") shouldBe true
+        // Still a Centaur Warrior too — "in addition to its other types".
+        projected.hasSubtype(prey, "Centaur") shouldBe true
+        // 3/3 base, now a Vampire I control, so the lord's +1/+1 applies.
+        projected.getPower(prey) shouldBe 4
+        projected.getToughness(prey) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoneymoonHearseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoneymoonHearseScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.vow.cards.HoneymoonHearse
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Honeymoon Hearse (VOW) — {2}{R} Artifact — Vehicle 5/5
+ *
+ * "Trample
+ *  Tap two untapped creatures you control: This Vehicle becomes an artifact creature until end of turn."
+ *
+ * A crewless Vehicle: it isn't a creature until its own ability animates it, and the animation lasts
+ * only for the turn. Printed trample rides along once it is one.
+ */
+class HoneymoonHearseScenarioTest : FunSpec({
+
+    val animateAbilityId = HoneymoonHearse.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HoneymoonHearse)
+        return driver
+    }
+
+    test("tapping two creatures animates the Vehicle into a 5/5 trampler for the turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val hearse = driver.putPermanentOnBattlefield(me, "Honeymoon Hearse")
+        val crewA = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val crewB = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        // A Vehicle is not a creature on its own.
+        driver.state.projectedState.isCreature(hearse) shouldBe false
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = hearse,
+                abilityId = animateAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(crewA, crewB))
+            )
+        )
+        driver.isTapped(crewA) shouldBe true
+        driver.isTapped(crewB) shouldBe true
+        // The Vehicle itself is not tapped — there is no {T} in the cost.
+        driver.isTapped(hearse) shouldBe false
+
+        driver.bothPass() // the ability resolves
+
+        val projected = driver.state.projectedState
+        projected.isCreature(hearse) shouldBe true
+        projected.getPower(hearse) shouldBe 5
+        projected.getToughness(hearse) shouldBe 5
+        projected.hasKeyword(hearse, Keyword.TRAMPLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MausoleumWandererScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MausoleumWandererScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.emn.cards.MausoleumWanderer
+import com.wingedsheep.mtg.sets.definitions.soi.cards.SpectralShepherd
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Mausoleum Wanderer (EMN) — {U} Creature — Spirit 1/1
+ *
+ * "Flying
+ *  Whenever another Spirit you control enters, this creature gets +1/+1 until end of turn.
+ *  Sacrifice this creature: Counter target instant or sorcery spell unless its controller pays {X},
+ *  where X is this creature's power."
+ *
+ * The load-bearing detail is that X is read *after* the Wanderer has already been sacrificed to pay
+ * the cost. `EntityReference.Source` resolves with last-known information (CR 112.7a / 608.2h), so
+ * the pre-sacrifice snapshot must supply the pumped power. These tests pin X to 1 unpumped and 2
+ * after one Spirit has entered, by giving the opposing spell's controller exactly one mana: at X=1
+ * they get a real pay-or-be-countered choice, at X=2 they simply can't pay.
+ */
+class MausoleumWandererScenarioTest : FunSpec({
+
+    val sacAbilityId = MausoleumWanderer.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MausoleumWanderer)
+        driver.registerCard(SpectralShepherd)
+        return driver
+    }
+
+    test("another Spirit entering pumps the Wanderer to 2/2 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val wanderer = driver.putCreatureOnBattlefield(me, "Mausoleum Wanderer")
+        driver.state.projectedState.getPower(wanderer) shouldBe 1
+
+        val shepherd = driver.putCardInHand(me, "Spectral Shepherd")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, shepherd).isSuccess shouldBe true
+        driver.bothPass() // Shepherd enters
+        driver.bothPass() // the +1/+1 trigger resolves
+
+        driver.state.projectedState.getPower(wanderer) shouldBe 2
+        driver.state.projectedState.getToughness(wanderer) shouldBe 2
+    }
+
+    test("unpumped: X is 1, so one floating mana is enough to pay through the counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val wanderer = driver.putCreatureOnBattlefield(me, "Mausoleum Wanderer")
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = wanderer,
+                abilityId = sacAbilityId,
+                targets = listOf(ChosenTarget.Spell(boltOnStack))
+            )
+        )
+        driver.getGraveyardCardNames(me) shouldContain "Mausoleum Wanderer"
+
+        // Exactly {1} available: enough for X = 1, so a real choice is offered.
+        driver.giveColorlessMana(opponent, 1)
+        driver.bothPass()
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        (driver.pendingDecision as YesNoDecision).playerId shouldBe opponent
+
+        driver.submitYesNo(opponent, true) // pay {1}
+        driver.bothPass() // Lightning Bolt resolves
+        driver.getLifeTotal(me) shouldBe 17
+    }
+
+    test("pumped: X is 2 by last-known information, so one floating mana can't save the spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val wanderer = driver.putCreatureOnBattlefield(me, "Mausoleum Wanderer")
+
+        // Pump it once: 1/1 → 2/2 for the turn.
+        val shepherd = driver.putCardInHand(me, "Spectral Shepherd")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, shepherd).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+        driver.state.projectedState.getPower(wanderer) shouldBe 2
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = wanderer,
+                abilityId = sacAbilityId,
+                targets = listOf(ChosenTarget.Spell(boltOnStack))
+            )
+        )
+
+        // Only {1} available but X is 2 — the tax can't be paid, so the Bolt is countered outright.
+        driver.giveColorlessMana(opponent, 1)
+        driver.bothPass()
+        driver.isPaused shouldBe false
+        driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+        driver.getLifeTotal(me) shouldBe 20
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkirsdagHighPriestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkirsdagHighPriestScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.cards.SkirsdagHighPriest
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Skirsdag High Priest (ISD) — {1}{B} Creature — Human Cleric 1/2
+ *
+ * "Morbid — {T}, Tap two untapped creatures you control: Create a 5/5 black Demon creature token
+ *  with flying. Activate only if a creature died this turn."
+ *
+ * Two things to prove: the morbid gate really blocks activation until something has died this turn,
+ * and the composite cost ({T} on the source plus two *other* tapped creatures) pays out the Demon.
+ */
+class SkirsdagHighPriestScenarioTest : FunSpec({
+
+    val demonAbilityId = SkirsdagHighPriest.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SkirsdagHighPriest)
+        return driver
+    }
+
+    test("morbid gate: can't activate before a creature has died this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val priest = driver.putCreatureOnBattlefield(me, "Skirsdag High Priest")
+        driver.removeSummoningSickness(priest)
+        val helperA = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val helperB = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me,
+                sourceId = priest,
+                abilityId = demonAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(helperA, helperB))
+            )
+        )
+
+        driver.findPermanent(me, "Demon Token") shouldBe null
+    }
+
+    test("after a creature dies: tapping the Priest and two other creatures makes a 5/5 flying Demon") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val priest = driver.putCreatureOnBattlefield(me, "Skirsdag High Priest")
+        driver.removeSummoningSickness(priest)
+        val helperA = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        val helperB = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        val fodder = driver.putCreatureOnBattlefield(me, "Goblin Guide")
+
+        // Something dies this turn — morbid is now satisfied.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(fodder)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.getGraveyardCardNames(me).contains("Goblin Guide") shouldBe true
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = priest,
+                abilityId = demonAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(helperA, helperB))
+            )
+        )
+
+        // The whole composite cost was paid: the Priest itself plus both helpers are tapped.
+        driver.isTapped(priest) shouldBe true
+        driver.isTapped(helperA) shouldBe true
+        driver.isTapped(helperB) shouldBe true
+
+        driver.bothPass() // the ability resolves
+
+        val demon = driver.findPermanent(me, "Demon Token")
+        demon shouldNotBe null
+        val projected = driver.state.projectedState
+        projected.getPower(demon!!) shouldBe 5
+        projected.getToughness(demon) shouldBe 5
+        projected.hasKeyword(demon, Keyword.FLYING) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UlvenwaldMysteriesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UlvenwaldMysteriesScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.ShadowsOverInnistradSet
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ulvenwald Mysteries (SOI) — {2}{G} Enchantment
+ *
+ * "Whenever a nontoken creature you control dies, investigate.
+ *  Whenever you sacrifice a Clue, create a 1/1 white Human Soldier creature token."
+ *
+ * The two halves chain: the first makes Clues off your own dying creatures, the second pays off when
+ * those Clues get cracked. The pieces are stock primitives, but the pairing is what has to work —
+ * a leaves-the-battlefield trigger feeding [com.wingedsheep.sdk.dsl.Effects.Investigate], and a
+ * per-object `PermanentsSacrificedEvent` filtered to Clues catching the Clue token's own
+ * "{2}, Sacrifice this token: Draw a card."
+ */
+class UlvenwaldMysteriesScenarioTest : FunSpec({
+
+    val clueSacAbilityId = PredefinedTokens.Clue.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + ShadowsOverInnistradSet.cards)
+        driver.registerCard(PredefinedTokens.Clue)
+        return driver
+    }
+
+    test("a nontoken creature you control dying investigates") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Ulvenwald Mysteries")
+        val goblin = driver.putCreatureOnBattlefield(me, "Goblin Guide")
+
+        driver.findPermanent(me, "Clue") shouldBe null
+
+        // Kill my own creature — 3 damage to a 2/2.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass() // Bolt resolves, Goblin dies, dies-trigger goes on the stack
+        driver.bothPass() // investigate resolves
+
+        driver.findPermanent(me, "Clue") shouldNotBe null
+    }
+
+    test("sacrificing that Clue creates a 1/1 white Human Soldier") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Ulvenwald Mysteries")
+        val goblin = driver.putCreatureOnBattlefield(me, "Goblin Guide")
+
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(goblin)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        val clue = driver.findPermanent(me, "Clue")!!
+        driver.findPermanent(me, "Human Soldier Token") shouldBe null
+
+        // Crack the Clue: "{2}, Sacrifice this token: Draw a card."
+        driver.giveColorlessMana(me, 2)
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = clue, abilityId = clueSacAbilityId))
+        driver.bothPass() // draw resolves
+        driver.bothPass() // the sacrifice-a-Clue payoff resolves
+
+        val soldier = driver.findPermanent(me, "Human Soldier Token")
+        soldier shouldNotBe null
+        val projected = driver.state.projectedState
+        projected.getPower(soldier!!) shouldBe 1
+        projected.getToughness(soldier) shouldBe 1
+        driver.state.projectedState.getSubtypes(soldier) shouldBe setOf("Human", "Soldier")
+    }
+
+    test("an opponent's creature dying does not investigate") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putPermanentOnBattlefield(me, "Ulvenwald Mysteries")
+        val theirGoblin = driver.putCreatureOnBattlefield(opponent, "Goblin Guide")
+
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(theirGoblin)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getGraveyardCardNames(opponent).contains("Goblin Guide") shouldBe true
+        driver.findPermanent(me, "Clue") shouldBe null
+    }
+})


### PR DESCRIPTION
Picks a handful of unimplemented Innistrad Remastered cards and implements them via the `add-card` flow. INR is an all-reprint set, so each card's canonical `CardDefinition` lands in its **earliest real printing** and INR contributes only a `Printing` row.

| Card | Canonical set | Cost / type |
|---|---|---|
| Ulvenwald Mysteries | SOI | `{2}{G}` Enchantment |
| Skirsdag High Priest | ISD | `{1}{B}` Human Cleric 1/2 |
| Mausoleum Wanderer | EMN | `{U}` Spirit 1/1 |
| Captivating Vampire | M11 | `{1}{B}{B}` Vampire 2/2 |
| Honeymoon Hearse | VOW | `{2}{R}` Artifact — Vehicle 5/5 |

Cards needing engine capability we don't have yet (undying, madness, meld, DFC werewolves, planeswalkers) were deliberately left out — all five here compose existing SDK primitives, **no new vocabulary**.

## Rules details worth a look

- **Ulvenwald Mysteries** — both triggers are `ANY`-bound, not `OTHER`: per the SOI rulings a creature dying *simultaneously* with the enchantment still triggers it, and if some effect made it a creature its own death triggers it too. The Clue half uses `perPermanent = true`, so cracking two Clues at once makes two Humans (CR 603.2c) rather than batching to one.
- **Skirsdag High Priest** — Morbid is an ability word with no rules meaning; the real gate is `ActivationRestriction.OnlyIfCondition(CreatureDiedThisTurn)`. The tap-two half sets `excludeSelf = true` — the Priest is already tapped by the `{T}` half of the same cost.
- **Mausoleum Wanderer** — the load-bearing bit: X is read *after* the Wanderer has been sacrificed to pay the cost. `EntityReference.Source` is `LIVE_THEN_LKI`, so the engine's pre-sacrifice snapshot supplies the **pumped** power (CR 112.7a / 608.2h), not the printed 1. That's the whole point of the card, so there's a test pinning X to 1 unpumped and 2 after one Spirit enters.
- **Captivating Vampire** — the tap-five cost has no `{T}` symbol, so the lord counts as one of the five and none of them need to have been under your control since your last turn. Both halves of the effect are permanent per the M11 rulings, and because the stolen creature *becomes* a Vampire it immediately picks up the lord's +1/+1.
- **Honeymoon Hearse** — a crewless Vehicle: the animate ability is written longhand with a flat tap-two cost instead of crew's total-power threshold, producing the same `BecomeCreature` shape the engine builds for crew.

## Also included

- `Printing` rows for C14 / J22 / C17, which `just check-card-printing` flagged as drift once the ISD and M11 canonicals landed. All five cards now report `ok`.
- Ticked Honeymoon Hearse in the VOW backlog and resynced its header count.

## Verification

- `just build` — green (2m10s).
- Card snapshot goldens re-blessed; the diff is **additions only** across EMN/ISD/M11/SOI/VOW.
- 12 new scenario tests across 5 classes, all passing — including the morbid gate rejecting activation before a death, the LKI power read, the steal-and-re-type interaction, and the Vehicle animating for the turn.
- All 15 image URIs verified HTTP 200.
- No UI work needed: the client already routes `TapPermanents` ability costs to battlefield selection (`costPayment.tappedPermanents`) and already supports an activated ability targeting a spell on the stack (Quicksilver Dragon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)