### PR TITLE
Add five Innistrad Remastered cards

### DIFF
--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 110 / 312
+**Implemented:** 111 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |
@@ -297,7 +297,7 @@
 - [ ] Tenuous Truce
 - [x] Terramorphic Expanse
 - [x] Tetsuko Umezawa, Fugitive
-- [ ] The Gitrog Monster
+- [x] The Gitrog Monster
 - [ ] The Odd Acorn Gang
 - [x] Thickest in the Thicket
 - [ ] Thopter Engineer

--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 148 / 272
+**Implemented:** 149 / 272
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -14,7 +14,7 @@
 - [x] Angelic Quartermaster
 - [x] Anje, Maid of Dishonor
 - [x] Apprentice Sharpshooter
-- [ ] Archghoul of Thraben
+- [x] Archghoul of Thraben
 - [x] Arm the Cathars
 - [x] Ascendant Packleader
 - [ ] Avabruck Caretaker

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TheGitrogMonsterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TheGitrogMonsterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * The Gitrog Monster reprint in BLC. Canonical CardDefinition lives in SOI (Shadows over Innistrad),
+ * the card's earliest real-expansion printing; this file contributes only presentation data.
+ */
+val TheGitrogMonsterReprint = Printing(
+    oracleId = "a5e54d2b-aad8-4ddd-af4b-13668913762b",
+    name = "The Gitrog Monster",
+    setCode = "BLC",
+    collectorNumber = "88",
+    scryfallId = "f74298f2-c9f7-4c5d-9fab-8fd8d6952059",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f74298f2-c9f7-4c5d-9fab-8fd8d6952059.jpg?1783910709",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BedlamReveler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BedlamReveler.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Bedlam Reveler
+ * {6}{R}{R}
+ * Creature — Devil Horror
+ * 3/4
+ *
+ * This spell costs {1} less to cast for each instant and sorcery card in your graveyard.
+ * Prowess
+ * When this creature enters, discard your hand, then draw three cards.
+ *
+ * The cost reduction is a self-cast [ModifySpellCost] over
+ * [CostReductionSource.CardsInGraveyardMatchingFilter] — it only ever eats generic mana, so the
+ * {R}{R} survives (2025-01-24 ruling), and the mana value stays 8 no matter what was paid.
+ * The enters trigger is an ordered composite: discard the whole hand first, *then* draw three, so
+ * the drawn cards are never discarded. An empty hand discards nothing and still draws three.
+ */
+val BedlamReveler = card("Bedlam Reveler") {
+    manaCost = "{6}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil Horror"
+    power = 3
+    toughness = 4
+    oracleText = "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\n" +
+        "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n" +
+        "When this creature enters, discard your hand, then draw three cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = GameObjectFilter.InstantOrSorcery,
+                    amountPerCard = 1
+                )
+            )
+        )
+    }
+
+    keywords(Keyword.PROWESS)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Hand.discardHand(),
+            Effects.DrawCards(3)
+        )
+        description = "When this creature enters, discard your hand, then draw three cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "118"
+        artist = "Jama Jurabaev"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg?1783937466"
+
+        ruling(
+            "2025-01-24",
+            "To determine the total cost of a spell, start with the mana cost or alternative cost " +
+                "you're paying, add any cost increases, then apply any cost reductions (such as that " +
+                "of Bedlam Reveler's first ability). The mana value of the spell is determined by " +
+                "only its mana cost, no matter what the total cost to cast that spell was."
+        )
+        ruling("2025-01-24", "Bedlam Reveler's first ability can't reduce the {R}{R} in its cost.")
+        ruling(
+            "2025-01-24",
+            "If you have no cards in hand when Bedlam Reveler's enters ability resolves, you just " +
+                "draw three cards."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArchghoulOfThrabenReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArchghoulOfThrabenReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archghoul of Thraben reprint in INR. Canonical CardDefinition lives in VOW (Innistrad: Crimson
+ * Vow), the card's earliest real-expansion printing; this file contributes only presentation data.
+ */
+val ArchghoulOfThrabenReprint = Printing(
+    oracleId = "575ffeb4-6d12-4f69-bcc9-15db325daac1",
+    name = "Archghoul of Thraben",
+    setCode = "INR",
+    collectorNumber = "95",
+    scryfallId = "687b8e00-80f4-474b-927f-d208a2e8c205",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/687b8e00-80f4-474b-927f-d208a2e8c205.jpg?1783908150",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BedlamRevelerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BedlamRevelerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bedlam Reveler reprint in INR. Canonical CardDefinition lives in EMN (Eldritch Moon), the card's
+ * earliest real-expansion printing; this file contributes only presentation data.
+ */
+val BedlamRevelerReprint = Printing(
+    oracleId = "01a7e0ce-c98f-4cf2-aba3-360aa0a9b9a7",
+    name = "Bedlam Reveler",
+    setCode = "INR",
+    collectorNumber = "142",
+    scryfallId = "4780d9d6-b5a2-4646-bd63-48ec58fea6b2",
+    artist = "Jama Jurabaev",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/4780d9d6-b5a2-4646-bd63-48ec58fea6b2.jpg?1783908127",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CultivatorColossusReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CultivatorColossusReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cultivator Colossus reprint in INR. Canonical CardDefinition lives in VOW (Innistrad: Crimson
+ * Vow), the card's earliest real-expansion printing; this file contributes only presentation data.
+ */
+val CultivatorColossusReprint = Printing(
+    oracleId = "4d8505d3-c8a1-4850-95d4-5ddb8ad49770",
+    name = "Cultivator Colossus",
+    setCode = "INR",
+    collectorNumber = "190",
+    scryfallId = "426ed66e-41b3-4e44-90a2-697aafaa8c5c",
+    artist = "Antonio José Manzanedo",
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/426ed66e-41b3-4e44-90a2-697aafaa8c5c.jpg?1783908104",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TheGitrogMonsterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TheGitrogMonsterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * The Gitrog Monster reprint in INR. Canonical CardDefinition lives in SOI (Shadows over Innistrad),
+ * the card's earliest real-expansion printing; this file contributes only presentation data.
+ */
+val TheGitrogMonsterReprint = Printing(
+    oracleId = "a5e54d2b-aad8-4ddd-af4b-13668913762b",
+    name = "The Gitrog Monster",
+    setCode = "INR",
+    collectorNumber = "238",
+    scryfallId = "c65d38ac-91a3-4407-8517-d8edeefbc89b",
+    artist = "Jason Kang",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c65d38ac-91a3-4407-8517-d8edeefbc89b.jpg?1783908076",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TirelessTrackerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TirelessTrackerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tireless Tracker reprint in INR. Canonical CardDefinition lives in SOI (Shadows over Innistrad),
+ * the card's earliest real-expansion printing; this file contributes only presentation data.
+ */
+val TirelessTrackerReprint = Printing(
+    oracleId = "e6555cca-e608-4c87-b835-9cd47fd1f543",
+    name = "Tireless Tracker",
+    setCode = "INR",
+    collectorNumber = "219",
+    scryfallId = "695ac524-b54a-4de7-90b7-ec4e5e94717e",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/695ac524-b54a-4de7-90b7-ec4e5e94717e.jpg?1783908087",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TheGitrogMonster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TheGitrogMonster.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * The Gitrog Monster
+ * {3}{B}{G}
+ * Legendary Creature — Frog Horror
+ * 6/6
+ *
+ * Deathtouch
+ * At the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land.
+ * You may play an additional land on each of your turns.
+ * Whenever one or more land cards are put into your graveyard from anywhere, draw a card.
+ *
+ * Three existing primitives, no new vocabulary:
+ * - The upkeep "unless" is [PayOrSufferEffect] with a sacrifice-a-land cost and
+ *   [SacrificeSelfEffect] as the punisher (same shape as Endless Wurm) — declining, or controlling
+ *   no land at all, sacrifices the Frog.
+ * - The extra land drop is the static [GrantAdditionalLandDrop] (cumulative with other such effects).
+ * - The draw trigger is the **batched** [Triggers.CardsPutIntoYourGraveyard], so per the 2025-01-24
+ *   ruling several lands hitting the graveyard at once (a mill, or two land creatures dying together)
+ *   draws one card, not one per land. "From anywhere" is intrinsic to that event — library, hand,
+ *   and battlefield all count.
+ */
+val TheGitrogMonster = card("The Gitrog Monster") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Frog Horror"
+    power = 6
+    toughness = 6
+    oracleText = "Deathtouch\n" +
+        "At the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land.\n" +
+        "You may play an additional land on each of your turns.\n" +
+        "Whenever one or more land cards are put into your graveyard from anywhere, draw a card."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(
+            cost = Costs.pay.Sacrifice(GameObjectFilter.Land),
+            suffer = SacrificeSelfEffect
+        )
+        description = "At the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land."
+    }
+
+    staticAbility {
+        ability = GrantAdditionalLandDrop(count = 1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsPutIntoYourGraveyard(GameObjectFilter.Land)
+        effect = Effects.DrawCards(1)
+        description = "Whenever one or more land cards are put into your graveyard from anywhere, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "245"
+        artist = "Jason Kang"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg?1783937714"
+
+        ruling(
+            "2025-01-24",
+            "If multiple land cards are put into your graveyard at once, The Gitrog Monster's last " +
+                "ability triggers only once. This could happen because an effect put them there from " +
+                "your library at the same time (such as by a mill effect) or because they were " +
+                "destroyed at the same time (such as two land creatures that were dealt lethal " +
+                "combat damage)."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TirelessTracker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TirelessTracker.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tireless Tracker
+ * {2}{G}
+ * Creature — Human Scout
+ * 3/2
+ *
+ * Landfall — Whenever a land you control enters, investigate.
+ * Whenever you sacrifice a Clue, put a +1/+1 counter on this creature.
+ *
+ * Both halves are existing vocabulary:
+ * - The landfall half is [Triggers.LandYouControlEnters] + [Effects.Investigate] (CR 701.36 — the
+ *   keyword-action spelling of "create a Clue token").
+ * - "Whenever you sacrifice **a** Clue" is the per-permanent template ([Triggers.YouSacrificeA],
+ *   CR 603.2c), not the batch one: sacrificing two Clues at once yields two +1/+1 counters. Per the
+ *   2024-02-02 ruling a Clue is any Clue *artifact*, not just a token, so the filter keys on the
+ *   artifact subtype rather than on token-ness — and it fires for a Clue sacrificed for any reason,
+ *   not only to its own draw ability.
+ */
+val TirelessTracker = card("Tireless Tracker") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Scout"
+    power = 3
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, investigate. (Create a Clue token. " +
+        "It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you sacrifice a Clue, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.Investigate()
+        description = "Landfall — Whenever a land you control enters, investigate."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Clue"))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you sacrifice a Clue, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "233"
+        artist = "Eric Deschamps"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg?1783937719"
+
+        ruling(
+            "2024-11-08",
+            "A landfall ability triggers whenever a land you control enters for any reason. It " +
+                "triggers whenever you play a land, as well as whenever a spell or ability puts a " +
+                "land onto the battlefield under your control."
+        )
+        ruling(
+            "2024-11-08",
+            "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+        )
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ArchghoulOfThraben.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ArchghoulOfThraben.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Archghoul of Thraben
+ * {2}{B}
+ * Creature — Zombie Cleric
+ * 3/2
+ *
+ * Whenever this creature or another Zombie you control dies, look at the top card of your library.
+ * If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into
+ * your hand, you may put it into your graveyard.
+ *
+ * "This creature **or another** Zombie you control" is [TriggerBinding.ANY] over a Zombie-you-control
+ * death — the source counts itself, and per the 2021-11-19 ruling a simultaneous death of Archghoul
+ * plus another Zombie triggers once per dying Zombie (the per-event `ZoneChangeEvent`, not a batch).
+ *
+ * The resolution is a plain Gather → Select → Move pipeline over the top card, in two stages so both
+ * "may"s are honored independently:
+ *  1. gather the top card (a *look*, not a move), then offer up to one **Zombie** card to reveal into
+ *     hand — declining keeps it in the remainder;
+ *  2. whatever wasn't taken is offered again, unfiltered, for the optional trip to the graveyard;
+ *     anything still left goes back on top, undisturbed.
+ *
+ * Neither select sets `showAllCards`, so a non-Zombie top card skips stage 1's prompt entirely rather
+ * than opening a modal with nothing selectable: the player then sees exactly one modal — stage 2's,
+ * which shows them the card and offers the only real choice. A Zombie top card gets two modals only
+ * because it genuinely carries two decisions.
+ *
+ * Deliberately not `Patterns.Library.surveil(1)` for stage 2 — surveil emits a `SurveiledEvent` and
+ * would fire unrelated surveil payoffs on a card that never surveils.
+ */
+val ArchghoulOfThraben = card("Archghoul of Thraben") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature or another Zombie you control dies, look at the top card of " +
+        "your library. If it's a Zombie card, you may reveal it and put it into your hand. If you " +
+        "don't put the card into your hand, you may put it into your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Any.withSubtype(Subtype.ZOMBIE),
+                storeSelected = "toHand",
+                storeRemainder = "notTaken",
+                prompt = "Reveal the Zombie card and put it into your hand?",
+                selectedLabel = "Reveal and put into your hand",
+                remainderLabel = "Leave it"
+            ),
+            MoveCollectionEffect(
+                from = "toHand",
+                destination = CardDestination.ToZone(Zone.HAND),
+                revealed = true
+            ),
+            SelectFromCollectionEffect(
+                from = "notTaken",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "toGraveyard",
+                storeRemainder = "staysOnTop",
+                prompt = "Put the card into your graveyard?",
+                selectedLabel = "Put into your graveyard",
+                remainderLabel = "Leave on top of your library"
+            ),
+            MoveCollectionEffect(
+                from = "toGraveyard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD)
+            ),
+            MoveCollectionEffect(
+                from = "staysOnTop",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top)
+            )
+        )
+        description = "Whenever this creature or another Zombie you control dies, look at the top " +
+            "card of your library. If it's a Zombie card, you may reveal it and put it into your " +
+            "hand. If you don't put the card into your hand, you may put it into your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "93"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg?1783924876"
+
+        ruling(
+            "2021-11-19",
+            "If Archghoul of Thraben and another Zombie you control die at the same time, this " +
+                "ability will trigger once for each of them."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1,3 +1,100 @@
+// Bedlam Reveler
+{
+    "name": "Bedlam Reveler",
+    "manaCost": "{6}{R}{R}",
+    "typeLine": "Creature — Devil Horror",
+    "oracleText": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, discard your hand, then draw three cards.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "discardedHand"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discardedHand",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, discard your hand, then draw three cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "instant|sorcery"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "RARE",
+        "artist": "Jama Jurabaev",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0232f188-44f2-4aee-963c-6f6edc4a21ac.jpg?1783937466",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions (such as that of Bedlam Reveler's first ability). The mana value of the spell is determined by only its mana cost, no matter what the total cost to cast that spell was."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Bedlam Reveler's first ability can't reduce the {R}{R} in its cost."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If you have no cards in hand when Bedlam Reveler's enters ability resolves, you just draw three cards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Blood Mist
 {
     "name": "Blood Mist",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1510,6 +1510,80 @@
     "colorIdentityOverride": []
 }
 
+// The Gitrog Monster
+{
+    "name": "The Gitrog Monster",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Legendary Creature — Frog Horror",
+    "oracleText": "Deathtouch\nAt the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land.\nYou may play an additional land on each of your turns.\nWhenever one or more land cards are put into your graveyard from anywhere, draw a card.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "land"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, sacrifice The Gitrog Monster unless you sacrifice a land."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CardsPutIntoYourGraveyardEvent",
+                    "filter": "land"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever one or more land cards are put into your graveyard from anywhere, draw a card."
+            }
+        ],
+        "staticAbilities": [
+            "GrantAdditionalLandDrop"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "MYTHIC",
+        "artist": "Jason Kang",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5790dd89-2be5-4a77-9450-2d3c1422bfc9.jpg?1783937714",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "If multiple land cards are put into your graveyard at once, The Gitrog Monster's last ability triggers only once. This could happen because an effect put them there from your library at the same time (such as by a mill effect) or because they were destroyed at the same time (such as two land creatures that were dealt lethal combat damage)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Thraben Inspector
 {
     "name": "Thraben Inspector",
@@ -1543,6 +1617,79 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Tireless Tracker
+{
+    "name": "Tireless Tracker",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Landfall — Whenever a land you control enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you sacrifice a Clue, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, investigate."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Clue",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you sacrifice a Clue, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "RARE",
+        "artist": "Eric Deschamps",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee8e9928-d9b2-4570-adb8-44b34115decd.jpg?1783937719",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -416,6 +416,123 @@
     ]
 }
 
+// Archghoul of Thraben
+{
+    "name": "Archghoul of Thraben",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Cleric",
+    "oracleText": "Whenever this creature or another Zombie you control dies, look at the top card of your library. If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Zombie ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "Zombie",
+                            "storeSelected": "toHand",
+                            "storeRemainder": "notTaken",
+                            "prompt": "Reveal the Zombie card and put it into your hand?",
+                            "selectedLabel": "Reveal and put into your hand",
+                            "remainderLabel": "Leave it"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "notTaken",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toGraveyard",
+                            "storeRemainder": "staysOnTop",
+                            "prompt": "Put the card into your graveyard?",
+                            "selectedLabel": "Put into your graveyard",
+                            "remainderLabel": "Leave on top of your library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "staysOnTop",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature or another Zombie you control dies, look at the top card of your library. If it's a Zombie card, you may reveal it and put it into your hand. If you don't put the card into your hand, you may put it into your graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cf81c9d-ddb2-470e-8a4a-590049713e95.jpg?1783924876",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "If Archghoul of Thraben and another Zombie you control die at the same time, this ability will trigger once for each of them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Arm the Cathars
 {
     "name": "Arm the Cathars",


### PR DESCRIPTION
Four new card implementations plus one reprint row for Innistrad Remastered. All four are built from existing SDK vocabulary — **no engine or SDK changes**, so the only test movement is the expected card-snapshot diff.

Canonical `CardDefinition`s live in each card's earliest real-expansion printing; INR gets a `Printing` row for each.

| Card | Canonical set | What it needed |
|---|---|---|
| Tireless Tracker | SOI | `LandYouControlEnters` + `Investigate`; per-permanent `YouSacrificeA(Clue)` |
| The Gitrog Monster | SOI | `PayOrSuffer` upkeep, `GrantAdditionalLandDrop`, batched `CardsPutIntoYourGraveyard(Land)` |
| Bedlam Reveler | EMN | `ModifySpellCost` / `CardsInGraveyardMatchingFilter`, prowess, discard-then-draw ETB |
| Archghoul of Thraben | VOW | ANY-binding Zombie-dies trigger over a Gather → Select → Move pipeline |
| Cultivator Colossus | VOW (already implemented) | INR `Printing` row only |

### Rules notes

- **Tireless Tracker** — "whenever you sacrifice **a** Clue" is the per-permanent template (`YouSacrificeA`), not the batch one, so two Clues sacrificed at once give two +1/+1 counters. The filter keys on the Clue *artifact subtype*, so a non-token Clue counts.
- **The Gitrog Monster** — the draw trigger is the **batched** `CardsPutIntoYourGraveyard`, matching the 2025-01-24 ruling: several lands hitting the graveyard together draws one card, not one per land. The upkeep "unless" falls through to sacrificing the Frog when the controller declines *or* controls no land. Also adds the missing BLC reprint row that `just check-card-printing` flagged.
- **Bedlam Reveler** — the ETB is an ordered composite (discard the whole hand, *then* draw three), so drawn cards are never discarded; an empty hand still draws three.
- **Archghoul of Thraben** — `TriggerBinding.ANY` so the source counts itself, and a simultaneous death of Archghoul plus another Zombie triggers once per Zombie. The resolution is two select stages so the optional reveal-to-hand and the optional graveyard drop stay independent "may"s. Deliberately *not* `Patterns.Library.surveil(1)` for stage 2 — surveil emits a `SurveiledEvent` and would fire unrelated surveil payoffs.

### UX

Neither Archghoul select sets `showAllCards`, so a non-Zombie top card skips stage 1's prompt entirely instead of opening a modal with nothing selectable — the player sees exactly one modal, which shows them the card and offers the only real choice. Gitrog's land sacrifice routes through the battlefield targeting UI (`useTargetingUI`), not an overlay.

### Verification

- `just build` — green, 10,037 tests, 0 failures.
- `just rebless-cards` — golden diff is **pure additions**, only the four new cards (SOI, EMN, VOW).
- `just check-card-printing` — clean for all five.
- Every field re-checked against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, image URI); all image URIs verified HTTP 200.
- Backlog ticked and headers resynced.

INR: **193 → 198** of 290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)