### PR TITLE
Count a card as boosterable if any of its printings in the set is

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -289,7 +289,8 @@ runtime, so `scripts/card-progress-graph` bakes the series (alongside the root
 
 The denominator (canonical booster + extra front-face card names) isn't knowable at runtime — it
 lives only in the local Scryfall cache. `scripts/gen-set-totals` bakes those canonical cards, split
-into `draft` (Scryfall `booster: true`) and `extra`, each `{ name, img }` (direct CDN art URL), into
+into `draft` (some printing of the card in that set is Scryfall `booster: true`) and `extra`, each
+`{ name, img }` (direct CDN art URL), into
 the committed `game-server/.../resources/coverage/set-totals.json` resource (same partitioning as
 `scripts/card-status`, so the numbers match the mtgish coverage TUI). Baking the art URL lets the
 detail view render set-specific images for *missing* cards too, without hammering the rate-limited

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageService.kt
@@ -13,9 +13,10 @@ import org.springframework.stereotype.Service
  * The denominator — how many cards a set canonically *has* — is not knowable at
  * runtime: it lives only in the local Scryfall cache that `scripts/card-status`
  * populates. `scripts/gen-set-totals` bakes those canonical card names into the
- * committed `coverage/set-totals.json` resource, split into **draft** (booster-relevant,
- * Scryfall `booster: true`) and **extra** (completionist exclusives), same partitioning
- * as `card-status` so the numbers match the mtgish coverage TUI.
+ * committed `coverage/set-totals.json` resource, split into **draft** (booster-relevant —
+ * some printing of the card in that set is Scryfall `booster: true`) and **extra**
+ * (completionist exclusives), same partitioning as `card-status` so the numbers match the
+ * mtgish coverage TUI.
  *
  * At request time this service joins that static denominator with the *live*
  * [MtgSetCatalog] numerator: a set's implemented count is the number of its canonical

--- a/game-server/src/main/resources/coverage/set-totals.json
+++ b/game-server/src/main/resources/coverage/set-totals.json
@@ -321,7 +321,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/2/2/22463284-2478-4b1e-9a37-6dd2383266cf.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/5/e5da22bf-bc8a-4810-b273-1e33a6b37323.jpg"
       },
       {
         "name": "Frozen in Ice",
@@ -481,7 +481,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/5/a/5a74175b-2418-4226-8435-1490532e644f.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/c/8c1467b1-ff2c-4f73-91ba-bc2b07afc2c3.jpg"
       },
       {
         "name": "Jennifer Walters",
@@ -621,7 +621,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/4/b/4bdbae27-9a55-485f-a1fc-3fa988184e9d.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/c/9c29ba11-7438-4fd7-98b9-961be882122d.jpg"
       },
       {
         "name": "Ms. Marvel, Kamala Khan",
@@ -677,7 +677,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/5/f/5f029c91-f20b-4aa5-a7d9-dd6ddef1c877.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/e/be30f027-ffdd-4d81-bed2-4adb6b4b803f.jpg"
       },
       {
         "name": "Political Triumph",
@@ -885,7 +885,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/7/4/74414c62-4b68-4e1b-9241-feff3231b9ee.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/d/dda87be6-317e-4227-a96d-7742ac054d2e.jpg"
       },
       {
         "name": "Swordsman, Sharp Scoundrel",
@@ -1459,7 +1459,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/f/1/f169dfb2-e4c8-46e9-8591-e51bb82da082.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/6/46196e8f-9339-4f00-b9cf-cab8f9abc80e.jpg"
       },
       {
         "name": "Forum Necroscribe",
@@ -1595,7 +1595,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/7/7/77b88bb8-6bd9-4632-b937-89468fcb5e6a.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/3/937250fe-bcad-4ff8-9406-286a69db7e0a.jpg"
       },
       {
         "name": "Jadzi, Steward of Fate",
@@ -1715,7 +1715,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/a/6/a642c7b1-d4d1-4125-a66d-560438e5ee51.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/a/6af1f1db-eb91-4297-83f6-9318b87fd220.jpg"
       },
       {
         "name": "Muse Seeker",
@@ -1783,7 +1783,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/d/8/d85d0f25-a24a-4de0-9b8b-93fb5017bce9.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/8/a845de50-4af0-4f4a-9c2a-db587973571c.jpg"
       },
       {
         "name": "Planar Engineering",
@@ -2083,7 +2083,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/5/1/51fe930f-2b5a-4b1e-9007-6ee74fb44715.jpg"
+        "img": "https://cards.scryfall.io/normal/front/1/7/1797d5c7-d3fa-4184-85ae-46db14ddf523.jpg"
       },
       {
         "name": "Tablet of Discovery",
@@ -2413,7 +2413,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/3/b/3b84ec1e-ccce-4b8b-9302-b26f84cfa469.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/1/6194850b-d70a-4f3e-be3e-bfb23ce1170b.jpg"
       },
       {
         "name": "Frog Butler",
@@ -2481,7 +2481,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/8/3/836f371b-34f5-40e8-a806-e457841e5bc7.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/e/be2319a6-d089-4d13-8a7b-3552e654cdc5.jpg"
       },
       {
         "name": "Jennika's Technique",
@@ -2629,7 +2629,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/0/2/021fa322-f38c-4d94-8122-5b13425106d9.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/2/6243f79f-b0e3-4fba-b899-7535e1a277e2.jpg"
       },
       {
         "name": "Mouser Attack!",
@@ -2725,7 +2725,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/2/d/2dfe1926-c0d5-40a2-b1aa-988524aefc31.jpg"
+        "img": "https://cards.scryfall.io/normal/front/1/b/1b405611-27d4-435a-8e8e-6d528626fd27.jpg"
       },
       {
         "name": "Prehistoric Pet",
@@ -2901,7 +2901,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/e/4/e43ac31a-942e-4871-be29-426e19e52701.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/1/41c7688d-8155-45fd-83ba-ff9be4d414a3.jpg"
       },
       {
         "name": "TCRI Building",
@@ -5418,7 +5418,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/c/4/c4fec728-8e3f-427d-81ab-e06114910223.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/b/7b6c2532-be5a-4f1f-893c-36bcda2a699d.jpg"
       },
       {
         "name": "Friendly Neighborhood",
@@ -5486,7 +5486,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/1/4/14fcdc57-12e2-429b-8916-4df752e462d4.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/5/d59cb0b5-fd4f-4dde-a69f-7ca6aa12b89f.jpg"
       },
       {
         "name": "J. Jonah Jameson",
@@ -5582,7 +5582,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/f/c/fc5004db-8db3-4506-bb01-f41be7968824.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/0/b044630d-50e7-431b-8e91-bd53e967f594.jpg"
       },
       {
         "name": "Multiversal Passage",
@@ -5642,7 +5642,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/9/4/94e88862-d53d-49b6-8aa5-95f07507c6e1.jpg"
+        "img": "https://cards.scryfall.io/normal/front/1/1/1164f7ec-7b2f-4cc9-90bb-7eaaa331b4cd.jpg"
       },
       {
         "name": "Prison Break",
@@ -5926,7 +5926,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/a/7/a7150a6e-240f-4628-acdc-153d404370ff.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/c/5cb03b18-d74c-4c89-9539-3549d2e8ff5f.jpg"
       },
       {
         "name": "Swarm, Being of Bees",
@@ -6364,7 +6364,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/f/b/fb62605c-a58e-4e53-8336-b2bee316b5a6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/3/8335b9f1-e726-423b-8ba7-6151448ab3fd.jpg"
       },
       {
         "name": "Frenzied Baloth",
@@ -6512,7 +6512,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/a/a/aaa212be-1db5-4493-86c8-c01d29348e31.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/6/76313c69-8ec7-49e3-a34e-ade26097284c.jpg"
       },
       {
         "name": "Kav Landseeker",
@@ -6648,7 +6648,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/5/c/5cd39b01-9a06-4575-9c63-9fb3ba9ef101.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/2/3204f401-1bcb-4d97-b15d-113a5d3c3e9f.jpg"
       },
       {
         "name": "Mouth of the Storm",
@@ -6708,7 +6708,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/d/f/df31f72c-076e-4d8e-9975-6d6281ab71f6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/0/8/089ae01b-e042-4255-b0ee-17d8f416a8d9.jpg"
       },
       {
         "name": "Plasma Bolt",
@@ -6940,7 +6940,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/5/8/58496a56-437f-4204-9691-f63795e5cdab.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/e/3e724e54-a622-4c77-8183-5a397a7c14a9.jpg"
       },
       {
         "name": "Swarm Culler",
@@ -8340,11 +8340,11 @@
     "extra": [
       {
         "name": "Beatrix, Loyal General",
-        "img": "https://cards.scryfall.io/normal/front/9/d/9da83b07-4978-4af7-be51-8aa8f35ec0bb.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/b/ab1b24dd-ab23-41b0-a074-e77e8d9c5564.jpg"
       },
       {
         "name": "Cloud, Planet's Champion",
-        "img": "https://cards.scryfall.io/normal/front/a/6/a6d58067-337d-43dc-b4a3-c6acc701d450.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/5/75180e47-064e-4dd6-adcf-d4fb497a445b.jpg"
       },
       {
         "name": "Deadly Embrace",
@@ -8356,7 +8356,7 @@
       },
       {
         "name": "Lightning, Security Sergeant",
-        "img": "https://cards.scryfall.io/normal/front/4/a/4ad4dce3-6e43-4528-b570-85547d03164e.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/0/40cce7b4-1d5d-4d91-90c5-71b79b5be1ac.jpg"
       },
       {
         "name": "Magitek Scythe",
@@ -8364,15 +8364,15 @@
       },
       {
         "name": "Rosa, Resolute White Mage",
-        "img": "https://cards.scryfall.io/normal/front/c/4/c44e0ad6-9f44-4e4c-8c3b-3ee99409a740.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/7/d7964800-1392-4bb8-84e2-c9f3938ceac3.jpg"
       },
       {
         "name": "Sephiroth, Planet's Heir",
-        "img": "https://cards.scryfall.io/normal/front/a/b/abd73e52-62f0-4e89-9dc6-90ff0bc2a9b7.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/0/b03e29e2-cfda-4284-8d30-0686c01e861e.jpg"
       },
       {
         "name": "Seymour Flux",
-        "img": "https://cards.scryfall.io/normal/front/c/5/c5fdc78e-0815-443c-8c26-35387b6f4f37.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/f/8fc42c17-a12b-42db-bb01-3e444ac2a376.jpg"
       },
       {
         "name": "Ultima Weapon",
@@ -8380,11 +8380,11 @@
       },
       {
         "name": "Ultimecia, Temporal Threat",
-        "img": "https://cards.scryfall.io/normal/front/b/6/b64e4475-f1c6-4d85-b42f-6d84d06855bb.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/9/f988af75-acf4-41bb-b4c5-58492fd1f6a0.jpg"
       },
       {
         "name": "Xande, Dark Mage",
-        "img": "https://cards.scryfall.io/normal/front/1/c/1caed9a8-b73b-470e-b9d8-8c3b7cac3eee.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/1/e11df7e8-e154-4fe2-b8d6-a452d0e0d7d5.jpg"
       }
     ]
   },
