### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AquaticAlchemist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AquaticAlchemist.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Aquatic Alchemist // Bubble Up
+ * {1}{U}
+ * Creature — Elemental
+ * 1/3
+ *
+ * Whenever you cast your first instant or sorcery spell each turn, this creature gets +2/+0
+ * until end of turn.
+ *
+ * Adventure: Bubble Up — {2}{U}, Sorcery — Adventure
+ * Put target instant or sorcery card from your graveyard on top of your library.
+ *
+ * "Your **first instant or sorcery** spell each turn" is a *single* combined counter, so the
+ * intervening-if is one `YouCastFirstSpellOfTypeThisTurn(InstantOrSorcery)` — not the two separate
+ * branches [AlaniaDivergentStorm][com.wingedsheep.mtg.sets.definitions.blb.cards.AlaniaDivergentStorm]
+ * uses for "the first instant spell, the first sorcery spell". Casting an instant and then a sorcery
+ * in the same turn pumps once here, twice on Alania.
+ *
+ * `triggerCondition` (not a plain filtered trigger) because CR 603.4 makes this an intervening "if":
+ * it is checked both when the ability would trigger and again on resolution. That's the behaviour we
+ * want — if the triggering spell somehow stops being the first matching spell before resolution, the
+ * ability does nothing.
+ *
+ * The pump resolves before the spell that triggered it (the ability goes on the stack above it), so
+ * the +2/+0 is live for anything the spell itself does — the usual "cast a burn spell, then block
+ * profitably" line.
+ *
+ * The Adventure is the graveyard-to-top-of-library shape of
+ * [WoodlandAcolyte]'s Mend the Wilds, narrowed to instants and sorceries via the pre-existing
+ * [TargetFilter.InstantOrSorceryInYourGraveyard]-equivalent construction; `ownedByYou()` is what
+ * "your graveyard" means (CR 404.1). With no instant or sorcery in your graveyard there is no legal
+ * target, so Bubble Up can't be cast at all — and the creature half therefore never becomes castable
+ * from exile that way.
+ */
+val AquaticAlchemist = card("Aquatic Alchemist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    oracleText = "Whenever you cast your first instant or sorcery spell each turn, this creature " +
+        "gets +2/+0 until end of turn."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        triggerCondition = Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.InstantOrSorcery)
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        description = "Whenever you cast your first instant or sorcery spell each turn, this " +
+            "creature gets +2/+0 until end of turn."
+    }
+
+    adventure("Bubble Up") {
+        manaCost = "{2}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Put target instant or sorcery card from your graveyard on top of your library. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val card = target(
+                "target instant or sorcery card from your graveyard",
+                TargetObject(
+                    filter = TargetFilter(
+                        baseFilter = GameObjectFilter.InstantOrSorcery.ownedByYou(),
+                        zone = Zone.GRAVEYARD,
+                    ),
+                ),
+            )
+            effect = Effects.Move(
+                target = card,
+                destination = Zone.LIBRARY,
+                placement = ZonePlacement.Top,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1783915124"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ConceitedWitch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ConceitedWitch.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Conceited Witch // Price of Beauty
+ * {2}{B}
+ * Creature — Human Warlock
+ * 2/3
+ * Menace
+ *
+ * Adventure: Price of Beauty — {B}, Sorcery — Adventure
+ * Create a Wicked Role token attached to target creature you control.
+ * (Enchanted creature gets +1/+1. When this Role is put into a graveyard, each opponent loses 1 life.)
+ *
+ * The same shape as [BesottedKnight] — a vanilla-plus body whose Adventure is a one-line Role maker —
+ * differing only in which Role it hands out. `Effects.CreateRoleToken` owns the whole Role ruleset
+ * (CR 113.2c: Roles are Auras; the "if you control another Role on it, put that one into the
+ * graveyard" state-based action in CR 704.5r), so nothing here needs to special-case Wicked.
+ *
+ * The Adventure targets `Targets.CreatureYouControl`, matching the oracle's "target creature you
+ * control" — an opponent's creature is not a legal target, and the spell is countered on resolution
+ * if the only target has left or become illegal (CR 608.2b).
+ */
+val ConceitedWitch = card("Conceited Witch") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    adventure("Price of Beauty") {
+        manaCost = "{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create a Wicked Role token attached to target creature you control. " +
+            "(If you control another Role on it, put that one into the graveyard. Enchanted creature " +
+            "gets +1/+1. When this Role is put into a graveyard, each opponent loses 1 life.) " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.CreatureYouControl)
+            effect = Effects.CreateRoleToken("Wicked Role", t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Anna Pavleeva"
+        flavorText = "She wasn't much for self-reflection."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1783915109"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ElvishArchivist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ElvishArchivist.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Elvish Archivist
+ * {1}{G}
+ * Creature — Elf Artificer
+ * 0/1
+ *
+ * Whenever one or more artifacts you control enter, put two +1/+1 counters on this creature.
+ * This ability triggers only once each turn.
+ * Whenever one or more enchantments you control enter, draw a card.
+ * This ability triggers only once each turn.
+ *
+ * Two independent batching triggers (CR 603.3b): each fires at most once per event batch no matter how
+ * many permanents entered together, and `oncePerTurn` then caps each at one firing per turn. The two
+ * caps are tracked separately — a turn where an artifact and an enchantment both enter gets *both* the
+ * counters and the card. An artifact **enchantment** entering satisfies both filters and likewise
+ * triggers both abilities once each.
+ *
+ * The default controller scope on [Triggers.OneOrMorePermanentsEnter] is "you control", which is what
+ * the oracle says; an opponent's artifacts entering do nothing here.
+ *
+ * `excludeSource` is deliberately left at its default: Elvish Archivist is a creature, not an artifact
+ * or enchantment, so it can never be a member of either batch and there is nothing to exclude. (It
+ * *could* become one — an animating effect making it an artifact creature would let its own re-entry
+ * count — and that is correct under the oracle wording, which has no "other".)
+ *
+ * A 0/1 body that never grew would be a blank; the counters are real +1/+1 counters in layer 7d, so a
+ * later "base power and toughness" effect still stacks on top of them rather than erasing them.
+ */
+val ElvishArchivist = card("Elvish Archivist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Artificer"
+    oracleText = "Whenever one or more artifacts you control enter, put two +1/+1 counters on this " +
+        "creature. This ability triggers only once each turn.\n" +
+        "Whenever one or more enchantments you control enter, draw a card. This ability triggers " +
+        "only once each turn."
+    power = 0
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMorePermanentsEnter(GameObjectFilter.Artifact)
+        oncePerTurn = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        description = "Whenever one or more artifacts you control enter, put two +1/+1 counters on " +
+            "this creature. This ability triggers only once each turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMorePermanentsEnter(GameObjectFilter.Enchantment)
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+        description = "Whenever one or more enchantments you control enter, draw a card. This " +
+            "ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "168"
+        artist = "Mila Pesic"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg?1783915083"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PicklockPrankster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PicklockPrankster.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Picklock Prankster // Free the Fae
+ * {1}{U}
+ * Creature — Faerie Rogue
+ * 1/3
+ * Flying, vigilance
+ *
+ * Adventure: Free the Fae — {1}{U}, Instant — Adventure
+ * Mill four cards. Then put an instant, sorcery, or Faerie card from among the milled cards
+ * into your hand.
+ *
+ * The Adventure is the standard Gather → Move → Select → Move mill-and-retrieve pipeline (the
+ * [CacheGrab][com.wingedsheep.mtg.sets.definitions.blb.cards.CacheGrab] shape). The cards go to the
+ * graveyard *first* and the selection reads the `milled` collection afterwards — that ordering is what
+ * makes "from among the milled cards" mean the specific four cards rather than "any card in your
+ * graveyard", which matters when the graveyard already holds instants.
+ *
+ * Oracle says "Then put ... into your hand", not "you may put", so this is
+ * [SelectionMode.ChooseExactly]`(1)`, not `ChooseUpTo`. The executor auto-selects nothing when the
+ * eligible pool is empty (all four milled cards were, say, lands), so the mandatory wording degrades
+ * correctly instead of deadlocking. `showAllCards = true` keeps the ineligible milled cards visible
+ * so the player can see what the mill actually hit.
+ *
+ * The three-way "instant, sorcery, or Faerie" is one `Or` predicate rather than three filters: a
+ * Faerie *card* is matched by subtype in any zone, so a Faerie creature card and a Faerie instant
+ * both qualify.
+ */
+val PicklockPrankster = card("Picklock Prankster") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Rogue"
+    oracleText = "Flying, vigilance"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    adventure("Free the Fae") {
+        manaCost = "{1}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Mill four cards. Then put an instant, sorcery, or Faerie card from among the " +
+            "milled cards into your hand. (Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                        storeAs = "milled",
+                    ),
+                    MoveCollectionEffect(
+                        from = "milled",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "milled",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        filter = GameObjectFilter(
+                            cardPredicates = listOf(
+                                CardPredicate.Or(
+                                    listOf(
+                                        CardPredicate.IsInstant,
+                                        CardPredicate.IsSorcery,
+                                        CardPredicate.HasSubtype(Subtype("Faerie")),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        storeSelected = "selected",
+                        showAllCards = true,
+                        prompt = "Put an instant, sorcery, or Faerie card into your hand",
+                        selectedLabel = "Put in hand",
+                        remainderLabel = "Leave in graveyard",
+                    ),
+                    MoveCollectionEffect(
+                        from = "selected",
+                        destination = CardDestination.ToZone(Zone.HAND),
+                    ),
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Iris Compiet"
+        flavorText = "You can't cage mischief."
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1783915116"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpellscornCoven.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SpellscornCoven.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spellscorn Coven // Take It Back
+ * {3}{B}
+ * Creature — Faerie Warlock
+ * 2/3
+ * Flying
+ * When this creature enters, each opponent discards a card.
+ *
+ * Adventure: Take It Back — {2}{U}, Instant — Adventure
+ * Return target spell to its owner's hand.
+ *
+ * The Adventure is a soft counter in the
+ * [Reprieve][com.wingedsheep.mtg.sets.definitions.ltr.cards.Reprieve] mould:
+ * `Effects.ReturnSpellToOwnersHand` moves the spell off the stack without *countering* it, so a
+ * can't-be-countered spell is still caught and no "whenever a spell is countered" trigger fires
+ * (CR 701.29 is a different action from the stack-to-hand move here). The card goes to its **owner's**
+ * hand, which matters when you've stolen a spell's control.
+ *
+ * `Targets.Spell` is unrestricted — Take It Back can bounce your own spell, which is a real line
+ * (rescuing something about to be countered).
+ *
+ * The two halves are the reason the card's colour identity is `UB` while the creature face is mono-black:
+ * the Adventure's `{2}{U}` counts toward identity (CR 903.4).
+ */
+val SpellscornCoven = card("Spellscorn Coven") {
+    manaCost = "{3}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Faerie Warlock"
+    oracleText = "Flying\nWhen this creature enters, each opponent discards a card."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.EachOpponentDiscards(1)
+        description = "When this creature enters, each opponent discards a card."
+    }
+
+    adventure("Take It Back") {
+        manaCost = "{2}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Return target spell to its owner's hand. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            target("spell", Targets.Spell)
+            effect = Effects.ReturnSpellToOwnersHand()
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1783915062"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -226,6 +226,96 @@
     "colorIdentityOverride": []
 }
 
+// Aquatic Alchemist
+{
+    "name": "Aquatic Alchemist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Whenever you cast your first instant or sorcery spell each turn, this creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        {
+                            "type": "EntityMatches",
+                            "entity": "TriggeringEntity",
+                            "filter": "instant|sorcery"
+                        },
+                        {
+                            "type": "Not",
+                            "condition": {
+                                "type": "PlayerCastSpellsThisTurn",
+                                "filter": "instant|sorcery",
+                                "atLeast": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast your first instant or sorcery spell each turn, this creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6f03f21-aeb9-428b-9167-b2604919bdd8.jpg?1783915124"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Bubble Up",
+            "manaCost": "{2}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Put target instant or sorcery card from your graveyard on top of your library. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target instant or sorcery card from your graveyard"
+                    },
+                    "destination": "Library",
+                    "placement": "Top"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "instant|sorcery own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target instant or sorcery card from your graveyard"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Archive Dragon
 {
     "name": "Archive Dragon",
@@ -1883,6 +1973,58 @@
     "colorIdentityOverride": []
 }
 
+// Conceited Witch
+{
+    "name": "Conceited Witch",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Anna Pavleeva",
+        "flavorText": "She wasn't much for self-reflection.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8a0c0f6-fef9-42c5-934d-a2855c11b440.jpg?1783915109"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Price of Beauty",
+            "manaCost": "{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create a Wicked Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1. When this Role is put into a graveyard, each opponent loses 1 life.) (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Wicked Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Cooped Up
 {
     "name": "Cooped Up",
@@ -2499,6 +2641,64 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Elvish Archivist
+{
+    "name": "Elvish Archivist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Artificer",
+    "oracleText": "Whenever one or more artifacts you control enter, put two +1/+1 counters on this creature. This ability triggers only once each turn.\nWhenever one or more enchantments you control enter, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsEnteredEvent",
+                    "filter": "artifact"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever one or more artifacts you control enter, put two +1/+1 counters on this creature. This ability triggers only once each turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsEnteredEvent",
+                    "filter": "enchantment"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever one or more enchantments you control enter, draw a card. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "RARE",
+        "artist": "Mila Pesic",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/0670dbf0-b150-4e8d-bb40-f768b2f06fe5.jpg?1783915083"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -6931,6 +7131,92 @@
     ]
 }
 
+// Picklock Prankster
+{
+    "name": "Picklock Prankster",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "UNCOMMON",
+        "artist": "Iris Compiet",
+        "flavorText": "You can't cage mischief.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5ebac73a-1ecf-4e6d-87b1-ea560bfeb064.jpg?1783915116"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Free the Fae",
+            "manaCost": "{1}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Mill four cards. Then put an instant, sorcery, or Faerie card from among the milled cards into your hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "milled",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "instant|sorcery|Faerie",
+                            "storeSelected": "selected",
+                            "prompt": "Put an instant, sorcery, or Faerie card into your hand",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Plunge into Winter
 {
     "name": "Plunge into Winter",
@@ -9459,6 +9745,106 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Spellscorn Coven
+{
+    "name": "Spellscorn Coven",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Faerie Warlock",
+    "oracleText": "Flying\nWhen this creature enters, each opponent discards a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this creature enters, each opponent discards a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c112f62-6034-4636-a75b-4a45bc916a91.jpg?1783915062"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Take It Back",
+            "manaCost": "{2}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Return target spell to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": "ReturnSpellToOwnersHand",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Stack"
+                        },
+                        "id": "spell"
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Implements five previously-missing Wilds of Eldraine main-set cards. All five compose existing SDK vocabulary — no new effects, triggers, conditions, or executors.

| Card | # | Rarity | Shape |
|---|---|---|---|
| Aquatic Alchemist // Bubble Up | 40 | common | first-spell intervening-if + graveyard→top-of-library Adventure |
| Conceited Witch // Price of Beauty | 84 | common | menace body + Wicked Role Adventure |
| Picklock Prankster // Free the Fae | 64 | uncommon | mill-and-retrieve pipeline Adventure |
| Elvish Archivist | 168 | rare | two `oncePerTurn` batch-enter triggers |
| Spellscorn Coven // Take It Back | 237 | uncommon | ETB discard + spell bounce Adventure |

## Notes on the tricky bits

**Aquatic Alchemist** — "your first instant **or** sorcery spell each turn" is a *single* combined counter, so it's one `YouCastFirstSpellOfTypeThisTurn(InstantOrSorcery)`, not the two separate branches Alania, Divergent Storm uses for "the first instant spell, the first sorcery spell". Casting an instant then a sorcery in one turn pumps once here, twice on Alania. Modelled as `triggerCondition` rather than a filtered trigger because CR 603.4 makes it an intervening "if" — checked both on trigger and on resolution.

**Elvish Archivist** — two independent `OneOrMorePermanentsEnter` batch triggers (CR 603.3b), each capped by `oncePerTurn`. The caps are tracked separately, so a turn with both an artifact and an enchantment entering gets both the counters and the card; an artifact enchantment triggers both abilities once each. `excludeSource` deliberately left default — the Archivist is a creature, so it can never be a member of either batch.

**Picklock Prankster** — oracle says "Then put … into your hand", not "you may put", so this is `SelectionMode.ChooseExactly(1)`, not `ChooseUpTo`. `SelectFromCollectionExecutor` auto-selects nothing when the eligible pool is empty (all four milled cards were lands), so the mandatory wording degrades correctly instead of deadlocking. Cards move to the graveyard *before* the selection reads the `milled` collection — that ordering is what makes "from among the milled cards" mean those specific four rather than "any card in your graveyard".

**Spellscorn Coven** — `ReturnSpellToOwnersHand` is a soft counter, not a counter: it catches can't-be-countered spells and fires no "spell was countered" trigger. `Targets.Spell` is unrestricted, so bouncing your own spell to rescue it from a counter is a legal line.

## Verification

- `just build` — green
- `just check-card-printing` — WOE confirmed as the earliest real printing for all five; no reprint rows needed
- All five `image_uris.normal` verified HTTP 200 against Scryfall
- Card golden re-blessed: **386 insertions, zero deletions** — only the five new cards moved, no unrelated card shifted

No scenario tests added: no new engine vocabulary, so the snapshot and lint nets cover these (per the `add-card` skill's Step 5 rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)