### PR TITLE
Engine AI Phase 1: the arena — a scoreboard we can trust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ CLAUDE.local.md
 
 # Bytecode from the shared modules the scripts/ tools import
 scripts/__pycache__/
+
+# Arena / benchmark run output (docs/ai/ carries the numbers worth keeping)
+/benchmarks/

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -141,12 +141,23 @@ class AIPlayer(
             cardRegistry: CardRegistry,
             playerId: EntityId,
             advisorModules: List<CardAdvisorModule> = emptyList()
+        ): AIPlayer = create(cardRegistry, playerId, AiProfile.CURRENT.copy(advisorModules = advisorModules))
+
+        /**
+         * Create an AI player from a named [AiProfile] — the single constructor everything else
+         * delegates to. The profile is what an arena report identifies an agent by, so two runs
+         * quoting the same profile id are comparing the same thing.
+         */
+        fun create(
+            cardRegistry: CardRegistry,
+            playerId: EntityId,
+            profile: AiProfile
         ): AIPlayer {
             val advisorRegistry = CardAdvisorRegistry()
-            advisorModules.forEach { it.register(advisorRegistry) }
+            profile.advisorModules.forEach { it.register(advisorRegistry) }
 
             val simulator = GameSimulator(cardRegistry)
-            val evaluator = defaultEvaluator()
+            val evaluator = profile.evaluationWeights.toEvaluator()
             val combatAdvisor = CombatAdvisor(simulator, evaluator, cardRegistry, advisorRegistry)
             val responder = DecisionResponder(simulator, evaluator, advisorRegistry = advisorRegistry)
 
@@ -169,21 +180,8 @@ class AIPlayer(
         /**
          * Default evaluator: weighted combination of strategic dimensions.
          *
-         * Weights reflect how much each dimension contributes to winning:
-         * - Board presence is king — creatures win games
-         * - Threat assessment catches lethal-on-board situations the other features miss
-         * - Life matters more when it's low (handled by non-linear scaling inside the feature)
-         * - Card advantage is a long-term edge
-         * - Tempo (mana development) matters early but less late
+         * The weights, and why each is what it is, live on [EvaluationWeights.DEFAULT].
          */
-        fun defaultEvaluator(): BoardEvaluator = CompositeBoardEvaluator(
-            listOf(
-                1.0 to LifeDifferential,
-                1.5 to BoardPresence,
-                1.0 to CardAdvantage,
-                1.2 to ThreatAssessment,
-                0.6 to Tempo
-            )
-        )
+        fun defaultEvaluator(): BoardEvaluator = EvaluationWeights.DEFAULT.toEvaluator()
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.ai.engine.advisor.CardAdvisorModule
+import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
+import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
+import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
+import com.wingedsheep.ai.engine.evaluation.BoardPresence
+import com.wingedsheep.ai.engine.evaluation.CardAdvantage
+import com.wingedsheep.ai.engine.evaluation.CompositeBoardEvaluator
+import com.wingedsheep.ai.engine.evaluation.LifeDifferential
+import com.wingedsheep.ai.engine.evaluation.Tempo
+import com.wingedsheep.ai.engine.evaluation.ThreatAssessment
+
+/**
+ * Weights for the five features [CompositeBoardEvaluator] combines.
+ *
+ * Every number here is a hand-guessed literal — that is the point of naming them: the arena can now
+ * pit two weight sets against each other as two agents, and Phase 9 of
+ * `backlog/engine-ai-improvement.md` replaces the guesses with a logistic fit.
+ *
+ * [DEFAULT] reproduces the values that used to be inline in `AIPlayer.defaultEvaluator()`, so
+ * changing nothing changes nothing.
+ */
+data class EvaluationWeights(
+    /** Life differential. Matters more when life is low — the non-linearity is inside the feature. */
+    val life: Double = 1.0,
+    /** Board presence. Creatures win games, so this is the largest term. */
+    val boardPresence: Double = 1.5,
+    /** Card advantage — a long-term edge. */
+    val cardAdvantage: Double = 1.0,
+    /** Threat assessment. Catches lethal-on-board situations the other features miss. */
+    val threatAssessment: Double = 1.2,
+    /** Tempo (mana development). Matters early, less late. Counts lands only today. */
+    val tempo: Double = 0.6,
+) {
+    fun toEvaluator(): BoardEvaluator = CompositeBoardEvaluator(
+        listOf(
+            life to LifeDifferential,
+            boardPresence to BoardPresence,
+            cardAdvantage to CardAdvantage,
+            threatAssessment to ThreatAssessment,
+            tempo to Tempo,
+        )
+    )
+
+    companion object {
+        val DEFAULT = EvaluationWeights()
+
+        /**
+         * Every weight zero, so the evaluator returns a constant and the Strategist can only
+         * ever pass. Not a playable agent — it exists so the arena can prove it *discriminates*:
+         * a harness that cannot separate this from [AiProfile.LEGACY_V0] is measuring noise.
+         */
+        val BLIND = EvaluationWeights(0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+}
+
+/**
+ * A named, reproducible configuration of the engine AI.
+ *
+ * This is the versioning seam the arena measures against, and the switchboard the later phases of
+ * `backlog/engine-ai-improvement.md` hang their features off (candidate evaluator, rollout counts,
+ * determinizations, budget overrides). Today it carries only what is actually wired — a profile
+ * field that nothing reads would be a lie about what a run measured.
+ *
+ * **[LEGACY_V0] is the permanent reference opponent.** Every later version reports its win rate
+ * against it, so the numbers stay comparable across months. It must never be "improved"; if a
+ * refactor moves it, `FrozenBaselineTest` fails, which is the whole point of that test.
+ */
+data class AiProfile(
+    /** Stable identifier. Appears in arena reports and CSV rows; treat it as part of the API. */
+    val id: String,
+    /**
+     * Per-set card advisor modules. Modules and the advisors they register are stateless
+     * singletons, so one profile instance is safe to share across threads and games.
+     */
+    val advisorModules: List<CardAdvisorModule> = emptyList(),
+    /** Leaf-evaluation weights. See [EvaluationWeights]. */
+    val evaluationWeights: EvaluationWeights = EvaluationWeights.DEFAULT,
+) {
+    companion object {
+        /**
+         * The frozen reference opponent: greedy 1-ply, default weights, no card advisors.
+         * Pinned as of Phase 1 (2026-07-27). **Do not change this.**
+         */
+        val LEGACY_V0 = AiProfile(id = "v0")
+
+        /**
+         * What `AIPlayer.create(registry, playerId)` builds today. Identical to [LEGACY_V0] right
+         * now — it diverges as later phases turn features on, and the gap between the two is
+         * exactly what the arena measures.
+         */
+        val CURRENT = AiProfile(id = "current")
+
+        /**
+         * What a player actually faces in a real game — see [EngineAiPlayerController]. Naming it
+         * here makes the production configuration arena-runnable instead of a literal buried in a
+         * controller constructor.
+         */
+        val PRODUCTION = AiProfile(
+            id = "production",
+            advisorModules = listOf(BloomburrowAdvisorModule(), OnslaughtAdvisorModule()),
+        )
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -2,8 +2,6 @@ package com.wingedsheep.ai.engine
 
 import com.wingedsheep.ai.ActionResponse
 import com.wingedsheep.ai.AiPlayerController
-import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
-import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
 import com.wingedsheep.ai.llm.BottomCardsInfo
 import com.wingedsheep.ai.llm.CardSummary
 import com.wingedsheep.ai.llm.MulliganInfo
@@ -21,8 +19,8 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
 /**
  * AI controller powered by the built-in rules-engine [AIPlayer].
  *
- * Runs entirely locally with no API calls. Uses the engine's ActionProcessor,
- * board evaluator, multi-ply searcher, and combat advisor directly.
+ * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
+ * greedy 1-ply [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION].
  *
  * Requires a [gameStateProvider] to access the real (unmasked) [GameState] from
  * the [com.wingedsheep.gameserver.session.GameSession]. This allows the engine AI
@@ -34,10 +32,7 @@ class EngineAiPlayerController(
     private val gameStateProvider: () -> GameState?
 ) : AiPlayerController {
 
-    private val aiPlayer = AIPlayer.create(
-        cardRegistry, playerId,
-        advisorModules = listOf(BloomburrowAdvisorModule(), OnslaughtAdvisorModule())
-    )
+    private val aiPlayer = AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION)
 
     override fun chooseAction(
         state: ClientGameState,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.core.DeckFormat
 import com.wingedsheep.sdk.model.CardDefinition
+import kotlin.random.Random
 import org.slf4j.LoggerFactory
 
 /**
@@ -27,6 +28,12 @@ import org.slf4j.LoggerFactory
 class ConstructedDeckGenerator(
     private val boosterGenerator: BoosterGenerator,
     private val cardRegistry: CardRegistry,
+    /**
+     * Randomness source for the colour pick, the curve fill and the basic-land art. Defaults to
+     * [Random.Default] so live lobbies keep drawing fresh decks; pass a seeded [Random] to make a
+     * run reproducible — the arena does, so a rerun at the same seed plays the same decks.
+     */
+    private val random: Random = Random.Default,
 ) {
     /**
      * Builds a format-legal deck from the cards printed in [setCodes].
@@ -66,6 +73,7 @@ class ConstructedDeckGenerator(
             cardPool = pool,
             basicLandVariants = basics,
             setCodes = setCodes,
+            random = random,
         ).generate()
     }
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/Arena.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/Arena.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.ai.arena
+
+import com.wingedsheep.ai.engine.buildSeededSealedDeck
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.sdk.model.MtgSet
+import java.util.Locale
+import java.util.concurrent.ExecutorCompletionService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.roundToInt
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.measureTime
+
+/**
+ * A head-to-head arena run: agent A vs agent B over N paired games.
+ *
+ * @param games total games. Rounded **up** to an even number, because a pair is the unit — a
+ *   half-played pair would reintroduce exactly the seat bias pairing exists to remove.
+ * @param seed the run seed. Everything downstream — decks, shuffles, turn order, every "at random"
+ *   choice in the engine — derives from it, so two runs at the same seed play the same games.
+ * @param setCode the sealed pool both seats build from. Both seats get the **same 40-card
+ *   decklist** in a pair (they still draw different shuffles of it), which is the lowest-variance
+ *   design and matches what `AdvisorBenchmark` measured.
+ */
+data class ArenaConfig(
+    val agentA: ArenaAgent,
+    val agentB: ArenaAgent,
+    val games: Int,
+    val seed: Long = DEFAULT_SEED,
+    val setCode: String = "BLB",
+    val maxTurns: Int = 50,
+    val threads: Int = Runtime.getRuntime().availableProcessors(),
+) {
+    val pairs: Int get() = (games + 1) / 2
+
+    companion object {
+        /** Fixed so `just arena` with no seed argument is still reproducible. */
+        const val DEFAULT_SEED = 20260727L
+    }
+}
+
+/** A completed run: the raw pairs, the derived statistics, and the wall clock it took. */
+data class ArenaRun(
+    val config: ArenaConfig,
+    val pairs: List<ArenaPair>,
+    val stats: ArenaStats,
+    val wallClock: Duration,
+)
+
+object Arena {
+
+    fun run(config: ArenaConfig, onProgress: (completed: Int, total: Int, pair: ArenaPair) -> Unit = { _, _, _ -> }): ArenaRun {
+        val set = MtgSetCatalog.requireByCode(config.setCode)
+        val registry = CardRegistry().apply {
+            register(set.cards)
+            register(set.basicLands)
+        }
+
+        val pool = Executors.newFixedThreadPool(config.threads)
+        try {
+            val completionService = ExecutorCompletionService<ArenaPair>(pool)
+            val finished = AtomicInteger(0)
+            var pairs: List<ArenaPair>
+            val wallClock = measureTime {
+                // Submitted as pairs, never as individual games: a partial run then always holds a
+                // whole number of pairs, so an interrupted arena is still an unbiased sample.
+                (1..config.pairs).forEach { pairId ->
+                    completionService.submit { playPair(registry, set, config, pairId) }
+                }
+                pairs = (1..config.pairs).map {
+                    completionService.take().get().also { pair ->
+                        onProgress(finished.incrementAndGet(), config.pairs, pair)
+                    }
+                }.sortedBy { it.pairId }
+            }
+            return ArenaRun(
+                config = config,
+                pairs = pairs,
+                stats = ArenaStats.of(config.agentA.name, config.agentB.name, pairs),
+                wallClock = wallClock,
+            )
+        } finally {
+            pool.shutdown()
+        }
+    }
+
+    /**
+     * One pair: identical decks, identical game seed, both seat orders.
+     *
+     * The seed is per pair, not per game, so game A and game B share seat 0's library, seat 1's
+     * library and the turn order. The only thing that differs is which agent sits where.
+     */
+    private fun playPair(registry: CardRegistry, set: MtgSet, config: ArenaConfig, pairId: Int): ArenaPair {
+        val pairSeed = mixSeed(config.seed, pairId.toLong())
+        val deck = buildSeededSealedDeck(set.cards, Random(pairSeed))
+
+        val gameA = ArenaGameRunner.play(
+            registry, seat0 = config.agentA, seat1 = config.agentB,
+            seat0Deck = deck, seat1Deck = deck,
+            seed = pairSeed, pairId = pairId, gameIndex = 0, maxTurns = config.maxTurns,
+        )
+        val gameB = ArenaGameRunner.play(
+            registry, seat0 = config.agentB, seat1 = config.agentA,
+            seat0Deck = deck, seat1Deck = deck,
+            seed = pairSeed, pairId = pairId, gameIndex = 1, maxTurns = config.maxTurns,
+        )
+        return ArenaPair(pairId, gameA, gameB)
+    }
+}
+
+/**
+ * SplitMix64 finalizer over `(runSeed, pairId)`.
+ *
+ * `runSeed + pairId` would be wrong: two runs one apart in seed would share most of their games and
+ * look far more correlated than they are.
+ */
+internal fun mixSeed(runSeed: Long, pairId: Long): Long {
+    var z = runSeed * -0x61c8864680b583ebL + pairId * -0x7ee3623a03d3c83fL
+    z = (z xor (z ushr 30)) * -0x40a7b892e31b1a47L
+    z = (z xor (z ushr 27)) * -0x6b2fb644ecceee15L
+    return z xor (z ushr 31)
+}
+
+/** `0.532` → `"53.2%"`. Locale-independent, so committed numbers read the same everywhere. */
+internal fun pct(value: Double): String = "${(value * 1000).roundToInt() / 10.0}%"
+
+/**
+ * `String.format` pinned to [Locale.ROOT].
+ *
+ * Not a nicety: on a machine with a comma decimal separator the default locale renders a pair
+ * score as `+0,000` and a CSV column as `11,4`, which silently corrupts every `results.csv` the
+ * arena writes.
+ */
+internal fun fmt(format: String, value: Double): String = String.format(Locale.ROOT, format, value)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.ai.arena
+
+import com.wingedsheep.ai.engine.AIPlayer
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.ai.engine.EvaluationWeights
+import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
+import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * A named competitor in the arena — an [AiProfile] plus the short name you type on the command
+ * line (`just arena v0 blb-advisors 1000`).
+ *
+ * One [AIPlayer] is built per seat per game and never shared: `GameSimulator.isResolving` and
+ * `decisionResolver` are mutable instance state, so a shared instance would corrupt its own
+ * recursion guard across concurrent games.
+ */
+data class ArenaAgent(val name: String, val profile: AiProfile) {
+    fun createPlayer(registry: CardRegistry, playerId: EntityId): AIPlayer =
+        AIPlayer.create(registry, playerId, profile)
+}
+
+/**
+ * The agents `just arena` can name.
+ *
+ * Adding an agent here is how a later phase enters the scoreboard: build the [AiProfile], give it
+ * a name, and every arena/gauntlet recipe can reach it with no other wiring.
+ */
+object ArenaAgents {
+
+    private val all: List<ArenaAgent> = listOf(
+        // The permanent reference opponent. Every version reports against this one.
+        ArenaAgent("v0", AiProfile.LEGACY_V0),
+        // Whatever `AIPlayer.create(registry, playerId)` builds today.
+        ArenaAgent("current", AiProfile.CURRENT),
+        // What a player actually faces in a real game: BLB + ONS card advisors.
+        ArenaAgent("production", AiProfile.PRODUCTION),
+        // V0 plus one advisor module each — this is the split `AdvisorBenchmark` measured, so
+        // `just arena v0 blb-advisors` is directly comparable to its published number.
+        ArenaAgent("blb-advisors", AiProfile.LEGACY_V0.copy(
+            id = "blb-advisors",
+            advisorModules = listOf(BloomburrowAdvisorModule()),
+        )),
+        ArenaAgent("ons-advisors", AiProfile.LEGACY_V0.copy(
+            id = "ons-advisors",
+            advisorModules = listOf(OnslaughtAdvisorModule()),
+        )),
+        // Not a playable agent — every evaluation weight is zero, so the Strategist can never
+        // prefer an action to passing. It exists to prove the harness *discriminates*: an arena
+        // that cannot separate this from `v0` is measuring noise, not strength.
+        ArenaAgent("v0-blind", AiProfile.LEGACY_V0.copy(
+            id = "v0-blind",
+            evaluationWeights = EvaluationWeights.BLIND,
+        )),
+    )
+
+    private val byName: Map<String, ArenaAgent> = all.associateBy { it.name }
+
+    val names: List<String> get() = all.map { it.name }
+
+    fun resolve(name: String): ArenaAgent = byName[name]
+        ?: throw IllegalArgumentException(
+            "Unknown arena agent \"$name\". Known agents: ${names.joinToString(", ")}"
+        )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaBenchmark.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.ai.arena
+
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The arena's command-line entry point. Both tests are disabled unless explicitly switched on, so
+ * a normal `:ai:test` run never pays for them.
+ *
+ * ```
+ * just arena v0 blb-advisors 1000
+ * just arena-gauntlet 200
+ * ```
+ *
+ * How to read the output — and the promotion rule — is in `docs/ai/measurement.md`.
+ */
+class ArenaBenchmark : FunSpec({
+
+    val games = System.getProperty("arenaGames")?.toIntOrNull() ?: 300
+    val seed = System.getProperty("arenaSeed")?.toLongOrNull() ?: ArenaConfig.DEFAULT_SEED
+    val setCode = System.getProperty("arenaSet") ?: "BLB"
+    val maxTurns = System.getProperty("arenaMaxTurns")?.toIntOrNull() ?: 50
+    val threads = System.getProperty("arenaThreads")?.toIntOrNull()
+        ?: Runtime.getRuntime().availableProcessors()
+
+    val headToHead = System.getProperty("arena") == "true"
+    val gauntlet = System.getProperty("arenaGauntlet") == "true"
+
+    test("arena: head to head").config(enabled = headToHead) {
+        val agentA = ArenaAgents.resolve(requireProperty("arenaA"))
+        val agentB = ArenaAgents.resolve(requireProperty("arenaB"))
+        val config = ArenaConfig(agentA, agentB, games, seed, setCode, maxTurns, threads)
+
+        println("=== ARENA: ${agentA.name} vs ${agentB.name} — ${config.pairs} pairs " +
+            "(${config.pairs * 2} games) on $threads threads, $setCode, seed $seed ===")
+        val run = Arena.run(config) { done, total, pair ->
+            if (done <= 5 || done % 25 == 0 || done == total) {
+                println("  [$done/$total] pair ${pair.pairId}: ${pair.aWins}-${pair.bWins}-${pair.draws} " +
+                    "(score ${fmt("%+.1f", pair.score)})")
+            }
+        }
+
+        println()
+        print(ArenaReport.summary(run))
+        println("Written to: ${ArenaReport.write(run)}")
+    }
+
+    test("arena: gauntlet").config(enabled = gauntlet) {
+        val agents = loadGauntlet()
+        println("=== GAUNTLET: ${agents.joinToString(", ") { it.name }} — $games games per matchup ===")
+
+        val runs = agents.indices.flatMap { i -> (i + 1 until agents.size).map { j -> agents[i] to agents[j] } }
+            .map { (a, b) ->
+                println("--- ${a.name} vs ${b.name} ---")
+                Arena.run(ArenaConfig(a, b, games, seed, setCode, maxTurns, threads)).also {
+                    print(ArenaReport.summary(it))
+                    println()
+                }
+            }
+
+        println()
+        print(ArenaReport.gauntletSummary(runs, agents.map { it.name }))
+        println("Written to: ${ArenaReport.writeGauntlet(runs, agents.map { it.name })}")
+    }
+})
+
+@Serializable
+private data class GauntletFile(val agents: List<String>)
+
+/**
+ * Gauntlet membership is a committed resource, not a command-line list: the whole point of a
+ * gauntlet is that every version faces the *same* field, and a field you retype each run is not
+ * the same field.
+ */
+internal fun loadGauntlet(): List<ArenaAgent> {
+    val resource = ArenaBenchmark::class.java.getResourceAsStream("/arena/gauntlet.json")
+        ?: error("Missing ai/src/test/resources/arena/gauntlet.json")
+    // ignoreUnknownKeys so the file can carry a "_comment" explaining what a gauntlet is for.
+    val json = Json { ignoreUnknownKeys = true }
+    val names = resource.use { json.decodeFromString<GauntletFile>(it.readBytes().decodeToString()) }.agents
+    require(names.size >= 2) { "A gauntlet needs at least two agents; gauntlet.json lists ${names.size}." }
+    return names.map(ArenaAgents::resolve)
+}
+
+private fun requireProperty(name: String): String = System.getProperty(name)
+    ?: error("-D$name is required. Known agents: ${ArenaAgents.names.joinToString(", ")}")

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaGameRunner.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaGameRunner.kt
@@ -1,0 +1,207 @@
+package com.wingedsheep.ai.arena
+
+import com.wingedsheep.ai.engine.safeFallbackAction
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import java.security.MessageDigest
+import kotlin.time.measureTime
+
+/**
+ * Result of one arena game, recorded **by seat**, never by agent.
+ *
+ * Seat-indexed is the whole point: a pair plays the same game twice with the agents swapped, and
+ * anything that reads "did agent A win" before the pair is assembled is how a seat bias sneaks in.
+ */
+data class ArenaGameOutcome(
+    val pairId: Int,
+    /** 0 = the agent that sat in seat 0 (on the play) played first. */
+    val gameIndex: Int,
+    val seat0Agent: String,
+    val seat1Agent: String,
+    val seed: Long,
+    /** 0, 1, or null for a draw / unfinished game. */
+    val winnerSeat: Int?,
+    val turns: Int,
+    val actions: Int,
+    val durationMs: Long,
+    val seat0Life: Int,
+    val seat1Life: Int,
+    val completed: Boolean,
+    /** Why the game ended without a winner. Empty when it ended normally. */
+    val drawReason: String,
+    /** A thrown engine exception, if any — the arena doubles as a crash finder at scale. */
+    val exception: String?,
+    /**
+     * Actions the AI proposed that the processor rejected, recovered by [safeFallbackAction].
+     * Keyed by `"<ActionType>: <error>"` so the report can histogram them — this is the arena
+     * doubling as a free bug finder at scale, and a rejected action is always a real defect
+     * somewhere (the enumerator offered it, or the AI mangled it).
+     */
+    val illegalActions: Map<String, Int>,
+    /** Set only when the runner was asked to record one. See [ArenaGameRunner.play]. */
+    val actionStreamHash: String?,
+)
+
+/**
+ * Plays a single arena game: two [ArenaAgent]s, one deck each, one seed.
+ *
+ * Built from `AdvisorBenchmark.playAdvisorGame`, not `AIBenchmark.playGame` — the latter
+ * round-trips every action through `ClientStateTransformer.transform` + `LegalActionEnricher.enrich`
+ * to satisfy the server's DTO interface, which is pure overhead for engine-vs-engine. The
+ * stuck-detector and draw taxonomy are `AIBenchmark`'s.
+ */
+object ArenaGameRunner {
+
+    /** Matches `AIBenchmark`: this many actions on one turn with no turn change means wedged. */
+    private const val STUCK_ACTION_THRESHOLD = 300
+
+    fun play(
+        registry: CardRegistry,
+        seat0: ArenaAgent,
+        seat1: ArenaAgent,
+        seat0Deck: Deck,
+        seat1Deck: Deck,
+        seed: Long,
+        pairId: Int,
+        gameIndex: Int,
+        maxTurns: Int = 50,
+        /** Hash every action and decision into [ArenaGameOutcome.actionStreamHash]. Off by
+         *  default: it costs a string per action, and only `FrozenBaselineTest` needs it. */
+        recordActionStream: Boolean = false,
+    ): ArenaGameOutcome {
+        val processor = ActionProcessor(registry)
+        val enumerator = LegalActionEnumerator.create(registry)
+        val initializer = GameInitializer(registry)
+
+        val init = initializer.initializeGame(
+            GameConfig(
+                players = listOf(PlayerConfig("Seat0", seat0Deck), PlayerConfig("Seat1", seat1Deck)),
+                // Mulligans are skipped so a rerun at the same seed is the same game. That puts
+                // mulligan quality out of test — schedule a separate mulligan A/B rather than
+                // pretending this measures it.
+                skipMulligans = true,
+                startingPlayerIndex = 0,
+                seed = seed,
+            )
+        )
+
+        val seat0Id = init.state.turnOrder[0]
+        val seat1Id = init.state.turnOrder[1]
+        val ai0 = seat0.createPlayer(registry, seat0Id)
+        val ai1 = seat1.createPlayer(registry, seat1Id)
+        fun aiFor(playerId: EntityId) = if (playerId == seat0Id) ai0 else ai1
+        fun seatOf(playerId: EntityId) = if (playerId == seat0Id) 0 else 1
+
+        var state: GameState = init.state
+        var actionCount = 0
+        val illegalActions = mutableMapOf<String, Int>()
+        var lastProgressTurn = 0
+        var lastProgressAction = 0
+        var drawReason = ""
+        var exception: String? = null
+        val stream = if (recordActionStream) MessageDigest.getInstance("SHA-256") else null
+        fun record(entry: String) = stream?.update(entry.toByteArray(Charsets.UTF_8))
+
+        val duration = measureTime {
+            try {
+                while (!state.gameOver && state.turnNumber < maxTurns) {
+                    if (actionCount - lastProgressAction > STUCK_ACTION_THRESHOLD &&
+                        state.turnNumber == lastProgressTurn
+                    ) {
+                        drawReason = "stuck(turn=${state.turnNumber},step=${state.step.name})"
+                        break
+                    }
+                    if (state.turnNumber > lastProgressTurn) {
+                        lastProgressTurn = state.turnNumber
+                        lastProgressAction = actionCount
+                    }
+
+                    val decision = state.pendingDecision
+                    if (decision != null) {
+                        actionCount++
+                        val response = aiFor(decision.playerId).respondToDecision(state, decision)
+                        record("D$actionCount|${seatOf(decision.playerId)}|${decision::class.simpleName}|$response\n")
+                        val r = processor.process(state, SubmitDecision(decision.playerId, response)).result
+                        if (r.error != null) {
+                            drawReason = "decisionError(${r.error})"
+                            break
+                        }
+                        state = r.state
+                        continue
+                    }
+
+                    val priorityPlayer = state.priorityPlayerId
+                    if (priorityPlayer == null) {
+                        drawReason = "noPriority(turn=${state.turnNumber})"
+                        break
+                    }
+
+                    actionCount++
+                    val action = aiFor(priorityPlayer).chooseAction(state)
+                    record("A$actionCount|${seatOf(priorityPlayer)}|${state.step.name}|$action\n")
+                    val r = processor.process(state, action).result
+                    val next = if (r.error != null) {
+                        val key = "${action::class.simpleName}: ${r.error}"
+                        illegalActions[key] = (illegalActions[key] ?: 0) + 1
+                        val fallback = processor
+                            .process(state, safeFallbackAction(state, priorityPlayer, enumerator))
+                            .result
+                        if (fallback.error != null) {
+                            drawReason = "error(${r.error}; fallback: ${fallback.error})"
+                            null
+                        } else fallback.state
+                    } else r.state
+
+                    if (next == null) break
+                    if (next === state) {
+                        drawReason = "noProgress(turn=${state.turnNumber},step=${state.step.name})"
+                        break
+                    }
+                    state = next
+                }
+                if (!state.gameOver && drawReason.isEmpty()) drawReason = "maxTurns($maxTurns)"
+            } catch (e: Throwable) {
+                exception = "${e::class.simpleName}: ${e.message}"
+                if (drawReason.isEmpty()) drawReason = "exception"
+            }
+        }
+
+        val seat0Life = state.getEntity(seat0Id)?.get<LifeTotalComponent>()?.life ?: 0
+        val seat1Life = state.getEntity(seat1Id)?.get<LifeTotalComponent>()?.life ?: 0
+        val winnerSeat = when {
+            !state.gameOver -> null
+            state.winnerId == seat0Id -> 0
+            state.winnerId == seat1Id -> 1
+            else -> null
+        }
+        record("END|turns=${state.turnNumber}|winner=$winnerSeat|life=$seat0Life/$seat1Life\n")
+
+        return ArenaGameOutcome(
+            pairId = pairId,
+            gameIndex = gameIndex,
+            seat0Agent = seat0.name,
+            seat1Agent = seat1.name,
+            seed = seed,
+            winnerSeat = winnerSeat,
+            turns = state.turnNumber,
+            actions = actionCount,
+            durationMs = duration.inWholeMilliseconds,
+            seat0Life = seat0Life,
+            seat1Life = seat1Life,
+            completed = state.gameOver,
+            drawReason = drawReason,
+            exception = exception,
+            illegalActions = illegalActions.toMap(),
+            actionStreamHash = stream?.digest()?.joinToString("") { "%02x".format(it) }?.take(16),
+        )
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaHarnessTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaHarnessTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.ai.arena
+
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Proves the arena measures what it claims to, before anyone reads a win rate off it.
+ *
+ * The Phase 1 exit criterion is "`just arena v0 v0 300` returns 50% with the CI containing 50%".
+ * That is weaker than what is actually true and testable: with the same agent on both seats, the
+ * two games of a pair are **the same game**, so the mirror must come out at *exactly* 50% with
+ * zero variance. Any deviation is a real defect — a seat leak, a seed leak, or nondeterminism in
+ * the AI — and would otherwise hide inside a confidence interval.
+ *
+ * Portal, not Bloomburrow: simpler cards run faster, and this test asserts structure, not strength.
+ */
+class ArenaHarnessTest : FunSpec({
+
+    // Six games. Enough for the structural claims; small enough to stay in the always-on suite.
+    val config = ArenaConfig(
+        agentA = ArenaAgents.resolve("v0"),
+        agentB = ArenaAgents.resolve("v0"),
+        games = 6,
+        setCode = "POR",
+        maxTurns = 25,
+    )
+
+    test("a v0 mirror is exactly 50% — the seat/seed-leak detector") {
+        val run = Arena.run(config)
+
+        run.pairs.forEach { pair ->
+            // Same agent on both seats + same seed + same decks => literally the same game twice.
+            withClue("pair ${pair.pairId}") {
+                pair.gameA.winnerSeat shouldBe pair.gameB.winnerSeat
+                pair.gameA.turns shouldBe pair.gameB.turns
+                pair.gameA.actions shouldBe pair.gameB.actions
+                pair.score shouldBe 0.0
+            }
+        }
+
+        run.stats.meanPairScore shouldBe 0.0
+        run.stats.pairWinShare shouldBe 0.5
+        run.stats.pairScoreCi shouldBe Interval(0.0, 0.0)
+        run.stats.aWins shouldBe run.stats.bWins
+    }
+
+    test("the same seed replays the same games, across threads") {
+        // Two runs of the same config, one of them single-threaded. Any thread-local
+        // nondeterminism in the AI or the engine would show up as a divergence here.
+        val parallel = Arena.run(config)
+        val sequential = Arena.run(config.copy(threads = 1))
+
+        parallel.pairs.zip(sequential.pairs).forEach { (a, b) ->
+            withClue("pair ${a.pairId}") {
+                a.gameA.winnerSeat shouldBe b.gameA.winnerSeat
+                a.gameA.turns shouldBe b.gameA.turns
+                a.gameA.actions shouldBe b.gameA.actions
+                a.gameA.seat0Life shouldBe b.gameA.seat0Life
+                a.gameA.seat1Life shouldBe b.gameA.seat1Life
+            }
+        }
+    }
+
+    test("a different seed plays different games") {
+        // Not a strength claim — just that the seed is threaded through to the decks and the
+        // shuffles rather than being decorative.
+        val original = Arena.run(config)
+        val other = Arena.run(config.copy(seed = config.seed + 1))
+        val identical = original.pairs.zip(other.pairs).count { (a, b) -> a.gameA.actions == b.gameA.actions }
+        withClue("all ${config.pairs} pairs played identically at two different seeds") {
+            (identical < config.pairs) shouldBe true
+        }
+    }
+
+    test("games run clean: no illegal actions, no engine exceptions") {
+        val run = Arena.run(config)
+        run.stats.illegalActions.keys.shouldBeEmpty()
+        run.stats.exceptions.keys.shouldBeEmpty()
+    }
+
+    test("every name in gauntlet.json resolves to a real agent") {
+        // Catches a typo in the committed gauntlet at :ai:test time rather than 40 minutes into
+        // a `just arena-gauntlet` run.
+        loadGauntlet().size shouldBe loadGauntlet().map { it.name }.distinct().size
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaReport.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaReport.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.ai.arena
+
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Renders arena results — to stdout while a run is in progress, and to
+ * `benchmarks/arena/<timestamp>/` afterwards so a claim in a PR body has a file behind it.
+ *
+ * `results.csv` is one row per game (never per pair): the pair-level statistics are derived, and a
+ * CSV that only carried them could not be re-analysed a different way later.
+ */
+object ArenaReport {
+
+    private val TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Head-to-head
+    // ─────────────────────────────────────────────────────────────────────────
+
+    fun summary(run: ArenaRun): String = buildString {
+        val s = run.stats
+        appendLine("--- ARENA: ${s.agentA} vs ${s.agentB} ---")
+        appendLine("Games:        ${s.games} (${s.pairs} pairs), set=${run.config.setCode}, seed=${run.config.seed}")
+        appendLine("Record:       ${s.aWins}W-${s.bWins}L-${s.draws}D for ${s.agentA}")
+        appendLine()
+        // Paired first: it is the estimator, and quoting the unpaired number first invites
+        // reading the wrong interval.
+        appendLine("Pair score:   ${fmt("%+.3f", s.meanPairScore)}  CI ${s.pairScoreCi}   (0 = parity)")
+        appendLine("Pair win %:   ${pct(s.pairWinShare)}  CI [${pct(s.pairWinShareCi.low)}, ${pct(s.pairWinShareCi.high)}]  <- the merge gate")
+        appendLine("Game score %: ${pct(s.gameScoreRate)}  Wilson [${pct(s.gameScoreCi.low)}, ${pct(s.gameScoreCi.high)}]  (unpaired, draws = 1/2)")
+        appendLine()
+        appendLine("Seat 0 wins:  ${s.seat0Wins} / ${s.games} (${pct(s.seat0WinRate)}) — first-player advantage, cancelled by pairing")
+        appendLine("Completed:    ${s.completedGames} / ${s.games} (${pct(s.completionRate)})")
+        appendLine("Illegal acts: ${s.illegalActions.values.sum()} (actions the processor rejected — should be 0)")
+        if (s.drawReasons.isNotEmpty()) {
+            appendLine("Unfinished:   " + s.drawReasons.entries.joinToString(", ") { "${it.value}x ${it.key}" })
+        }
+        if (s.illegalActions.isNotEmpty()) {
+            appendLine()
+            appendLine("--- REJECTED AI ACTIONS (distinct) — each is a bug, not noise ---")
+            s.illegalActions.forEach { (message, count) -> appendLine("  [${count}x] $message") }
+        }
+        if (s.exceptions.isNotEmpty()) {
+            appendLine()
+            appendLine("--- ENGINE EXCEPTIONS (distinct) ---")
+            s.exceptions.forEach { (message, count) -> appendLine("  [${count}x] $message") }
+        }
+        appendLine()
+        appendLine("Avg turns:    ${fmt("%.1f", s.meanTurns)}   avg actions: ${fmt("%.0f", s.meanActions)}   " +
+            "avg game: ${fmt("%.0f", s.meanGameMs)}ms")
+        appendLine("Wall clock:   ${run.wallClock.inWholeSeconds}s on ${run.config.threads} threads " +
+            "(${fmt("%.1f", s.games * 1000.0 / run.wallClock.inWholeMilliseconds.coerceAtLeast(1))} games/sec)")
+        appendLine()
+        appendLine(verdict(s))
+    }
+
+    /** The promotion rule, stated as a sentence so a report cannot be misread as more than it is. */
+    private fun verdict(s: ArenaStats): String = when {
+        s.games < 100 ->
+            "VERDICT: ${s.games} games is a smoke test, not evidence. The merge gate is 1,000."
+        s.beatsOpponent ->
+            "VERDICT: ${s.agentA} beats ${s.agentB} — lower CI bound ${pct(s.pairWinShareCi.low)} is above parity."
+        s.pairWinShareCi.high < 0.5 ->
+            "VERDICT: ${s.agentA} LOSES to ${s.agentB} — upper CI bound ${pct(s.pairWinShareCi.high)} is below parity."
+        else ->
+            "VERDICT: not distinguishable. CI [${pct(s.pairWinShareCi.low)}, ${pct(s.pairWinShareCi.high)}] " +
+                "spans parity — this is not a demonstrated improvement."
+    }
+
+    /** Writes `results.csv` + `summary.md` under `benchmarks/arena/<timestamp>-<a>-vs-<b>/`. */
+    fun write(run: ArenaRun): File {
+        val dir = outputDir("${run.stats.agentA}-vs-${run.stats.agentB}")
+        File(dir, "results.csv").writeText(buildString {
+            appendLine("pair,game,seat0_agent,seat1_agent,seed,winner_seat,turns,actions,duration_ms," +
+                "seat0_life,seat1_life,completed,illegal_actions,draw_reason,exception")
+            for (pair in run.pairs) {
+                for (game in pair.games) {
+                    appendLine(listOf(
+                        game.pairId, game.gameIndex, game.seat0Agent, game.seat1Agent, game.seed,
+                        game.winnerSeat ?: "", game.turns, game.actions, game.durationMs,
+                        game.seat0Life, game.seat1Life, game.completed, game.illegalActions.values.sum(),
+                        csv(game.drawReason), csv(game.exception ?: ""),
+                    ).joinToString(","))
+                }
+            }
+        })
+        File(dir, "summary.md").writeText("```\n${summary(run)}```\n")
+        return dir
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Gauntlet
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The full pairwise matrix plus Bradley-Terry Elo.
+     *
+     * The matrix is the deliverable and the Elo is the convenience: a single rating cannot express
+     * a rock-paper-scissors cycle, and MTG agents produce them routinely.
+     */
+    fun gauntletSummary(runs: List<ArenaRun>, agents: List<String>): String = buildString {
+        val byPair = runs.associateBy { it.stats.agentA to it.stats.agentB }
+        appendLine("--- GAUNTLET: ${agents.size} agents, ${runs.size} matchups ---")
+        appendLine()
+        val width = maxOf(12, agents.maxOf { it.length } + 1)
+        append("".padEnd(width))
+        agents.forEach { append(it.take(width - 1).padStart(width)) }
+        appendLine()
+        for (row in agents) {
+            append(row.padEnd(width))
+            for (column in agents) {
+                val cell = when {
+                    row == column -> "-"
+                    else -> byPair[row to column]?.let { pct(it.stats.pairWinShare) }
+                        ?: byPair[column to row]?.let { pct(1.0 - it.stats.pairWinShare) }
+                        ?: "?"
+                }
+                append(cell.padStart(width))
+            }
+            appendLine()
+        }
+        appendLine()
+        appendLine("Cell = row's pair win share vs column. 50% is parity.")
+        appendLine()
+
+        val matchups = runs.flatMap { run ->
+            val s = run.stats
+            listOf(
+                Matchup(s.agentA, s.agentB, s.aWins + s.draws / 2.0, s.games),
+                Matchup(s.agentB, s.agentA, s.bWins + s.draws / 2.0, s.games),
+            )
+        }
+        val elo = BradleyTerry.elo(agents, matchups)
+        appendLine("--- BRADLEY-TERRY ELO (report alongside the matrix, never instead of it) ---")
+        elo.entries.sortedByDescending { it.value }.forEach { (agent, rating) ->
+            appendLine("  ${agent.padEnd(width)} ${fmt("%.0f", rating)}")
+        }
+        appendLine()
+        appendLine("Promotion rule: a new version must beat BOTH v0 and the version before it, and")
+        appendLine("must not lose to any gauntlet member worse than 45%.")
+    }
+
+    fun writeGauntlet(runs: List<ArenaRun>, agents: List<String>): File {
+        val dir = outputDir("gauntlet")
+        File(dir, "matrix.md").writeText("```\n${gauntletSummary(runs, agents)}```\n")
+        File(dir, "results.csv").writeText(buildString {
+            appendLine("agent_a,agent_b,games,a_wins,b_wins,draws,pair_win_share,ci_low,ci_high")
+            for (run in runs) {
+                val s = run.stats
+                appendLine("${s.agentA},${s.agentB},${s.games},${s.aWins},${s.bWins},${s.draws}," +
+                    "${fmt("%.4f", s.pairWinShare)},${fmt("%.4f", s.pairWinShareCi.low)}," +
+                    "${fmt("%.4f", s.pairWinShareCi.high)}")
+            }
+        })
+        return dir
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private fun csv(value: String) = value.replace(',', ';').replace('\n', ' ')
+
+    private fun outputDir(label: String): File {
+        val stamp = LocalDateTime.now().format(TIMESTAMP)
+        return File(repoRoot(), "benchmarks/arena/$stamp-$label").apply { mkdirs() }
+    }
+
+    /**
+     * Gradle runs tests with the *module* directory as the working directory, so results would
+     * otherwise land in `ai/benchmarks/`. Walk up to the build root instead.
+     */
+    private fun repoRoot(): File {
+        var dir: File? = File(System.getProperty("user.dir")).absoluteFile
+        while (dir != null) {
+            if (File(dir, "settings.gradle.kts").isFile) return dir
+            dir = dir.parentFile
+        }
+        return File(System.getProperty("user.dir"))
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaStats.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaStats.kt
@@ -1,0 +1,242 @@
+package com.wingedsheep.ai.arena
+
+import kotlin.math.abs
+import kotlin.math.log10
+import kotlin.math.pow
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+/** A two-sided confidence interval. */
+data class Interval(val low: Double, val high: Double) {
+    fun contains(value: Double) = value in low..high
+    override fun toString() = "[${fmt("%.3f", low)}, ${fmt("%.3f", high)}]"
+}
+
+/**
+ * One pair: the same decks and the same game seed played twice with the seats swapped.
+ *
+ * [gameA] seats agent A in seat 0; [gameB] seats agent B in seat 0. Pairing is the estimator — the
+ * first-player advantage and the deck draw are identical across the two games, so they cancel.
+ */
+data class ArenaPair(val pairId: Int, val gameA: ArenaGameOutcome, val gameB: ArenaGameOutcome) {
+    val games: List<ArenaGameOutcome> get() = listOf(gameA, gameB)
+
+    /** Games agent A won across the pair (0-2). */
+    val aWins: Int = (if (gameA.winnerSeat == 0) 1 else 0) + (if (gameB.winnerSeat == 1) 1 else 0)
+
+    /** Games agent B won across the pair (0-2). */
+    val bWins: Int = (if (gameA.winnerSeat == 1) 1 else 0) + (if (gameB.winnerSeat == 0) 1 else 0)
+
+    val draws: Int = 2 - aWins - bWins
+
+    /**
+     * Agent A's score for the pair, in [-1, 1]: +1 swept, 0 split, -1 swept against. Draws land on
+     * the halves. This — not the per-game win rate — is the quantity the merge gate is read off.
+     */
+    val score: Double = (aWins - bWins) / 2.0
+}
+
+/**
+ * Everything a head-to-head arena run reports. Two independent estimators of the same thing (paired
+ * and unpaired) plus the health signals that say whether either can be trusted.
+ */
+data class ArenaStats(
+    val agentA: String,
+    val agentB: String,
+    val pairs: Int,
+    val games: Int,
+    val aWins: Int,
+    val bWins: Int,
+    val draws: Int,
+    /** Agent A's per-game score rate, draws counted as a half. Unpaired. */
+    val gameScoreRate: Double,
+    /** Wilson score interval on [gameScoreRate]. */
+    val gameScoreCi: Interval,
+    /** Mean of [ArenaPair.score]. 0.0 is parity. */
+    val meanPairScore: Double,
+    /** Paired bootstrap percentile interval on [meanPairScore]. */
+    val pairScoreCi: Interval,
+    /** [meanPairScore] rescaled to a 0-1 win-rate-like number, so 0.5 is parity. */
+    val pairWinShare: Double,
+    val pairWinShareCi: Interval,
+    /** Games won by whoever sat in seat 0. A seat/seed leak shows up here first. */
+    val seat0Wins: Int,
+    val completedGames: Int,
+    /** Rejected AI actions by `"<ActionType>: <error>"`. Every entry is a bug worth a look. */
+    val illegalActions: Map<String, Int>,
+    val drawReasons: Map<String, Int>,
+    val exceptions: Map<String, Int>,
+    val meanTurns: Double,
+    val meanActions: Double,
+    val meanGameMs: Double,
+) {
+    val seat0WinRate: Double get() = if (games > 0) seat0Wins.toDouble() / games else 0.0
+    val completionRate: Double get() = if (games > 0) completedGames.toDouble() / games else 0.0
+
+    /** The merge gate: agent A is a demonstrated improvement only if the whole interval clears parity. */
+    val beatsOpponent: Boolean get() = pairWinShareCi.low > 0.5
+
+    companion object {
+        /** Resamples for the paired bootstrap. Fixed so a rerun of the same games reports the same CI. */
+        const val BOOTSTRAP_RESAMPLES = 2_000
+
+        fun of(agentA: String, agentB: String, pairs: List<ArenaPair>, bootstrapSeed: Long = 20260727L): ArenaStats {
+            val games = pairs.flatMap { it.games }
+            val aWins = pairs.sumOf { it.aWins }
+            val bWins = pairs.sumOf { it.bWins }
+            val drawCount = pairs.sumOf { it.draws }
+            val scoreSuccesses = aWins + drawCount / 2.0
+            val pairScores = pairs.map { it.score }
+
+            val pairCi = bootstrapMeanCi(pairScores, BOOTSTRAP_RESAMPLES, Random(bootstrapSeed))
+            return ArenaStats(
+                agentA = agentA,
+                agentB = agentB,
+                pairs = pairs.size,
+                games = games.size,
+                aWins = aWins,
+                bWins = bWins,
+                draws = drawCount,
+                gameScoreRate = if (games.isEmpty()) 0.0 else scoreSuccesses / games.size,
+                gameScoreCi = wilsonInterval(scoreSuccesses, games.size),
+                meanPairScore = pairScores.average(),
+                pairScoreCi = pairCi,
+                pairWinShare = (pairScores.average() + 1.0) / 2.0,
+                pairWinShareCi = Interval((pairCi.low + 1.0) / 2.0, (pairCi.high + 1.0) / 2.0),
+                seat0Wins = games.count { it.winnerSeat == 0 },
+                completedGames = games.count { it.completed },
+                illegalActions = games.flatMap { it.illegalActions.entries }
+                    .groupingBy { it.key }.fold(0) { total, e -> total + e.value }
+                    .toList().sortedByDescending { it.second }.toMap(),
+                drawReasons = games.filter { it.drawReason.isNotEmpty() }
+                    .groupingBy { it.drawReason.substringBefore('(') }.eachCount()
+                    .toList().sortedByDescending { it.second }.toMap(),
+                exceptions = games.mapNotNull { it.exception }
+                    .groupingBy { it }.eachCount()
+                    .toList().sortedByDescending { it.second }.toMap(),
+                meanTurns = games.map { it.turns }.averageOrZero(),
+                meanActions = games.map { it.actions }.averageOrZero(),
+                meanGameMs = games.map { it.durationMs }.averageOrZero(),
+            )
+        }
+    }
+}
+
+private fun List<Int>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()
+
+@JvmName("averageOrZeroLong")
+private fun List<Long>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Estimators
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 95% two-sided normal quantile. */
+private const val Z_95 = 1.959963984540054
+
+/**
+ * Wilson score interval — the right one for a proportion at small n or near 0/1, where the normal
+ * approximation runs off the end of the scale.
+ *
+ * [successes] is a Double so draws can count as a half; the formula is unchanged by that.
+ */
+internal fun wilsonInterval(successes: Double, n: Int, z: Double = Z_95): Interval {
+    if (n <= 0) return Interval(0.0, 1.0)
+    val p = successes / n
+    val z2 = z * z
+    val denominator = 1.0 + z2 / n
+    val center = (p + z2 / (2 * n)) / denominator
+    val margin = z / denominator * sqrt(p * (1 - p) / n + z2 / (4.0 * n * n))
+    return Interval((center - margin).coerceAtLeast(0.0), (center + margin).coerceAtMost(1.0))
+}
+
+/**
+ * Percentile bootstrap interval for the mean of [samples].
+ *
+ * Resampling **whole pairs** is what makes this the paired estimator: the two games in a pair move
+ * together, so the between-game correlation that pairing bought is preserved in the resample.
+ */
+internal fun bootstrapMeanCi(
+    samples: List<Double>,
+    resamples: Int,
+    rng: Random,
+    alpha: Double = 0.05,
+): Interval {
+    if (samples.isEmpty()) return Interval(-1.0, 1.0)
+    if (samples.size == 1) return Interval(samples[0], samples[0])
+    val means = DoubleArray(resamples) {
+        var sum = 0.0
+        repeat(samples.size) { sum += samples[rng.nextInt(samples.size)] }
+        sum / samples.size
+    }
+    means.sort()
+    val lowIndex = ((alpha / 2) * resamples).toInt().coerceIn(0, resamples - 1)
+    val highIndex = ((1 - alpha / 2) * resamples).toInt().coerceIn(0, resamples - 1)
+    return Interval(means[lowIndex], means[highIndex])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gauntlet rating
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One cell of the gauntlet matrix: [row]'s record against [column]. */
+data class Matchup(val row: String, val column: String, val wins: Double, val games: Int) {
+    val winRate: Double get() = if (games > 0) wins / games else 0.0
+}
+
+/**
+ * Bradley-Terry strengths fitted by iterative MM (minorization-maximization).
+ *
+ * ~40 lines and no dependency. Report it **alongside the full pairwise matrix, never instead of
+ * it**: MTG agents are frequently non-transitive — an aggressive agent beats a controlling one that
+ * beats a midrange one that beats the aggressive one — and a single rating number erases exactly
+ * that structure.
+ */
+object BradleyTerry {
+
+    private const val MAX_ITERATIONS = 500
+    private const val CONVERGENCE = 1e-9
+
+    /** Floor on a strength, so an agent that never won maps to a finite (very low) Elo. */
+    private const val MIN_STRENGTH = 1e-6
+
+    /**
+     * @param matchups **one entry per ordered pair** — both `(X vs Y)` and `(Y vs X)` — with draws
+     *   already split as half a win to each side. [ArenaReport] builds them that way.
+     * @return Elo-scaled ratings, centred on 1500.
+     */
+    fun elo(agents: List<String>, matchups: List<Matchup>): Map<String, Double> {
+        val strengths = agents.associateWith { 1.0 }.toMutableMap()
+        val wins = agents.associateWith { 0.0 }.toMutableMap()
+        val played = mutableMapOf<Pair<String, String>, Int>()
+        for (m in matchups) {
+            wins[m.row] = wins.getValue(m.row) + m.wins
+            played[m.row to m.column] = (played[m.row to m.column] ?: 0) + m.games
+        }
+
+        for (iteration in 0 until MAX_ITERATIONS) {
+            val next = agents.associateWith { i ->
+                var denominator = 0.0
+                for (j in agents) {
+                    if (i == j) continue
+                    val n = played[i to j] ?: continue
+                    denominator += n / (strengths.getValue(i) + strengths.getValue(j))
+                }
+                if (denominator > 0.0) wins.getValue(i) / denominator else strengths.getValue(i)
+            }
+            // Normalize to geometric mean 1 — BT strengths are only identified up to a scale
+            // factor, and without this they drift toward 0 or infinity over the iterations.
+            val floored = next.mapValues { it.value.coerceAtLeast(MIN_STRENGTH) }
+            val scale = 10.0.pow(-floored.values.sumOf { log10(it) } / floored.size)
+            var maxDelta = 0.0
+            for (i in agents) {
+                val value = (floored.getValue(i) * scale).coerceAtLeast(MIN_STRENGTH)
+                maxDelta = maxOf(maxDelta, abs(value - strengths.getValue(i)))
+                strengths[i] = value
+            }
+            if (maxDelta < CONVERGENCE) break
+        }
+
+        return agents.associateWith { 1500.0 + 400.0 * log10(strengths.getValue(it)) }
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaStatsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaStatsTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.ai.arena
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+import kotlin.random.Random
+
+/**
+ * Unit tests for the arena's estimators.
+ *
+ * These matter more than they look: every strength claim this plan makes is read off these three
+ * functions, and a subtly wrong interval is worse than no interval — it makes noise look like
+ * evidence.
+ */
+class ArenaStatsTest : FunSpec({
+
+    context("Wilson interval") {
+        test("a 50/50 split at n=100 is roughly +/-10 points") {
+            val ci = wilsonInterval(50.0, 100)
+            abs(ci.low - 0.404) shouldBeLessThan 0.01
+            abs(ci.high - 0.596) shouldBeLessThan 0.01
+        }
+
+        test("narrows as n grows") {
+            val small = wilsonInterval(50.0, 100)
+            val large = wilsonInterval(500.0, 1000)
+            (large.high - large.low) shouldBeLessThan (small.high - small.low)
+        }
+
+        test("stays inside [0, 1] at the extremes, where the normal approximation would not") {
+            val perfect = wilsonInterval(20.0, 20)
+            perfect.high shouldBe 1.0
+            perfect.low shouldBeGreaterThan 0.0
+            val shutout = wilsonInterval(0.0, 20)
+            shutout.low shouldBe 0.0
+            shutout.high shouldBeLessThan 1.0
+        }
+
+        test("accepts fractional successes, so draws can count as a half") {
+            val ci = wilsonInterval(49.5, 100)
+            ci.contains(0.495) shouldBe true
+        }
+
+        test("n = 0 is total ignorance, not a crash") {
+            wilsonInterval(0.0, 0) shouldBe Interval(0.0, 1.0)
+        }
+    }
+
+    context("paired bootstrap") {
+        test("brackets the sample mean") {
+            val samples = List(200) { if (it % 3 == 0) 1.0 else -0.5 }
+            val ci = bootstrapMeanCi(samples, 2000, Random(1))
+            ci.contains(samples.average()) shouldBe true
+        }
+
+        test("is deterministic at a fixed seed — a CI that moves between reruns is not a CI") {
+            val samples = List(120) { Random(it).nextDouble(-1.0, 1.0) }
+            bootstrapMeanCi(samples, 2000, Random(7)) shouldBe bootstrapMeanCi(samples, 2000, Random(7))
+        }
+
+        test("collapses to a point when every pair scored the same") {
+            val ci = bootstrapMeanCi(List(50) { 0.0 }, 500, Random(3))
+            ci shouldBe Interval(0.0, 0.0)
+        }
+
+        test("excludes parity when one side swept") {
+            val ci = bootstrapMeanCi(List(200) { 1.0 }, 2000, Random(5))
+            ci.low shouldBeGreaterThan 0.0
+        }
+    }
+
+    context("pair scoring") {
+        test("a sweep is +1 and a split is 0, regardless of which seat won") {
+            // gameA: agent A in seat 0. gameB: agent B in seat 0, so seat 1 is agent A.
+            sweep().score shouldBe 1.0
+            ArenaPair(1, game(winnerSeat = 0), game(winnerSeat = 0)).score shouldBe 0.0
+            ArenaPair(1, game(winnerSeat = 1), game(winnerSeat = 1)).score shouldBe 0.0
+            ArenaPair(1, game(winnerSeat = 1), game(winnerSeat = 0)).score shouldBe -1.0
+        }
+
+        test("a draw costs half a point, not a whole one") {
+            val pair = ArenaPair(1, game(winnerSeat = 0), game(winnerSeat = null))
+            pair.aWins shouldBe 1
+            pair.bWins shouldBe 0
+            pair.draws shouldBe 1
+            pair.score shouldBe 0.5
+        }
+    }
+
+    context("Bradley-Terry") {
+        test("recovers the ordering of a transitive field") {
+            val agents = listOf("strong", "middle", "weak")
+            val elo = BradleyTerry.elo(agents, listOf(
+                Matchup("strong", "middle", 70.0, 100), Matchup("middle", "strong", 30.0, 100),
+                Matchup("strong", "weak", 90.0, 100), Matchup("weak", "strong", 10.0, 100),
+                Matchup("middle", "weak", 70.0, 100), Matchup("weak", "middle", 30.0, 100),
+            ))
+            elo.getValue("strong") shouldBeGreaterThan elo.getValue("middle")
+            elo.getValue("middle") shouldBeGreaterThan elo.getValue("weak")
+        }
+
+        test("rates a perfectly balanced field equally") {
+            val agents = listOf("a", "b", "c")
+            val elo = BradleyTerry.elo(agents, agents.flatMap { i ->
+                agents.filter { it != i }.map { j -> Matchup(i, j, 50.0, 100) }
+            })
+            elo.values.forEach { abs(it - 1500.0) shouldBeLessThan 1.0 }
+        }
+
+        test("gives an agent that never won a finite rating rather than -infinity") {
+            val elo = BradleyTerry.elo(listOf("winner", "loser"), listOf(
+                Matchup("winner", "loser", 100.0, 100), Matchup("loser", "winner", 0.0, 100),
+            ))
+            elo.getValue("loser").isFinite() shouldBe true
+            elo.getValue("winner") shouldBeGreaterThan elo.getValue("loser")
+        }
+
+        test("cannot express a rock-paper-scissors cycle — which is why the matrix is the deliverable") {
+            val agents = listOf("rock", "paper", "scissors")
+            val elo = BradleyTerry.elo(agents, listOf(
+                Matchup("rock", "scissors", 70.0, 100), Matchup("scissors", "rock", 30.0, 100),
+                Matchup("scissors", "paper", 70.0, 100), Matchup("paper", "scissors", 30.0, 100),
+                Matchup("paper", "rock", 70.0, 100), Matchup("rock", "paper", 30.0, 100),
+            ))
+            // All three are equal, so Elo alone says "identical strength" about a field where
+            // every matchup is 70/30. Report it next to the matrix, never in place of it.
+            elo.values.forEach { abs(it - 1500.0) shouldBeLessThan 1.0 }
+        }
+    }
+
+    context("run seeds") {
+        test("adjacent run seeds do not produce adjacent pair seeds") {
+            val a = (1..50).map { mixSeed(1L, it.toLong()) }
+            val b = (1..50).map { mixSeed(2L, it.toLong()) }
+            a.intersect(b.toSet()) shouldBe emptySet()
+        }
+    }
+})
+
+private fun game(winnerSeat: Int?) = ArenaGameOutcome(
+    pairId = 1, gameIndex = 0, seat0Agent = "a", seat1Agent = "b", seed = 0L,
+    winnerSeat = winnerSeat, turns = 10, actions = 100, durationMs = 1, seat0Life = 0, seat1Life = 0,
+    completed = winnerSeat != null, drawReason = "", exception = null, illegalActions = emptyMap(),
+    actionStreamHash = null,
+)
+
+/** Agent A wins seat 0 in game A and seat 1 in game B. */
+private fun sweep() = ArenaPair(1, game(winnerSeat = 0), game(winnerSeat = 1))

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/FrozenBaselineTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/FrozenBaselineTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.ai.arena
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards `AiProfile.LEGACY_V0` against silent drift.
+ *
+ * `LEGACY_V0` is the permanent reference opponent: every later version quotes its win rate against
+ * it, so if a refactor quietly changes how V0 plays, months of numbers stop being comparable and
+ * nothing says so. This test plays one fixed game and asserts the action stream hashes to a
+ * constant, which is far cheaper and more honest than copying 5,575 LOC into a `frozen/v0/`
+ * package that would then rot on its own.
+ *
+ * **The deck is deliberately all-vanilla.** Four Portal creatures with no abilities and 24
+ * Mountains exercise the parts of V0 that matter — the curve, the candidate scoring, the whole
+ * `CombatAdvisor` attack/block search — while touching almost none of the engine surface that
+ * changes week to week. A hash over a Bloomburrow sealed game would go red every time somebody
+ * implemented a card.
+ *
+ * **If this fails:**
+ * - You changed how the AI plays. If that was intentional, it belongs behind a *new* profile,
+ *   not inside `LEGACY_V0`. Re-bless [GOLDEN_HASH] only if `LEGACY_V0` genuinely had to move, and
+ *   say so in the commit message — the arena numbers in `docs/ai/` were measured against the old
+ *   one.
+ * - You changed the engine's behaviour for a vanilla creature, a Mountain, or combat damage. Then
+ *   re-blessing is correct and uninteresting.
+ */
+class FrozenBaselineTest : FunSpec({
+
+    test("LEGACY_V0 plays the frozen baseline game exactly as it always has") {
+        val registry = CardRegistry().apply {
+            register(PortalSet.cards)
+            register(PortalSet.basicLands)
+        }
+        val v0 = ArenaAgents.resolve("v0")
+
+        val outcome = ArenaGameRunner.play(
+            registry = registry,
+            seat0 = v0, seat1 = v0,
+            seat0Deck = FROZEN_DECK, seat1Deck = FROZEN_DECK,
+            seed = FROZEN_SEED, pairId = 0, gameIndex = 0,
+            maxTurns = 30,
+            recordActionStream = true,
+        )
+
+        withClue(
+            "LEGACY_V0's behaviour moved. Actual hash: ${outcome.actionStreamHash} " +
+                "(${outcome.turns} turns, winner seat ${outcome.winnerSeat}, " +
+                "life ${outcome.seat0Life}/${outcome.seat1Life}). See this test's KDoc before re-blessing."
+        ) {
+            outcome.actionStreamHash shouldBe GOLDEN_HASH
+        }
+    }
+}) {
+    companion object {
+        private const val FROZEN_SEED = 20260727L
+
+        /**
+         * Mono-red vanilla: no triggers, no targets, no activated abilities, nothing on the stack
+         * but creature spells. Pinned as a literal so a change to the sealed-pool generator or to
+         * Portal's card list cannot move the baseline.
+         */
+        private val FROZEN_DECK = Deck(
+            List(24) { "Mountain" } +
+                List(4) { "Goblin Bully" } +      // {1}{R} 2/1
+                List(4) { "Minotaur Warrior" } +  // {2}{R} 2/3
+                List(4) { "Lizard Warrior" } +    // {3}{R} 4/2
+                List(4) { "Highland Giant" }      // {2}{R}{R} 3/4
+        )
+
+        /**
+         * Blessed 2026-07-27 against `AiProfile.LEGACY_V0` as pinned in Phase 1: seat 1 wins on
+         * turn 10, life -8 / 16. Re-bless only for the reasons listed in this class's KDoc.
+         */
+        private const val GOLDEN_HASH = "506577c26cba1a9c"
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AiBenchmarkSupport.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AiBenchmarkSupport.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Rarity
+import kotlin.random.Random
+
+/**
+ * Shared helpers for the benchmarks that drive real AI-vs-AI games —
+ * [SimulationThroughputBenchmark] and the arena (`com.wingedsheep.ai.arena`).
+ *
+ * The unseeded deck builders in [GameBenchmark] and [AdvisorBenchmark] predate this and are left
+ * alone: they measure per-game cost, where deck reproducibility buys nothing.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Seeded sealed decks — same seed, same decks, every rerun
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Opens six boosters' worth of cards and autobuilds a 40-card limited deck from them. */
+internal fun buildSeededSealedDeck(allCards: List<CardDefinition>, rng: Random): Deck {
+    val pool = generateSeededSealedPool(allCards, rng)
+    val deckMap = buildHeuristicSealedDeck(pool)
+    return Deck(deckMap.flatMap { (name, count) -> List(count) { name } })
+}
+
+/** Six boosters: 11 commons, 3 uncommons and a rare (1-in-8 mythic) each, no duplicates per pack. */
+internal fun generateSeededSealedPool(allCards: List<CardDefinition>, rng: Random): List<CardDefinition> {
+    val nonBasics = allCards.filter { !it.typeLine.isBasicLand }
+    val commons = nonBasics.filter { it.metadata.rarity == Rarity.COMMON }
+    val uncommons = nonBasics.filter { it.metadata.rarity == Rarity.UNCOMMON }
+    val rares = nonBasics.filter { it.metadata.rarity == Rarity.RARE }
+    val mythics = nonBasics.filter { it.metadata.rarity == Rarity.MYTHIC }
+
+    val pool = mutableListOf<CardDefinition>()
+    repeat(6) {
+        val usedNames = mutableSetOf<String>()
+        fun pick(from: List<CardDefinition>): CardDefinition? {
+            val available = from.filter { it.name !in usedNames }
+            if (available.isEmpty()) return null
+            return available[rng.nextInt(available.size)].also { usedNames.add(it.name) }
+        }
+        repeat(11) { pick(commons)?.let { pool.add(it) } }
+        repeat(3) { pick(uncommons)?.let { pool.add(it) } }
+        val rare = if (mythics.isNotEmpty() && rng.nextDouble() < 0.125) pick(mythics) else null
+        pool.add(rare ?: pick(rares) ?: pick(uncommons) ?: pick(commons)!!)
+    }
+    return pool
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Illegal-action recovery
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mirror of `AIPlayer.playPriorityWindow`'s fallback: when the chosen action is rejected, pass —
+ * except in a combat declaration step, where passing leaves mandatory attackers/blockers
+ * undeclared and the game wedges.
+ *
+ * A benchmark that needs this has already found a bug; the point is to keep the *rest* of the run
+ * going so the exception histogram sees every distinct failure, not just the first.
+ */
+internal fun safeFallbackAction(
+    state: GameState,
+    playerId: EntityId,
+    enumerator: LegalActionEnumerator
+): GameAction {
+    val attackersDeclared = state.getEntity(playerId)?.has<AttackersDeclaredThisCombatComponent>() == true
+    val blockersDeclared = state.getEntity(playerId)?.has<BlockersDeclaredThisCombatComponent>() == true
+    return when {
+        state.step == Step.DECLARE_ATTACKERS && state.activePlayerId == playerId && !attackersDeclared -> {
+            val la = enumerator.enumerate(state, playerId, EnumerationMode.ACTIONS_ONLY)
+                .find { it.actionType == "DeclareAttackers" }
+            val mandatory = la?.mandatoryAttackers ?: emptyList()
+            val opponentId = state.getOpponents(playerId).firstOrNull()
+            DeclareAttackers(
+                playerId,
+                if (mandatory.isNotEmpty() && opponentId != null) mandatory.associateWith { opponentId } else emptyMap()
+            )
+        }
+
+        state.step == Step.DECLARE_BLOCKERS && state.activePlayerId != playerId && !blockersDeclared -> {
+            val la = enumerator.enumerate(state, playerId, EnumerationMode.ACTIONS_ONLY)
+                .find { it.actionType == "DeclareBlockers" }
+            val mandatory = la?.mandatoryBlockerAssignments ?: emptyMap()
+            DeclareBlockers(playerId, mandatory.mapValues { (_, targets) -> targets.take(1) })
+        }
+
+        else -> PassPriority(playerId)
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SimulationThroughputBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SimulationThroughputBenchmark.kt
@@ -1,12 +1,8 @@
 package com.wingedsheep.ai.engine
 
 import com.wingedsheep.engine.core.ActionProcessor
-import com.wingedsheep.engine.core.DeclareAttackers
-import com.wingedsheep.engine.core.DeclareBlockers
-import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.GameInitializer
-import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.core.PlayerConfig
 import com.wingedsheep.engine.core.SubmitDecision
 import com.wingedsheep.engine.legalactions.EnumerationMode
@@ -14,14 +10,9 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
-import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
 import com.wingedsheep.mtg.sets.MtgSetCatalog
-import com.wingedsheep.sdk.core.Step
-import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.model.Rarity
 import io.kotest.core.spec.style.FunSpec
 import java.util.Locale
 import java.util.concurrent.ExecutorCompletionService
@@ -93,8 +84,8 @@ class SimulationThroughputBenchmark : FunSpec({
             // Seeded per game so a rerun measures the same games.
             val rng = Random(gameId.toLong())
             completionService.submit {
-                val deck1 = buildRandomSealedDeck(set.cards, rng)
-                val deck2 = buildRandomSealedDeck(set.cards, rng)
+                val deck1 = buildSeededSealedDeck(set.cards, rng)
+                val deck2 = buildSeededSealedDeck(set.cards, rng)
                 measureGame(registry, deck1, deck2, seed = gameId.toLong()).also {
                     val n = finished.incrementAndGet()
                     if (n <= 3 || n % 5 == 0 || n == total) {
@@ -288,7 +279,7 @@ private fun measureGame(
             playedProcessCalls++
 
             state = if (r.error != null) {
-                val fallback = processor.process(state, safeFallback(state, priorityPlayer, enumerator)).result
+                val fallback = processor.process(state, safeFallbackAction(state, priorityPlayer, enumerator)).result
                 if (fallback.error != null) break
                 fallback.state
             } else {
@@ -331,37 +322,6 @@ private fun measureGame(
  */
 private fun strategistCandidateFilter(actions: List<LegalAction>): List<LegalAction> =
     actions.filter { it.affordable && !it.isManaAbility && it.actionType != "PassPriority" }
-
-/** Mirror of AIPlayer.playPriorityWindow's fallback: honour mandatory combat assignments. */
-private fun safeFallback(
-    state: GameState,
-    playerId: EntityId,
-    enumerator: LegalActionEnumerator
-): GameAction {
-    val attackersDeclared = state.getEntity(playerId)?.has<AttackersDeclaredThisCombatComponent>() == true
-    val blockersDeclared = state.getEntity(playerId)?.has<BlockersDeclaredThisCombatComponent>() == true
-    return when {
-        state.step == Step.DECLARE_ATTACKERS && state.activePlayerId == playerId && !attackersDeclared -> {
-            val la = enumerator.enumerate(state, playerId, EnumerationMode.ACTIONS_ONLY)
-                .find { it.actionType == "DeclareAttackers" }
-            val mandatory = la?.mandatoryAttackers ?: emptyList()
-            val opponentId = state.getOpponents(playerId).firstOrNull()
-            DeclareAttackers(
-                playerId,
-                if (mandatory.isNotEmpty() && opponentId != null) mandatory.associateWith { opponentId } else emptyMap()
-            )
-        }
-
-        state.step == Step.DECLARE_BLOCKERS && state.activePlayerId != playerId && !blockersDeclared -> {
-            val la = enumerator.enumerate(state, playerId, EnumerationMode.ACTIONS_ONLY)
-                .find { it.actionType == "DeclareBlockers" }
-            val mandatory = la?.mandatoryBlockerAssignments ?: emptyMap()
-            DeclareBlockers(playerId, mandatory.mapValues { (_, targets) -> targets.take(1) })
-        }
-
-        else -> PassPriority(playerId)
-    }
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Reporting
@@ -465,35 +425,5 @@ private fun printReport(samples: List<ThroughputSample>, numGames: Int) {
         "across the ${fmt(meanWhenNonEmpty, 1)} candidates a non-trivial window actually offers.")
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Deck generation (seeded — same games on every rerun)
-// ─────────────────────────────────────────────────────────────────────────────
-
-private fun buildRandomSealedDeck(allCards: List<CardDefinition>, rng: Random): Deck {
-    val pool = generateSealedPool(allCards, rng)
-    val deckMap = buildHeuristicSealedDeck(pool)
-    return Deck(deckMap.flatMap { (name, count) -> List(count) { name } })
-}
-
-private fun generateSealedPool(allCards: List<CardDefinition>, rng: Random): List<CardDefinition> {
-    val nonBasics = allCards.filter { !it.typeLine.isBasicLand }
-    val commons = nonBasics.filter { it.metadata.rarity == Rarity.COMMON }
-    val uncommons = nonBasics.filter { it.metadata.rarity == Rarity.UNCOMMON }
-    val rares = nonBasics.filter { it.metadata.rarity == Rarity.RARE }
-    val mythics = nonBasics.filter { it.metadata.rarity == Rarity.MYTHIC }
-
-    val pool = mutableListOf<CardDefinition>()
-    repeat(6) {
-        val usedNames = mutableSetOf<String>()
-        fun pick(from: List<CardDefinition>): CardDefinition? {
-            val available = from.filter { it.name !in usedNames }
-            if (available.isEmpty()) return null
-            return available[rng.nextInt(available.size)].also { usedNames.add(it.name) }
-        }
-        repeat(11) { pick(commons)?.let { pool.add(it) } }
-        repeat(3) { pick(uncommons)?.let { pool.add(it) } }
-        val rare = if (mythics.isNotEmpty() && rng.nextDouble() < 0.125) pick(mythics) else null
-        pool.add(rare ?: pick(rares) ?: pick(uncommons) ?: pick(commons)!!)
-    }
-    return pool
-}
+// Seeded deck generation and the illegal-action fallback live in `AiBenchmarkSupport.kt` — the
+// arena needs both, and two copies of either would silently drift apart.

--- a/ai/src/test/resources/arena/gauntlet.json
+++ b/ai/src/test/resources/arena/gauntlet.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "The standing field every AI version is measured against. Add a version when it ships; never remove one, or the historical matrix stops being comparable. Names must exist in ArenaAgents.",
+  "agents": [
+    "v0",
+    "blb-advisors",
+    "ons-advisors",
+    "production"
+  ]
+}

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -3,9 +3,10 @@
 A phased plan to make the in-game engine AI measurably stronger, on a scoreboard we trust, using
 mechanisms that generalize across the whole card catalog rather than per-card special cases.
 
-**Status:** **Phase 0 shipped** (2026-07-27) — baseline in
-[`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md). Phases 1+ not started. Phases are
-individually shippable and ordered by dependency, not by appeal.
+**Status:** **Phases 0 and 1 shipped** (2026-07-27) — baselines in
+[`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md), measurement guide in
+[`docs/ai/measurement.md`](../docs/ai/measurement.md). Next up is **Phase 2, the puzzle suite**.
+Phases are individually shippable and ordered by dependency, not by appeal.
 
 **Related:** [`engine-performance.md`](engine-performance.md) — the CPU profile this plan's
 performance phase builds on. See "Cross-reference" below; parts of that doc are stale.
@@ -225,7 +226,35 @@ throughput, projection share and branching factor — plus the three plan correc
 
 ---
 
-### Phase 1 — The Arena · *4–6 d*
+### Phase 1 — The Arena · *4–6 d* — ✅ **DONE 2026-07-27**
+
+> **Shipped.** Baselines and findings in
+> [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md#phase-1--arena-baselines); how to
+> run and read a report in [`docs/ai/measurement.md`](../docs/ai/measurement.md).
+>
+> Three corrections the build produced:
+>
+> 1. **The arena is ~100× cheaper than budgeted.** ~5 games/sec on 8 threads, so a 1,000-game
+>    merge gate is **3.5 minutes**, not 30–60. The 111-CPU-hour estimate assumed a 2 s
+>    `DecisionBudget` that does not exist yet, so **the "reduced ~150 ms budget" mitigation was not
+>    needed and was not built.** Phase 4b must re-measure before shipping a budget — the budget, not
+>    the game count, is what makes an arena expensive.
+> 2. **The v0-vs-v0 exit criterion was weaker than what is actually true.** With the same agent on
+>    both seats the two games of a pair are *literally the same game*, so the mirror is **exactly**
+>    50% with CI `[0.000, 0.000]`. That is asserted in the always-on suite rather than checked by
+>    hand. A control run (`v0` vs a zero-weight `v0-blind`) proves the harness discriminates: 200-0.
+> 3. **The BLB advisors are measurably neutral** — 1,000 paired games, 50.0%, CI [49.3%, 50.8%].
+>    `AdvisorBenchmark`'s 46.1% on the same game count is the *unpaired, unseeded* view of the same
+>    conclusion; the arena's paired interval is **4× tighter**. This lowers the retirement bar for
+>    the 42 advisor entries in Phase 6.
+>
+> Also found, and **not fixed** (an AI/enumerator bug, not scoreboard work): the AI proposes an
+> illegal action ~0.9 times per game, 889 of 945 being `CastSpell: No valid targets available`, at
+> ~3× the rate when a `CardAdvisor` is in play. Quantified in the baseline doc.
+>
+> **Deferred:** `arena-puzzles` ships with the puzzles in Phase 2 — a recipe pointing at a test
+> that does not exist is worse than no recipe. `ArenaBudgetScalingTest` stays in Phase 4b as
+> planned; there is no budget to scale yet.
 
 **Lives in `ai/src/test/kotlin/com/wingedsheep/ai/arena/`.** `:ai` already declares
 `testImplementation(testFixtures(project(":rules-engine")))` and `testImplementation(project(":mtg-sets"))`,
@@ -264,14 +293,16 @@ a `frozen/v0/` package.
 - `skipMulligans = true` for determinism — note this puts mulligan quality **out of test**; schedule
   a separate mulligan A/B later.
 
-**justfile:** `arena A B GAMES="300"`, `arena-gauntlet GAMES="200"`, `arena-puzzles`. Gauntlet
-membership in `ai/src/test/resources/arena/gauntlet.json`. Results append to
-`benchmarks/arena/<timestamp>/` (results.csv + summary.md), matching the existing
-`benchmarks/ai-benchmark-*` convention already committed at repo root.
+**justfile:** `arena A B GAMES="300"`, `arena-gauntlet GAMES="200"`. (`arena-puzzles` moved to
+Phase 2, with the puzzles it would run.) Gauntlet membership in
+`ai/src/test/resources/arena/gauntlet.json`. Results go to `benchmarks/arena/<timestamp>-<a>-vs-<b>/`
+(results.csv + summary.md) — **gitignored**; there was no committed `benchmarks/ai-benchmark-*`
+convention at the repo root, that claim was wrong.
 
-**Exit:** `just arena v0 v0 300` returns 50% with the CI **containing** 50% — a seat/seed-leak
-detector; if V0 vs V0 isn't ~50/50 the harness is biased. And `just arena v0 blb-advisors 1000`
-reproduces `AdvisorBenchmark`'s known result.
+**Exit:** ✅ `just arena v0 v0 300` returns exactly 50%, CI `[50.0%, 50.0%]` — a seat/seed-leak
+detector, asserted in the always-on suite rather than eyeballed. ✅ `just arena v0 blb-advisors 1000`
+returns 50.0% CI [49.3%, 50.8%] against `AdvisorBenchmark`'s unpaired 46.1% — the same conclusion
+(advisors are not an improvement) at 4× the precision.
 
 ---
 
@@ -787,12 +818,13 @@ but tanks a puzzle category, look hard before shipping.
 ## Recommended order
 
 ```
-0̶ → 1 → 2 → 3 → 4 → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
+0̶ → 1̶ → 2 → 3 → 4 → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
 ```
 
-Phase 0 is done. **Phase 5 has left the critical path** — simulation is already ~2× the speed the
-rollout budget needs, so 5a is now an independent engine-perf task and 5c is almost certainly not
-justified. Next up is **Phase 1, the arena**: nothing below is knowable without it.
+Phases 0 and 1 are done. **Phase 5 has left the critical path** — simulation is already ~2× the
+speed the rollout budget needs, so 5a is now an independent engine-perf task and 5c is almost
+certainly not justified. Next up is **Phase 2, the puzzle suite**: the arena says *that* something
+regressed, a puzzle says *what*.
 
 Ranked by strength-per-effort, independent of ordering:
 
@@ -802,7 +834,7 @@ Ranked by strength-per-effort, independent of ordering:
 | 2 | **6** CardIntent | 5–7 d | Removes flat-0.5 blindness to every artifact/enchantment/PW; feeds 4 other consumers. |
 | 3 | **9** Texel tuning | 4–6 d | Replaces ~25 guessed constants with fitted ones. Cheap once the arena exists. |
 | 4 | **7** rollout evaluator | 6–9 d | Highest *ceiling*; the real lever. Costly, and worthless without the rest. |
-| 5 | **1 / 2** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. |
+| 5 | **1̶ / 2** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Arena done. |
 | 6 | **4a** auto-pass filter | 3–5 d | Demoted by Phase 0: at 1.75 candidates there is little to filter. Still saves ~148 ms/game of pointless enumeration, and a rollout pays it repeatedly. |
 | 7 | **4b** DecisionBudget | 2–3 d | Enabling infrastructure. |
 | 8 | **8** determinization | 5–7 d | **Costs** strength (fairness price). Do it because search over a cheated state is search over a lie. |
@@ -825,11 +857,11 @@ two phases' worth of assumed work.
 | **Overfitting to self-play** | Held-out set + gauntlet + puzzles | ≥3 collecting agents; hold out by game *and* by set; arena is the arbiter, not log-loss |
 | **Non-transitive strength** | Full pairwise matrix, not just Elo | Must beat V0 *and* previous version; lose to no gauntlet member worse than 45% |
 | **Combat's 1 s cap fights the global budget** | Blocking puzzle category; per-tier latency logging | Combat declaration is always CRITICAL; keep `MAX_BLOCK_SIMULATIONS = 10` as a floor, not a ceiling |
-| **`GameSimulator.isResolving` / `decisionResolver` thread-safety** | Nondeterminism across arena reruns at the same seed | One `AIPlayer` per game, never shared; `PlayoutEngine` owns its own processor; determinism test at parallelism 1 vs N |
+| **`GameSimulator.isResolving` / `decisionResolver` thread-safety** | Nondeterminism across arena reruns at the same seed | One `AIPlayer` per *seat* per game, never shared. `ArenaHarnessTest` asserts identical outcomes at 8 threads and at 1 — **green as of Phase 1**, so the AI is deterministic today. `PlayoutEngine` must own its own processor when Phase 7 lands |
 | **Persistent collections break persisted sessions / committed replays** | `GameStateSerializationFormatStabilityTest` golden JSON | Serializers delegate to standard `MapSerializer`/`ListSerializer` ⇒ byte-identical wire format |
 | **`CardInstantiator` extraction produces malformed cards** | `DeterminizerInvariantsTest` + full engine suite | Reuse `GameInitializer`'s own construction path, don't hand-roll |
-| **Arena wall-clock makes the merge gate unaffordable** | Measured in Phase 1 | Reduced budget (~150 ms) for 1,000-game runs; 300-game full-budget cross-check; validate budget-monotonicity separately |
-| **`AiProfile.LEGACY_V0` silently drifts, moving the goalpost** | `FrozenBaselineTest` golden action-stream hash | Cheaper and more honest than a 5,575-LOC frozen copy |
+| ~~**Arena wall-clock makes the merge gate unaffordable**~~ | Measured in Phase 1 | **Not a risk today** — 1,000 games is 3.5 min, because no `DecisionBudget` exists yet. Re-opens in Phase 4b: re-measure before shipping a budget, and only then consider a reduced-budget arena mode |
+| ~~**`AiProfile.LEGACY_V0` silently drifts**~~ | `FrozenBaselineTest` golden action-stream hash | **Closed in Phase 1** — one fixed all-vanilla Portal game, SHA-256 over the action stream. All-vanilla so the hash tracks *AI* behaviour, not every card that ships |
 | ~~**`respondBudgetModal` zero-cost infinite loop**~~ | Arena stuck-game detector | **Closed in Phase 0** — free modes are taken once; regression test committed |
 | ~~**`Searcher.kt`'s `Double.MIN_VALUE/2` gets accidentally revived**~~ | — | **Closed in Phase 0** — file deleted rather than repaired |
 
@@ -847,13 +879,14 @@ Per phase, in addition to the exit criteria above:
   targeted leaf shrank.
 - **SDK docs:** no card-SDK surface changes are expected. If any phase adds an SDK primitive,
   `docs/card-sdk-language-reference.md` updates in the *same* change.
-- **New docs:** `docs/ai/baseline-metrics.md` (Phase 0, updated per phase) ·
-  `docs/ai/measurement.md` (how to read an arena report; the promotion rule) ·
+- **New docs:** `docs/ai/baseline-metrics.md` (Phase 0, appended per phase) ·
+  `docs/ai/measurement.md` (Phase 1 — how to read an arena report; the promotion rule) ·
   `docs/ai/architecture.md` (profile / budget / evaluator seams, once Phase 7 lands).
 - **End-to-end sanity:** after Phases 7 and 8, play a real game via `just server` and confirm decision
   latency feels right and the AI no longer plays around cards it shouldn't know about.
-- **Standing regression set** after each merge: `just arena-puzzles` (seconds) +
+- **Standing regression set** after each merge: `just arena-puzzles` (seconds, from Phase 2) +
   `just arena <prev> <new> 1000` (the gate) + `just arena <new> v0 1000` (the compounding check).
+  Both 1,000-game runs are ~3.5 min each today.
 
 ---
 

--- a/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
@@ -35,6 +35,16 @@ tasks.withType<Test>().configureEach {
         }
     }
 
+    // Forward the arena flags (see ai/src/test/kotlin/com/wingedsheep/ai/arena) so `just arena`
+    // and `just arena-gauntlet` reach the test JVM. Both recipes also pass -Dbenchmark=true, which
+    // is what relaxes TestHangGuard for a run that legitimately takes half an hour.
+    for (prop in listOf(
+        "arena", "arenaGauntlet", "arenaA", "arenaB",
+        "arenaGames", "arenaSeed", "arenaSet", "arenaMaxTurns", "arenaThreads",
+    )) {
+        System.getProperty(prop)?.let { systemProperty(prop, it) }
+    }
+
     // Forward the anti-hang guard tunables (see TestHangGuard) so they can be set from the CLI.
     // Also forward the opt-in flags for the heavy replay-divergence fuzzer (ReplayDivergenceReproTest),
     // which is skipped in CI and only runs when `runReproTests=true` is passed on the CLI.

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -145,7 +145,94 @@ Deliberately out of scope for Phase 0, each owned by a later phase:
 
 - **Puzzle pass rate per category** — Phase 2. The "non-creature valuation" category is expected to
   baseline near 0%.
-- **Arena win rate vs `LEGACY_V0`** — Phase 1. There is no scoreboard yet, so no strength claim in
-  this document is possible or intended.
+- ~~**Arena win rate vs `LEGACY_V0`**~~ — Phase 1, below.
 - **p50/p95 decision latency per budget tier** — Phase 4b, once `DecisionBudget` exists. The 2.6 ms
   mean above is the whole distribution's mean with no tiering.
+
+---
+
+# Phase 1 — Arena baselines
+
+**Measured:** 2026-07-27. Same hardware. How to run and read these:
+[`measurement.md`](measurement.md).
+
+All runs: BLB sealed, seed 20260727, mirror decklists, `skipMulligans`, `maxTurns = 50`.
+
+## The scoreboard's own calibration
+
+| Run | Result | What it proves |
+|---|---|---|
+| `just arena v0 v0 300` | **50.0%**, CI **[50.0%, 50.0%]**, 300/300 completed | No seat or seed leak. A mirror is exact, not merely "within the interval" |
+| `just arena v0 v0-blind 200` | **100.0%**, 200-0 | The harness **discriminates**. Without this, a 50% reading is indistinguishable from a broken harness |
+
+`v0-blind` is `LEGACY_V0` with every evaluation weight zeroed, so its Strategist can never prefer
+an action to passing. Losing 200-0 to a greedy 1-ply agent is the expected floor.
+
+## Reference-opponent baselines
+
+| Agent A | Agent B | Games | Pair win % | 95% CI | Verdict |
+|---|---|---|---|---|---|
+| `v0` | `v0` | 300 | 50.0% | [50.0%, 50.0%] | mirror (harness check) |
+| `v0` | `blb-advisors` | 1,000 | **50.0%** | **[49.3%, 50.8%]** | **not distinguishable** |
+| `v0` | `v0-blind` | 200 | 100.0% | [100.0%, 100.0%] | v0 wins |
+
+## Throughput
+
+**~5 games/sec on 8 threads** (~1.6 s of wall clock per game, ~11 turns, ~497 actions). A
+1,000-game merge gate is **3.5 minutes**, not the ~30–60 minutes the plan budgeted.
+
+The plan's 111-CPU-hour estimate assumed a 2 s `DecisionBudget` per decision. That budget does not
+exist yet — combat has a 1 s cap and nothing else is bounded at all. **So the plan's "run the arena
+at a reduced ~150 ms budget" mitigation is not needed in Phase 1, and Phase 4b must re-measure this
+table before it ships a budget**: it is the budget, not the game count, that decides whether a
+1,000-game gate is affordable.
+
+---
+
+## What Phase 1 found
+
+### 1. The BLB card advisors are not an improvement over generic `v0`
+
+1,000 paired games: **50.0%, CI [49.3%, 50.8%]**, 500W-500L-0D. Only ~3% of pairs came out
+differently at all, and those split evenly. The advisors change behaviour — the CI is non-degenerate,
+unlike the `v0` mirror's `[0.000, 0.000]` — they just do not change results.
+
+`AdvisorBenchmark`, run at the same 1,000 games for comparison, reports **46.1%** for the advised
+side. The two do not contradict each other so much as bracket the same conclusion: *advisors are
+not helping*. The difference is explained by `AdvisorBenchmark` being **unseeded** — it sets no
+`GameConfig.seed`, so the two games of its "pair" are different shuffles, and its estimator is
+therefore unpaired. On the same 1,000 games the arena's paired interval is **±0.8 pp** against the
+unpaired **±3.1 pp** — a **4× variance reduction**, well beyond the 15–30% the plan predicted,
+because mirror decklists plus an identical game seed make the pairing unusually tight.
+
+This is worth stating plainly because Phase 6 plans to retire advisors that `CardIntent` reproduces:
+**the retirement bar for the 42 BLB/ONS advisor entries is lower than it looked.** Two of them had
+already been silently overwritten before Phase 0 fixed the registry collision, and the module as a
+whole is measurably neutral.
+
+### 2. The AI proposes illegal actions roughly once per game
+
+The arena is a free bug finder at scale, and it found one immediately. Across the 1,000-game run:
+
+| Count | Rejection |
+|---|---|
+| 889 | `CastSpell: No valid targets available` |
+| 33 | `CastSpell: Not enough mana to cast this spell` |
+| 23 | `ActivateAbility: Must choose 1 card(s) to discard` |
+
+Every one of these is a defect — either the enumerator offered an action it should not have, or the
+Strategist mangled it on the way out. The runner recovers with a safe fallback and continues, so
+none of them break a game, but ~0.9 wasted decisions per game is real.
+
+The rate is **advisor-dependent**: 0.34/game in the `v0` mirror versus 0.95/game with
+`blb-advisors` on one side. That points at a `CardAdvisor` recommending a cast whose target
+selection then fails, and it is a concrete lead rather than a vague one. **Not fixed in Phase 1** —
+it is an AI/enumerator bug, not scoreboard work — but it is now measured, and any fix has a
+number to move.
+
+### 3. Seat 0 is not worth what you would guess
+
+Seat 0 (on the play) wins **46–51%** depending on the run — at 300 games it was 46.0%, at 1,000 it
+was 51.0%. In BLB sealed against this AI, being on the play is close to neutral and may be slightly
+negative. It does not bias any result here (both agents sit in both seats), but it is a reminder
+that "on the play wins more" is an assumption about human play, not a property of the engine.

--- a/docs/ai/measurement.md
+++ b/docs/ai/measurement.md
@@ -1,0 +1,137 @@
+# Engine AI — How to Measure a Change
+
+How to run the arena, how to read a report, and what does and does not count as evidence that the
+AI got better. Built in Phase 1 of [`backlog/engine-ai-improvement.md`](../../backlog/engine-ai-improvement.md).
+
+The numbers themselves live in [`baseline-metrics.md`](baseline-metrics.md).
+
+---
+
+## The one-paragraph version
+
+Two agents play N games. Each **pair** is the same two decks and the same game seed played twice
+with the seats swapped, so the first-player advantage and the shuffle cancel out. The number that
+decides anything is the **pair win share** and its bootstrap interval. **A change that cannot clear
+53% over 1,000 games is not a demonstrated improvement** — quote the interval, never the point
+estimate alone.
+
+```bash
+just arena v0 blb-advisors 1000      # head-to-head, the merge gate
+just arena-gauntlet 200              # everyone vs everyone + the pairwise matrix
+```
+
+---
+
+## Running it
+
+```
+just arena A B [GAMES] [SET] [SEED]
+```
+
+| Purpose | Games | Roughly | CI half-width at parity |
+|---|---|---|---|
+| Smoke — "did I break it" | 100 | 25 s | ±5 pp |
+| Directional | 300 | 70 s | ±3 pp |
+| **Merge gate** | **1,000** | **3.5 min** | **±0.8 pp** |
+| Publish | 3,000 | 10 min | ±0.4 pp |
+
+Wall clock is measured on an 8-core M1 Pro at ~5 games/sec. **This is ~100× cheaper than the plan
+assumed**, because the plan budgeted a 2 s `DecisionBudget` that does not exist yet; today the AI
+spends ~1.6 s of wall clock on a whole game. When Phase 4b lands a real budget, re-measure this
+table before promising anyone a 1,000-game gate — it is the budget, not the game count, that makes
+an arena expensive.
+
+Agents are named in `ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt`:
+
+| Name | What it is |
+|---|---|
+| `v0` | `AiProfile.LEGACY_V0` — **the permanent reference opponent** |
+| `current` | whatever `AIPlayer.create(registry, playerId)` builds today |
+| `production` | what a player actually faces: BLB + ONS card advisors |
+| `blb-advisors` / `ons-advisors` | v0 plus one advisor module |
+| `v0-blind` | all evaluation weights zero. Not playable — it is the harness's own control |
+
+Results land in `benchmarks/arena/<timestamp>-<a>-vs-<b>/` (gitignored): `results.csv` is one row
+per game, `summary.md` is the report below.
+
+---
+
+## Reading a report
+
+```
+--- ARENA: v0 vs blb-advisors ---
+Games:        1000 (500 pairs), set=BLB, seed=20260727
+Record:       500W-500L-0D for v0
+
+Pair score:   +0.000  CI [-0.014, 0.016]   (0 = parity)
+Pair win %:   50.0%  CI [49.3%, 50.8%]  <- the merge gate
+Game score %: 50.0%  Wilson [46.9%, 53.1%]  (unpaired, draws = 1/2)
+
+Seat 0 wins:  510 / 1000 (51.0%) — first-player advantage, cancelled by pairing
+Completed:    1000 / 1000 (100.0%)
+Illegal acts: 945 (actions the processor rejected — should be 0)
+```
+
+- **Pair score** — per pair, +1 if agent A swept it, 0 if they split, −1 if A was swept. Draws land
+  on the halves. The interval is a **percentile bootstrap over 2,000 resamples of whole pairs**,
+  seeded, so rerunning the analysis on the same games gives the same interval.
+- **Pair win %** is that score rescaled so 50% is parity. **This is the merge gate.**
+- **Game score %** is the same games scored *unpaired*, with a Wilson interval. It is reported for
+  comparability with older benchmarks and as a sanity check — the two point estimates should agree,
+  and the paired interval should be much tighter. On the run above it is **4× tighter** (±0.8 pp vs
+  ±3.1 pp). If they ever *disagree*, something is wrong with the pairing, not with the agent.
+- **Seat 0 wins** is the diagnostic that pairing is doing its job. It is normal for this to sit
+  away from 50% — BLB sealed reads ~46–51% depending on the seed — and it does not bias the result,
+  because both agents sit in both seats.
+- **Illegal acts** is a bug counter, not a metric. Every entry is an action the AI proposed and the
+  processor rejected; the run recovers and continues so the histogram sees all of them.
+
+### The promotion rule
+
+A new version must:
+
+1. beat `v0` with the **lower CI bound above 50%**, *and*
+2. beat the **immediately preceding version** on the same terms, *and*
+3. not lose to **any** gauntlet member worse than 45%.
+
+Rule 3 is why `just arena-gauntlet` prints the full pairwise matrix and not just an Elo. MTG agents
+are frequently non-transitive — an aggressive agent beats a controlling one that beats a midrange
+one that beats the aggressive one — and a single rating erases exactly that structure. The
+Bradley–Terry numbers underneath the matrix are a convenience; `ArenaStatsTest` contains a
+rock-paper-scissors case where all three agents rate 1500 despite every matchup being 70/30.
+
+---
+
+## What makes the scoreboard trustworthy
+
+Four properties, each with a test that fails if it stops holding. They are in the always-on
+`:ai:test` suite, not behind the benchmark flag, because a broken scoreboard is worse than none.
+
+| Property | Test | Why |
+|---|---|---|
+| No seat or seed leak | `ArenaHarnessTest` — a `v0` mirror is **exactly** 50%, CI `[0.000, 0.000]` | With the same agent on both seats, the two games of a pair are literally the same game. Anything other than an exact mirror is a defect, and would otherwise hide inside a confidence interval |
+| Determinism | same test — same seed replays identically at 8 threads and at 1 | `GameSimulator.isResolving` is mutable instance state; a shared `AIPlayer` would corrupt its own recursion guard |
+| It can tell agents apart | `just arena v0 v0-blind 200` → **200-0** | A harness that reports 50% for everything is indistinguishable from a broken one. This is the control |
+| `v0` has not drifted | `FrozenBaselineTest` — golden action-stream hash | `v0` is the permanent reference. If it moves, every historical number silently stops meaning what it said |
+
+`FrozenBaselineTest` plays one fixed game: 24 Mountains and four vanilla Portal creatures, fixed
+seed, `LEGACY_V0` on both seats, SHA-256 over every action and decision. The deck is deliberately
+all-vanilla so the hash tracks *AI* behaviour rather than going red every time somebody implements
+a card. If it fails and you did not mean to change how `v0` plays, you have found real drift; the
+test's KDoc says when re-blessing is legitimate.
+
+---
+
+## What the arena does **not** measure
+
+Say these out loud rather than letting a reader assume otherwise.
+
+- **Mulligans.** `skipMulligans = true`, because a mulligan decision would make a seed
+  irreproducible. Mulligan quality needs its own A/B.
+- **Deck diversity within a pair.** Both seats get the *same* 40-card sealed decklist (they still
+  draw different shuffles of it). Lowest variance, and it matches what `AdvisorBenchmark` measured —
+  but it means the arena tests symmetric matchups only.
+- **Multiplayer.** Two seats. Phase 3 adds FFA/Commander/2HG games, and it has to: every feature in
+  `BoardFeatures.kt` returns 0.0 with more than one opponent.
+- **Latency per budget tier.** There are no tiers until Phase 4b.
+- **Anything about a real player.** The reference opponent is another bot.

--- a/justfile
+++ b/justfile
@@ -81,6 +81,23 @@ benchmark-random GAMES="100" SET="POR":
 benchmark-throughput GAMES="20" SET="BLB":
     ./gradlew :ai:test --tests "*.SimulationThroughputBenchmark" -Dbenchmark=true -DbenchmarkGames={{GAMES}} -DbenchmarkSet={{SET}}
 
+# Play two AI agents head-to-head over paired-swap games and report a win rate with a confidence
+# interval (e.g., just arena v0 blb-advisors 1000). Agents: v0, current, production, blb-advisors,
+# ons-advisors, v0-blind. 1000 games is the merge gate; 300 is directional; 100 is a smoke test.
+# Results land in benchmarks/arena/. How to read one: docs/ai/measurement.md.
+[group: 'ai']
+arena A B GAMES="300" SET="BLB" SEED="20260727":
+    scripts/gradle-locked :ai:test --tests "*.ArenaBenchmark" -Dbenchmark=true -Darena=true \
+        -DarenaA={{A}} -DarenaB={{B}} -DarenaGames={{GAMES}} -DarenaSet={{SET}} -DarenaSeed={{SEED}}
+
+# Run every agent in ai/src/test/resources/arena/gauntlet.json against every other and print the
+# full pairwise matrix plus Bradley-Terry Elo. The matrix is the deliverable — MTG agents are
+# frequently non-transitive, and a single rating erases exactly that.
+[group: 'ai']
+arena-gauntlet GAMES="200" SET="BLB" SEED="20260727":
+    scripts/gradle-locked :ai:test --tests "*.ArenaBenchmark" -Dbenchmark=true -DarenaGauntlet=true \
+        -DarenaGames={{GAMES}} -DarenaSet={{SET}} -DarenaSeed={{SEED}}
+
 # Clean build artifacts
 [group: 'build']
 clean:


### PR DESCRIPTION
Phase 1 of [`backlog/engine-ai-improvement.md`](backlog/engine-ai-improvement.md): a paired-swap arena so every later phase has a number to move instead of an opinion. Phase 0 shipped the throughput baseline; this ships the strength scoreboard.

## What's here

**`AiProfile` — the versioning seam.** `AIPlayer.create(registry, playerId, profile)` is now the single constructor (the 3-arg overload delegates, so all ~30 call sites are untouched). `LEGACY_V0` pins today's greedy 1-ply AI as the **permanent** reference opponent; `PRODUCTION` names what a player actually faces (BLB + ONS advisors) instead of leaving it a literal in a controller constructor. It carries only what is wired today — advisor modules and the five evaluation weights that used to be inline in `defaultEvaluator()`. A profile field nothing reads would be a lie about what a run measured.

**The arena** (`ai/src/test/.../arena/`). A *pair* is the same decks and the same game seed played twice with the seats swapped. The merge gate is the **pair win share** and its 2,000-resample bootstrap interval, reported next to an unpaired Wilson interval for comparability with the older benchmarks.

```
just arena v0 blb-advisors 1000     # head-to-head — 3.5 min
just arena-gauntlet 200             # everyone vs everyone + pairwise matrix + Bradley-Terry Elo
```

The gauntlet prints the **matrix**, with Elo underneath as a convenience — a single rating cannot express the non-transitive cycles MTG agents produce, and `ArenaStatsTest` has a rock-paper-scissors case where all three agents rate 1500 despite every matchup being 70/30.

## Four properties that keep the scoreboard honest

All in the always-on `:ai:test` suite, not behind the benchmark flag, because a broken scoreboard is worse than none.

| Property | How |
|---|---|
| No seat/seed leak | `ArenaHarnessTest` — a v0 mirror is **exactly** 50%, CI `[0.000, 0.000]` |
| Determinism | same test — identical outcomes at 8 threads and at 1 |
| It can tell agents apart | `just arena v0 v0-blind 200` → **200-0** |
| v0 hasn't drifted | `FrozenBaselineTest` — golden action-stream hash |

The mirror assertion is deliberately **stronger than the plan's exit criterion**. The plan asked for "50% with the CI containing 50%"; with the same agent on both seats the two games of a pair are *literally the same game*, so it must be exact. A real seat bias would have hidden inside the looser interval.

`FrozenBaselineTest` plays one fixed game — 24 Mountains and four vanilla Portal creatures — so the hash tracks *AI* behaviour rather than going red every time somebody implements a card.

## Findings

Recorded in [`docs/ai/baseline-metrics.md`](docs/ai/baseline-metrics.md); how to read a report is in the new [`docs/ai/measurement.md`](docs/ai/measurement.md).

**1. The BLB card advisors are not an improvement over generic v0.** 1,000 paired games: **50.0%, CI [49.3%, 50.8%]**, 500W-500L-0D. Only ~3% of pairs came out differently at all, and those split evenly.

`AdvisorBenchmark`, run at the same 1,000 games for comparison, reports 46.1%. Not a contradiction — it sets no `GameConfig.seed`, so the two games of its "pair" are different shuffles and its estimator is unpaired. Same conclusion, **4× wider** (±3.1 pp vs the arena's ±0.8 pp), well beyond the 15–30% variance reduction the plan predicted. This lowers the Phase 6 bar for retiring the 42 advisor entries.

**2. The AI proposes an illegal action ~0.9× per game.** The arena is a free bug finder at scale and found one immediately:

| Count | Rejection |
|---|---|
| 889 | `CastSpell: No valid targets available` |
| 33 | `CastSpell: Not enough mana to cast this spell` |
| 23 | `ActivateAbility: Must choose 1 card(s) to discard` |

The rate is advisor-dependent — 0.34/game in the v0 mirror vs 0.95/game with `blb-advisors` on one side — which points at a `CardAdvisor` recommending a cast whose target selection then fails. **Not fixed here**: it's AI/enumerator work, not scoreboard work. It's now measured, so a fix has a number to move.

**3. The arena is ~100× cheaper than budgeted.** ~5 games/sec on 8 threads, so a 1,000-game merge gate is **3.5 minutes**, not 30–60. The plan's 111-CPU-hour estimate assumed a 2 s `DecisionBudget` that doesn't exist yet. So the planned reduced-budget arena mode **was not built** — and Phase 4b has to re-measure before shipping a budget, because it's the budget, not the game count, that makes an arena expensive.

## Scope notes

- **`arena-puzzles` moved to Phase 2**, with the puzzles it would run. A recipe pointing at a test that doesn't exist is worse than no recipe.
- **`ArenaBudgetScalingTest` stays in Phase 4b** as planned — there's no budget to scale yet.
- The plan claimed a committed `benchmarks/ai-benchmark-*` convention at the repo root. There isn't one; results go to `benchmarks/arena/<timestamp>-<a>-vs-<b>/`, gitignored. Corrected in the plan.
- `SimulationThroughputBenchmark`'s seeded deck builder and illegal-action fallback moved to a shared `AiBenchmarkSupport.kt` rather than being copied — same function bodies, so Phase 0's committed numbers still reproduce.

## Verification

- `:ai:test` green (including the 22 new always-on arena tests).
- `:game-server:test` green — 409 tests, 0 failures.
- `just arena v0 v0 300` → 50.0%, CI [50.0%, 50.0%], 300/300 completed.
- `just arena v0 v0-blind 200` → 100.0%, 200-0.
- `just arena v0 blb-advisors 1000` → 50.0%, CI [49.3%, 50.8%].

No card-SDK surface changed, so `docs/card-sdk-language-reference.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)