### PR TITLE
Add Carnelian Orb of Dragonkind with mana-rider keyword grants

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6833,6 +6833,16 @@ the rider twice (Pyromancer's Goggles: "That many copies will be created").
   happens at payment time against the spell's cast characteristics; a non-matching spell is a silent
   no-op. Because the queued trigger's source is the *spell*, it still fires if the mana's producer
   has already left the battlefield.
+- `ManaSpellRider.GrantsKeywordWhenSpent(keyword, spellFilter)` — Carnelian Orb of Dragonkind
+  (`Keyword.HASTE`, `GameObjectFilter.Creature.withSubtype("Dragon")`): "If that mana is spent on a
+  [filter] spell, it gains [keyword] until end of turn." The one rider that puts **nothing** on the
+  stack — the printed effect is continuous, so it floats a `Layer.ABILITY` `GrantKeyword`
+  `Duration.EndOfTurn` modification keyed to the spell's entity id instead of queuing a trigger. A
+  permanent spell keeps that id as it resolves, so the keyword is live the moment the permanent
+  exists (which is what haste needs); on a non-permanent spell the grant never finds a permanent to
+  apply to. Matching happens at payment time against the spell's cast characteristics, per the
+  printed rulings: mana spent on a non-Dragon spell that *becomes* a Dragon later in the turn grants
+  nothing, and an instant or sorcery that makes Dragon tokens is not a Dragon creature spell.
 
 ### `ManaExpiry`<a id="manaexpiry"></a>
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaSpellRider.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaSpellRider.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting.effects
 
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -74,5 +75,36 @@ sealed interface ManaSpellRider {
         override val description: String =
             "When that mana is spent to cast a ${spellFilter.description} spell, copy that spell " +
                 "and you may choose new targets for the copy"
+    }
+
+    /**
+     * "If that mana is spent on a [spellFilter] spell, it gains [keyword] until end of turn."
+     * (Carnelian Orb of Dragonkind, with `spellFilter = GameObjectFilter.Creature.withSubtype("Dragon")`
+     * and `keyword = Keyword.HASTE`.)
+     *
+     * Unlike the trigger-queuing riders this is a continuous effect, not a triggered ability — the
+     * printed card puts nothing on the stack. On consumption the cast pipeline matches the spell
+     * against [spellFilter] and, on a match, floats an end-of-turn keyword grant keyed to the spell's
+     * entity id. A permanent spell keeps that id as it resolves, so the keyword is live the moment it
+     * becomes a permanent; on a non-permanent spell the grant simply never has a permanent to apply to.
+     *
+     * Matching happens at payment time against the spell's cast characteristics, per the printed
+     * ruling: mana spent on a non-Dragon spell that *becomes* a Dragon later in the turn grants
+     * nothing, and an instant or sorcery that makes Dragon tokens is not a Dragon creature spell.
+     *
+     * @property keyword Keyword enum name (e.g. `"HASTE"`), matching [GrantKeywordEffect.keyword].
+     * @property spellFilter Which cast spells the rider grants [keyword] to.
+     */
+    @SerialName("GrantsKeywordWhenSpent")
+    @Serializable
+    data class GrantsKeywordWhenSpent(
+        val keyword: String,
+        val spellFilter: GameObjectFilter,
+    ) : ManaSpellRider {
+        constructor(keyword: Keyword, spellFilter: GameObjectFilter) : this(keyword.name, spellFilter)
+
+        override val description: String =
+            "If that mana is spent on a ${spellFilter.description} spell, it gains " +
+                "${keyword.lowercase().replace('_', ' ')} until end of turn"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/CommanderLegendsBattleForBaldursGateSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/CommanderLegendsBattleForBaldursGateSet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.clb
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Commander Legends: Battle for Baldur's Gate (2022)
+ *
+ * A Commander-draft set. Scaffolded to hold the canonical [CardDefinition] for cards that first
+ * appeared here and are reprinted in later sets (e.g. Carnelian Orb of Dragonkind, reprinted in
+ * Foundations).
+ *
+ * Set Code: CLB
+ * Release Date: June 10, 2022
+ */
+object CommanderLegendsBattleForBaldursGateSet : MtgSet {
+
+    override val code = "CLB"
+    override val displayName = "Commander Legends: Battle for Baldur's Gate"
+    override val releaseDate = "2022-06-10"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.clb.cards"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CarnelianOrbOfDragonkind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CarnelianOrbOfDragonkind.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
+
+/**
+ * Carnelian Orb of Dragonkind
+ * {2}{R}
+ * Artifact
+ *
+ * {T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.
+ *
+ * The rider carries the whole ability: the {R} itself is unrestricted (it can pay for anything),
+ * and [ManaSpellRider.GrantsKeywordWhenSpent] fires only when the mana lands on a Dragon *creature*
+ * spell — matched at payment time, which is what the printed rulings require.
+ */
+val CarnelianOrbOfDragonkind = card("Carnelian Orb of Dragonkind") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(
+            Color.RED,
+            riders = setOf(
+                ManaSpellRider.GrantsKeywordWhenSpent(
+                    keyword = Keyword.HASTE,
+                    spellFilter = GameObjectFilter.Creature.withSubtype("Dragon"),
+                )
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "166"
+        artist = "Olena Richards"
+        flavorText = "The essence of a red dragon burns within, always ready to rise with wrath."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg?1783922743"
+        ruling("2022-06-10", "The mana created by Carnelian Orb of Dragonkind can be spent on anything, not just Dragon creature spells.")
+        ruling(
+            "2022-06-10",
+            "If the mana from Carnelian Orb of Dragonkind is spent to pay any part of the Dragon creature spell's cost, " +
+                "including an alternative or additional cost, the Dragon will gain haste until end of turn."
+        )
+        ruling("2022-06-10", "An instant or sorcery spell is not a creature spell, even if that spell creates Dragon creature tokens.")
+        ruling("2022-06-10", "If the mana is spent on a non-Dragon spell that becomes a Dragon later in the turn, that creature won't have haste.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
@@ -15,8 +15,9 @@ import com.wingedsheep.sdk.model.Printing
  * for Modern-legal staples referenced by MageZero training decks (see
  * backlog/magezero-coverage.md).
  *
- * All 262 booster cards are implemented, so the set is draftable (not `incomplete`).
- * The one gap is a starter-deck exclusive that never appears in a pack.
+ * All 262 booster cards are implemented, so the set is draftable (not `incomplete`). The remaining
+ * FDN cards are non-booster exclusives — Beginner Box, Starter Collection, and the 2026 set
+ * extension — which the coverage view counts separately from the headline draft pool.
  */
 object FoundationsSet : MtgSet {
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CarnelianOrbOfDragonkindReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CarnelianOrbOfDragonkindReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carnelian Orb of Dragonkind reprint in FDN. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander Legends: Battle for Baldur's Gate
+ * (CLB); this file contributes only the FDN presentation row.
+ *
+ * FDN prints it twice outside the Play Booster pool — #534 in the Beginner Box and #759 in the 2026
+ * set extension. This row follows the printing Scryfall serves as the set default (#759).
+ */
+val CarnelianOrbOfDragonkindReprint = Printing(
+    oracleId = "651c967c-8f71-4eb5-b22f-545e55ea050e",
+    name = "Carnelian Orb of Dragonkind",
+    setCode = "FDN",
+    collectorNumber = "759",
+    scryfallId = "6db2741d-2722-4eb7-b09d-0d81649c7ca2",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6db2741d-2722-4eb7-b09d-0d81649c7ca2.jpg?1783903948",
+    releaseDate = "2026-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/CLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CLB.json
@@ -1,0 +1,63 @@
+// Carnelian Orb of Dragonkind
+{
+    "name": "Carnelian Orb of Dragonkind",
+    "manaCost": "{2}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "riders": [
+                        {
+                            "type": "GrantsKeywordWhenSpent",
+                            "keyword": "HASTE",
+                            "spellFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Dragon"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "artist": "Olena Richards",
+        "flavorText": "The essence of a red dragon burns within, always ready to rise with wrath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7e41166-bdaa-4aed-986a-7be1d043240c.jpg?1783922743",
+        "rulings": [
+            {
+                "date": "2022-06-10",
+                "text": "The mana created by Carnelian Orb of Dragonkind can be spent on anything, not just Dragon creature spells."
+            },
+            {
+                "date": "2022-06-10",
+                "text": "If the mana from Carnelian Orb of Dragonkind is spent to pay any part of the Dragon creature spell's cost, including an alternative or additional cost, the Dragon will gain haste until end of turn."
+            },
+            {
+                "date": "2022-06-10",
+                "text": "An instant or sorcery spell is not a creature spell, even if that spell creates Dragon creature tokens."
+            },
+            {
+                "date": "2022-06-10",
+                "text": "If the mana is spent on a non-Dragon spell that becomes a Dragon later in the turn, that creature won't have haste."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -47,6 +47,9 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.bend.BendEvents
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.mechanics.mana.AlternativePaymentHandler
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaPool
@@ -88,6 +91,7 @@ import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.CastRestriction
+import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.EventPattern as SdkGameEvent
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -4072,6 +4076,51 @@ class CastSpellHandler(
 
         is com.wingedsheep.sdk.scripting.effects.ManaSpellRider.CopySpellWhenSpent ->
             buildCopySpellRiderTrigger(state, action, cardComponent, rider.spellFilter)
+
+        is com.wingedsheep.sdk.scripting.effects.ManaSpellRider.GrantsKeywordWhenSpent ->
+            applyKeywordGrantRider(state, action, rider.keyword, rider.spellFilter) to emptyList()
+    }
+
+    /**
+     * Carnelian Orb of Dragonkind's rider: if the cast spell matches [spellFilter], float an
+     * end-of-turn grant of [keyword] keyed to the spell. Otherwise no-op (the mana paid for
+     * something else).
+     *
+     * Unlike the copy / scry riders this queues nothing onto the stack — "it gains haste until end
+     * of turn" is a continuous effect the printed card applies without a triggered ability. The
+     * grant is keyed to the spell's entity id, which a permanent spell keeps as it resolves onto the
+     * battlefield (see [com.wingedsheep.engine.mechanics.stack.StackResolver.resolvePermanentSpell]),
+     * so the keyword is live the instant the permanent exists — exactly what haste needs.
+     *
+     * The spell is matched with [PredicateEvaluator] against its stack characteristics, at payment
+     * time rather than at resolution. That's what the printed rulings require: mana spent on a
+     * non-Dragon spell that *becomes* a Dragon later in the turn grants nothing.
+     *
+     * The floating effect's source is the spell itself, not the mana's producer — the producer may
+     * already have left the battlefield, and the source is only read for the effect's display name.
+     */
+    private fun applyKeywordGrantRider(
+        state: GameState,
+        action: CastSpell,
+        keyword: String,
+        spellFilter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+    ): GameState {
+        val matches = predicateEvaluator.matches(
+            state,
+            state.projectedState,
+            action.cardId,
+            spellFilter,
+            PredicateContext(controllerId = action.playerId)
+        )
+        if (!matches) return state
+
+        return state.addFloatingEffect(
+            layer = Layer.ABILITY,
+            modification = SerializableModification.GrantKeyword(keyword),
+            affectedEntities = setOf(action.cardId),
+            duration = Duration.EndOfTurn,
+            context = EffectContext(sourceId = action.cardId, controllerId = action.playerId)
+        )
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnelianOrbOfDragonkindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnelianOrbOfDragonkindScenarioTest.kt
@@ -1,0 +1,166 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.clb.cards.CarnelianOrbOfDragonkind
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Carnelian Orb of Dragonkind (canonical CLB #166, reprinted FDN #759).
+ *
+ * {T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.
+ *
+ * Covers the new [com.wingedsheep.sdk.scripting.effects.ManaSpellRider.GrantsKeywordWhenSpent]
+ * rider — the first rider that applies a continuous effect instead of queuing a trigger. The
+ * grant is keyed to the *spell's* entity id while it is still on the stack, so the interesting
+ * question these tests answer is whether it survives the stack → battlefield transition and lands
+ * on the permanent in time to matter. Haste makes that observable: the assertion is an actual
+ * attack the turn the Dragon enters, not just a projected keyword.
+ *
+ * The negatives pin the filter on both axes the printed rulings call out: card type (a Dragon
+ * *token-making sorcery* is not a Dragon creature spell) and subtype (a non-Dragon creature). The
+ * last test covers "the mana can be spent on anything" — the rider rides along on every cast the
+ * mana pays for and simply no-ops when the spell doesn't match.
+ */
+class CarnelianOrbOfDragonkindScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+    val orbAbilityId = CarnelianOrbOfDragonkind.activatedAbilities[0].id
+
+    /** A {R} Dragon — one Orb activation pays its whole cost. */
+    val dragon = CardDefinition.creature(
+        name = "Test Ember Wyrm",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Dragon")),
+        power = 2,
+        toughness = 2,
+    )
+
+    /** Same cost, same colour, no Dragon subtype — the rider must not fire. */
+    val nonDragon = CardDefinition.creature(
+        name = "Test Ember Imp",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Imp")),
+        power = 2,
+        toughness = 2,
+    )
+
+    /**
+     * "An instant or sorcery spell is not a creature spell, even if that spell creates Dragon
+     * creature tokens." A noncreature spell the {R} genuinely pays for, so the rider is consumed
+     * and must then no-op.
+     */
+    val dragonSorcery = CardDefinition.sorcery(
+        name = "Test Dragon Call",
+        manaCost = ManaCost.parse("{R}"),
+        oracleText = "You gain 2 life.",
+        script = CardScript.spell(effect = Effects.GainLife(2)),
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(CarnelianOrbOfDragonkind, dragon, nonDragon, dragonSorcery)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Tap the Orb, putting one rider-carrying {R} into the pool. */
+    fun tapOrb(driver: GameTestDriver, you: EntityId, orb: EntityId) {
+        driver.submitSuccess(
+            ActivateAbility(playerId = you, sourceId = orb, abilityId = orbAbilityId)
+        )
+    }
+
+    test("a Dragon creature spell paid with the Orb's mana has haste and can attack at once") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val orb = driver.putPermanentOnBattlefield(you, "Carnelian Orb of Dragonkind")
+        val wyrm = driver.putCardInHand(you, "Test Ember Wyrm")
+        tapOrb(driver, you, orb)
+
+        driver.castSpell(you, wyrm).error shouldBe null
+        driver.bothPass()
+
+        // The grant was floated onto the spell on the stack; a permanent spell keeps its entity id
+        // as it resolves, so it is already live on the permanent.
+        projector.project(driver.state).hasKeyword(wyrm, Keyword.HASTE) shouldBe true
+        driver.state.getEntity(wyrm)?.has<SummoningSicknessComponent>() shouldBe true
+
+        // Pinning the turn is what makes this assertion discriminating: the engine skips the
+        // declare-attackers step outright when the active player has no legal attacker, so a
+        // Dragon *without* haste would sail past this turn's combat and only be able to attack a
+        // turn later. Reaching declare-attackers in the turn it entered is haste doing its job.
+        val turn = driver.state.turnNumber
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.turnNumber shouldBe turn
+        driver.declareAttackers(you, listOf(wyrm), opponent).error shouldBe null
+    }
+
+    test("the same Dragon cast with ordinary red mana stays summoning sick") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val wyrm = driver.putCardInHand(you, "Test Ember Wyrm")
+        driver.giveMana(you, Color.RED, 1)
+
+        driver.castSpell(you, wyrm).error shouldBe null
+        driver.bothPass()
+
+        // The control for the test above: same Dragon, same turn, mana from anywhere else. It is
+        // summoning sick with no haste to bypass it, so this turn's combat is not open to it.
+        projector.project(driver.state).hasKeyword(wyrm, Keyword.HASTE) shouldBe false
+        driver.state.getEntity(wyrm)?.has<SummoningSicknessComponent>() shouldBe true
+    }
+
+    test("a non-Dragon creature spell paid with the Orb's mana gains nothing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val orb = driver.putPermanentOnBattlefield(you, "Carnelian Orb of Dragonkind")
+        val imp = driver.putCardInHand(you, "Test Ember Imp")
+        tapOrb(driver, you, orb)
+
+        driver.castSpell(you, imp).error shouldBe null
+        driver.bothPass()
+
+        projector.project(driver.state).hasKeyword(imp, Keyword.HASTE) shouldBe false
+    }
+
+    test("the mana can be spent on anything — a noncreature spell casts fine and gains nothing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val orb = driver.putPermanentOnBattlefield(you, "Carnelian Orb of Dragonkind")
+        val call = driver.putCardInHand(you, "Test Dragon Call")
+        tapOrb(driver, you, orb)
+
+        // The {R} is unrestricted, so it really does pay for this sorcery: the rider is consumed
+        // and must no-op rather than error.
+        driver.castSpell(you, call).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe 22
+    }
+})


### PR DESCRIPTION
Implements **Carnelian Orb of Dragonkind** — `{2}{R}` Artifact, `{T}: Add {R}. If that mana is spent on a Dragon creature spell, it gains haste until end of turn.`

The mana itself is unrestricted (it can pay for anything); the entire card lives in the rider.

## New SDK vocabulary

`ManaSpellRider.GrantsKeywordWhenSpent(keyword, spellFilter)`.

Unlike the two existing riders, this one queues **nothing** onto the stack — "it gains haste until end of turn" is a continuous effect, not a triggered ability, so the cast pipeline floats a `Layer.ABILITY` / `GrantKeyword` / `Duration.EndOfTurn` modification keyed to the spell's entity id. A permanent spell keeps that id as it resolves onto the battlefield, so the keyword is live the moment the permanent exists — exactly what haste needs. On a non-permanent spell the grant simply never finds a permanent to apply to.

Matching happens at payment time against the spell's cast characteristics, which is what the printed rulings require:

- mana spent on a non-Dragon spell that *becomes* a Dragon later in the turn grants nothing;
- an instant or sorcery is not a creature spell even if it makes Dragon tokens;
- the mana can still be spent on anything — the rider rides along on every cast it pays for and no-ops when the spell doesn't match.

Like the sibling `MakesSpellUncounterable`, this applies as a silent state mutation rather than emitting a `GameEvent` — `applyManaSpellRider` has no event channel, and the granted keyword reaches the client through projected state.

## Canonical placement

The card's earliest real printing is **Commander Legends: Battle for Baldur's Gate** (2022-06-10), so CLB is scaffolded to hold the `CardDefinition` — same shape as the existing VOC scaffold (`sealedSupported = false`, `incomplete = true`) — and Foundations gets a `Printing` row for #759. `just check-card-printing "Carnelian Orb of Dragonkind"` passes clean.

## Tests

Four scenario tests, all passing; `just build` green with the new `CLB.json` golden (no other set moved).

The positive test pins the turn number across `passPriorityUntil(DECLARE_ATTACKERS)`. That matters: the engine **skips the declare-attackers step outright** when the active player has no legal attacker, so without the turn check a hasteless Dragon would sail into the following turn and "attack successfully" anyway — the assertion would have been vacuous. This caught a real hole in the first draft of the test.

## Note on set completion

This card is why FDN showed a missing tile while badged Complete. That badge is working as designed — the headline % covers only the booster (draft) pool, and this card has no Play Booster printing in FDN (#534 Beginner Box, #759 2026 set extension), so it sits in the separately-reported `extra` bucket.

Separately, and **not fixed here**: `scripts/card-status` derives the draft/extra split from a single arbitrary printing per name (`unique=cards`), so 14 FDN cards that genuinely are Play Booster cards (collector # 1–291) are currently filed as extras because Scryfall serves their 2026 `setextension` printing — silently shrinking FDN's booster denominator from 276 to 262. Worth a follow-up that ORs the `booster` flag across all printings of a name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)