@@ -9483,23 +9483,23 @@
     "extra": [
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/8/1/8100bceb-ffba-487a-bb45-4fe2a156a8dc.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/8/48811e13-5774-4da1-95ec-6ea5dc4976ad.jpg"
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/1/f/1ff6acc9-581c-468f-894d-41f725da7f33.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/2/4208e66c-8c98-4c48-ab07-8523c0b26ca4.jpg"
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/b/f/bfa10a88-12e0-4b79-80bb-6f4620277e20.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/e/fe0865ba-47c0-40bc-b0c6-e1ea5ae08a98.jpg"
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/1/2/12cff32a-a365-43ee-a196-8ce32b3bb9fd.jpg"
+        "img": "https://cards.scryfall.io/normal/front/0/d/0d0f1dd6-9564-4adc-af7d-f83252e8581a.jpg"
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/f/0/f0bfdb9e-318f-4acd-9fbd-41b98a8875d6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/f/ef235170-8276-4ef0-bdfd-ba68d5b218ec.jpg"
       }
     ]
   },
@@ -9840,7 +9840,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg"
       },
       {
         "name": "Foul Roads",
@@ -9984,7 +9984,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg"
       },
       {
         "name": "Jibbirik Omnivore",
@@ -10120,7 +10120,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg"
       },
       {
         "name": "Mu Yanling, Wind Rider",
@@ -10184,7 +10184,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg"
+        "img": "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg"
       },
       {
         "name": "Plow Through",
@@ -10444,7 +10444,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg"
       },
       {
         "name": "Swiftwater Cliffs",
@@ -12088,6 +12088,10 @@
         "img": "https://cards.scryfall.io/normal/front/9/6/96e84bdc-8a9a-4c58-ba8b-9f052fd60069.jpg"
       },
       {
+        "name": "Dazzling Angel",
+        "img": "https://cards.scryfall.io/normal/front/0/2/027dc444-e544-4693-8653-3dcdda530162.jpg"
+      },
+      {
         "name": "Diregraf Ghoul",
         "img": "https://cards.scryfall.io/normal/front/4/6/4682012c-d7e0-4257-b538-3de497507464.jpg"
       },
@@ -12110,6 +12114,10 @@
       {
         "name": "Drake Hatcher",
         "img": "https://cards.scryfall.io/normal/front/b/c/bcaf4196-6bf3-47fa-b5c7-0e77f45cf820.jpg"
+      },
+      {
+        "name": "Drakuseth, Maw of Flames",
+        "img": "https://cards.scryfall.io/normal/front/0/2/029b1edb-e1de-4f1c-81df-8d17f4920318.jpg"
       },
       {
         "name": "Dreadwing Scavenger",
@@ -12176,6 +12184,10 @@
         "img": "https://cards.scryfall.io/normal/front/3/a/3a0b9356-5b91-4542-8802-f0f7275238e1.jpg"
       },
       {
+        "name": "Exemplar of Light",
+        "img": "https://cards.scryfall.io/normal/front/9/2/920c8fc5-fdd2-446a-a676-5c363f96928f.jpg"
+      },
+      {
         "name": "Exsanguinate",
         "img": "https://cards.scryfall.io/normal/front/f/1/f11d7311-4066-4a5d-ba28-9857fa707a0b.jpg"
       },
@@ -12214,6 +12226,10 @@
       {
         "name": "Firebrand Archer",
         "img": "https://cards.scryfall.io/normal/front/f/e/fe0312f1-4c98-4b7f-8a34-0059ea80edef.jpg"
+      },
+      {
+        "name": "Firespitter Whelp",
+        "img": "https://cards.scryfall.io/normal/front/4/b/4b3a4c7d-3126-4bde-9dca-cb6a1e2f37c9.jpg"
       },
       {
         "name": "Fishing Pole",
@@ -12312,6 +12328,10 @@
         "img": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg"
       },
       {
+        "name": "Healer's Hawk",
+        "img": "https://cards.scryfall.io/normal/front/c/c/cc8e4563-04bb-46b5-835e-64ba11c0e972.jpg"
+      },
+      {
         "name": "Heartfire Immolator",
         "img": "https://cards.scryfall.io/normal/front/3/c/3ca38f4d-01f5-4a02-9000-01261a440dbf.jpg"
       },
@@ -12354,6 +12374,10 @@
       {
         "name": "Hungry Ghoul",
         "img": "https://cards.scryfall.io/normal/front/7/9/790f9433-7565-4f7f-88e8-8af762ea0296.jpg"
+      },
+      {
+        "name": "Icewind Elemental",
+        "img": "https://cards.scryfall.io/normal/front/f/d/fd0eba76-3829-408b-828f-0b223c884728.jpg"
       },
       {
         "name": "Imprisoned in the Moon",
@@ -12496,6 +12520,10 @@
         "img": "https://cards.scryfall.io/normal/front/7/2/7214d984-6400-44d7-bde6-57d96b606e78.jpg"
       },
       {
+        "name": "Mocking Sprite",
+        "img": "https://cards.scryfall.io/normal/front/f/6/f6792f63-b651-497d-8aa5-cddf4cedeca8.jpg"
+      },
+      {
         "name": "Mossborn Hydra",
         "img": "https://cards.scryfall.io/normal/front/7/0/7054a0d7-396f-40b4-ab24-db591c3b08f0.jpg"
       },
@@ -12632,6 +12660,10 @@
         "img": "https://cards.scryfall.io/normal/front/1/e/1eae3165-554d-4759-8f18-794e2a7d8464.jpg"
       },
       {
+        "name": "Rune-Sealed Wall",
+        "img": "https://cards.scryfall.io/normal/front/d/a/da0f147b-95ed-4f32-9b46-6a633ae31976.jpg"
+      },
+      {
         "name": "Sanguine Syphoner",
         "img": "https://cards.scryfall.io/normal/front/b/1/b1daf5bb-c8e9-4e79-a532-ca92a9a885cd.jpg"
       },
@@ -12670,6 +12702,14 @@
       {
         "name": "Self-Reflection",
         "img": "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg"
+      },
+      {
+        "name": "Serra Angel",
+        "img": "https://cards.scryfall.io/normal/front/3/c/3cee9303-9d65-45a2-93d4-ef4aba59141b.jpg"
+      },
+      {
+        "name": "Shivan Dragon",
+        "img": "https://cards.scryfall.io/normal/front/1/f/1fcff1e0-2745-448d-a27b-e31719e222e9.jpg"
       },
       {
         "name": "Sire of Seven Deaths",
@@ -12712,6 +12752,10 @@
         "img": "https://cards.scryfall.io/normal/front/7/f/7ff50606-491c-4946-8d03-719b01cfad77.jpg"
       },
       {
+        "name": "Spectral Sailor",
+        "img": "https://cards.scryfall.io/normal/front/0/3/03a49535-c5f3-4a6f-b333-7ac7bffdc9ae.jpg"
+      },
+      {
         "name": "Sphinx of Forgotten Lore",
         "img": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg"
       },
@@ -12730,6 +12774,10 @@
       {
         "name": "Stab",
         "img": "https://cards.scryfall.io/normal/front/6/8/6859a5ba-1c1c-4631-bba8-f9900b827178.jpg"
+      },
+      {
+        "name": "Strix Lookout",
+        "img": "https://cards.scryfall.io/normal/front/f/b/fbd2422e-8e84-4c39-af29-3b4d38baee63.jpg"
       },
       {
         "name": "Stroke of Midnight",
@@ -12836,6 +12884,14 @@
         "img": "https://cards.scryfall.io/normal/front/9/1/917514c0-9cd5-4b97-85b9-c4f753560ad4.jpg"
       },
       {
+        "name": "Vampire Nighthawk",
+        "img": "https://cards.scryfall.io/normal/front/0/a/0a1934ab-3171-4fc6-8033-ad998899ba73.jpg"
+      },
+      {
+        "name": "Vampire Soulcaller",
+        "img": "https://cards.scryfall.io/normal/front/2/d/2d076293-3b45-4878-8f67-978927cc1f68.jpg"
+      },
+      {
         "name": "Vanguard Seraph",
         "img": "https://cards.scryfall.io/normal/front/4/3/4329c861-fc16-4a96-9c03-25af6ac2adc8.jpg"
       },
