### PR TITLE
Guard face-down combat abilities and mask the damage board per viewer

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/DecisionEnricher.kt
@@ -10,7 +10,37 @@ import com.wingedsheep.sdk.model.EntityId
 
 class DecisionEnricher(private val cardRegistry: CardRegistry) {
 
-    fun enrich(decision: PendingDecision, state: GameState): PendingDecision {
+    private companion object {
+        /** Generic label for a face-down (morph / manifest) creature; mirrors the client state transformer. */
+        const val FACE_DOWN_CREATURE_NAME = "Face-down creature"
+    }
+
+    /**
+     * Whether [entityId]'s real name must be hidden from [viewerId]. A face-down permanent's identity
+     * is known only to the player who controls it (they may look at their own face-down creatures);
+     * everyone else sees the generic label. Mirrors the battlefield masking in ClientStateTransformer
+     * (`isFaceDown && controllerId != viewingPlayerId`). It intentionally does not honour
+     * Lens-of-Clarity-style reveals — omitting them only ever over-masks, so it can't leak.
+     */
+    private fun isHiddenFrom(state: GameState, entityId: EntityId, viewerId: EntityId): Boolean =
+        state.getEntity(entityId)?.has<FaceDownComponent>() == true &&
+            state.projectedState.getController(entityId) != viewerId
+
+    /**
+     * The source name to display for [decision] to [viewerId]. The combat board copies the (single)
+     * attacker's real name into [DecisionContext.sourceName]; mask it when the viewer isn't its
+     * controller. The multi-attacker board already uses a generic "Combat damage" label.
+     */
+    private fun maskedSourceName(decision: PendingDecision, state: GameState, viewerId: EntityId): String? {
+        val sourceName = decision.context.sourceName ?: return null
+        if (decision is CombatResolutionDecision) {
+            val single = decision.attackers.singleOrNull() ?: return sourceName
+            if (single.name == sourceName && isHiddenFrom(state, single.id, viewerId)) return FACE_DOWN_CREATURE_NAME
+        }
+        return sourceName
+    }
+
+    fun enrich(decision: PendingDecision, state: GameState, viewerId: EntityId): PendingDecision {
         return when (decision) {
             is SearchLibraryDecision -> decision.copy(
                 cards = decision.cards.mapValues { (entityId, cardInfo) ->
@@ -66,12 +96,41 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
                 }
                 decision.copy(cardInfo = enrichedCardInfo)
             }
+            is CombatResolutionDecision -> {
+                // The combat-damage board is shown to every chooser (the attacker assigns its damage,
+                // the defender assigns any blocker damage), so a face-down creature's real name would
+                // leak to the opponent through a shared node. Mask per viewer: the controller keeps
+                // its own creature's name, everyone else sees the generic label.
+                val maskedAttackers = decision.attackers.map {
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                }
+                val maskedBlockers = decision.blockers.map {
+                    if (isHiddenFrom(state, it.id, viewerId)) it.copy(name = FACE_DOWN_CREATURE_NAME) else it
+                }
+                // The single-attacker prompt embeds that attacker's name; mask it in lockstep.
+                val single = decision.attackers.singleOrNull()
+                val maskedPrompt = if (single != null && isHiddenFrom(state, single.id, viewerId)) {
+                    decision.prompt.replaceFirst(single.name, FACE_DOWN_CREATURE_NAME)
+                } else {
+                    decision.prompt
+                }
+                decision.copy(
+                    attackers = maskedAttackers,
+                    blockers = maskedBlockers,
+                    prompt = maskedPrompt,
+                    context = decision.context.copy(sourceName = maskedSourceName(decision, state, viewerId)),
+                )
+            }
             // Other decision types don't have card info to enrich
             else -> decision
         }
     }
 
-    fun createOpponentDecisionStatus(decision: PendingDecision): ServerMessage.OpponentDecisionStatus {
+    fun createOpponentDecisionStatus(
+        decision: PendingDecision,
+        state: GameState,
+        viewerId: EntityId,
+    ): ServerMessage.OpponentDecisionStatus {
         val displayText = when (decision) {
             is SelectCardsDecision -> "Selecting cards"
             is ChooseTargetsDecision -> "Choosing targets"
@@ -96,7 +155,7 @@ class DecisionEnricher(private val cardRegistry: CardRegistry) {
             playerId = decision.playerId.value,
             decisionType = decision::class.simpleName ?: "Unknown",
             displayText = displayText,
-            sourceName = decision.context.sourceName
+            sourceName = maskedSourceName(decision, state, viewerId)
         )
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -886,7 +886,7 @@ class GameSession(
         // decision to the controller, not the affected player.
         // Enrich with imageUri from card registry since engine doesn't have access to metadata
         val pendingDecision = state.pendingDecision?.takeIf { state.actorFor(it.playerId) == playerId }?.let {
-            decisionEnricher.enrich(it, state)
+            decisionEnricher.enrich(it, state, playerId)
         }
 
         // Calculate next stop point for the Pass button (only if player has priority,
@@ -908,7 +908,7 @@ class GameSession(
         // Include opponent decision status for the player who is NOT driving this
         // decision — i.e. when their seat is not the actor for the affected player.
         val opponentDecisionStatus = state.pendingDecision?.takeIf { state.actorFor(it.playerId) != playerId }?.let {
-            decisionEnricher.createOpponentDecisionStatus(it)
+            decisionEnricher.createOpponentDecisionStatus(it, state, playerId)
         }
 
         val stateWithLog = clientState.copy(gameLog = playerLog.toList())

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/CombatDamageMaskingEnricherTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Per-viewer masking of the combat-damage board (state masking is a game-server concern). The
+ * engine emits ONE [CombatResolutionDecision] with real card names, shown to both choosers (the
+ * attacker assigns its damage, the defender assigns any blocker damage). [DecisionEnricher] masks a
+ * face-down (morph / manifest) creature's real name for every viewer who doesn't control it — the
+ * controller keeps its own creature's name, mirroring the battlefield masking in ClientStateTransformer.
+ */
+class CombatDamageMaskingEnricherTest : FunSpec({
+
+    fun GameTestDriver.morphFaceDown(entityId: EntityId) {
+        replaceState(state.updateEntity(entityId) { container ->
+            val defId = container.get<CardComponent>()?.cardDefinitionId ?: ""
+            container.with(FaceDownComponent).with(MorphDataComponent(PayCost.OwnManaCost, defId))
+        })
+    }
+
+    fun GameTestDriver.manifestFaceDown(entityId: EntityId) {
+        replaceState(state.updateEntity(entityId) { container ->
+            container.with(FaceDownComponent).with(ManifestedComponent)
+        })
+    }
+
+    fun advanceUntilDecision(driver: GameTestDriver, maxPasses: Int = 50) {
+        var passes = 0
+        while (driver.state.pendingDecision == null && passes < maxPasses) {
+            val priority = driver.state.priorityPlayerId ?: error("No priority and no pending decision")
+            driver.submit(PassPriority(priority))
+            passes++
+            if (driver.state.gameOver) error("Game ended before a decision was emitted")
+        }
+        if (passes >= maxPasses) error("No pending decision within $maxPasses passes; step=${driver.currentStep}")
+    }
+
+    test("combat-damage board masks face-down names per viewer") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val attacker = driver.activePlayer!!
+        val defender = if (attacker == driver.player1) driver.player2 else driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Face-down morph attacker (really "Centaur Courser"), controlled by the attacker.
+        val morphAttacker = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        driver.morphFaceDown(morphAttacker)
+        driver.removeSummoningSickness(morphAttacker)
+
+        // Two blockers so the 2/2 attacker must assign combat damage → board decision. One is a
+        // face-down manifest (really "Savannah Lions") the DEFENDER controls, one is plain.
+        val manifestBlocker = driver.putCreatureOnBattlefield(defender, "Savannah Lions")
+        driver.manifestFaceDown(manifestBlocker)
+        val plainBlocker = driver.putCreatureOnBattlefield(defender, "Trample Beast")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(morphAttacker), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            defender,
+            mapOf(manifestBlocker to listOf(morphAttacker), plainBlocker to listOf(morphAttacker)),
+        )
+
+        val ordering = driver.state.pendingDecision
+        if (ordering is OrderObjectsDecision) {
+            driver.submitDecision(ordering.playerId, OrderedResponse(ordering.id, listOf(manifestBlocker, plainBlocker)))
+        }
+        advanceUntilDecision(driver)
+        val decision = driver.state.pendingDecision
+        decision.shouldBeInstanceOf<CombatResolutionDecision>()
+
+        // Engine keeps the real names; masking happens in the enricher, per viewer.
+        decision.attackers.single { it.id == morphAttacker }.name shouldBe "Centaur Courser"
+
+        val enricher = DecisionEnricher(driver.cardRegistry)
+
+        // The attacker's controller sees their OWN morph's real name; the opponent's manifest is masked.
+        val forAttacker = enricher.enrich(decision, driver.state, attacker) as CombatResolutionDecision
+        forAttacker.attackers.single { it.id == morphAttacker }.name shouldBe "Centaur Courser"
+        forAttacker.blockers.single { it.id == manifestBlocker }.name shouldBe "Face-down creature"
+        forAttacker.blockers.single { it.id == plainBlocker }.name shouldBe "Trample Beast"
+        forAttacker.prompt shouldContain "Centaur Courser"
+
+        // The defender sees the attacker's morph masked on the board node, the prompt, and the source
+        // name — but keeps the real name of the manifest creature THEY control.
+        val forDefender = enricher.enrich(decision, driver.state, defender) as CombatResolutionDecision
+        forDefender.attackers.single { it.id == morphAttacker }.name shouldBe "Face-down creature"
+        forDefender.blockers.single { it.id == manifestBlocker }.name shouldBe "Savannah Lions"
+        forDefender.prompt shouldNotContain "Centaur Courser"
+        forDefender.context.sourceName shouldBe "Face-down creature"
+
+        // The opponent-decision status shown to the defender also masks the attacker's real name.
+        val status = enricher.createOpponentDecisionStatus(decision, driver.state, defender)
+        (status.sourceName ?: "") shouldNotContain "Centaur Courser"
+    }
+})

--- a/manual-scenarios/bugs/facedown-morph-name-leak-combat-damage.json
+++ b/manual-scenarios/bugs/facedown-morph-name-leak-combat-damage.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Pine Walker"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Gorilla Warrior"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": ["DECLARE_BLOCKERS"]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -55,6 +55,11 @@ internal class CombatDamageManager(
     private val damageCalculator: DamageCalculator,
 ) {
 
+    private companion object {
+        /** Generic label for a face-down (morph / manifest) creature; mirrors the client transformer. */
+        const val FACE_DOWN_CREATURE_NAME = "Face-down creature"
+    }
+
     private val damageModifiers: List<CombatDamageModifier> = listOf(
         PreventAllCombatDamageModifier(),
         PreventAllDamageFromSourceModifier(),
@@ -394,6 +399,16 @@ internal class CombatDamageManager(
         return emitCombatResolutionDecision(state, projected, candidates, firstStrike)
     }
 
+    /**
+     * The name shown for a combat participant in the damage-assignment board. Face-down permanents
+     * (morph / manifest) are masked to a generic label so the board never leaks the hidden card's
+     * identity — the whole decision graph is shared across every chooser (including the opponent
+     * assigning blocker damage), so masking must be unconditional, not keyed on any one viewer. This
+     * mirrors the "Face-down creature" masking in the client state transformer.
+     */
+    private fun combatDisplayName(state: GameState, entityId: EntityId, realName: String): String =
+        if (state.getEntity(entityId)?.has<FaceDownComponent>() == true) FACE_DOWN_CREATURE_NAME else realName
+
     private fun emitCombatResolutionDecision(
         state: GameState,
         projected: ProjectedState,
@@ -409,7 +424,7 @@ internal class CombatDamageManager(
             val container = state.getEntity(c.attackerId)
             ResolutionAttacker(
                 id = c.attackerId,
-                name = c.attackerName,
+                name = combatDisplayName(state, c.attackerId, c.attackerName),
                 power = projected.getPower(c.attackerId) ?: c.availablePower,
                 toughness = projected.getToughness(c.attackerId) ?: 0,
                 hasTrample = c.hasTrample,
@@ -430,7 +445,7 @@ internal class CombatDamageManager(
             val blocking = container.get<BlockingComponent>()
             ResolutionBlocker(
                 id = blockerId,
-                name = card.name,
+                name = combatDisplayName(state, blockerId, card.name),
                 power = projected.getPower(blockerId) ?: 0,
                 toughness = projected.getToughness(blockerId) ?: 0,
                 hasDeathtouch = projected.hasKeyword(blockerId, Keyword.DEATHTOUCH),
@@ -560,8 +575,11 @@ internal class CombatDamageManager(
         val choosers = attackerChoosers + blockerChoosers
 
         val decisionId = UUID.randomUUID().toString()
+        // Mask face-down attackers in the prompt / source name too — otherwise a single face-down
+        // attacker's real name leaks through the decision text even when the board node is masked.
+        val firstAttackerName = candidates.firstOrNull()?.let { combatDisplayName(state, it.attackerId, it.attackerName) }
         val prompt = if (candidates.size == 1) {
-            "Assign ${candidates[0].attackerName}'s ${candidates[0].availablePower} combat damage"
+            "Assign $firstAttackerName's ${candidates[0].availablePower} combat damage"
         } else {
             "Assign combat damage for ${candidates.size} attackers"
         }
@@ -571,7 +589,7 @@ internal class CombatDamageManager(
             prompt = prompt,
             context = DecisionContext(
                 sourceId = candidates.firstOrNull()?.attackerId,
-                sourceName = if (candidates.size == 1) candidates[0].attackerName else "Combat damage",
+                sourceName = if (candidates.size == 1) firstAttackerName ?: "Combat damage" else "Combat damage",
                 phase = DecisionPhase.COMBAT,
             ),
             firstStrike = firstStrike,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -55,11 +55,6 @@ internal class CombatDamageManager(
     private val damageCalculator: DamageCalculator,
 ) {
 
-    private companion object {
-        /** Generic label for a face-down (morph / manifest) creature; mirrors the client transformer. */
-        const val FACE_DOWN_CREATURE_NAME = "Face-down creature"
-    }
-
     private val damageModifiers: List<CombatDamageModifier> = listOf(
         PreventAllCombatDamageModifier(),
         PreventAllDamageFromSourceModifier(),
@@ -90,6 +85,11 @@ internal class CombatDamageManager(
             if (attackerId !in state.getBattlefield()) continue
             val attackerContainer = state.getEntity(attackerId) ?: continue
             val attackerCard = attackerContainer.get<CardComponent>() ?: continue
+
+            // A face-down permanent has no abilities (CR 708.2a), so this ability-gated pre-check
+            // must not read the face-up card's abilities off cardDef below — doing so would both
+            // mis-apply the ability and leak the hidden card's name into the decision prompt.
+            if (attackerContainer.has<FaceDownComponent>()) continue
 
             // Only relevant when blocked
             val blockedBy = attackerContainer.get<BlockedComponent>() ?: continue
@@ -144,6 +144,8 @@ internal class CombatDamageManager(
         for ((attackerId, attackingComponent) in attackers) {
             val attackerContainer = state.getEntity(attackerId) ?: continue
             val attackerCard = attackerContainer.get<CardComponent>() ?: continue
+            // CR 708.2a: a face-down permanent has no abilities, so it can't divide freely.
+            if (attackerContainer.has<FaceDownComponent>()) continue
             val cardDef = cardRegistry.getCard(attackerCard.cardDefinitionId) ?: continue
             val hasDivideDamageFreely = cardDef.staticAbilities.any { it is DivideCombatDamageFreely }
             if (!hasDivideDamageFreely) continue
@@ -348,8 +350,11 @@ internal class CombatDamageManager(
             val attackerCard = attackerContainer.get<CardComponent>() ?: continue
 
             val cardDef = cardRegistry.getCard(attackerCard.cardDefinitionId)
-            // DivideCombatDamageFreely (Butcher Orgg) keeps its own DistributeDecision pre-check.
-            if (cardDef?.staticAbilities?.any { it is DivideCombatDamageFreely } == true) continue
+            // DivideCombatDamageFreely (Butcher Orgg) keeps its own DistributeDecision pre-check —
+            // but only when face up. A face-down permanent has no abilities (CR 708.2a), so it takes
+            // part in the normal board here rather than being dropped from it.
+            if (!attackerContainer.has<FaceDownComponent>() &&
+                cardDef?.staticAbilities?.any { it is DivideCombatDamageFreely } == true) continue
             // AssignAsUnblocked, once answered, has written a DamageAssignmentComponent → skip.
             if (attackerContainer.get<DamageAssignmentComponent>() != null) continue
             if (!dealsDamageThisStep(projected, attackerId, firstStrike)) continue
@@ -399,16 +404,6 @@ internal class CombatDamageManager(
         return emitCombatResolutionDecision(state, projected, candidates, firstStrike)
     }
 
-    /**
-     * The name shown for a combat participant in the damage-assignment board. Face-down permanents
-     * (morph / manifest) are masked to a generic label so the board never leaks the hidden card's
-     * identity — the whole decision graph is shared across every chooser (including the opponent
-     * assigning blocker damage), so masking must be unconditional, not keyed on any one viewer. This
-     * mirrors the "Face-down creature" masking in the client state transformer.
-     */
-    private fun combatDisplayName(state: GameState, entityId: EntityId, realName: String): String =
-        if (state.getEntity(entityId)?.has<FaceDownComponent>() == true) FACE_DOWN_CREATURE_NAME else realName
-
     private fun emitCombatResolutionDecision(
         state: GameState,
         projected: ProjectedState,
@@ -424,7 +419,7 @@ internal class CombatDamageManager(
             val container = state.getEntity(c.attackerId)
             ResolutionAttacker(
                 id = c.attackerId,
-                name = combatDisplayName(state, c.attackerId, c.attackerName),
+                name = c.attackerName,
                 power = projected.getPower(c.attackerId) ?: c.availablePower,
                 toughness = projected.getToughness(c.attackerId) ?: 0,
                 hasTrample = c.hasTrample,
@@ -445,7 +440,7 @@ internal class CombatDamageManager(
             val blocking = container.get<BlockingComponent>()
             ResolutionBlocker(
                 id = blockerId,
-                name = combatDisplayName(state, blockerId, card.name),
+                name = card.name,
                 power = projected.getPower(blockerId) ?: 0,
                 toughness = projected.getToughness(blockerId) ?: 0,
                 hasDeathtouch = projected.hasKeyword(blockerId, Keyword.DEATHTOUCH),
@@ -575,11 +570,10 @@ internal class CombatDamageManager(
         val choosers = attackerChoosers + blockerChoosers
 
         val decisionId = UUID.randomUUID().toString()
-        // Mask face-down attackers in the prompt / source name too — otherwise a single face-down
-        // attacker's real name leaks through the decision text even when the board node is masked.
-        val firstAttackerName = candidates.firstOrNull()?.let { combatDisplayName(state, it.attackerId, it.attackerName) }
+        // Names here are the real card names; per-viewer face-down masking is applied downstream at
+        // delivery time (DecisionEnricher), since this one decision graph is shown to both choosers.
         val prompt = if (candidates.size == 1) {
-            "Assign $firstAttackerName's ${candidates[0].availablePower} combat damage"
+            "Assign ${candidates[0].attackerName}'s ${candidates[0].availablePower} combat damage"
         } else {
             "Assign combat damage for ${candidates.size} attackers"
         }
@@ -589,7 +583,7 @@ internal class CombatDamageManager(
             prompt = prompt,
             context = DecisionContext(
                 sourceId = candidates.firstOrNull()?.attackerId,
-                sourceName = if (candidates.size == 1) firstAttackerName ?: "Combat damage" else "Combat damage",
+                sourceName = if (candidates.size == 1) candidates[0].attackerName else "Combat damage",
                 phase = DecisionPhase.COMBAT,
             ),
             firstStrike = firstStrike,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDamageFaceDownNameLeakTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDamageFaceDownNameLeakTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.OrderObjectsDecision
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Regression test for a hidden-information leak: a morphed or manifested (face-down) creature must
+ * not reveal the identity of the card it really is through the combat-damage-assignment board
+ * ([CombatResolutionDecision]). The engine used to copy the raw [CardComponent] name straight into
+ * the [com.wingedsheep.engine.core.ResolutionAttacker] / [com.wingedsheep.engine.core.ResolutionBlocker]
+ * nodes (and into the decision prompt / source name), so the assigning player could read e.g.
+ * "Unstoppable Slasher" off the assign-combat-damage GUI even though the card was face down.
+ *
+ * The whole decision graph is shared across every chooser (the attacker assigns its damage, the
+ * defender assigns any blocker damage — opponents), so face-down names are masked to the generic
+ * "Face-down creature" label unconditionally, mirroring the client state transformer.
+ */
+class CombatDamageFaceDownNameLeakTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    /** Turn an on-battlefield creature into a face-down morph (keeps its hidden real name). */
+    fun GameTestDriver.morphFaceDown(entityId: EntityId) {
+        replaceState(state.updateEntity(entityId) { container ->
+            val defId = container.get<CardComponent>()?.cardDefinitionId ?: ""
+            container.with(FaceDownComponent).with(MorphDataComponent(PayCost.OwnManaCost, defId))
+        })
+    }
+
+    /** Turn an on-battlefield creature into a face-down manifested permanent. */
+    fun GameTestDriver.manifestFaceDown(entityId: EntityId) {
+        replaceState(state.updateEntity(entityId) { container ->
+            container.with(FaceDownComponent).with(ManifestedComponent)
+        })
+    }
+
+    /** Advance steps until a pending decision shows up (without auto-resolving). */
+    fun advanceUntilDecision(driver: GameTestDriver, maxPasses: Int = 50) {
+        var passes = 0
+        while (driver.state.pendingDecision == null && passes < maxPasses) {
+            val priority = driver.state.priorityPlayerId ?: error("No priority and no pending decision")
+            driver.submit(PassPriority(priority))
+            passes++
+            if (driver.state.gameOver) error("Game ended before a decision was emitted")
+        }
+        if (passes >= maxPasses) {
+            error("No pending decision emitted within $maxPasses passes; current step=${driver.currentStep}")
+        }
+    }
+
+    test("morphed attacker and manifested blocker do not leak their real names in the combat-damage board") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val attacker = driver.activePlayer!!
+        val defender = if (attacker == driver.player1) driver.player2 else driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Face-down morph attacker — really "Centaur Courser", shows as a 2/2 face-down creature.
+        val morphAttacker = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        driver.morphFaceDown(morphAttacker)
+        driver.removeSummoningSickness(morphAttacker)
+
+        // Two blockers so the 2/2 attacker must assign combat damage (CR 510.1c) → board decision.
+        // One is a face-down manifested creature (really "Savannah Lions"), one is a plain creature.
+        val manifestBlocker = driver.putCreatureOnBattlefield(defender, "Savannah Lions")
+        driver.manifestFaceDown(manifestBlocker)
+        val plainBlocker = driver.putCreatureOnBattlefield(defender, "Trample Beast")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(morphAttacker), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            defender,
+            mapOf(manifestBlocker to listOf(morphAttacker), plainBlocker to listOf(morphAttacker)),
+        )
+
+        // Declaring two blockers on one attacker pauses on an OrderObjectsDecision first.
+        var decision: PendingDecision? = driver.state.pendingDecision
+        if (decision is OrderObjectsDecision) {
+            driver.submitDecision(
+                decision.playerId,
+                OrderedResponse(decision.id, listOf(manifestBlocker, plainBlocker)),
+            )
+        }
+        advanceUntilDecision(driver)
+        decision = driver.state.pendingDecision
+
+        decision.shouldBeInstanceOf<CombatResolutionDecision>()
+
+        // The morph attacker's node is masked, not its real card name.
+        val attackerNode = decision.attackers.single { it.id == morphAttacker }
+        attackerNode.name shouldBe "Face-down creature"
+
+        // The manifested blocker is masked; the plain blocker keeps its real name.
+        decision.blockers.single { it.id == manifestBlocker }.name shouldBe "Face-down creature"
+        decision.blockers.single { it.id == plainBlocker }.name shouldBe "Trample Beast"
+
+        // The hidden real names appear nowhere in what the assigning player receives — not in the
+        // node names, the prompt, or the decision source name.
+        val displayedNames = decision.attackers.map { it.name } + decision.blockers.map { it.name }
+        (displayedNames.contains("Centaur Courser")) shouldBe false
+        (displayedNames.contains("Savannah Lions")) shouldBe false
+        decision.prompt.contains("Centaur Courser") shouldBe false
+        decision.context.sourceName shouldBe "Face-down creature"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDamageFaceDownNameLeakTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CombatDamageFaceDownNameLeakTest.kt
@@ -11,31 +11,52 @@ import com.wingedsheep.engine.state.components.identity.ManifestedComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AssignCombatDamageAsUnblocked
+import com.wingedsheep.sdk.scripting.DivideCombatDamageFreely
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
- * Regression test for a hidden-information leak: a morphed or manifested (face-down) creature must
- * not reveal the identity of the card it really is through the combat-damage-assignment board
- * ([CombatResolutionDecision]). The engine used to copy the raw [CardComponent] name straight into
- * the [com.wingedsheep.engine.core.ResolutionAttacker] / [com.wingedsheep.engine.core.ResolutionBlocker]
- * nodes (and into the decision prompt / source name), so the assigning player could read e.g.
- * "Unstoppable Slasher" off the assign-combat-damage GUI even though the card was face down.
+ * Engine-level combat-damage board contract plus a regression for CR 708.2a: a face-down (morph /
+ * manifest) permanent has no abilities, so the combat-damage-step pre-checks that key off a card's
+ * [AssignCombatDamageAsUnblocked] / [DivideCombatDamageFreely] static abilities must NOT fire for a
+ * face-down creature. Those pre-checks read the abilities off the *face-up* [CardDefinition], so
+ * firing them for a face-down morph both mis-applies the ability and leaks the hidden card's name
+ * into the decision prompt (a [CombatResolutionDecision] would never be reached).
  *
- * The whole decision graph is shared across every chooser (the attacker assigns its damage, the
- * defender assigns any blocker damage — opponents), so face-down names are masked to the generic
- * "Face-down creature" label unconditionally, mirroring the client state transformer.
+ * The names on the board nodes here are the *real* card names — per-viewer face-down masking is
+ * applied downstream at delivery time (game-server `DecisionEnricher`), covered by
+ * `CombatDamageMaskingEnricherTest`. This test locks that the engine itself does not mask, so there
+ * is a single masking point.
  */
 class CombatDamageFaceDownNameLeakTest : FunSpec({
+
+    // A creature whose face-up card carries BOTH combat-damage-assignment static abilities. Morphed,
+    // it is a vanilla 2/2, so neither ability may be offered.
+    val sneakyBrute = CardDefinition.creature(
+        name = "Sneaky Brute",
+        manaCost = ManaCost.parse("{3}{R}"),
+        subtypes = setOf(Subtype("Ogre")),
+        power = 3,
+        toughness = 3,
+        script = CardScript(
+            staticAbilities = listOf(AssignCombatDamageAsUnblocked(), DivideCombatDamageFreely()),
+        ),
+    )
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(sneakyBrute))
         return driver
     }
 
@@ -68,7 +89,7 @@ class CombatDamageFaceDownNameLeakTest : FunSpec({
         }
     }
 
-    test("morphed attacker and manifested blocker do not leak their real names in the combat-damage board") {
+    test("a face-down attacker's face-up combat-damage abilities are not offered (CR 708.2a); board keeps real names") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
         val attacker = driver.activePlayer!!
@@ -76,13 +97,14 @@ class CombatDamageFaceDownNameLeakTest : FunSpec({
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
-        // Face-down morph attacker — really "Centaur Courser", shows as a 2/2 face-down creature.
-        val morphAttacker = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
+        // Face-down morph attacker — really "Sneaky Brute" (assign-as-unblocked + divide-freely),
+        // face down it is a vanilla 2/2. If either ability fired, the engine would pause on that
+        // ability's own decision (a YesNoDecision / DistributeDecision) instead of the board.
+        val morphAttacker = driver.putCreatureOnBattlefield(attacker, "Sneaky Brute")
         driver.morphFaceDown(morphAttacker)
         driver.removeSummoningSickness(morphAttacker)
 
         // Two blockers so the 2/2 attacker must assign combat damage (CR 510.1c) → board decision.
-        // One is a face-down manifested creature (really "Savannah Lions"), one is a plain creature.
         val manifestBlocker = driver.putCreatureOnBattlefield(defender, "Savannah Lions")
         driver.manifestFaceDown(manifestBlocker)
         val plainBlocker = driver.putCreatureOnBattlefield(defender, "Trample Beast")
@@ -106,22 +128,12 @@ class CombatDamageFaceDownNameLeakTest : FunSpec({
         advanceUntilDecision(driver)
         decision = driver.state.pendingDecision
 
+        // Reaching the board (rather than an ability decision) proves both CR 708.2a guards fired.
         decision.shouldBeInstanceOf<CombatResolutionDecision>()
 
-        // The morph attacker's node is masked, not its real card name.
-        val attackerNode = decision.attackers.single { it.id == morphAttacker }
-        attackerNode.name shouldBe "Face-down creature"
-
-        // The manifested blocker is masked; the plain blocker keeps its real name.
-        decision.blockers.single { it.id == manifestBlocker }.name shouldBe "Face-down creature"
+        // The engine keeps the real names; masking is per-viewer downstream.
+        decision.attackers.single { it.id == morphAttacker }.name shouldBe "Sneaky Brute"
+        decision.blockers.single { it.id == manifestBlocker }.name shouldBe "Savannah Lions"
         decision.blockers.single { it.id == plainBlocker }.name shouldBe "Trample Beast"
-
-        // The hidden real names appear nowhere in what the assigning player receives — not in the
-        // node names, the prompt, or the decision source name.
-        val displayedNames = decision.attackers.map { it.name } + decision.blockers.map { it.name }
-        (displayedNames.contains("Centaur Courser")) shouldBe false
-        (displayedNames.contains("Savannah Lions")) shouldBe false
-        decision.prompt.contains("Centaur Courser") shouldBe false
-        decision.context.sourceName shouldBe "Face-down creature"
     }
 })


### PR DESCRIPTION
Before:
<img width="830" height="523" alt="image" src="https://github.com/user-attachments/assets/927477e8-6ec2-440c-96b6-0d9ce4f7d68e" />

After:
<img width="799" height="528" alt="image" src="https://github.com/user-attachments/assets/2a40bf68-09bf-4bc6-9fdb-0485a0cefc0d" />


## Enumerate from-hand activated abilities

Stacked on `spm-no-engine`; this PR is only the diff against that base.

### What

Generalizes the graveyard-only `GraveyardAbilityEnumerator` into
`ZoneActivatedAbilityEnumerator(zone)` and registers one instance per
non-battlefield zone the engine surfaces (`GRAVEYARD` + `HAND`). No new SDK
type, no handler change.

### Why

Several cards already ship with `activateFromZone = Zone.HAND` "{cost}, Discard
this card: …" abilities, but there was no enumerator for the HAND zone — so
those abilities were **unreachable as legal actions** even though
`ActivateAbilityHandler` already accepts any non-battlefield
`activateFromZone` generically (owner + zone-membership check). Affected cards
span three sets:

- **SPM** — Steel Wrecking Ball, Stegron the Dinosaur Man, Urban Retreat
- **OTJ** — Spinewoods Armadillo
- **BIG** — Harvester of Misery

### How

- Rename `GraveyardAbilityEnumerator` → `ZoneActivatedAbilityEnumerator`,
  parameterized by `zone`; iterate `state.getZone(playerId, zone)` and filter
  abilities by `activateFromZone == zone`.
- Fold `DiscardSelf` into the "self-removal cost, always payable" branch
  alongside `ExileSelf` (the source card *is* the object being discarded).
- Register `ZoneActivatedAbilityEnumerator(Zone.GRAVEYARD)` and
  `ZoneActivatedAbilityEnumerator(Zone.HAND)` in `LegalActionEnumerator`.
- Update all stale doc-comment references (RenewDsl, Gollum ×2, CastSpell,
  CommandZone) and add an `activateFromZone` section to
  `docs/card-sdk-language-reference.md`.

`COMMAND` keeps its own `CommandZoneAbilityEnumerator` (Momir's X-cost-triple
discard specifics); the boundary is documented.

### Tests

New `HandActivatedAbilityEnumerationTest` (6 cases): mana payable/unpayable,
target presence, bounce-cost payability (tapped vs untapped), and the
sorcery-timing gate. Existing graveyard/renew/blight enumerator tests updated
for the rename. All green:

```
HandActivatedAbilityEnumerationTest      6/6 PASSED
GraveyardAbilityEnumeratorTest              PASSED
RenewKeywordEnumerationTest              3/3 PASSED
EvershrikesGiftTest                      3/3 PASSED
BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
