### PR TITLE
Borrow main-set token art for The Big Score and Bloomburrow Commander

### DIFF
--- a/backlog/token-art-gaps.md
+++ b/backlog/token-art-gaps.md
@@ -18,7 +18,6 @@ Wizards printed no token cards before roughly Odyssey.
 | DST | 2 |
 | JMP | 2 |
 | MRD | 2 |
-| BLC | 1 |
 | CHK | 1 |
 | DKA | 1 |
 | EMN | 1 |
@@ -35,7 +34,7 @@ Wizards printed no token cards before roughly Odyssey.
 | RIX | 1 |
 | SCG | 1 |
 
-**22 distinct tokens across 19 sets.**
+**21 distinct tokens across 18 sets.**
 
 ## DST
 
@@ -80,14 +79,6 @@ _No Scryfall token set (`tmrd`) — every token here needs self-hosted art._
   - image: `web-client/public/images/tokens/mrd-spirit.jpeg`
   - ```kotlin
     TokenPrinting(name = "Spirit", imageUri = "/images/tokens/mrd-spirit.jpeg", power = 1, toughness = 1, colors = setOf(Color.WHITE)),
-    ```
-
-## BLC
-
-- **Treasure** — created by 4 card(s): Alchemist's Talent, Big Score, Bootleggers' Stash, Prosperous Bandit
-  - image: `web-client/public/images/tokens/blc-treasure.jpeg`
-  - ```kotlin
-    TokenPrinting(name = "Treasure", imageUri = "/images/tokens/blc-treasure.jpeg"),
     ```
 
 ## CHK

--- a/backlog/token-art-gaps.md
+++ b/backlog/token-art-gaps.md
@@ -15,7 +15,6 @@ Wizards printed no token cards before roughly Odyssey.
 
 | Set | Distinct tokens missing art |
 |-----|-----------------------------|
-| BIG | 2 |
 | DST | 2 |
 | JMP | 2 |
 | MRD | 2 |
@@ -36,20 +35,7 @@ Wizards printed no token cards before roughly Odyssey.
 | RIX | 1 |
 | SCG | 1 |
 