@@ -12915,7 +12971,7 @@
       },
       {
         "name": "Arcanis the Omnipotent",
-        "img": "https://cards.scryfall.io/normal/front/9/d/9d31e3e3-f398-4c0e-a2c9-4c614a4d41de.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/6/a6fee90a-7cb3-4fad-91a7-1b1edbde0133.jpg"
       },
       {
         "name": "Archway Angel",
@@ -12963,7 +13019,7 @@
       },
       {
         "name": "Bloodtithe Collector",
-        "img": "https://cards.scryfall.io/normal/front/3/7/37931135-100d-4a23-a6e3-baf90fb259ee.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/f/ff16d951-dd85-4d22-9505-ce6e2eaf47cf.jpg"
       },
       {
         "name": "Bolt Bend",
@@ -12987,7 +13043,7 @@
       },
       {
         "name": "Carnelian Orb of Dragonkind",
-        "img": "https://cards.scryfall.io/normal/front/6/d/6db2741d-2722-4eb7-b09d-0d81649c7ca2.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/0/f0c07546-c5a1-4dfc-b5e1-d697578a8c11.jpg"
       },
       {
         "name": "Cemetery Recruitment",
@@ -13035,11 +13091,11 @@
       },
       {
         "name": "Crusader of Odric",
-        "img": "https://cards.scryfall.io/normal/front/2/f/2fd0400a-ef3e-4b03-9852-63e28304da53.jpg"
+        "img": "https://cards.scryfall.io/normal/front/0/0/009029c2-26b9-498f-8765-e91c2e1f3aee.jpg"
       },
       {
         "name": "Cryptic Caves",
-        "img": "https://cards.scryfall.io/normal/front/9/d/9d126c8f-a3df-497c-aad5-a448c55f51cc.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/7/a7976098-b560-458a-ad3c-18f7873add21.jpg"
       },
       {
         "name": "Cultivator's Caravan",
@@ -13052,10 +13108,6 @@
       {
         "name": "Dawnwing Marshal",
         "img": "https://cards.scryfall.io/normal/front/8/0/807db84f-addb-4ef0-b9ba-32b3e1bced3d.jpg"
-      },
-      {
-        "name": "Dazzling Angel",
-        "img": "https://cards.scryfall.io/normal/front/a/0/a0bdf4d1-576f-41b6-a077-8725be608331.jpg"
       },
       {
         "name": "Deadly Brew",
@@ -13095,7 +13147,7 @@
       },
       {
         "name": "Diamond Mare",
-        "img": "https://cards.scryfall.io/normal/front/3/c/3c39b0ce-db4c-472c-b68e-07e6ba3a4588.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/2/721463ad-9531-487f-bd82-5e638c4fc35f.jpg"
       },
       {
         "name": "Dictate of Kruphix",
@@ -13128,10 +13180,6 @@
       {
         "name": "Dragonmaster Outcast",
         "img": "https://cards.scryfall.io/normal/front/b/7/b720f3a8-f38f-4460-86a3-dad541e7add7.jpg"
-      },
-      {
-        "name": "Drakuseth, Maw of Flames",
-        "img": "https://cards.scryfall.io/normal/front/9/e/9e9b40f5-3dd0-4607-a78d-b004d57fa4ea.jpg"
       },
       {
         "name": "Dread Summons",
@@ -13178,10 +13226,6 @@
         "img": "https://cards.scryfall.io/normal/front/6/2/62c8024e-490a-484a-bcee-da7728a64a1f.jpg"
       },
       {
-        "name": "Exemplar of Light",
-        "img": "https://cards.scryfall.io/normal/front/b/7/b7393efb-da40-4b55-a6ff-ce774f0815f9.jpg"
-      },
-      {
         "name": "Expedition Map",
         "img": "https://cards.scryfall.io/normal/front/0/8/08e66835-c228-48fa-bcaa-eb96edbd4f5a.jpg"
       },
@@ -13218,10 +13262,6 @@
         "img": "https://cards.scryfall.io/normal/front/4/8/484fbce6-71bd-40eb-a71b-86958a094708.jpg"
       },
       {
-        "name": "Firespitter Whelp",
-        "img": "https://cards.scryfall.io/normal/front/d/d/ddcc3c1b-b564-4444-9a1a-0f62f8e6b8bb.jpg"
-      },
-      {
         "name": "Flashfreeze",
         "img": "https://cards.scryfall.io/normal/front/9/1/91e37a7e-6093-4ef5-b6e4-4aa800ddfc1b.jpg"
       },
@@ -13247,7 +13287,7 @@
       },
       {
         "name": "Gatekeeper of Malakir",
-        "img": "https://cards.scryfall.io/normal/front/5/8/58c45158-7858-409e-ab37-8a9a66ad8714.jpg"
+        "img": "https://cards.scryfall.io/normal/front/2/c/2cd61c12-f5e2-4698-9080-097679754f16.jpg"
       },
       {
         "name": "Gateway Sneak",
@@ -13314,16 +13354,12 @@
         "img": "https://cards.scryfall.io/normal/front/4/7/47082081-bf52-4914-bac2-ace398beff56.jpg"
       },
       {
-        "name": "Healer's Hawk",
-        "img": "https://cards.scryfall.io/normal/front/0/6/069cfaa5-bba4-4503-b54e-b98fa9f0a0fc.jpg"
-      },
-      {
         "name": "Hedron Archive",
         "img": "https://cards.scryfall.io/normal/front/5/3/535b9ac6-dba2-4162-86ed-df3e9fad0306.jpg"
       },
       {
         "name": "Herald of Faith",
-        "img": "https://cards.scryfall.io/normal/front/2/e/2e1705da-dc35-4bcb-82d4-b77712e79af3.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/5/5579f35b-b3d2-4342-a52b-ae36b579d044.jpg"
       },
       {
         "name": "Heroes' Bane",
@@ -13340,10 +13376,6 @@
       {
         "name": "Hoarding Dragon",
         "img": "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg"
-      },
-      {
-        "name": "Icewind Elemental",
-        "img": "https://cards.scryfall.io/normal/front/c/2/c2bfdfb6-aa0b-4bd7-89ba-6435da730e5e.jpg"
       },
       {
         "name": "Immersturm Predator",
@@ -13363,7 +13395,7 @@
       },
       {
         "name": "Inspiring Overseer",
-        "img": "https://cards.scryfall.io/normal/front/7/9/79016cf3-6eea-4b21-9ff3-f187d606e19a.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/3/c3e9aa54-e5d5-4cbb-9d2a-263b9eba398f.jpg"
       },
       {
         "name": "Into the Roil",
@@ -13383,11 +13415,11 @@
       },
       {
         "name": "Kalastria Highborn",
-        "img": "https://cards.scryfall.io/normal/front/a/3/a3a055ed-60b0-4d35-ad58-04f324b56d65.jpg"
+        "img": "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg"
       },
       {
         "name": "Kargan Dragonrider",
-        "img": "https://cards.scryfall.io/normal/front/7/0/7023129c-09f5-49cf-ae32-b9bd30e0ff63.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg"
       },
       {
         "name": "Kindled Fury",
@@ -13395,7 +13427,7 @@
       },
       {
         "name": "Kitesail Corsair",
-        "img": "https://cards.scryfall.io/normal/front/a/a/aa127602-10b2-4144-985b-38e075f1e1f7.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/8/c82d7c6d-523c-46c9-a189-44c0bd8386d1.jpg"
       },
       {
         "name": "Knight of Grace",
@@ -13419,11 +13451,11 @@
       },
       {
         "name": "Linden, the Steadfast Queen",
-        "img": "https://cards.scryfall.io/normal/front/e/0/e0bb07cd-9b74-4ba7-8089-27a565d74197.jpg"
+        "img": "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg"
       },
       {
         "name": "Lyra Dawnbringer",
-        "img": "https://cards.scryfall.io/normal/front/f/9/f9fa30b6-3a33-46fd-8b32-ac1cfa41500d.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/2/b2abce4d-ef21-4028-8a86-b7d1387bc937.jpg"
       },
       {
         "name": "Maalfeld Twins",
@@ -13443,7 +13475,7 @@
       },
       {
         "name": "Massacre Wurm",
-        "img": "https://cards.scryfall.io/normal/front/6/7/670a36cc-34e1-4d11-808e-1b6bc88eb5d8.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg"
       },
       {
         "name": "Maze's End",
@@ -13464,10 +13496,6 @@
       {
         "name": "Mindsparker",
         "img": "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg"
-      },
-      {
-        "name": "Mocking Sprite",
-        "img": "https://cards.scryfall.io/normal/front/d/5/d52d16be-c74b-4e40-94f9-2ffa497b6337.jpg"
       },
       {
         "name": "Mold Adder",
@@ -13539,7 +13567,7 @@
       },
       {
         "name": "Pelakka Wurm",
-        "img": "https://cards.scryfall.io/normal/front/3/0/304c635c-de4d-46ee-8ab0-e5c4d55b61b3.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/a/fa150070-80b6-453d-b00f-4462175cac79.jpg"
       },
       {
         "name": "Pirate's Cutlass",
@@ -13547,7 +13575,7 @@
       },
       {
         "name": "Prayer of Binding",
-        "img": "https://cards.scryfall.io/normal/front/8/d/8d05289c-d8de-4085-ac01-5dd8fd954d35.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/3/a30b42c4-90d8-462d-aca5-891906992ab8.jpg"
       },
       {
         "name": "Predator Ooze",
@@ -13555,7 +13583,7 @@
       },
       {
         "name": "Primal Might",
-        "img": "https://cards.scryfall.io/normal/front/6/9/69b3f7b9-9499-4883-b5c5-c5474e470b21.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/a/9ae57d6b-15e8-4f2a-97c2-76d801a1a42a.jpg"
       },
       {
         "name": "Prime Speaker Zegana",
@@ -13567,7 +13595,7 @@
       },
       {
         "name": "Pulse Tracker",
-        "img": "https://cards.scryfall.io/normal/front/7/b/7bc1441e-7d75-4a74-8733-19077dfa69b2.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/d/fdcbbe4d-5c93-4b14-8123-cd835452870f.jpg"
       },
       {
         "name": "Pyromancer's Goggles",
@@ -13622,10 +13650,6 @@
         "img": "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg"
       },
       {
-        "name": "Rune-Sealed Wall",
-        "img": "https://cards.scryfall.io/normal/front/4/6/46674bd4-5160-44b2-bd2a-2da85c1e2697.jpg"
-      },
-      {
         "name": "Sanguine Indulgence",
         "img": "https://cards.scryfall.io/normal/front/0/3/03a26ca7-b26f-4b86-a060-712f15f4bf7f.jpg"
       },
@@ -13646,16 +13670,8 @@
         "img": "https://cards.scryfall.io/normal/front/6/7/6718d4e7-768e-473f-8064-a68422e977f6.jpg"
       },
       {
-        "name": "Serra Angel",
-        "img": "https://cards.scryfall.io/normal/front/b/8/b8c5e74c-96e7-4a1f-93b7-14d776fe4b2d.jpg"
-      },
-      {
         "name": "Shipwreck Dowser",
         "img": "https://cards.scryfall.io/normal/front/1/f/1f20fe3d-792a-4030-a25c-e81b48b2bcb4.jpg"
-      },
-      {
-        "name": "Shivan Dragon",
-        "img": "https://cards.scryfall.io/normal/front/7/0/702c4781-670b-49ae-b511-90ed119841b0.jpg"
       },
       {
         "name": "Simic Guildgate",
@@ -13678,16 +13694,12 @@
         "img": "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg"
       },
       {
-        "name": "Spectral Sailor",
-        "img": "https://cards.scryfall.io/normal/front/5/e/5ef30b6c-0806-4bf6-9a84-c2aea8d84cf1.jpg"
-      },
-      {
         "name": "Sphinx of the Final Word",
-        "img": "https://cards.scryfall.io/normal/front/6/0/6071239e-0b85-4c54-bef8-d9456eb8d8fc.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/2/a2cf2366-40d0-4f94-84a5-8aa42308e223.jpg"
       },
       {
         "name": "Springbloom Druid",
-        "img": "https://cards.scryfall.io/normal/front/1/7/17d67b88-3f76-401f-b04a-f2bcaab4aa97.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/a/fa87cb5f-4dc9-49a4-9ae6-ebc7fedac018.jpg"
       },
       {
         "name": "Starlight Snare",
@@ -13706,16 +13718,12 @@
         "img": "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg"
       },
       {
-        "name": "Strix Lookout",
-        "img": "https://cards.scryfall.io/normal/front/3/b/3b0c77ab-15cd-49d8-ac5b-7b8b968d14cd.jpg"
-      },
-      {
         "name": "Stromkirk Noble",
         "img": "https://cards.scryfall.io/normal/front/0/f/0f306c7e-cacc-4c26-a3f1-fad4f3ff7cf3.jpg"
       },
       {
         "name": "Surrak, the Hunt Caller",
-        "img": "https://cards.scryfall.io/normal/front/d/e/deb328c7-fdda-4d63-9fe4-0482c1de6098.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/6/d6a8759d-0dc8-4218-93ac-b1a35088f776.jpg"
       },
       {
         "name": "Suspicious Shambler",
@@ -13743,7 +13751,7 @@
       },
       {
         "name": "Tempest Djinn",
-        "img": "https://cards.scryfall.io/normal/front/3/d/3de55b97-059c-4d7b-afd0-44fd8380df4c.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/7/7766506c-bc18-4ac3-9034-e8f7e54c4039.jpg"
       },
       {
         "name": "Temple of Abandon",
@@ -13787,7 +13795,7 @@
       },
       {
         "name": "Terror of Mount Velus",
-        "img": "https://cards.scryfall.io/normal/front/4/0/4047b1c3-06eb-400d-993d-69b5210977ee.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/9/3959a6c7-d615-4524-b94d-65f4164a2656.jpg"
       },
       {
         "name": "Thornweald Archer",
@@ -13827,7 +13835,7 @@
       },
       {
         "name": "Unsummon",
-        "img": "https://cards.scryfall.io/normal/front/2/8/2815d8e6-3668-4b9d-abe6-eca6a500707d.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/3/b378d319-ab98-422a-8f72-121a9d26f5c6.jpg"
       },
       {
         "name": "Untamed Hunger",
@@ -13839,19 +13847,11 @@
       },
       {
         "name": "Vampire Interloper",
-        "img": "https://cards.scryfall.io/normal/front/a/c/ac01d4eb-10ec-4bda-aa9b-04c74dabfcaf.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/5/65455d94-487c-4104-a1a0-149515a90eaa.jpg"
       },
       {
         "name": "Vampire Neonate",
         "img": "https://cards.scryfall.io/normal/front/8/6/86d64a1d-cda4-4c76-8d58-ccab5a6859a0.jpg"
-      },
-      {
-        "name": "Vampire Nighthawk",
-        "img": "https://cards.scryfall.io/normal/front/7/a/7aff07f9-9528-4149-9af0-f4e3c66c9dc5.jpg"
-      },
-      {
-        "name": "Vampire Soulcaller",
-        "img": "https://cards.scryfall.io/normal/front/4/7/4734e3fe-7cd7-4045-983f-f89eae9396fa.jpg"
       },
       {
         "name": "Vampire Spawn",
@@ -13875,7 +13875,7 @@
       },
       {
         "name": "Vizier of the Menagerie",
-        "img": "https://cards.scryfall.io/normal/front/1/4/14ab742a-89dc-4c01-99e3-21fc609128f2.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/0/3010ec33-c3f6-42ce-ad5a-e149e5c9a805.jpg"
       },
       {
         "name": "Volley Veteran",
@@ -14264,7 +14264,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg"
       },
       {
         "name": "Found Footage",
@@ -14416,7 +14416,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg"
       },
       {
         "name": "Jump Scare",
@@ -14532,7 +14532,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg"
       },
       {
         "name": "Murder",
@@ -14640,7 +14640,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg"
       },
       {
         "name": "Popular Egotist",
@@ -14816,7 +14816,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg"
       },
       {
         "name": "Terramorphic Expanse",
@@ -16587,6 +16587,10 @@
         "img": "https://cards.scryfall.io/normal/front/3/e/3ec72a27-b622-47d7-bdf3-970ccaef0d2a.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/f/7/f791876a-f3fb-45b8-90a9-af846d8b8f74.jpg"
+      },
+      {
         "name": "Fountainport",
         "img": "https://cards.scryfall.io/normal/front/6/5/658cfcb7-81b7-48c6-9dd2-1663d06108cf.jpg"
       },
@@ -16715,6 +16719,10 @@
         "img": "https://cards.scryfall.io/normal/front/b/2/b2bc854c-4e72-48e0-a098-e3451d6e511d.jpg"
       },
       {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/1/0/106a5332-0104-4ec9-9e1f-806381ae4cad.jpg"
+      },
+      {
         "name": "Jackdaw Savior",
         "img": "https://cards.scryfall.io/normal/front/1/2/121af600-6143-450a-9f87-12ce4833f1ec.jpg"
       },
