### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarshalsPathcruiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarshalsPathcruiser.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Marshals' Pathcruiser
+ * {3}
+ * Artifact — Vehicle
+ * 6/5
+ * When this Vehicle enters, search your library for a basic land card, reveal it, put it into
+ * your hand, then shuffle.
+ * Exhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters
+ * on it. (Activate each exhaust ability only once.)
+ * Crew 5
+ *
+ * The exhaust ability animates the Vehicle **permanently** (no "until end of turn" clause), so it
+ * uses `Duration.Permanent` rather than the crew default — the same [Effects.BecomeCreature] shape
+ * the engine's crew handler builds, with the Vehicle's printed 6/5 as the base P/T so the +1/+1
+ * counters layer on top in 7d.
+ */
+val MarshalsPathcruiser = card("Marshals' Pathcruiser") {
+    manaCost = "{3}"
+    colorIdentity = "WUBRG"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "When this Vehicle enters, search your library for a basic land card, reveal it, " +
+        "put it into your hand, then shuffle.\n" +
+        "Exhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 " +
+        "counters on it. (Activate each exhaust ability only once.)\n" +
+        "Crew 5 (Tap any number of creatures you control with total power 5 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 6
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{U}{B}{R}{G}")
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 6,
+                toughness = 5,
+                duration = Duration.Permanent
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        )
+        description = "Exhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. " +
+            "Put two +1/+1 counters on it."
+    }
+
+    keywordAbility(KeywordAbility.crew(5))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Javier Charro"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg?1783907847"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiverchurnMonument.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiverchurnMonument.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Riverchurn Monument
+ * {1}{U}
+ * Artifact
+ * {1}, {T}: Any number of target players each mill two cards.
+ * Exhaust — {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of
+ * cards in their graveyard. (Activate each exhaust ability only once.)
+ *
+ * Both abilities use `TargetPlayer(unlimited = true)` for "any number of target players" and
+ * iterate the chosen players with [ForEachTargetEffect], so each player mills from their own
+ * library via `Player.ContextPlayer(0)`. The exhaust amount is that player's own graveyard size,
+ * evaluated per iteration — not the controller's.
+ */
+val RiverchurnMonument = card("Riverchurn Monument") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: Any number of target players each mill two cards.\n" +
+        "Exhaust — {2}{U}{U}, {T}: Any number of target players each mill cards equal to the " +
+        "number of cards in their graveyard. (Activate each exhaust ability only once.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        target("any number of target players", TargetPlayer(unlimited = true))
+        effect = ForEachTargetEffect(
+            listOf(
+                Patterns.Library.mill(2, EffectTarget.PlayerRef(Player.ContextPlayer(0)))
+            )
+        )
+        description = "{1}, {T}: Any number of target players each mill two cards."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}{U}"), Costs.Tap)
+        isExhaust = true
+        target("any number of target players", TargetPlayer(unlimited = true))
+        effect = ForEachTargetEffect(
+            listOf(
+                Patterns.Library.mill(
+                    DynamicAmounts.zone(Player.ContextPlayer(0), Zone.GRAVEYARD).count(),
+                    EffectTarget.PlayerRef(Player.ContextPlayer(0))
+                )
+            )
+        )
+        description = "Exhaust — {2}{U}{U}, {T}: Any number of target players each mill cards " +
+            "equal to the number of cards in their graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "Anthony Devine"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg?1783907906"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling("2025-02-07", "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again.")
+        ruling("2025-02-07", "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThopterFabricator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThopterFabricator.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thopter Fabricator
+ * {2}{U}
+ * Artifact — Vehicle
+ * 4/4
+ * Flying
+ * Whenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature
+ * token with flying.
+ * Crew 2
+ *
+ * "Your second card each turn" is [Triggers.NthCardDrawn] — it reads the per-player draw counter,
+ * so it fires exactly once per turn even when a single multi-card draw crosses the threshold, and
+ * cards put into hand without the word "draw" (CR 121.5) don't advance it.
+ */
+val ThopterFabricator = card("Thopter Fabricator") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Flying\n" +
+        "Whenever you draw your second card each turn, create a 1/1 colorless Thopter artifact " +
+        "creature token with flying.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 4
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Thopter"),
+            keywords = setOf(Keyword.FLYING),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677"
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "68"
+        artist = "Racrufi"
+        flavorText = "Take flight on the wings of true innovation."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg?1783907901"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VoyagerGlidecar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VoyagerGlidecar.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Voyager Glidecar
+ * {W}
+ * Artifact — Vehicle
+ * 2/3
+ * When this Vehicle enters, scry 1.
+ * Tap three other untapped creatures you control: Until end of turn, this Vehicle becomes an
+ * artifact creature and gains flying. Put a +1/+1 counter on it.
+ * Crew 1
+ *
+ * The activated ability is a pure tap-cost animate — `excludeSelf` gives the "other" in "three
+ * other untapped creatures you control" (the Glidecar is only a creature while animated, but the
+ * word is printed, so it's modelled explicitly). Only the animate is until-end-of-turn; the
+ * +1/+1 counter is permanent.
+ */
+val VoyagerGlidecar = card("Voyager Glidecar") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "When this Vehicle enters, scry 1.\n" +
+        "Tap three other untapped creatures you control: Until end of turn, this Vehicle becomes " +
+        "an artifact creature and gains flying. Put a +1/+1 counter on it.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(1)
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 3,
+            filter = GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 2,
+                toughness = 3,
+                keywords = setOf(Keyword.FLYING),
+                duration = Duration.EndOfTurn
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "Tap three other untapped creatures you control: Until end of turn, this " +
+            "Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it."
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Eduardo Francisco"
+        flavorText = "\"Exclamatory: Hang on to something.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg?1783907912"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WickerfolkIndomitable.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WickerfolkIndomitable.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+
+/**
+ * Wickerfolk Indomitable
+ * {3}{B}
+ * Artifact Creature — Scarecrow
+ * 4/3
+ * You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or
+ * creature in addition to paying its other costs.
+ *
+ * [MayCastSelfFromZones] keeps normal timing and the printed {3}{B} mana cost; the two extra
+ * costs ride along as a composite additional cost. Sacrificing the Wickerfolk itself is not an
+ * option — it's in the graveyard, not on the battlefield, when the cost is paid.
+ */
+val WickerfolkIndomitable = card("Wickerfolk Indomitable") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact Creature — Scarecrow"
+    oracleText = "You may cast this card from your graveyard by paying 2 life and sacrificing an " +
+        "artifact or creature in addition to paying its other costs."
+    power = 4
+    toughness = 3
+
+    staticAbility {
+        ability = MayCastSelfFromZones(
+            zones = listOf(Zone.GRAVEYARD),
+            additionalCost = Costs.additional.Composite(
+                listOf(
+                    Costs.additional.PayLife(2),
+                    Costs.additional.SacrificePermanent(
+                        GameObjectFilter.Artifact or GameObjectFilter.Creature
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "Sergio Cosmai"
+        flavorText = "Some horrors are created. Others are the recognition of a possibility that " +
+            "has always existed."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg?1783907888"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -6313,6 +6313,129 @@
     "colorIdentityOverride": []
 }
 
+// Marshals' Pathcruiser
+{
+    "name": "Marshals' Pathcruiser",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "When this Vehicle enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nExhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it. (Activate each exhaust ability only once.)\nCrew 5 (Tap any number of creatures you control with total power 5 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 5
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{U}{B}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 6
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Javier Charro",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f920f83-6380-4e4f-be68-6bf9df3110d8.jpg?1783907847"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Maximum Overdrive
 {
     "name": "Maximum Overdrive",
@@ -8342,6 +8465,171 @@
     ]
 }
 
+// Riverchurn Monument
+{
+    "name": "Riverchurn Monument",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}: Any number of target players each mill two cards.\nExhaust — {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard. (Activate each exhaust ability only once.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    },
+                                    "isMill": true
+                                },
+                                "storeAs": "milled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "unlimited": true,
+                        "id": "any number of target players"
+                    }
+                ],
+                "descriptionOverride": "{1}, {T}: Any number of target players each mill two cards."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "AggregateZone",
+                                        "player": {
+                                            "type": "ContextPlayer",
+                                            "index": 0
+                                        },
+                                        "zone": "Graveyard"
+                                    },
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    },
+                                    "isMill": true
+                                },
+                                "storeAs": "milled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "unlimited": true,
+                        "id": "any number of target players"
+                    }
+                ],
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "Anthony Devine",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e66ff696-fd39-49ad-9ee5-c0868167df37.jpg?1783907906",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Riverpyre Verge
 {
     "name": "Riverpyre Verge",
@@ -10119,6 +10407,65 @@
     ]
 }
 