-**24 distinct tokens across 20 sets.**
-
-## BIG
-
-- **Clue** — created by 2 card(s): Hostile Investigator, Transmutation Font
-  - image: `web-client/public/images/tokens/big-clue.jpeg`
-  - ```kotlin
-    TokenPrinting(name = "Clue", imageUri = "/images/tokens/big-clue.jpeg"),
-    ```
-- **Treasure** — created by 2 card(s): Generous Plunderer, Sword of Wealth and Power
-  - image: `web-client/public/images/tokens/big-treasure.jpeg`
-  - ```kotlin
-    TokenPrinting(name = "Treasure", imageUri = "/images/tokens/big-treasure.jpeg"),
-    ```
+**22 distinct tokens across 19 sets.**
 
 ## DST
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
@@ -27,22 +27,10 @@ object TheBigScoreSet : MtgSet {
     // together with at least one regular set.
     override val extensionSet = true
 
-    /**
-     * Tokens the bonus sheet mints that `tbig` doesn't print, borrowed from Outlaws of Thunder
-     * Junction.
-     *
-     * The Big Score was opened inside OTJ boosters and shares its token sheet: Scryfall's `tbig`
-     * lists only the tokens unique to the bonus sheet, so the Clue and Treasure its cards create
-     * live in `totj`. Taking OTJ's whole sheet minus what BIG prints itself means any token a
-     * later BIG card mints picks up the right art too, instead of the engine-wide generic.
-     *
-     * The filter matters because the wiring registers `tokenArt` *ahead* of the set's own synced
-     * rows — without it, a token both sheets print would render OTJ's art on a BIG card.
-     */
+    // The bonus sheet was opened inside OTJ boosters and shares its token sheet, so `tbig` lists
+    // only the tokens unique to BIG — the Clue and Treasure its cards mint are OTJ tokens.
     override val tokenArt: List<TokenPrinting> by lazy {
-        val own = TokenArtData.forSet(code)
-        TokenArtData.forSet(OutlawsOfThunderJunctionSet.code)
-            .filterNot { borrowed -> own.any { it.matchesName(borrowed.name) } }
+        TokenArtData.borrowedFrom(OutlawsOfThunderJunctionSet.code, code)
     }
 
     override val cards: List<CardDefinition> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
@@ -1,9 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.big
 
+import com.wingedsheep.mtg.sets.definitions.otj.OutlawsOfThunderJunctionSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.mtg.sets.tokens.TokenArtData
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.TokenPrinting
 
 /**
  * The Big Score (2024) — bonus sheet shipped alongside Outlaws of Thunder Junction.
@@ -23,6 +26,24 @@ object TheBigScoreSet : MtgSet {
     // A 30-card bonus sheet can't sustain a sealed/draft pool by itself — it is only playable
     // together with at least one regular set.
     override val extensionSet = true
+
+    /**
+     * Tokens the bonus sheet mints that `tbig` doesn't print, borrowed from Outlaws of Thunder
+     * Junction.
+     *
+     * The Big Score was opened inside OTJ boosters and shares its token sheet: Scryfall's `tbig`
+     * lists only the tokens unique to the bonus sheet, so the Clue and Treasure its cards create
+     * live in `totj`. Taking OTJ's whole sheet minus what BIG prints itself means any token a
+     * later BIG card mints picks up the right art too, instead of the engine-wide generic.
+     *
+     * The filter matters because the wiring registers `tokenArt` *ahead* of the set's own synced
+     * rows — without it, a token both sheets print would render OTJ's art on a BIG card.
+     */
+    override val tokenArt: List<TokenPrinting> by lazy {
+        val own = TokenArtData.forSet(code)
+        TokenArtData.forSet(OutlawsOfThunderJunctionSet.code)
+            .filterNot { borrowed -> own.any { it.matchesName(borrowed.name) } }
+    }
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/BloomburrowCommanderSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/BloomburrowCommanderSet.kt
@@ -1,9 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.blc
 
+import com.wingedsheep.mtg.sets.definitions.blb.BloomburrowSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.mtg.sets.tokens.TokenArtData
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.TokenPrinting
 
 /**
  * Bloomburrow Commander Set (2024)
@@ -20,6 +23,12 @@ object BloomburrowCommanderSet : MtgSet {
     override val displayName = "Bloomburrow Commander"
     override val releaseDate = "2024-08-02"
     override val sealedSupported = false
+
+    // The Commander decks shipped alongside Bloomburrow and share its token sheet, so `tblc` skips
+    // tokens the main set already printed — the Treasure its cards mint is a Bloomburrow token.
+    override val tokenArt: List<TokenPrinting> by lazy {
+        TokenArtData.borrowedFrom(BloomburrowSet.code, code)
+    }
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/TokenArtData.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/TokenArtData.kt
@@ -34,6 +34,24 @@ object TokenArtData {
     /** Token printings this set contributes, or empty when the set has none on Scryfall. */
     fun forSet(setCode: String): List<TokenPrinting> = bySet[setCode].orEmpty()
 
+    /**
+     * [donor]'s synced sheet minus every token name [setCode] prints itself — the `tokenArt` for a
+     * companion product that shares another set's token sheet.
+     *
+     * Bonus sheets and Commander decks mint tokens their own `t<code>` never printed, because the
+     * physical token came in the main set's boosters: The Big Score's Clue and Treasure are OTJ
+     * tokens, Bloomburrow Commander's Treasure is a Bloomburrow token. Those render with
+     * engine-wide generic art unless the companion set claims the main set's printings.
+     *
+     * Names the companion prints itself are dropped rather than shadowed: the wiring registers
+     * `set.tokenArt` *ahead* of `forSet(set.code)`, so a token on both sheets would otherwise show
+     * the donor's art on the companion's card.
+     */
+    fun borrowedFrom(donor: String, setCode: String): List<TokenPrinting> {
+        val own = forSet(setCode)
+        return forSet(donor).filterNot { borrowed -> own.any { it.matchesName(borrowed.name) } }
+    }
+
     /** Set codes carrying synced token art. */
     val setCodes: Set<String> get() = bySet.keys
 


### PR DESCRIPTION
## Problem

Companion products mint tokens their own `t<code>` never printed, because the physical token came in the main set's boosters. Two cases showed engine-wide generic art:

- **BIG** — Clue (Hostile Investigator, Transmutation Font) and Treasure (Generous Plunderer, Sword of Wealth and Power). The Big Score was opened inside Outlaws of Thunder Junction boosters; `tbig` lists only the seven tokens unique to the bonus sheet.
- **BLC** — Treasure (Alchemist's Talent, Big Score, Bootleggers' Stash, Prosperous Bandit). Bloomburrow Commander shipped alongside Bloomburrow; `tblc` skips what the main set already printed.

## Change

`TokenArtData.borrowedFrom(donor, setCode)` returns the donor set's synced sheet minus every token name the companion prints itself, and both sets declare their `tokenArt` with it:

```kotlin
// TheBigScoreSet
override val tokenArt: List<TokenPrinting> by lazy {
    TokenArtData.borrowedFrom(OutlawsOfThunderJunctionSet.code, code)
}
```

Taking the whole donor sheet rather than hand-writing the two missing rows means any token a later BIG/BLC card mints picks up the right art as well. The subtraction is load-bearing: the wiring registers `set.tokenArt` *ahead* of `TokenArtData.forSet(set.code)`, so without it a token on both sheets (BLC prints its own Rat, Bird, Beast, …) would render the donor's art on the companion's card.

No new image files — this reuses art already synced from Scryfall.

## Verification

`just token-art-gaps` (compiles `:mtg-sets` and regenerates the report): both sets drop out, 24 distinct tokens across 20 sets → 21 across 18. Report regenerated in the same commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)