@@ -16839,6 +16847,10 @@
         "img": "https://cards.scryfall.io/normal/front/5/9/59e4aa8d-1d06-48db-b205-aa2f1392bbcb.jpg"
       },
       {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/c/1/c1bba8fb-d763-4efa-8db1-e5e81994b5f9.jpg"
+      },
+      {
         "name": "Mouse Trapper",
         "img": "https://cards.scryfall.io/normal/front/8/b/8ba1bc5a-03e7-44ec-893e-44042cbc02ef.jpg"
       },
@@ -16909,6 +16921,10 @@
       {
         "name": "Pileated Provisioner",
         "img": "https://cards.scryfall.io/normal/front/a/e/ae442cd6-c4df-4aad-9b1d-ccd936c5ec96.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/3/6/3663ff0c-d02f-49ac-bb88-6f0dbd684337.jpg"
       },
       {
         "name": "Playful Shove",
@@ -17155,6 +17171,10 @@
         "img": "https://cards.scryfall.io/normal/front/8/9/8995ceaf-b7e0-423c-8f3e-25212d522502.jpg"
       },
       {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/f/a/faa54bef-c90e-4e9b-b94b-942ea829e0d2.jpg"
+      },
+      {
         "name": "Take Out the Trash",
         "img": "https://cards.scryfall.io/normal/front/7/a/7a1c6f00-af4c-4d35-b682-6c0e759df9a5.jpg"
       },
@@ -17357,28 +17377,12 @@
         "img": "https://cards.scryfall.io/normal/front/c/6/c6440439-7178-4a97-9e18-7fdef4b02678.jpg"
       },
       {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/4/3/43b3be4a-973d-4aeb-a94e-37e2710ac178.jpg"
-      },
-      {
         "name": "Giant Growth",
         "img": "https://cards.scryfall.io/normal/front/e/7/e70722d6-b4d5-45c2-9488-9a5eb0bdb9bd.jpg"
       },
       {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/4/6/46848fc2-ba58-4738-b4ce-0399d9053f48.jpg"
-      },
-      {
         "name": "Mind Spring",
         "img": "https://cards.scryfall.io/normal/front/e/7/e7e7d174-eb7c-41ad-a241-cfbfdc71e3a7.jpg"
-      },
-      {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/4/b/4b827c54-8bfe-4ef5-830e-e17b8690bbe7.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/4/4/449d4122-ee9d-477c-976a-809ba8cb1443.jpg"
       },
       {
         "name": "Rabid Bite",
@@ -17387,10 +17391,6 @@
       {
         "name": "Serra Redeemer",
         "img": "https://cards.scryfall.io/normal/front/2/3/230b9aef-bd9c-4332-ace4-b5b065bac6d8.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/6/1/6125ffe3-4e48-4e0f-8390-7462446fc8bf.jpg"
       },
       {
         "name": "Swiftwater Cliffs",
@@ -17734,6 +17734,10 @@
         "img": "https://cards.scryfall.io/normal/front/8/f/8f8c931e-219f-4032-b55b-b5975fbea1e7.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/b/a/baf8a774-65f3-431e-b084-328ff1000895.jpg"
+      },
+      {
         "name": "Forlorn Flats",
         "img": "https://cards.scryfall.io/normal/front/9/6/963c100e-4e12-438f-b5ae-14391406dff6.jpg"
       },
@@ -17878,6 +17882,10 @@
         "img": "https://cards.scryfall.io/normal/front/c/d/cd7f984a-0b56-45df-958d-6178e4da61ed.jpg"
       },
       {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/a/6/a624d656-207d-4e73-b615-59e7cf64ad64.jpg"
+      },
+      {
         "name": "Jace Reawakened",
         "img": "https://cards.scryfall.io/normal/front/f/d/fd17e8d4-499e-4005-ae3c-bc9c44dc5a67.jpg"
       },
@@ -18010,6 +18018,10 @@
         "img": "https://cards.scryfall.io/normal/front/d/5/d5fa82e4-0b77-498a-bec0-52764d24957a.jpg"
       },
       {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/0/a/0a7dbfd2-cda7-4fc9-9677-e442fb5f5f6f.jpg"
+      },
+      {
         "name": "Mourner's Surprise",
         "img": "https://cards.scryfall.io/normal/front/9/8/980b0b68-7218-49c6-b6bf-022218f3abf4.jpg"
       },
@@ -18100,6 +18112,10 @@
       {
         "name": "Pitiless Carnage",
         "img": "https://cards.scryfall.io/normal/front/f/a/fa76fc45-a106-4dc9-9d44-a005eaa2784d.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/c/f/cfe51d97-66f6-4ac3-b926-01ab7e4c5686.jpg"
       },
       {
         "name": "Plan the Heist",
@@ -18366,6 +18382,10 @@
         "img": "https://cards.scryfall.io/normal/front/6/d/6d963eb4-d20b-4d3f-bf5d-c75f7bcb9670.jpg"
       },
       {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/3/b/3b383b16-8128-4d9e-a0d0-9b8ccc9ad6df.jpg"
+      },
+      {
         "name": "Taii Wakeen, Perfect Shot",
         "img": "https://cards.scryfall.io/normal/front/1/6/1643af0b-fcbf-4636-8c50-77ec77eaa34d.jpg"
       },
@@ -18498,28 +18518,7 @@
         "img": "https://cards.scryfall.io/normal/front/b/c/bc97ffcf-4f51-44cd-8daa-a7dae4592ee5.jpg"
       }
     ],
-    "extra": [
-      {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/d/c/dc20a07e-5f92-49c2-9c97-d5eda536d3f6.jpg"
-      },
-      {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/a/c/acd6be3f-745c-41ad-95c9-1db66ba56be2.jpg"
-      },
-      {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/9/1/9137b4aa-2289-4a4d-b1f5-ae75a0928278.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/6/f/6f501773-1b39-4a4c-9b45-a950385c9e82.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/e/b/eb7dc259-9949-4673-a8f1-874396948392.jpg"
-      }
-    ]
+    "extra": []
   },
   {
     "code": "BIG",
@@ -19068,7 +19067,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/c/c/cc485069-e081-4e83-bbad-d5faf7a5bd03.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/1/8126b842-ea58-4988-8b3f-0394cf766b91.jpg"
       },
       {
         "name": "Forum Familiar",
@@ -19204,7 +19203,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/6/9/6908b583-4a52-4819-82a3-9db9c860aeb6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/e/fe5f01e9-f85f-41e8-9527-88f76e7bfc02.jpg"
       },
       {
         "name": "It Doesn't Add Up",
@@ -19352,7 +19351,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/d/e/de754d20-5371-456b-9064-8f0687d2eab7.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/3/5383b66e-e559-47d2-9967-9c2d5f898653.jpg"
       },
       {
         "name": "Murder",
@@ -19432,7 +19431,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/8/1/81a1a8a6-916b-4eef-8079-6775afcb63cf.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/9/598f857d-ee17-4478-bb39-cc3ab77ab8d8.jpg"
       },
       {
         "name": "Polygraph Orb",
@@ -19620,7 +19619,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/7/0/70d0ef58-c0b3-4bcd-b470-0cf41219a4e6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/3/53d0a415-26b8-4ba2-9503-b4ee2b93617c.jpg"
       },
       {
         "name": "Tenth District Hero",
@@ -20159,7 +20158,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/f/9/f954219a-fd4b-4fb1-945f-7950efc1d975.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg"
       },
       {
         "name": "Forgotten Monument",
@@ -20315,7 +20314,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/2/3/23e3ed2c-342b-44aa-8e3e-0c53602397c3.jpg"
+        "img": "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg"
       },
       {
         "name": "Itzquinth, Firstborn of Gishath",
@@ -20443,7 +20442,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/e/8/e82fc4bc-ac81-4ad6-8b33-781d047f60d5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg"
       },
       {
         "name": "Nicanzil, Current Conductor",
@@ -20523,7 +20522,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/4/7/4716a32c-91a6-470a-a686-d5eb3d27f46e.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg"
       },
       {
         "name": "Plundering Pirate",
@@ -20767,7 +20766,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/4/f/4f893107-84b0-4e3f-b1f5-b04632f192c5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg"
       },
       {
         "name": "Swashbuckler's Whip",
@@ -21265,7 +21264,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/a/4/a4c99f1b-f304-42d5-bbea-32283b01d43b.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/c/ecd6d8fb-780c-446c-a8bf-93386b22fe95.jpg"
       },
       {
         "name": "Frantic Firebolt",
@@ -21413,7 +21412,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/6/2/6245d2f8-8ef0-4d2a-9abb-99839dc3abf0.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/d/bd4b4da4-83f6-4280-880b-b6033308f2a2.jpg"
       },
       {
         "name": "Johann's Stopgap",
@@ -21513,7 +21512,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/8/9/8996cd43-5ecd-4a05-a5a9-e49326befaa1.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/8/8822db23-34dc-452a-92bc-a3ceee4db375.jpg"
       },
       {
         "name": "Neva, Stalked by Nightmares",
@@ -21545,7 +21544,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/e/e/eed1af19-e075-4e6f-9394-d258143e15a4.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/9/c9cd4d57-8c51-4fcf-8a9f-5d6a61c33e3d.jpg"
       },
       {
         "name": "Plunge into Winter",
@@ -21797,7 +21796,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/d/0/d0a801ba-ebf7-4b9e-98c2-db50448845b7.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/e/ee68f2cb-851b-4196-ac58-844d72628e6a.jpg"
       },
       {
         "name": "Sweettooth Witch",
@@ -22379,6 +22378,10 @@
         "img": "https://cards.scryfall.io/normal/front/5/f/5fea0c66-c776-4dc7-a235-f3822521cacd.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/c/b/cbe793e4-c034-4a22-929d-d743c0255bf1.jpg"
+      },
+      {
         "name": "Forge Anew",
         "img": "https://cards.scryfall.io/normal/front/5/6/56274b88-6e3f-4538-bb0c-eb5e52a58ef3.jpg"
       },