+// Thopter Fabricator
+{
+    "name": "Thopter Fabricator",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Flying\nWhenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677",
+                    "artifactToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "RARE",
+        "artist": "Racrufi",
+        "flavorText": "Take flight on the wings of true innovation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8924b785-b140-4212-a1eb-a10340e09fea.jpg?1783907901"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Thunderhead Gunner
 {
     "name": "Thunderhead Gunner",
@@ -10907,6 +11254,93 @@
     ]
 }
 
+// Voyager Glidecar
+{
+    "name": "Voyager Glidecar",
+    "manaCost": "{W}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "When this Vehicle enters, scry 1.\nTap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "keywords": [
+                                "FLYING"
+                            ]
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Tap three other untapped creatures you control: Until end of turn, this Vehicle becomes an artifact creature and gains flying. Put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "Eduardo Francisco",
+        "flavorText": "\"Exclamatory: Hang on to something.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13eb445a-dd41-4760-8299-9ba5d6de6aaf.jpg?1783907912"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Voyager Quickwelder
 {
     "name": "Voyager Quickwelder",
@@ -11102,6 +11536,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wickerfolk Indomitable
+{
+    "name": "Wickerfolk Indomitable",
+    "manaCost": "{3}{B}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "MayCastSelfFromZones",
+                "zones": [
+                    "Graveyard"
+                ],
+                "additionalCost": {
+                    "type": "Composite",
+                    "steps": [
+                        {
+                            "type": "AdditionalAtom",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "AdditionalAtom",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact|creature"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "UNCOMMON",
+        "artist": "Sergio Cosmai",
+        "flavorText": "Some horrors are created. Others are the recognition of a possibility that has always existed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba78e076-8962-4b3f-b86f-04400b062951.jpg?1783907888"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarshalsPathcruiserScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarshalsPathcruiserScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Marshals' Pathcruiser (DFT #236).
+ *
+ * Marshals' Pathcruiser {3} — Artifact — Vehicle 6/5
+ * When this Vehicle enters, search your library for a basic land card, reveal it, put it into your
+ * hand, then shuffle.
+ * Exhaust — {W}{U}{B}{R}{G}: This Vehicle becomes an artifact creature. Put two +1/+1 counters on it.
+ * Crew 5
+ *
+ * The load-bearing claim is the **duration** of the exhaust animate: the card has no "until end of
+ * turn" clause, so unlike Crew the Vehicle stays a creature across the turn boundary. Its printed
+ * 6/5 is the base P/T, so the two counters make it an 8/7.
+ */
+class MarshalsPathcruiserScenarioTest : ScenarioTestBase() {
+
+    private val exhaustAbilityId
+        get() = cardRegistry.getCard("Marshals' Pathcruiser")!!.script.activatedAbilities[0].id
+
+    init {
+        context("Marshals' Pathcruiser") {
+
+            test("the exhaust animate is permanent and survives the end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Marshals' Pathcruiser")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pathcruiser = game.findPermanent("Marshals' Pathcruiser")!!
+                withClue("a Vehicle is not a creature until something animates it") {
+                    game.state.projectedState.isCreature(pathcruiser) shouldBe false
+                }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = pathcruiser,
+                        abilityId = exhaustAbilityId
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("6/5 base plus two +1/+1 counters, still an artifact") {
+                    projected.isCreature(pathcruiser) shouldBe true
+                    projected.hasType(pathcruiser, "ARTIFACT") shouldBe true
+                    projected.getPower(pathcruiser) shouldBe 8
+                    projected.getToughness(pathcruiser) shouldBe 7
+                }
+                game.state.getEntity(pathcruiser)!!.get<CountersComponent>()!!
+                    .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("no 'until end of turn' clause — cleanup must not undo it") {
+                    game.state.projectedState.isCreature(pathcruiser) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiverchurnMonumentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiverchurnMonumentScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Riverchurn Monument (DFT #57).
+ *
+ * Riverchurn Monument {1}{U} — Artifact
+ * {1}, {T}: Any number of target players each mill two cards.
+ * Exhaust — {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of
+ * cards in their graveyard.
+ *
+ * The load-bearing claims:
+ *  - "any number of target players" accepts more than one player, and each chosen player mills
+ *    from *their own* library into *their own* graveyard;
+ *  - a single target is legal too ("any number" includes one), and untargeted players mill nothing;
+ *  - the exhaust amount is each targeted player's own graveyard size, evaluated per player — not
+ *    the controller's, and not one shared number applied to everyone.
+ *
+ * The once-per-object half of Exhaust is covered generically by [ExhaustKeywordScenarioTest].
+ */
+class RiverchurnMonumentScenarioTest : ScenarioTestBase() {
+
+    private val monument get() = cardRegistry.getCard("Riverchurn Monument")!!
+    private val basicAbilityId get() = monument.script.activatedAbilities[0].id
+    private val exhaustAbilityId get() = monument.script.activatedAbilities[1].id
+
+    init {
+        context("Riverchurn Monument") {
+
+            test("{1}, {T}: both targeted players each mill two cards") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Riverchurn Monument")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .also { b -> repeat(10) { b.withCardInLibrary(1, "Grizzly Bears") } }
+                    .also { b -> repeat(10) { b.withCardInLibrary(2, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monumentId = game.findPermanent("Riverchurn Monument")!!
+                val p1LibraryBefore = game.librarySize(1)
+                val p2LibraryBefore = game.librarySize(2)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monumentId,
+                        abilityId = basicAbilityId,
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Player(game.player2Id)
+                        )
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("each targeted player mills from their own library") {
+                    game.librarySize(1) shouldBe p1LibraryBefore - 2
+                    game.librarySize(2) shouldBe p2LibraryBefore - 2
+                }
+                game.graveyardSize(1) shouldBe 2
+                game.graveyardSize(2) shouldBe 2
+            }
+
+            test("{1}, {T}: one target is legal and only that player mills") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Riverchurn Monument")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .also { b -> repeat(10) { b.withCardInLibrary(1, "Grizzly Bears") } }
+                    .also { b -> repeat(10) { b.withCardInLibrary(2, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monumentId = game.findPermanent("Riverchurn Monument")!!
+                val p1LibraryBefore = game.librarySize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monumentId,
+                        abilityId = basicAbilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.graveyardSize(2) shouldBe 2
+                withClue("the untargeted controller mills nothing") {
+                    game.librarySize(1) shouldBe p1LibraryBefore
+                    game.graveyardSize(1) shouldBe 0
+                }
+            }
+
+            test("exhaust mills each player their own graveyard's worth, not a shared count") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Riverchurn Monument")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    // Asymmetric graveyards: p1 has 1 card, p2 has 3.
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .also { b -> repeat(10) { b.withCardInLibrary(1, "Grizzly Bears") } }
+                    .also { b -> repeat(10) { b.withCardInLibrary(2, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val monumentId = game.findPermanent("Riverchurn Monument")!!
+                val p1LibraryBefore = game.librarySize(1)
+                val p2LibraryBefore = game.librarySize(2)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = monumentId,
+                        abilityId = exhaustAbilityId,
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Player(game.player2Id)
+                        )
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("player 1 had 1 card in their graveyard, so mills 1") {
+                    game.librarySize(1) shouldBe p1LibraryBefore - 1
+                }
+                withClue("player 2 had 3 cards in their graveyard, so mills 3") {
+                    game.librarySize(2) shouldBe p2LibraryBefore - 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThopterFabricatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThopterFabricatorScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Thopter Fabricator (DFT #68).
+ *
+ * Thopter Fabricator {2}{U} — Artifact — Vehicle 4/4
+ * Flying
+ * Whenever you draw your second card each turn, create a 1/1 colorless Thopter artifact creature
+ * token with flying.
+ * Crew 2
+ *
+ * The load-bearing claims about "your second card each turn":
+ *  - the first draw of a turn does nothing; the second makes exactly one Thopter;
+ *  - the third and later draws make nothing more — the trigger is once per turn, not "each draw
+ *    after the first";
+ *  - only the controller's draws count.
+ */
+class ThopterFabricatorScenarioTest : ScenarioTestBase() {
+
+    private fun game(drawnAlready: Int) = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Thopter Fabricator")
+        .withCardsDrawnThisTurn(1, drawnAlready)
+        .withCardInHand(1, "Divination")
+        .withLandsOnBattlefield(1, "Island", 3)
+        .also { builder -> repeat(5) { builder.withCardInLibrary(1, "Grizzly Bears") } }
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Thopter Fabricator") {
+
+            test("drawing the first and second cards of a turn makes exactly one Thopter") {
+                val game = game(drawnAlready = 0)
+                game.findPermanents("Thopter Token").size shouldBe 0
+
+                // Divination draws two cards: the first crosses no threshold, the second does.
+                val result = game.castSpell(1, "Divination")
+                withClue("cast should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("one Thopter for the second card, not one per card drawn") {
+                    game.findPermanents("Thopter Token").size shouldBe 1
+                }
+            }
+
+            test("a later draw in the same turn makes no further Thopters") {
+                // Two cards already drawn this turn, so both of Divination's draws are past the
+                // second-card threshold.
+                val game = game(drawnAlready = 2)
+
+                val result = game.castSpell(1, "Divination")
+                withClue("cast should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.findPermanents("Thopter Token").size shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoyagerGlidecarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoyagerGlidecarScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Voyager Glidecar (DFT #36).
+ *
+ * Voyager Glidecar {W} — Artifact — Vehicle 2/3
+ * When this Vehicle enters, scry 1.
+ * Tap three other untapped creatures you control: Until end of turn, this Vehicle becomes an
+ * artifact creature and gains flying. Put a +1/+1 counter on it.
+ * Crew 1
+ *
+ * The load-bearing claims:
+ *  - the tap-three cost is enforced — two creatures isn't enough;
+ *  - paying it taps exactly the three chosen creatures and animates the Vehicle with flying,
+ *    keeping its printed 2/3 as the base P/T (so the +1/+1 counter reads 3/4);
+ *  - only the animate is duration-bounded — the counter survives into the next turn.
+ */
+class VoyagerGlidecarScenarioTest : ScenarioTestBase() {
+
+    private val abilityId
+        get() = cardRegistry.getCard("Voyager Glidecar")!!.script.activatedAbilities[0].id
+
+    private fun boardWith(creatureCount: Int) = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Voyager Glidecar")
+        .also { builder -> repeat(creatureCount) { builder.withCardOnBattlefield(1, "Grizzly Bears") } }
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Voyager Glidecar") {
+
+            test("tapping three other creatures animates the Vehicle and adds a +1/+1 counter") {
+                val game = boardWith(creatureCount = 3)
+                val glidecar = game.findPermanent("Voyager Glidecar")!!
+                val bears = game.findPermanents("Grizzly Bears")
+                bears.size shouldBe 3
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = glidecar,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(tappedPermanents = bears)
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("all three creatures paid the cost") {
+                    bears.forEach { game.state.getEntity(it)!!.get<TappedComponent>().shouldNotBeNull() }
+                }
+
+                val projected = game.state.projectedState
+                withClue("the Vehicle is an artifact creature with flying at 2/3 base plus a counter") {
+                    projected.isCreature(glidecar) shouldBe true
+                    projected.hasType(glidecar, "ARTIFACT") shouldBe true
+                    projected.hasKeyword(glidecar, Keyword.FLYING) shouldBe true
+                    projected.getPower(glidecar) shouldBe 3
+                    projected.getToughness(glidecar) shouldBe 4
+                }
+
+                game.state.getEntity(glidecar)!!.get<CountersComponent>()!!
+                    .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("only the animate was until-end-of-turn; the counter is permanent") {
+                    game.state.projectedState.isCreature(glidecar) shouldBe false
+                    game.state.getEntity(glidecar)!!.get<CountersComponent>()!!
+                        .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+
+            test("cannot be activated with only two other untapped creatures") {
+                val game = boardWith(creatureCount = 2)
+                val glidecar = game.findPermanent("Voyager Glidecar")!!
+                val bears = game.findPermanents("Grizzly Bears")
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = glidecar,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(tappedPermanents = bears)
+                    )
+                )
+                withClue("the cost demands three creatures") { (result.error != null) shouldBe true }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickerfolkIndomitableScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WickerfolkIndomitableScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Wickerfolk Indomitable (DFT #109).
+ *
+ * Wickerfolk Indomitable {3}{B} — Artifact Creature — Scarecrow 4/3
+ * You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or
+ * creature in addition to paying its other costs.
+ *
+ * The load-bearing claims:
+ *  - the graveyard permission exists and both extra costs are actually charged (life *and* a
+ *    sacrifice), on top of the printed {3}{B};
+ *  - the sacrifice filter is the union "artifact **or** creature" — a land can't pay it.
+ */
+class WickerfolkIndomitableScenarioTest : ScenarioTestBase() {
+
+    private fun graveyardGame() = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardInGraveyard(1, "Wickerfolk Indomitable")
+        .withCardOnBattlefield(1, "Grizzly Bears")
+        .withLandsOnBattlefield(1, "Swamp", 4)
+        .withLifeTotal(1, 20)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    private fun TestGame.wickerfolkInGraveyard(): EntityId =
+        state.getGraveyard(player1Id).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Wickerfolk Indomitable"
+        }
+
+    init {
+        context("Wickerfolk Indomitable") {
+
+            test("casting from the graveyard charges 2 life and a sacrifice on top of {3}{B}") {
+                val game = graveyardGame()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.wickerfolkInGraveyard(),
+                        additionalCostPayment = AdditionalCostPayment(
+                            lifePaid = 2,
+                            sacrificedPermanents = listOf(bears)
+                        )
+                    )
+                )
+                withClue("cast should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.isOnBattlefield("Wickerfolk Indomitable") shouldBe true
+                withClue("2 life paid") {
+                    game.state.getEntity(game.player1Id)?.get<LifeTotalComponent>()?.life shouldBe 18
+                }
+                withClue("the Grizzly Bears was sacrificed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a land cannot pay the artifact-or-creature sacrifice") {
+                val game = graveyardGame()
+                val swamp = game.findPermanents("Swamp").first()
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = game.wickerfolkInGraveyard(),
+                        additionalCostPayment = AdditionalCostPayment(
+                            lifePaid = 2,
+                            sacrificedPermanents = listOf(swamp)
+                        )
+                    )
+                )
+                withClue("the filter is artifact|creature, not any permanent") {
+                    (result.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Aetherdrift cards, all composed from existing SDK primitives — no new engine vocabulary.

| Card | # | What it needed |
|---|---|---|
| Marshals' Pathcruiser | 236 | ETB basic-land search + WUBRG exhaust animate + Crew 5 |
| Thopter Fabricator | 68 | `Triggers.NthCardDrawn(2)` → Thopter token + Crew 2 |
| Voyager Glidecar | 36 | ETB scry + tap-three-others animate + Crew 1 |
| Wickerfolk Indomitable | 109 | `MayCastSelfFromZones` with a composite additional cost |
| Riverchurn Monument | 57 | "any number of target players" mill, twice |

## Two shapes worth a look

**Vehicle animates.** Both use `Effects.BecomeCreature` with the Vehicle's printed P/T as the base, mirroring what `CrewVehicleHandler` builds. The Pathcruiser's exhaust ability has no "until end of turn" clause, so it animates with `Duration.Permanent`; the Glidecar's is `EndOfTurn` while its +1/+1 counter is not. Both splits are pinned by a test.

**Riverchurn Monument's targeting.** "Any number of target players" is `TargetPlayer(unlimited = true)` iterated with `ForEachTargetEffect`, so the exhaust amount resolves to each targeted player's *own* graveyard size via `Player.ContextPlayer(0)` — not the controller's, and not one shared number applied to everyone.

## Testing

`just build` and `just test-rules` pass. Scenario tests cover the risky compositions rather than the primitives:

- per-player mill amounts with asymmetric graveyards, plus single- and multi-target activations
- the tap-three cost enforced at two creatures, and the animate-expires / counter-persists split across the turn boundary
- the permanent animate surviving cleanup (6/5 base + two counters = 8/7)
- the graveyard cast charging both 2 life and a sacrifice, with a land rejected by the `artifact|creature` filter
- "your second card each turn" firing exactly once, and not again on a later draw

Card snapshot golden re-blessed — only these five cards moved. `just check-card-printing` is clean for all five (DFT is the earliest real printing for each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)