### PR TITLE
Fix sticky nav covering the masthead on /contribute

### DIFF
--- a/web-client/public/contribute/assets/js/app.js
+++ b/web-client/public/contribute/assets/js/app.js
@@ -62,14 +62,19 @@
   btnPrev.addEventListener('click', function(){ if(currentIndex > 0) goToSection(currentIndex - 1); });
   btnNext.addEventListener('click', function(){ if(currentIndex < sections.length - 1) goToSection(currentIndex + 1); });
 
+  /* Sticky-nav visibility is derived from geometry every scroll frame, not latched by an
+     IntersectionObserver on the TOC. An observer only fires when the sentinel *crosses* a
+     viewport edge, so jumping straight from deep in the page back to the top (Home key,
+     in-page anchor, scroll restored on reload) left the sentinel out of view both before
+     and after — no callback, the bar stayed visible, and it covered the masthead. */
   var tocSentinel = document.getElementById('toc-section');
-  if(tocSentinel && 'IntersectionObserver' in window){
-    var tocObserver = new IntersectionObserver(function(entries){
-      entries.forEach(function(entry){
-        stickyNav.classList.toggle('visible', !entry.isIntersecting && window.scrollY > 200);
-      });
-    }, { threshold: 0 });
-    tocObserver.observe(tocSentinel);
+  var masthead = document.querySelector('.masthead');
+  function updateStickyVisibility(){
+    var pastSentinel = tocSentinel
+      ? tocSentinel.getBoundingClientRect().bottom < 0
+      : window.scrollY > 200;
+    var mastheadCleared = masthead ? masthead.getBoundingClientRect().bottom <= 0 : true;
+    stickyNav.classList.toggle('visible', pastSentinel && mastheadCleared);
   }
 
   if('IntersectionObserver' in window){
@@ -86,7 +91,7 @@
   var ticking = false;
   function onScroll(){
     if(!ticking){
-      window.requestAnimationFrame(function(){ updateProgress(); updateStepCounter(); ticking = false; });
+      window.requestAnimationFrame(function(){ updateStickyVisibility(); updateProgress(); updateStepCounter(); ticking = false; });
       ticking = true;
     }
   }
@@ -109,6 +114,10 @@
     stickyStep.textContent = n ? ('STEP ' + n + ' / ' + totalSteps) : '';
   }
   window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', updateStickyVisibility, { passive: true });
+  /* opening/collapsing a section reflows the page without scrolling it; `toggle` doesn't bubble */
+  document.addEventListener('toggle', updateStickyVisibility, true);
+  updateStickyVisibility();
   updateProgress();
 
   // ---- search index ----


### PR DESCRIPTION
## Problem

On <https://magic.wingedsheep.com/contribute/>, the fixed reading-position bar (`#sticky-nav`, `z-index: 80`) could sit on top of the page masthead (`z-index: 5`) at the very top of the page, hiding the Argentum wordmark and the PLAY / GITHUB / DISCORD / CARDS links entirely.

## Cause

Visibility was *latched* by an `IntersectionObserver` on the `#toc-section` sentinel:

```js
stickyNav.classList.toggle('visible', !entry.isIntersecting && window.scrollY > 200);
```

An observer callback only fires when the sentinel **crosses** a viewport edge. Jumping straight from deep in the page back to the top — Home key, an in-page anchor, or scroll position restored on reload — leaves the sentinel out of view both before *and* after the jump. No crossing, no callback, so `.visible` stayed on while `scrollY` was 0 and the bar covered the masthead.

(The same latch failed in the other direction too: an instant jump *into* the guide left the bar hidden until the next gradual scroll.)

## Fix

Derive visibility from geometry on the scroll handler that already runs rAF-throttled, so it's a pure function of scroll position rather than a latch, and gate it on the masthead having actually scrolled clear:

```js
function updateStickyVisibility(){
  var pastSentinel = tocSentinel
    ? tocSentinel.getBoundingClientRect().bottom < 0
    : window.scrollY > 200;
  var mastheadCleared = masthead ? masthead.getBoundingClientRect().bottom <= 0 : true;
  stickyNav.classList.toggle('visible', pastSentinel && mastheadCleared);
}
```

Also recomputed on `resize` and on `details` `toggle` — the two ways this page reflows without firing a scroll event.

## Verification

Playwright against the static guide, 1280×800, comparing `main` and this branch. Sequence: gradual scroll to y=4500 (so the old observer latches `visible`), then an instant jump back to y=0. `overlapPx` is the measured intersection between the fixed bar and the masthead:

| | on load | deep (y=4500) | back at top (y=0) |
|---|---|---|---|
| **main** | hidden, 0px | visible, 0px | **visible, 70px overlap** |
| **this branch** | hidden, 0px | visible, 0px | hidden, 0px |

The bar still appears and behaves normally while reading (`deep` row unchanged).

### Before — masthead completely covered at the top of the page

![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/sticky-nav-overlap-screenshots/before.png)

### After — masthead visible, sticky nav correctly hidden

![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/sticky-nav-overlap-screenshots/after.png)

_Screenshots live on the throwaway branch `sticky-nav-overlap-screenshots`, kept off this diff; delete it once merged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)