@@ -22559,6 +22562,10 @@
         "img": "https://cards.scryfall.io/normal/front/4/b/4bf08071-fbf8-463e-9a57-59dbf0280dd8.jpg"
       },
       {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/b/b/bbeca27a-6c5b-40b9-83a4-a3a2096ff6f8.jpg"
+      },
+      {
         "name": "Isolation at Orthanc",
         "img": "https://cards.scryfall.io/normal/front/5/4/54b9c323-ac9b-4864-bd57-81b557f44114.jpg"
       },
@@ -22699,6 +22706,10 @@
         "img": "https://cards.scryfall.io/normal/front/b/5/b5bc71a1-2344-4bc6-aa60-658cec19d0d6.jpg"
       },
       {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/e/3/e3731001-4e6a-4a91-9e7d-fc2ea039a60b.jpg"
+      },
+      {
         "name": "Mushroom Watchdogs",
         "img": "https://cards.scryfall.io/normal/front/d/1/d15fd66d-fa7e-411d-9014-a56caa879d93.jpg"
       },
@@ -22773,6 +22784,10 @@
       {
         "name": "Pippin, Guard of the Citadel",
         "img": "https://cards.scryfall.io/normal/front/0/8/08b7a4d8-1183-430e-8ea4-016844f33200.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/f/7/f724ae86-b968-4f49-8267-c2c34c22f1b6.jpg"
       },
       {
         "name": "Press the Enemy",
@@ -23003,6 +23018,10 @@
         "img": "https://cards.scryfall.io/normal/front/1/c/1c50d4c8-2311-4394-b73f-389eb81e898b.jpg"
       },
       {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/2/a/2a0fba6e-54d2-498c-83bc-41024307e608.jpg"
+      },
+      {
         "name": "Swarming of Moria",
         "img": "https://cards.scryfall.io/normal/front/0/a/0a1bd073-4351-4c56-9b07-4430d0d83084.jpg"
       },
@@ -23169,10 +23188,6 @@
         "img": "https://cards.scryfall.io/normal/front/b/9/b9db8702-fc72-453b-afc8-62266f7cd1c2.jpg"
       },
       {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/1/5/150d0710-9ecb-4187-a0f8-a70b330c8879.jpg"
-      },
-      {
         "name": "Frodo, Determined Hero",
         "img": "https://cards.scryfall.io/normal/front/8/3/83d1b37c-a8c6-4690-8701-3395397711e7.jpg"
       },
@@ -23193,10 +23208,6 @@
         "img": "https://cards.scryfall.io/normal/front/7/f/7f93ad17-b655-4a10-990e-b26ead90d221.jpg"
       },
       {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/a/a/aa03a3b5-cdc3-40cc-bd45-69ad65809d2f.jpg"
-      },
-      {
         "name": "Knight of the Keep",
         "img": "https://cards.scryfall.io/normal/front/3/a/3af21576-3793-4796-ab60-112fbbb5fc0d.jpg"
       },
@@ -23207,14 +23218,6 @@
       {
         "name": "Mirkwood Channeler",
         "img": "https://cards.scryfall.io/normal/front/c/a/ca533454-8bea-4e08-ab0b-e2f4affffaef.jpg"
-      },
-      {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/6/4/6410d20e-408a-42c6-9884-ea9e22e2ee7c.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/c/0/c05ce2e3-44e9-441b-9467-46a3c6642184.jpg"
       },
       {
         "name": "Riders of the Mark",
@@ -23231,10 +23234,6 @@
       {
         "name": "Sauron, the Lidless Eye",
         "img": "https://cards.scryfall.io/normal/front/d/8/d82a4c78-d2fc-425a-8d0e-2e64509a08f1.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/d/5/d56b5831-e39a-4898-be06-b84f62d38456.jpg"
       },
       {
         "name": "The Balrog, Flame of Udûn",
@@ -24765,6 +24764,10 @@
         "img": "https://cards.scryfall.io/normal/front/2/7/272c9888-ef13-4d47-a4bc-f5239b357a1b.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg"
+      },
+      {
         "name": "Forgehammer Centurion",
         "img": "https://cards.scryfall.io/normal/front/c/4/c4c2c914-e9a7-450b-88d9-8885fe0f6643.jpg"
       },
@@ -24879,6 +24882,10 @@
       {
         "name": "Infested Fleshcutter",
         "img": "https://cards.scryfall.io/normal/front/9/f/9f03d6bf-cbba-4ad7-8cec-065a47f03dbe.jpg"
+      },
+      {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg"
       },
       {
         "name": "Jace, the Perfected Mind",
@@ -25013,6 +25020,10 @@
         "img": "https://cards.scryfall.io/normal/front/a/b/ab892e7b-6797-4ede-ab5d-d9d0fa488c80.jpg"
       },
       {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg"
+      },
+      {
         "name": "Myr Convert",
         "img": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg"
       },
@@ -25111,6 +25122,10 @@
       {
         "name": "Plague Nurse",
         "img": "https://cards.scryfall.io/normal/front/5/e/5e7eef9e-68ae-4743-ad89-64f6fafbe365.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg"
       },
       {
         "name": "Planar Disruption",
@@ -25263,6 +25278,10 @@
       {
         "name": "Surgical Skullbomb",
         "img": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg"
+      },
+      {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg"
       },
       {
         "name": "Swooping Lookout",
@@ -25503,16 +25522,8 @@
     ],
     "extra": [
       {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg"
-      },
-      {
         "name": "Goliath Hatchery",
         "img": "https://cards.scryfall.io/normal/front/0/e/0e1141ca-78c0-46e5-99f8-28069d69f23a.jpg"
-      },
-      {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg"
       },
       {
         "name": "Kinzu of the Bleak Coven",
@@ -25523,24 +25534,12 @@
         "img": "https://cards.scryfall.io/normal/front/a/5/a55a5edb-edf3-4f6c-90b8-1780b1e73997.jpg"
       },
       {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg"
-      },
-      {
         "name": "Rhuk, Hexgold Nabber",
         "img": "https://cards.scryfall.io/normal/front/d/7/d7c25806-1da6-4789-a17e-d2440184ec40.jpg"
       },
       {
         "name": "Serum Sovereign",
         "img": "https://cards.scryfall.io/normal/front/7/0/70d562aa-8b49-40a3-a5c1-3af8afa98edc.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg"
       }
     ]
   },
@@ -35103,7 +35102,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/7/a/7ae6380e-b1b6-4a5a-a8d9-7cdf8eab3557.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/4/e4c83b60-3d49-4fdc-a6b7-06d1a0c4a126.jpg"
       },
       {
         "name": "Frenzied Devils",
@@ -35251,7 +35250,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/f/8/f82b281f-d3c7-4eb8-9a10-b4808ca6cfcd.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/4/54ddd3aa-593c-4adb-b591-33c15d02131c.jpg"
       },
       {
         "name": "Jacob Hauken, Inspector",
@@ -35355,7 +35354,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/b/8/b86fbf78-57ec-4a0f-9fb6-e4bf13861563.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/a/8a4448b6-0dbe-427c-b145-8ac915fc0dfc.jpg"
       },
       {
         "name": "Mulch",
@@ -35439,7 +35438,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/2/0/20ddb0be-d62d-46fa-b753-36dfab935e8a.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/e/deabdaa1-6227-48e4-82d5-63a1771320b2.jpg"
       },
       {
         "name": "Pointed Discussion",
@@ -35627,7 +35626,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/b/e/be87de91-aa10-4ed8-83a2-261b4f57e7db.jpg"
+        "img": "https://cards.scryfall.io/normal/front/4/a/4abfe418-15f8-46ce-9b39-fd5a38b25d12.jpg"
       },
       {
         "name": "Syncopate",
@@ -36818,6 +36817,10 @@
         "img": "https://cards.scryfall.io/normal/front/5/3/53289e69-74da-46d2-91c2-a11378ba76ef.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/a/d/ad8ff40e-2d40-4557-8209-d2c84eb4ccf2.jpg"
+      },
+      {
         "name": "Foul Play",
         "img": "https://cards.scryfall.io/normal/front/8/7/87e4b75c-e993-4983-8933-977be314bba6.jpg"
       },
@@ -36934,6 +36937,10 @@
         "img": "https://cards.scryfall.io/normal/front/7/7/773199f9-c83b-4a77-8342-9f1552ecf595.jpg"
       },
       {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/8/d/8dc3bd34-4d12-4728-a53a-b5ae434d74b0.jpg"
+      },
+      {
         "name": "Jack-o'-Lantern",
         "img": "https://cards.scryfall.io/normal/front/2/1/21b589ab-45a0-480a-a891-581c34f8a9bf.jpg"
       },
@@ -37038,6 +37045,10 @@
         "img": "https://cards.scryfall.io/normal/front/3/1/318fe8a2-a68a-4c7e-9581-ae6800826164.jpg"
       },
       {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/3/b/3ba24a61-e529-4490-8536-6276ea77c511.jpg"
+      },
+      {
         "name": "Mounted Dreadknight",
         "img": "https://cards.scryfall.io/normal/front/d/1/d1814fc8-011f-4cd4-825b-f00ae6ec0fe0.jpg"
       },
@@ -37136,6 +37147,10 @@
       {
         "name": "Pithing Needle",
         "img": "https://cards.scryfall.io/normal/front/5/5/556ec6ab-a19f-4caa-8bfa-145555402caf.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/6/e/6ed1902d-0b09-4bbe-9059-a0779450ee05.jpg"
       },
       {
         "name": "Play with Fire",
@@ -37358,6 +37373,10 @@
         "img": "https://cards.scryfall.io/normal/front/a/b/ab17c8fa-4c06-4542-848a-e3f2f9f47c27.jpg"
       },
       {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/7/7/77ba59d8-c13c-4966-845f-c090e9f061cb.jpg"
+      },
+      {
         "name": "Tainted Adversary",
         "img": "https://cards.scryfall.io/normal/front/e/6/e6b9b8fc-c30d-49e7-bb6c-219380d73a82.jpg"
       },
@@ -37482,28 +37501,7 @@
         "img": "https://cards.scryfall.io/normal/front/a/7/a7757e99-8d51-4b92-b346-6961845def24.jpg"
       }
     ],
-    "extra": [
-      {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/e/c/ec8de02c-7954-4424-8b95-a21d8e104bd4.jpg"
-      },
-      {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/6/0/60e6b919-e7c0-4844-a65c-d8b83b3e5287.jpg"
-      },
-      {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/f/9/f92e9e94-e5e9-4b2c-b9e5-35de42ca7b8e.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/4/6/46b94de4-099e-43d7-8f24-d5450b09f1f1.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/2/f/2f4b9030-f04a-4f42-8dd8-2eae0ce7e420.jpg"
-      }
-    ]
+    "extra": []
   },
   {
     "code": "AFR",
@@ -45097,7 +45095,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/2/b/2b90e88b-60a3-4d1d-bb8c-14633e5005a5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/9/d949485e-5188-49f4-9d30-5e135532d445.jpg"
       },
       {
         "name": "Forsaken Monument",
@@ -45177,7 +45175,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/5/8/589a324f-4466-4d4a-8cfb-806a041d7c1f.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/7/77ea783b-adaa-47be-9918-ca2f161c5d9e.jpg"
       },
       {
         "name": "Jace, Mirror Mage",
@@ -45361,7 +45359,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/3/c/3c6a38dd-e8f5-420f-9576-66937c71286b.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/6/96297bcc-8480-4b14-8612-1c395d481bce.jpg"
       },
       {
         "name": "Murasa Brute",
@@ -45461,7 +45459,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/a/e/ae92e656-6c9d-48c3-a238-5a11c2c62ec8.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/5/9591fd15-78d9-4089-a075-031ab2affd2d.jpg"
       },
       {
         "name": "Practiced Tactics",
@@ -45733,7 +45731,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/1/9/1967d4a8-6cc4-4a4d-9d24-93257de35e6d.jpg"
+        "img": "https://cards.scryfall.io/normal/front/9/5/95a58ce4-e07f-4c9c-98ae-3173d6d63cc5.jpg"
       },
       {
         "name": "Swarm Shambler",
@@ -50242,6 +50240,10 @@
         "img": "https://cards.scryfall.io/normal/front/1/f/1f70bcef-7ab6-4547-aca4-dd3ba68fd26b.jpg"
       },
       {
+        "name": "Forest",
+        "img": "https://cards.scryfall.io/normal/front/3/2/32af9f41-89e2-4e7a-9fec-fffe79cae077.jpg"
+      },
+      {
         "name": "Fruit of Tizerus",
         "img": "https://cards.scryfall.io/normal/front/6/6/66e577a0-e5d7-4e6a-919c-d85c2ae819ce.jpg"
       },
@@ -50378,6 +50380,10 @@
         "img": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg"
       },
       {
+        "name": "Island",
+        "img": "https://cards.scryfall.io/normal/front/a/c/acf7b664-3e75-4018-81f6-2a14ab59f258.jpg"
+      },
+      {
         "name": "Karametra's Blessing",
         "img": "https://cards.scryfall.io/normal/front/8/8/88c8e4dc-5378-48d6-85b2-f5ea9ec7cf36.jpg"
       },
@@ -50460,6 +50466,10 @@
       {
         "name": "Moss Viper",
         "img": "https://cards.scryfall.io/normal/front/a/4/a4d35ec4-0e0d-4611-8ad9-39d2c8a2ad6e.jpg"
+      },
+      {
+        "name": "Mountain",
+        "img": "https://cards.scryfall.io/normal/front/5/3/53fb7b99-9e47-46a6-9c8a-88e28b5197f1.jpg"
       },
       {
         "name": "Mystic Repeal",
@@ -50596,6 +50606,10 @@
       {
         "name": "Pious Wayfarer",
         "img": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg"
+      },
+      {
+        "name": "Plains",
+        "img": "https://cards.scryfall.io/normal/front/a/9/a9891b7b-fc52-470c-9f74-292ae665f378.jpg"
       },
       {
         "name": "Plummet",
@@ -50772,6 +50786,10 @@
       {
         "name": "Sunmane Pegasus",
         "img": "https://cards.scryfall.io/normal/front/5/2/52e28f5a-55ee-4fcc-bc16-e59944592fcd.jpg"
+      },
+      {
+        "name": "Swamp",
+        "img": "https://cards.scryfall.io/normal/front/0/2/02cb5cfd-018e-4c5e-bef1-166262aa5f1d.jpg"
       },
       {
         "name": "Sweet Oblivion",
@@ -51008,10 +51026,6 @@
         "img": "https://cards.scryfall.io/normal/front/b/f/bf9867e5-9d69-400c-a84f-3b085a4fd510.jpg"
       },
       {
-        "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/c/4/c4be31c4-9cb3-4a07-865b-5621127df660.jpg"
-      },
-      {
         "name": "Grasping Giant",
         "img": "https://cards.scryfall.io/normal/front/a/2/a238aa9c-661e-449a-8f05-70b7954e544f.jpg"
       },
@@ -51020,20 +51034,8 @@
         "img": "https://cards.scryfall.io/normal/front/0/2/0215cbbf-7bac-4ff7-bceb-23d728797848.jpg"
       },
       {
-        "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/9/2/92daaa39-cd2f-4c03-8f41-92d99d0a3366.jpg"
-      },
-      {
         "name": "Mindwrack Harpy",
         "img": "https://cards.scryfall.io/normal/front/6/c/6c5ce79a-fcbd-46ab-8911-480f967ca57f.jpg"
-      },
-      {
-        "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/d/c/dc3f4154-9347-4ceb-8744-9f1ace90d33f.jpg"
-      },
-      {
-        "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/4/0/40aca5ca-a37b-4919-aef6-2510b4779161.jpg"
       },
       {
         "name": "Serpent of Yawning Depths",
@@ -51046,10 +51048,6 @@
       {
         "name": "Sunlit Hoplite",
         "img": "https://cards.scryfall.io/normal/front/2/f/2f89cf0f-f682-44f8-879c-ed1e22f849b0.jpg"
-      },
-      {
-        "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/6/6/66bb5192-58bc-4efe-a145-2e804fd3483d.jpg"
       },
       {
         "name": "Swimmer in Nightmares",
@@ -63660,7 +63658,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/c/5/c5cbd941-53ab-4b02-b96c-a9af7767e606.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/3/c318bae5-5d3f-4e91-adfe-13c182511ef7.jpg"
       },
       {
         "name": "Fraying Sanity",
@@ -63776,7 +63774,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/0/a/0a4717cd-f9a7-4386-9091-d25218e23d79.jpg"
+        "img": "https://cards.scryfall.io/normal/front/a/7/a735e9b5-1231-4aa9-9eb3-c83037b849f2.jpg"
       },
       {
         "name": "Jace's Defeat",
@@ -63852,7 +63850,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/b/2/b2e439e2-2c7c-42fd-a47b-f615641f7392.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/a/6ad4e9cd-76e2-4ee0-8185-8b3aec3578ce.jpg"
       },
       {
         "name": "Mummy Paramount",
@@ -63908,7 +63906,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/c/e/ce617aad-2c72-4b47-a9ae-51792459cffd.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/2/c20ec10e-78fc-49dc-a112-7863a34056b1.jpg"
       },
       {
         "name": "Pride Sovereign",
@@ -64080,7 +64078,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/4/4/447f8dbc-2f09-4995-81e2-2dc1654031fd.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/f/ef5cb444-7b48-40c8-a4d9-3fee37429513.jpg"
       },
       {
         "name": "Swarm Intelligence",
@@ -64571,7 +64569,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/1/8/18f4e594-01e5-40ae-903c-f55aad740de0.jpg"
+        "img": "https://cards.scryfall.io/normal/front/2/c/2c2fc9f7-21af-4416-abf5-6fcb4f543680.jpg"
       },
       {
         "name": "Forsake the Worldly",
@@ -64735,7 +64733,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/c/5/c559fc49-54f3-426f-b2d2-525790a249a5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/e/bec6fced-62bb-4a99-9ea1-374056b5781b.jpg"
       },
       {
         "name": "Kefnet the Mindful",
@@ -64811,7 +64809,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/3/7/37827425-f304-43eb-979b-1ec5b923a2b5.jpg"
+        "img": "https://cards.scryfall.io/normal/front/d/3/d3112990-3919-46b0-b927-14566c689a81.jpg"
       },
       {
         "name": "Mouth",
@@ -64907,7 +64905,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/0/4/0422da01-0252-4f3b-b2e5-9f5b2c0b94ae.jpg"
+        "img": "https://cards.scryfall.io/normal/front/c/7/c7191d23-b68f-406b-8c28-8dadbaef6562.jpg"
       },
       {
         "name": "Pouncing Cheetah",
@@ -65099,7 +65097,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/6/2/62dbed02-6871-4830-8308-9f2f48e6730d.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/0/60b7c997-e520-4ff6-8b3b-705c2f12a9d4.jpg"
       },
       {
         "name": "Sweltering Suns",
@@ -71320,7 +71318,7 @@
       },
       {
         "name": "Wastes",
-        "img": "https://cards.scryfall.io/normal/front/9/c/9cc070d3-4b83-4684-9caf-063e5c473a77.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/0/7019912c-bd9b-4b96-9388-400794909aa1.jpg"
       },
       {
         "name": "Weapons Trainer",
@@ -72992,7 +72990,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/f/7/f7f865d8-fced-4763-b73e-fd40e9387e45.jpg"
+        "img": "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg"
       },
       {
         "name": "Fortified Rampart",
@@ -73100,7 +73098,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/f/5/f52db5b6-59bb-4215-9bdb-ba3dde3e5e4b.jpg"
+        "img": "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg"
       },
       {
         "name": "Jaddi Offshoot",
@@ -73204,7 +73202,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/e/0/e0e2923f-a585-4096-8268-1136655bbf3c.jpg"
+        "img": "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg"
       },
       {
         "name": "Munda, Ambush Leader",
@@ -73296,7 +73294,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/8/4/84908444-ee0f-430b-9a5e-f6810aa8bce1.jpg"
+        "img": "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg"
       },
       {
         "name": "Planar Outburst",
@@ -73532,7 +73530,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/a/2/a20e773f-9220-4212-b39a-eaccb1c265c6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg"
       },
       {
         "name": "Swarm Surge",
@@ -99028,7 +99026,7 @@
       },
       {
         "name": "Forest",
-        "img": "https://cards.scryfall.io/normal/front/c/6/c6d6876e-7d83-44bd-b721-5070f4087325.jpg"
+        "img": "https://cards.scryfall.io/normal/front/f/0/f0ca4b9f-4ee6-4ad8-a95f-326ada9de3cd.jpg"
       },
       {
         "name": "Frontier Guide",
@@ -99164,7 +99162,7 @@
       },
       {
         "name": "Island",
-        "img": "https://cards.scryfall.io/normal/front/c/4/c4ec37bf-80bd-4f51-a79e-9c20e4048a00.jpg"
+        "img": "https://cards.scryfall.io/normal/front/e/f/efd86f2a-bd28-4731-838d-78e67be8b49e.jpg"
       },
       {
         "name": "Joraga Bard",
@@ -99340,7 +99338,7 @@
       },
       {
         "name": "Mountain",
-        "img": "https://cards.scryfall.io/normal/front/4/f/4f570888-effb-44ff-a250-a7726a0b01f4.jpg"
+        "img": "https://cards.scryfall.io/normal/front/2/3/232ee129-0db1-4a03-9eda-4692a8495b53.jpg"
       },
       {
         "name": "Murasa Pyromancer",
@@ -99420,7 +99418,7 @@
       },
       {
         "name": "Plains",
-        "img": "https://cards.scryfall.io/normal/front/5/1/51afc6cd-1a39-4160-a265-d92610db1d44.jpg"
+        "img": "https://cards.scryfall.io/normal/front/b/c/bc4f4b6d-ff35-4b1f-974b-f39569e6b3c7.jpg"
       },
       {
         "name": "Plated Geopede",
@@ -99620,7 +99618,7 @@
       },
       {
         "name": "Swamp",
-        "img": "https://cards.scryfall.io/normal/front/d/8/d8a3e999-c75b-4be3-ae7f-ac5430b760b6.jpg"
+        "img": "https://cards.scryfall.io/normal/front/7/c/7cd6becc-f06a-4fd3-8305-70604b92a187.jpg"
       },
       {
         "name": "Tajuru Archer",

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
@@ -3,7 +3,9 @@ package com.wingedsheep.gameserver.coverage
 import com.wingedsheep.mtg.sets.MtgSetCatalog
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
@@ -54,13 +56,29 @@ class SetCoverageServiceTest : FunSpec({
         dates shouldBe dates.sortedDescending()
     }
 
-    test("a set with all booster cards implemented reads 100% — Bloomburrow is 261/261 draft") {
+    test("a set with all booster cards implemented reads 100% — Bloomburrow is 266/266 draft") {
         val blb = coverage.find { it.code == "BLB" }.shouldNotBeNull()
-        blb.total shouldBe 261
-        blb.implemented shouldBe 261
+        // 261 numbered main-set cards plus the 5 basic lands, which are Play Booster cards at
+        // #262–281 even though Scryfall's preferred printing for each is the full-art promo.
+        blb.total shouldBe 266
+        blb.implemented shouldBe 266
         blb.percent shouldBe 100.0
-        // The 18 completionist extras are reported separately, not folded into the headline %.
-        blb.extraTotal shouldBe 18
+        // The 13 completionist extras are reported separately, not folded into the headline %.
+        blb.extraTotal shouldBe 13
+    }
+
+    test("a card counts as draft when *any* of its printings in the set is boosterable") {
+        // Regression: the booster flag used to be read off a single arbitrary printing per name
+        // (`unique=cards`), so a card Scryfall happened to serve as its non-booster printing was
+        // filed as a completionist extra. Foundations is the worst case — 14 of its Play Booster
+        // cards (collector # 1–291) also have a Beginner Box or 2026 set-extension reprint, and
+        // the arbitrary pick landed on the reprint, shrinking the booster denominator to 262.
+        val fdn = coverage.find { it.code == "FDN" }.shouldNotBeNull()
+        fdn.total shouldBe 276
+        val detail = service.detail("FDN").shouldNotBeNull()
+        // Serra Angel is FDN #147 (booster) and #740 (Beginner Box); it belongs to the draft pool.
+        detail.draft.map { it.name } shouldContain "Serra Angel"
+        detail.extra.map { it.name } shouldNotContain "Serra Angel"
     }
 
     test("a set with no booster falls back to the whole set — Bloomburrow Commander has cards, not 0%") {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Scryfall.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/Scryfall.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import java.io.File
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URLEncoder
@@ -18,15 +19,17 @@ import java.time.format.DateTimeParseException
 
 /**
  * Self-contained Scryfall layer — set discovery from source, implementation scanning, and the
- * Scryfall fetch + `~/.cache/scryfall/<code>.json` schema-v6 cache. It reads and writes the *same*
+ * Scryfall fetch + `~/.cache/scryfall/<code>.json` schema-v7 cache. It reads and writes the *same*
  * cache files as the `scripts/card-status` tool, so the two share state and never duplicate fetches.
  */
 object Scryfall {
     private const val SCRYFALL_BASE = "https://api.scryfall.com"
     private const val USER_AGENT = "argentum-engine-card-status/1.0"
     private const val REQUEST_DELAY_MS = 150L
+    private const val CONNECT_TIMEOUT_MS = 10_000
+    private const val READ_TIMEOUT_MS = 30_000
     private const val REFRESH_WINDOW_DAYS = 30L
-    private const val CACHE_SCHEMA_VERSION = 6
+    private const val CACHE_SCHEMA_VERSION = 7
     val STANDARD_SET_TYPES = setOf("core", "expansion", "draft_innovation")
 
     private val CACHE_ROOT = File(System.getProperty("user.home"), ".cache/scryfall")
@@ -136,15 +139,22 @@ object Scryfall {
         return !releasedDate.isAfter(LocalDate.now().minusDays(REFRESH_WINDOW_DAYS))
     }
 
-    /** GET a Scryfall URL with polite pacing and 429-aware exponential backoff. */
+    /**
+     * GET a Scryfall URL with polite pacing and exponential backoff over the transient failures:
+     * 429 (rate limit) and 5xx (outage). Any other 4xx is a real answer about the URL and throws on
+     * the first try. Both timeouts are set explicitly — an unbounded read once hung the sibling
+     * `scripts/card-status` for 1h44m on a half-open socket during a Scryfall outage.
+     */
     fun scryfallGet(url: String, maxRetries: Int = 5): JsonObject {
         for (attempt in 0 until maxRetries) {
             Thread.sleep(REQUEST_DELAY_MS)
             val conn = URI(url).toURL().openConnection() as HttpURLConnection
             conn.setRequestProperty("User-Agent", USER_AGENT)
             conn.setRequestProperty("Accept", "application/json")
+            conn.connectTimeout = CONNECT_TIMEOUT_MS
+            conn.readTimeout = READ_TIMEOUT_MS
             val code = conn.responseCode
-            if (code == 429 && attempt < maxRetries - 1) {
+            if ((code == 429 || code >= 500) && attempt < maxRetries - 1) {
                 val retryAfter = conn.getHeaderField("Retry-After")
                 val wait = retryAfter?.toLongOrNull()?.times(1000) ?: (1000L shl attempt)
                 conn.disconnect()
@@ -192,24 +202,53 @@ object Scryfall {
         }
     }
 
+    private val LEADING_DIGITS = Regex("""^\d+""")
+
+    /**
+     * Orders a name's printings so the first is its representative: a booster printing before a
+     * non-booster one, then the lowest collector number. That's the Play Booster art and number a
+     * card generator wants — not whichever reprint Scryfall happens to order first.
+     */
+    private val PRINTING_ORDER: Comparator<JsonObject> = compareBy(
+        { if (it["booster"] == JsonPrimitive(true)) 0 else 1 },
+        { LEADING_DIGITS.find(it["collector_number"].asStr() ?: "")?.value?.toIntOrNull() ?: Int.MAX_VALUE },
+        { it["collector_number"].asStr() ?: "" },
+    )
+
+    /**
+     * Searches `unique=prints`, not `unique=cards`: one card can have several printings *inside* a
+     * single set (a Play Booster printing plus a Beginner Box or set-extension reprint), and the
+     * per-card row Scryfall serves is an arbitrary one of them. Reading `booster` off that arbitrary
+     * row files a genuine booster card as an extra whenever the pick lands on the non-booster
+     * printing — 14 Foundations cards did exactly that, shrinking FDN's booster denominator from 276
+     * to 262. So the flag is OR-ed across a name's printings instead, and the printing whose metadata
+     * we keep is chosen deliberately ([PRINTING_ORDER]) rather than inherited from result order.
+     */
     private fun fetchFromScryfall(code: String): JsonObject {
         val setMeta = scryfallGet("$SCRYFALL_BASE/sets/${code.lowercase()}")
-        val draftNames = mutableListOf<String>()
-        val extraNames = mutableListOf<String>()
-        var standardLegalCount = 0
-        val cards = linkedMapOf<String, JsonObject>()
+        val printings = linkedMapOf<String, MutableList<JsonObject>>()  // card name -> its printings in this set
         val q = URLEncoder.encode("set:${code.lowercase()} -is:rebalanced", StandardCharsets.UTF_8).replace("+", "%20")
-        var url: String? = "$SCRYFALL_BASE/cards/search?q=$q&unique=cards&order=name"
+        var url: String? = "$SCRYFALL_BASE/cards/search?q=$q&unique=prints&order=name"
         while (url != null) {
             val data = scryfallGet(url)
             for (cardEl in data["data"].asArr ?: JsonArray(emptyList())) {
                 val card = cardEl as JsonObject
                 val name = card["name"].asStr() ?: continue
-                if (card["booster"] == JsonPrimitive(true)) draftNames.add(name) else extraNames.add(name)
-                if (card["legalities"].field("standard").asStr() == "legal") standardLegalCount++
-                cards.putIfAbsent(frontFace(name), cardMetadata(card))
+                printings.getOrPut(name) { mutableListOf() }.add(card)
             }
             url = if (data["has_more"] == JsonPrimitive(true)) data["next_page"].asStr() else null
+        }
+
+        val draftNames = mutableListOf<String>()
+        val extraNames = mutableListOf<String>()
+        var standardLegalCount = 0
+        val cards = linkedMapOf<String, JsonObject>()
+        for ((name, group) in printings) {
+            if (group.any { it["booster"] == JsonPrimitive(true) }) draftNames.add(name) else extraNames.add(name)
+            val representative = group.minWith(PRINTING_ORDER)
+            // Format legality is a property of the card, not the printing — read it off the one.
+            if (representative["legalities"].field("standard").asStr() == "legal") standardLegalCount++
+            cards.putIfAbsent(frontFace(name), cardMetadata(representative))
         }
         return buildJsonObject {
             put("_v", CACHE_SCHEMA_VERSION)
@@ -222,6 +261,16 @@ object Scryfall {
         }
     }
 
+    /** Last resort after a failed refresh: the set's stale cache if we have one, else nothing. */
+    private fun staleCacheOrNull(code: String, path: File, e: Exception): JsonObject? {
+        if (path.isFile) {
+            System.err.println("warning: refresh for $code failed ($e); using stale cache")
+            return J.parseToJsonElement(path.readText()) as JsonObject
+        }
+        System.err.println("warning: failed to fetch $code: $e")
+        return null
+    }
+
     fun loadCanonical(code: String, forceRefresh: Boolean = false): JsonObject? {
         val path = cachePath(code)
         if (!forceRefresh && path.isFile) {
@@ -231,12 +280,11 @@ object Scryfall {
         val payload = try {
             fetchFromScryfall(code)
         } catch (e: ScryfallHttpError) {
-            if (path.isFile) {
-                System.err.println("warning: refresh for $code failed ($e); using stale cache")
-                return J.parseToJsonElement(path.readText()) as JsonObject
-            }
-            System.err.println("warning: failed to fetch $code: $e")
-            return null
+            return staleCacheOrNull(code, path, e)
+        } catch (e: IOException) {
+            // A timeout or connection blip that outlived the retries degrades to the stale cache for
+            // this one set rather than aborting a whole multi-set sweep.
+            return staleCacheOrNull(code, path, e)
         }
         CACHE_ROOT.mkdirs()
         path.writeText(PRETTY.encodeToString(JsonElement.serializer(), payload))

--- a/scripts/card-status
+++ b/scripts/card-status
@@ -8,9 +8,9 @@ For each set folder under `mtg-sets/.../definitions/<code>/`:
   - scans `.kt` files in `<code>/cards/` for implemented names
     (matches both `card("Name") { }` DSL calls and `name = "..."` Printing rows)
   - loads the canonical name list from Scryfall, cached under
-    `~/.cache/scryfall/<code>.json`, partitioned into draft cards
-    (Scryfall `booster: true`) and extras (starter-deck exclusives,
-    Special Guests, bonus sheets, etc.)
+    `~/.cache/scryfall/<code>.json`, partitioned into draft cards (any
+    printing in the set has Scryfall `booster: true`) and extras
+    (starter-deck exclusives, Special Guests, bonus sheets, etc.)
   - diffs the two to compute what's missing, reported per partition
 
 Cards listed in `coverage/card-exclusions.json` (ante, subgames, physical
@@ -53,8 +53,11 @@ CACHE_ROOT = Path.home() / ".cache" / "scryfall"
 SCRYFALL_BASE = "https://api.scryfall.com"
 USER_AGENT = "argentum-engine-card-status/1.0"
 REQUEST_DELAY_SEC = 0.15  # Scryfall asks for 50–100ms between requests; pad for bursty paginations
+# urlopen blocks forever by default. A Scryfall outage left a socket half-open mid-refresh and hung
+# the script for 1h44m on one set, so every request is bounded and a timeout is retried like a 429.
+REQUEST_TIMEOUT_SEC = 30
 REFRESH_WINDOW_DAYS = 30
-CACHE_SCHEMA_VERSION = 6  # v6: per-card oracle_text captured for the codegen bridge
+CACHE_SCHEMA_VERSION = 7  # v7: booster flag OR-ed across a name's printings (was one arbitrary printing)
 
 # A set is in current Standard if both:
 #   (a) its set_type is one of these (excludes commander, masters, alchemy, etc.), AND
@@ -190,7 +193,12 @@ def is_cache_fresh(payload: dict) -> bool:
 
 
 def scryfall_get(url: str, *, max_retries: int = 5) -> dict:
-    """GET a Scryfall URL with polite pacing and 429-aware exponential backoff."""
+    """GET a Scryfall URL with polite pacing and exponential backoff.
+
+    Retries the transient failures: 429 (rate limit), 5xx (Scryfall outage — a 503 storm once left
+    47 sets on a stale cache mid-migration), and network timeouts. Any other HTTPError is a real
+    answer about the URL (404 for an unknown set) and propagates on the first try.
+    """
     for attempt in range(max_retries):
         time.sleep(REQUEST_DELAY_SEC)
         req = urllib.request.Request(
@@ -198,14 +206,19 @@ def scryfall_get(url: str, *, max_retries: int = 5) -> dict:
             headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
         )
         try:
-            with urllib.request.urlopen(req) as resp:
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SEC) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
-            if e.code != 429 or attempt == max_retries - 1:
+            if (e.code != 429 and e.code < 500) or attempt == max_retries - 1:
                 raise
             retry_after = e.headers.get("Retry-After") if e.headers else None
             wait = float(retry_after) if retry_after and retry_after.isdigit() else 2 ** attempt
             time.sleep(wait)
+        except (urllib.error.URLError, TimeoutError):
+            # Includes the read timeout above and DNS/connection blips — same backoff as a 429.
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(2 ** attempt)
     raise RuntimeError("unreachable")  # loop either returns or raises
 
 
@@ -218,32 +231,59 @@ def is_standard_legal(payload: dict) -> bool:
     return payload.get("standard_legal_count", 0) >= total * STANDARD_LEGAL_RATIO
 
 
+def printing_rank(card: dict) -> tuple[int, int, str]:
+    """Sort key choosing a name's representative printing: a booster printing first, then the
+    lowest collector number. That's the Play Booster art and number a card generator wants —
+    not whichever reprint Scryfall happens to order first."""
+    number = card.get("collector_number") or ""
+    leading = re.match(r"\d+", number)
+    return (
+        0 if card.get("booster", False) else 1,
+        int(leading.group()) if leading else sys.maxsize,
+        number,
+    )
+
+
 def fetch_from_scryfall(code: str) -> dict:
-    """Metadata + paginated card search for one set, returned as a cache payload."""
+    """Metadata + paginated card search for one set, returned as a cache payload.
+
+    Searches `unique=prints`, not `unique=cards`: one card can have several printings *inside* a
+    single set (a Play Booster printing plus a Beginner Box or set-extension reprint), and the
+    per-card row Scryfall serves is an arbitrary one of them. Reading `booster` off that arbitrary
+    row files a genuine booster card as an extra whenever the pick lands on the non-booster
+    printing — 14 Foundations cards did exactly that, shrinking FDN's booster denominator from 276
+    to 262. So the flag is OR-ed across a name's printings instead, and the printing whose metadata
+    we keep is chosen deliberately (see `printing_rank`) rather than inherited from result order.
+    """
     set_meta = scryfall_get(f"{SCRYFALL_BASE}/sets/{code.lower()}")
     released_at = set_meta.get("released_at")
     set_type = set_meta.get("set_type")
-    draft_names: list[str] = []
-    extra_names: list[str] = []
-    standard_legal_count = 0
-    cards: dict[str, dict] = {}  # front-face name -> per-card Scryfall metadata (for codegen)
+    printings: dict[str, list[dict]] = {}  # card name -> every printing of it in this set
     url = (
         f"{SCRYFALL_BASE}/cards/search"
         f"?q={urllib.parse.quote(f'set:{code.lower()} -is:rebalanced')}"
-        f"&unique=cards&order=name"
+        f"&unique=prints&order=name"
     )
     while url:
         data = scryfall_get(url)
         for card in data.get("data", []):
-            name = card["name"]
-            if card.get("booster", False):
-                draft_names.append(name)
-            else:
-                extra_names.append(name)
-            if card.get("legalities", {}).get("standard") == "legal":
-                standard_legal_count += 1
-            cards.setdefault(front_face(name), card_metadata(card))
+            printings.setdefault(card["name"], []).append(card)
         url = data.get("next_page") if data.get("has_more") else None
+
+    draft_names: list[str] = []
+    extra_names: list[str] = []
+    standard_legal_count = 0
+    cards: dict[str, dict] = {}  # front-face name -> per-card Scryfall metadata (for codegen)
+    for name, group in printings.items():
+        if any(p.get("booster", False) for p in group):
+            draft_names.append(name)
+        else:
+            extra_names.append(name)
+        representative = min(group, key=printing_rank)
+        # Format legality is a property of the card, not the printing — read it off the one.
+        if representative.get("legalities", {}).get("standard") == "legal":
+            standard_legal_count += 1
+        cards.setdefault(front_face(name), card_metadata(representative))
     return {
         "_v": CACHE_SCHEMA_VERSION,
         "released_at": released_at,
@@ -295,7 +335,9 @@ def load_canonical(code: str, *, force_refresh: bool) -> dict | None:
             return cached
     try:
         payload = fetch_from_scryfall(code)
-    except urllib.error.HTTPError as e:
+    except (urllib.error.URLError, TimeoutError) as e:
+        # URLError covers HTTPError; a timeout or DNS blip that outlived the retries must degrade to
+        # the stale cache for this one set, not abort the whole sweep.
         if path.is_file():
             print(
                 f"warning: refresh for {code} failed ({e}); using stale cache",

--- a/scripts/gen-set-totals
+++ b/scripts/gen-set-totals
@@ -14,9 +14,10 @@ For each set we've catalogued (a `definitions/<code>/` folder with a `*Set.kt`):
   - reads the set `code` and `displayName` from the Kotlin source
   - loads the canonical card list from `~/.cache/scryfall/<code>.json`
     (same cache `scripts/card-status` reads/writes)
-  - partitions canonical front-face names into draft (Scryfall `booster: true`)
-    and extras, deduping extras against draft — identical semantics to
-    `card-status`, so the numbers match the mtgish coverage TUI
+  - partitions canonical front-face names into draft (some printing of the card
+    in that set has Scryfall `booster: true`) and extras, deduping extras against
+    draft — identical semantics to `card-status`, so the numbers match the mtgish
+    coverage TUI
 
 Output: `game-server/src/main/resources/coverage/set-totals.json`, an array of
   { code, name, releaseDate, setType, standardLegal,
@@ -59,7 +60,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFINITIONS_ROOT = REPO_ROOT / "mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions"
 OUTPUT = REPO_ROOT / "game-server/src/main/resources/coverage/set-totals.json"
 CACHE_ROOT = Path.home() / ".cache" / "scryfall"
-CACHE_SCHEMA_VERSION = 6
+CACHE_SCHEMA_VERSION = 7
 REFRESH_WINDOW_DAYS = 30
 
 # Standard-format membership, computed here (not at runtime) because the signal lives only in the


### PR DESCRIPTION
Follow-up to the note on #1473: `scripts/card-status` derived the draft/extra split from a single arbitrary printing per name, misfiling genuine Play Booster cards as completionist extras.

## The bug

Both fetchers searched `unique=cards`, which collapses a name to **one** printing. A card printed twice *inside* a set — a Play Booster printing plus a Beginner Box or set-extension reprint — was classified by whichever row Scryfall happened to serve. When that was the non-booster reprint, a real booster card landed in `extra`.

Foundations was the worst case. 14 Play Booster cards (collector # 1–291) were filed as extras because Scryfall serves their 2026 `setextension` printing, shrinking FDN's booster denominator from **276 to 262**. Serra Angel is FDN #147 (`booster: true`) and #740 (Beginner Box); the pick was #740.

## The fix

Search `unique=prints`, group printings by name, OR the `booster` flag across the group.

The change **only ever promotes** — I diffed every set, and nothing moves from draft to extra:

| Set | before | after | why |
|---|---|---|---|
| FDN | 262 / 255 | **276 / 241** | the 14 Beginner Box + set-extension reprints |
| BLB | 261 / 18 | **266 / 13** | the 5 basic lands |
| LTR | 261 / 28 | **266 / 23** | the 5 basic lands |
| DSK, INR, POR, EOE, … | — | unchanged | no intra-set double printings |

The BLB/LTR basics are legitimate: they're Play Booster cards at #262–281, but Scryfall prefers the full-art promo printing for each.

The metadata printing is now chosen deliberately as well — booster first, then lowest collector number — rather than inherited from result order, so the codegen bridge gets the Play Booster art instead of a set-extension reprint's. That accounts for most of the `img` churn in `set-totals.json`.

## Scope

Cache schema **6 → 7** in all three readers of `~/.cache/scryfall/<code>.json` (`card-status`, `gen-set-totals`, and the Kotlin `Scryfall.kt`, which reads *and writes* the same files) to force the rebuild. `set-totals.json` is regenerated off the rebuilt cache — otherwise the fix never reaches the Set Completion view.

## Two defects found while running the migration

Not the original ask, but the migration couldn't complete reliably without them:

- **Unbounded requests.** Neither fetcher set a socket timeout. A Scryfall 503 storm left a half-open socket that hung one refresh for **1h44m** on a single set. Now bounded (30s read / 10s connect), and 5xx joins 429 as retryable.
- **The callers only caught `HTTPError` / `ScryfallHttpError`.** A bare timeout fix would have been *worse* than the hang — a `TimeoutError` would have escaped and killed the whole 151-set sweep instead of degrading one set. Both now catch the network family and fall back to that set's stale cache.

Happy to split these into their own PR if you'd rather keep this one to the partition bug.

## Verification

- All 151 catalogued sets rebuilt to v7 and gated on before regenerating.
- `SetCoverageServiceTest` — BLB pin updated 261/261 + 18 extras → 266/266 + 13, plus a new regression test asserting Serra Angel lands in FDN's draft pool.
- `SetCoverageStandardTest` green; MSH still has no draft pool, so its comment stands.
- `:game-server` and `:mtgish-tooling` test suites pass.

Not fixed here: FDN's headline was already reported correctly as Complete — this only corrects the denominator it's computed over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)