### PR TITLE
Engine AI Phase 2: 48 tactical puzzles — the localizing signal

### DIFF
--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
@@ -1,0 +1,206 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.CycleCard
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The eight things the suite is built to catch. Categories are the localizing signal: an arena run
+ * says *that* the AI got worse, a category pass-rate says *what* got worse.
+ *
+ * See `backlog/engine-ai-improvement.md` § "How we measure" for why these eight.
+ */
+enum class PuzzleCategory(val id: String, val catches: String) {
+    LETHAL_DETECTION("lethal", "Missing an alpha strike / burn-to-face kill"),
+    BLOCKING("blocking", "Chump vs trade vs no-block; deathtouch / first strike"),
+    REMOVAL_TARGETING("removal", "Shooting the 1/1 instead of the bomb"),
+    HOLDING_INSTANTS("instants", "Casting a combat trick in your own main phase"),
+    SEQUENCING("sequencing", "Land before spell; the land that unlocks the spell"),
+    BOARD_WIPE_TIMING("wipe", "Wrathing while ahead"),
+    RACE_MATH("race", "Attack-vs-hold when both players are on a clock"),
+    NON_CREATURE_VALUATION("noncreature", "Ignoring an opposing O-Ring / mana rock / anthem"),
+}
+
+/**
+ * One tactical position plus a predicate over the move the AI makes in it.
+ *
+ * **Never assert exact action equality.** A puzzle says *"removal targets the 4/4, not the 1/1"* or
+ * *"attacks with at least the evasive creature"*; it does not name a `GameAction`. Exact assertions
+ * break on harmless tie-break changes, and a suite that cries wolf is a suite you learn to ignore.
+ * [PuzzleMove] carries the vocabulary the checks are written in.
+ */
+class AiPuzzle(
+    /** Stable id, `"<category>-NN"`. It is what `KNOWN_FAILURES` records, so treat it as an API. */
+    val id: String,
+    val category: PuzzleCategory,
+    /** What a competent player does here, in one line. Printed on failure. */
+    val expectation: String,
+    /** Which seat the AI plays — 1 or 2. Blocking and race puzzles usually want seat 2. */
+    val aiSeat: Int,
+    /**
+     * Build the position. The returned game's `state` is what the AI is asked about, so it must
+     * leave [aiSeat] holding priority with no pending decision — [PuzzleRunner] enforces that
+     * rather than letting a mis-built position silently score as a pass.
+     */
+    val position: (ScenarioTestBase.ScenarioBuilder) -> ScenarioTestBase.TestGame,
+    /** The predicate. Throws [AssertionError] (via the `should…` helpers) when the move is wrong. */
+    val check: PuzzleMove.() -> Unit,
+)
+
+/**
+ * The move the AI actually chose, in the vocabulary a puzzle asserts over.
+ *
+ * Everything is keyed by **card name** rather than [EntityId]: a puzzle reads
+ * `shouldTarget("Craw Wurm")`, and the ids are scenario-build artifacts nobody should have to
+ * thread through an assertion.
+ */
+class PuzzleMove internal constructor(
+    val state: GameState,
+    val aiId: EntityId,
+    val opponentId: EntityId,
+    val action: GameAction,
+) {
+    private fun nameOf(entityId: EntityId): String =
+        state.getEntity(entityId)?.get<CardComponent>()?.name
+            ?: when (entityId) {
+                aiId -> "you"
+                opponentId -> "the opponent"
+                else -> entityId.value
+            }
+
+    /** Name of the card this action puts into play or onto the stack, if any. */
+    val playedCard: String? = when (action) {
+        is CastSpell -> nameOf(action.cardId)
+        is PlayLand -> nameOf(action.cardId)
+        is CycleCard -> nameOf(action.cardId)
+        is ActivateAbility -> nameOf(action.sourceId)
+        else -> null
+    }
+
+    /** Names of everything the action targets. Players read as `"you"` / `"the opponent"`. */
+    val targetNames: List<String> = when (action) {
+        is CastSpell -> action.targets
+        is ActivateAbility -> action.targets
+        else -> emptyList()
+    }.map { target ->
+        when (target) {
+            is ChosenTarget.Player -> nameOf(target.playerId)
+            is ChosenTarget.Permanent -> nameOf(target.entityId)
+            is ChosenTarget.Card -> nameOf(target.cardId)
+            is ChosenTarget.Spell -> nameOf(target.spellEntityId)
+        }
+    }
+
+    /** Declared attackers by card name. Empty when the action is not an attack declaration. */
+    val attackerNames: List<String> =
+        (action as? DeclareAttackers)?.attackers?.keys?.map(::nameOf).orEmpty()
+
+    /** Declared blocks as `blocker name -> attackers it blocks`. */
+    val blockAssignments: Map<String, List<String>> =
+        (action as? DeclareBlockers)?.blockers.orEmpty()
+            .entries.associate { (blocker, attackers) -> nameOf(blocker) to attackers.map(::nameOf) }
+
+    /** Total projected power of the declared attackers — what a lethal-detection puzzle counts. */
+    val attackingPower: Int = (action as? DeclareAttackers)?.attackers?.keys
+        ?.sumOf { state.projectedState.getPower(it) ?: 0 } ?: 0
+
+    /** A one-line rendering of the move, shown on every failure. */
+    fun describe(): String = when (action) {
+        is PassPriority -> "PassPriority"
+        is DeclareAttackers ->
+            if (attackerNames.isEmpty()) "DeclareAttackers(none)"
+            else "DeclareAttackers(${attackerNames.sorted().joinToString(", ")}) — $attackingPower power"
+        is DeclareBlockers ->
+            if (blockAssignments.isEmpty()) "DeclareBlockers(none)"
+            else "DeclareBlockers(" + blockAssignments.entries.joinToString("; ") { (b, a) ->
+                "$b blocks ${a.joinToString(" & ")}"
+            } + ")"
+        else -> {
+            val base = "${action::class.simpleName}($playedCard)"
+            if (targetNames.isEmpty()) base else "$base → ${targetNames.joinToString(", ")}"
+        }
+    }
+
+    private fun fail(what: String): Nothing = throw AssertionError("$what, but chose ${describe()}")
+
+    // ── Assertions. Each has many callers across the 48 puzzles; that is what earns them a name. ──
+
+    fun shouldCast(cardName: String) {
+        if (action !is CastSpell || playedCard != cardName) fail("Expected to cast $cardName")
+    }
+
+    fun shouldNotCast(cardName: String) {
+        if (action is CastSpell && playedCard == cardName) fail("Expected NOT to cast $cardName")
+    }
+
+    fun shouldPlayLand(landName: String? = null) {
+        if (action !is PlayLand) fail("Expected to play a land")
+        if (landName != null && playedCard != landName) fail("Expected to play $landName")
+    }
+
+    /** The action must target [cardName] — and, when it targets several things, [cardName] among them. */
+    fun shouldTarget(cardName: String) {
+        if (cardName !in targetNames) fail("Expected a target on $cardName")
+    }
+
+    fun shouldNotTarget(cardName: String) {
+        if (cardName in targetNames) fail("Expected NOT to target $cardName")
+    }
+
+    /** Targets the opposing player's face rather than any permanent. */
+    fun shouldTargetOpponentFace() = shouldTarget("the opponent")
+
+    fun shouldPass() {
+        if (action !is PassPriority) fail("Expected to pass priority")
+    }
+
+    /** Attacks with exactly this set of creatures — by name, so duplicates are compared as counts. */
+    fun shouldAttackWithExactly(vararg cardNames: String) {
+        if (attackerNames.sorted() != cardNames.sorted()) {
+            fail("Expected to attack with exactly ${cardNames.sorted().joinToString(", ")}")
+        }
+    }
+
+    fun shouldAttackWithAtLeast(vararg cardNames: String) {
+        val missing = cardNames.toList() - attackerNames.toSet()
+        if (missing.isNotEmpty()) fail("Expected to attack with at least ${missing.joinToString(", ")}")
+    }
+
+    fun shouldNotAttack() {
+        if (action !is DeclareAttackers) fail("Expected an attack declaration")
+        if (attackerNames.isNotEmpty()) fail("Expected to declare no attackers")
+    }
+
+    /** Lethal detection: the declared attack must put at least [damage] power on the table. */
+    fun shouldAttackForAtLeast(damage: Int) {
+        if (action !is DeclareAttackers) fail("Expected an attack declaration")
+        if (attackingPower < damage) fail("Expected to attack for at least $damage")
+    }
+
+    fun shouldBlock(blocker: String, attacker: String) {
+        if (blockAssignments[blocker]?.contains(attacker) != true) {
+            fail("Expected $blocker to block $attacker")
+        }
+    }
+
+    /** At least [count] creatures must be blocking [attacker] — the double-block assertion. */
+    fun shouldBlockWithAtLeast(count: Int, attacker: String) {
+        val blocking = blockAssignments.count { attacker in it.value }
+        if (blocking < count) fail("Expected at least $count blockers on $attacker")
+    }
+
+    fun shouldNotBlock() {
+        if (action !is DeclareBlockers) fail("Expected a block declaration")
+        if (blockAssignments.isNotEmpty()) fail("Expected to declare no blockers")
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleCatalog.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleCatalog.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.ai.puzzles.categories.BlockingPuzzles
+import com.wingedsheep.ai.puzzles.categories.BoardWipeTimingPuzzles
+import com.wingedsheep.ai.puzzles.categories.HoldingInstantsPuzzles
+import com.wingedsheep.ai.puzzles.categories.LethalDetectionPuzzles
+import com.wingedsheep.ai.puzzles.categories.NonCreatureValuationPuzzles
+import com.wingedsheep.ai.puzzles.categories.RaceMathPuzzles
+import com.wingedsheep.ai.puzzles.categories.RemovalTargetingPuzzles
+import com.wingedsheep.ai.puzzles.categories.SequencingPuzzles
+
+/**
+ * Every puzzle, in category order. Eight categories × six positions.
+ *
+ * Adding a puzzle is: write it in its category file, run `just arena-puzzles`, and add its id to
+ * [PuzzleSuiteTest.KNOWN_FAILURES] if the AI does not solve it yet.
+ */
+object PuzzleCatalog {
+
+    val all: List<AiPuzzle> = listOf(
+        LethalDetectionPuzzles.all(),
+        BlockingPuzzles.all(),
+        RemovalTargetingPuzzles.all(),
+        HoldingInstantsPuzzles.all(),
+        SequencingPuzzles.all(),
+        BoardWipeTimingPuzzles.all(),
+        RaceMathPuzzles.all(),
+        NonCreatureValuationPuzzles.all(),
+    ).flatten()
+
+    fun byCategory(category: PuzzleCategory): List<AiPuzzle> = all.filter { it.category == category }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.ai.engine.EvaluationWeights
+import com.wingedsheep.engine.support.ScenarioTestBase
+
+/**
+ * The same 48 puzzles across several agents, side by side.
+ *
+ * ```
+ * just arena-puzzles-compare
+ * ```
+ *
+ * Disabled unless `-Dbenchmark=true`, so a normal `:ai:test` run only pays for [PuzzleSuiteTest].
+ * The value over the plain suite is attribution: the `v0` / `production` columns say whether the
+ * card advisors are earning anything on the tactics they were written for, and later phases add a
+ * column each.
+ */
+class PuzzleComparisonBenchmark : ScenarioTestBase() {
+
+    init {
+        val enabled = System.getProperty("benchmark") == "true"
+
+        test("puzzles: profile comparison").config(enabled = enabled) {
+            val runner = PuzzleRunner(cardRegistry) { scenario() }
+            val profiles = listOf(
+                AiProfile.LEGACY_V0,
+                AiProfile.PRODUCTION,
+                // The discrimination control, same as the arena's: every weight zero.
+                AiProfile.LEGACY_V0.copy(id = "v0-blind", evaluationWeights = EvaluationWeights.BLIND),
+            )
+
+            val runs = profiles.map { profile ->
+                val results = runner.runAll(PuzzleCatalog.all, profile)
+                println(PuzzleReport.summary(profile.id, results))
+                println()
+                profile.id to results
+            }
+
+            println(PuzzleReport.comparison(runs))
+        }
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzlePositions.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzlePositions.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
+import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Advancing a scenario to the exact window a puzzle probes.
+ *
+ * `TestGame.passUntilPhase` stops at the first priority window of a step regardless of *who* holds
+ * priority, which is one window too early for half of these puzzles: a combat trick is cast in the
+ * declare-blockers step **after** blocks are in, not in the window where the defender is still
+ * being asked to declare them. These two helpers name that difference.
+ */
+
+internal fun ScenarioTestBase.TestGame.seatId(seat: Int): EntityId =
+    if (seat == 1) player1Id else player2Id
+
+/**
+ * Advance until [seat] is being asked to declare attackers or blockers in [step] and has not yet
+ * done so — the window a combat puzzle probes.
+ */
+fun ScenarioTestBase.TestGame.advanceToDeclaration(seat: Int, step: Step): ScenarioTestBase.TestGame =
+    advanceUntil("$seat's ${step.displayName} declaration") {
+        state.step == step && state.priorityPlayerId == seatId(seat) && needsDeclaration(seatId(seat))
+    }
+
+/**
+ * Advance until [seat] holds ordinary priority in [step], with every combat declaration already
+ * submitted — the window an instant is cast in.
+ */
+fun ScenarioTestBase.TestGame.advanceToPriority(seat: Int, step: Step): ScenarioTestBase.TestGame =
+    advanceUntil("$seat's priority in ${step.displayName}") {
+        state.step == step && state.priorityPlayerId == seatId(seat) && !needsDeclaration(seatId(seat))
+    }
+
+/** Whether [playerId] still owes this combat an attacker or blocker declaration. */
+private fun ScenarioTestBase.TestGame.needsDeclaration(playerId: EntityId): Boolean = when {
+    state.step == Step.DECLARE_ATTACKERS && playerId == state.activePlayerId ->
+        state.getEntity(playerId)?.get<AttackersDeclaredThisCombatComponent>() == null
+    state.step == Step.DECLARE_BLOCKERS && playerId != state.activePlayerId ->
+        state.getEntity(playerId)?.get<BlockersDeclaredThisCombatComponent>() == null
+    else -> false
+}
+
+/**
+ * Pass priority — auto-submitting empty combat declarations, as `passUntilPhase` does — until
+ * [stop] holds. Every failure mode is loud: a puzzle position that silently ends up in the wrong
+ * window would score the AI on a decision it was never asked to make.
+ */
+private fun ScenarioTestBase.TestGame.advanceUntil(
+    target: String,
+    stop: ScenarioTestBase.TestGame.() -> Boolean,
+): ScenarioTestBase.TestGame {
+    var iterations = 0
+    while (!stop()) {
+        check(iterations++ < MAX_ADVANCE_ITERATIONS) {
+            "Never reached $target — stalled at ${state.phase}/${state.step}"
+        }
+        val decision = state.pendingDecision
+        check(decision == null) {
+            "Puzzle setup paused on ${decision!!::class.simpleName} while advancing to $target. " +
+                "Puzzle positions must be quiet; rebuild the board so nothing triggers."
+        }
+        val priorityPlayer = checkNotNull(state.priorityPlayerId) {
+            "No priority player at ${state.phase}/${state.step} while advancing to $target"
+        }
+        val result = when {
+            state.step == Step.DECLARE_ATTACKERS && priorityPlayer == state.activePlayerId &&
+                needsDeclaration(priorityPlayer) -> execute(DeclareAttackers(priorityPlayer, emptyMap()))
+            state.step == Step.DECLARE_BLOCKERS && priorityPlayer != state.activePlayerId &&
+                needsDeclaration(priorityPlayer) -> execute(DeclareBlockers(priorityPlayer, emptyMap()))
+            else -> execute(PassPriority(priorityPlayer))
+        }
+        check(result.error == null) { "Advancing to $target was rejected: ${result.error}" }
+    }
+    return this
+}
+
+private const val MAX_ADVANCE_ITERATIONS = 200

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleReport.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleReport.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.ai.puzzles
+
+/**
+ * Formatting for a puzzle run: the overall pass rate, the per-category breakdown, and the failing
+ * moves.
+ *
+ * The per-category number is the point. A win rate says the AI got worse; "removal targeting fell
+ * from 5/6 to 2/6" says where to look. This is the number quoted alongside arena win rate in
+ * `docs/ai/baseline-metrics.md`.
+ */
+object PuzzleReport {
+
+    fun summary(profileId: String, results: List<PuzzleResult>): String = buildString {
+        val passed = results.count { it.passed }
+        appendLine("=== PUZZLES: $profileId — $passed/${results.size} (${pct(passed, results.size)}) ===")
+        appendLine()
+        appendLine(categoryTable(results))
+        val failures = results.filterNot { it.passed }
+        if (failures.isNotEmpty()) {
+            appendLine()
+            appendLine("Failing:")
+            for (result in failures) {
+                appendLine("  ${result.puzzle.id}  ${result.puzzle.expectation}")
+                appendLine("      ${result.failure}")
+            }
+        }
+    }
+
+    fun categoryTable(results: List<PuzzleResult>): String = buildString {
+        appendLine("| Category | Pass | Rate | Catches |")
+        appendLine("|---|---|---|---|")
+        for (category in PuzzleCategory.entries) {
+            val inCategory = results.filter { it.puzzle.category == category }
+            if (inCategory.isEmpty()) continue
+            val passed = inCategory.count { it.passed }
+            appendLine(
+                "| ${category.id} | $passed/${inCategory.size} | ${pct(passed, inCategory.size)} " +
+                    "| ${category.catches} |"
+            )
+        }
+        val total = results.count { it.passed }
+        appendLine("| **total** | **$total/${results.size}** | **${pct(total, results.size)}** | |")
+    }
+
+    /** Side-by-side per-category pass counts, for comparing agents on the same suite. */
+    fun comparison(runs: List<Pair<String, List<PuzzleResult>>>): String = buildString {
+        appendLine("| Category | ${runs.joinToString(" | ") { it.first }} |")
+        appendLine("|---|${runs.joinToString("|") { "---" }}|")
+        for (category in PuzzleCategory.entries) {
+            val cells = runs.map { (_, results) ->
+                val inCategory = results.filter { it.puzzle.category == category }
+                "${inCategory.count { it.passed }}/${inCategory.size}"
+            }
+            appendLine("| ${category.id} | ${cells.joinToString(" | ")} |")
+        }
+        val totals = runs.map { (_, results) -> "${results.count { it.passed }}/${results.size}" }
+        appendLine("| **total** | ${totals.joinToString(" | ") { "**$it**" }} |")
+    }
+
+    private fun pct(passed: Int, total: Int): String =
+        if (total == 0) "—" else "%.0f%%".format(100.0 * passed / total)
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleRunner.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleRunner.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.ai.engine.AIPlayer
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.ScenarioTestBase
+
+/** How one agent did on one puzzle. [failure] is null exactly when [passed] is true. */
+data class PuzzleResult(
+    val puzzle: AiPuzzle,
+    val passed: Boolean,
+    /** [PuzzleMove.describe] of the chosen move, or why no move could be obtained. */
+    val move: String,
+    val failure: String?,
+)
+
+/**
+ * Builds a puzzle position, asks an [AiProfile] for one move, and scores it.
+ *
+ * Takes the registry and scenario factory rather than extending [ScenarioTestBase] itself: the
+ * builder is an inner class, so it needs a spec instance to exist, and the runner wants to be
+ * callable from more than one spec (the always-on suite and the benchmark-gated report).
+ *
+ * A fresh [AIPlayer] per puzzle, never a shared one: `GameSimulator.isResolving` and
+ * `decisionResolver` are mutable instance state.
+ */
+class PuzzleRunner(
+    private val registry: CardRegistry,
+    private val newScenario: () -> ScenarioTestBase.ScenarioBuilder,
+) {
+    private val processor = ActionProcessor(registry)
+
+    fun run(puzzle: AiPuzzle, profile: AiProfile): PuzzleResult {
+        val game = try {
+            // `ScenarioBuilder` seeds itself from `System.nanoTime()` so repeated builds vary coin
+            // flips. A CI gate cannot be seeded from the clock — pin it, exactly as the arena pins
+            // `GameConfig.seed`.
+            puzzle.position(newScenario().withRngSeed(PUZZLE_SEED))
+        } catch (e: Throwable) {
+            return PuzzleResult(puzzle, false, "—", "position failed to build: ${e.message}")
+        }
+
+        val state = game.state
+        val aiId = game.seatId(puzzle.aiSeat)
+        val opponentId = game.seatId(if (puzzle.aiSeat == 1) 2 else 1)
+
+        // A position where the AI is not the one to move scores whatever the first branch of the
+        // check happens to say — which is worse than no puzzle at all. Fail loudly instead.
+        state.pendingDecision?.let {
+            return PuzzleResult(puzzle, false, "—", "position paused on ${it::class.simpleName}")
+        }
+        if (state.priorityPlayerId != aiId) {
+            return PuzzleResult(
+                puzzle, false, "—",
+                "position gives priority to ${state.priorityPlayerId} at ${state.phase}/${state.step}, " +
+                    "not the AI (seat ${puzzle.aiSeat})",
+            )
+        }
+
+        val ai = AIPlayer.create(registry, aiId, profile)
+        val action = try {
+            ai.chooseAction(state)
+        } catch (e: Throwable) {
+            return PuzzleResult(puzzle, false, "—", "AI threw ${e::class.simpleName}: ${e.message}")
+        }
+        val move = PuzzleMove(state, aiId, opponentId, action)
+
+        // The arena found the AI proposing ~0.9 illegal actions per game. A puzzle that "passes"
+        // on an action the engine would reject is measuring nothing, so legality is part of the bar.
+        processor.process(state, action).result.error?.let { error ->
+            return PuzzleResult(puzzle, false, move.describe(), "engine rejected the move: $error")
+        }
+
+        return try {
+            puzzle.check(move)
+            PuzzleResult(puzzle, true, move.describe(), null)
+        } catch (e: AssertionError) {
+            PuzzleResult(puzzle, false, move.describe(), e.message ?: "assertion failed")
+        }
+    }
+
+    fun runAll(puzzles: List<AiPuzzle>, profile: AiProfile): List<PuzzleResult> =
+        puzzles.map { run(it, profile) }
+
+    private companion object {
+        /** Same date-stamp convention as the arena's `ArenaConfig.DEFAULT_SEED`. */
+        const val PUZZLE_SEED = 20260727L
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.ai.engine.EvaluationWeights
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+
+/**
+ * The always-on tactical suite. Runs in seconds; `just arena-puzzles`.
+ *
+ * The gate is **"the failing set equals [KNOWN_FAILURES]"**, not "everything passes". Today's AI
+ * solves some of these and not others, and a suite pinned to 48/48 would be red forever and
+ * therefore ignored. Equality flags a regression *and* an unexpected fix — if a change makes the
+ * AI solve `noncreature-04`, this test fails until the id is deleted from the set, which is
+ * exactly the moment you want to notice.
+ *
+ * The reference profile is [AiProfile.PRODUCTION] — what a player actually faces, card advisors
+ * included. `PuzzleComparisonBenchmark` runs the same suite across profiles.
+ */
+class PuzzleSuiteTest : ScenarioTestBase() {
+
+    init {
+        val runner = PuzzleRunner(cardRegistry) { scenario() }
+
+        test("the suite covers eight categories, six puzzles each, with unique ids") {
+            PuzzleCatalog.all.map { it.id }.toSet().size shouldBe PuzzleCatalog.all.size
+            PuzzleCategory.entries.forEach { category ->
+                withClue(category) { PuzzleCatalog.byCategory(category).size shouldBe 6 }
+            }
+            PuzzleCatalog.all.size shouldBe 48
+        }
+
+        test("every KNOWN_FAILURES id names a real puzzle") {
+            (KNOWN_FAILURES - PuzzleCatalog.all.map { it.id }.toSet()) shouldBe emptySet()
+        }
+
+        test("the AI solves every puzzle outside KNOWN_FAILURES") {
+            val results = runner.runAll(PuzzleCatalog.all, AiProfile.PRODUCTION)
+            println(PuzzleReport.summary(AiProfile.PRODUCTION.id, results))
+            results.filterNot { it.passed }.map { it.puzzle.id }.toSet() shouldBe KNOWN_FAILURES
+        }
+
+        // The arena proved it discriminates by beating a zero-weight agent 200-0. Same argument,
+        // same control: if an evaluator that scores every board identically solves as many
+        // positions as the real one, these are not puzzles, they are coin flips.
+        test("a zero-weight agent solves strictly fewer puzzles") {
+            val blind = AiProfile.LEGACY_V0.copy(
+                id = "v0-blind",
+                evaluationWeights = EvaluationWeights.BLIND,
+            )
+            val blindResults = runner.runAll(PuzzleCatalog.all, blind)
+            val blindPassed = blindResults.count { it.passed }
+            println(PuzzleReport.summary(blind.id, blindResults))
+            blindPassed shouldBeLessThan (PuzzleCatalog.all.size - KNOWN_FAILURES.size)
+        }
+    }
+
+    companion object {
+        /**
+         * Puzzles today's AI does not solve. **Shrinking this set is the deliverable of Phases 3–9**
+         * of `backlog/engine-ai-improvement.md`; growing it needs a reason in the commit message.
+         *
+         * Baselined 2026-07-27 against `AiProfile.PRODUCTION`. Per-category rates are in
+         * `docs/ai/baseline-metrics.md`.
+         */
+        val KNOWN_FAILURES: Set<String> = setOf(
+            // Instant timing is ad-hoc: `Strategist` has no notion of "this spell wants a window",
+            // only a hard-coded `passScore - 1.5` on the opponent's end step. Phase 6's `HoldPolicy`.
+            "instants-01",
+            "instants-06",
+            // A one-ply evaluator cannot see a prevention effect: the state right after Fog
+            // resolves has the same life totals as passing, so Fog is only ever "-1 card".
+            // Needs the rollout evaluator (Phase 7) to play out the damage step.
+            "instants-05",
+            // `CardAdvantage.cardValue(0) = -3.0` makes emptying your hand read as a disaster, so
+            // the AI holds its last land rather than playing it. Phase 9 refits these constants;
+            // sequencing-04 is the same decision with one card of slack and passes.
+            "sequencing-02",
+            // No model of "keep a blocker home": every attacker is scored on the damage it deals.
+            "race-03",
+            // The headline blindness. `BoardFeatures.permanentValue` flat-values every non-creature
+            // permanent at 0.5 and `heuristicTargetRank` ranks one at 0.0, so destroying an artifact
+            // gains +0.5 board and costs -1 card — the AI would rather hold the removal forever.
+            // Phase 6 (`CardIntent`) exists to fix exactly this; noncreature-05/06 already pass
+            // because their effect shows up in *creature* stats, which the evaluator can see.
+            "noncreature-01",
+            "noncreature-02",
+            "noncreature-03",
+            "noncreature-04",
+        )
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BlockingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BlockingPuzzles.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * Chump vs trade vs no-block, and whether the combat keywords are read at all.
+ *
+ * The AI defends from seat 2 in every one of these; seat 1's attack is scripted by the position so
+ * the only judgement being measured is the block.
+ */
+object BlockingPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "blocking-01",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "Chump-block the 6/4 rather than die at 3 life",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLifeTotal(2, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldBlock("Grizzly Bears", "Craw Wurm") },
+        ),
+
+        AiPuzzle(
+            id = "blocking-02",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "Do not chump at 20 life: the Bears would die for three damage",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Hill Giant" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldNotBlock() },
+        ),
+
+        AiPuzzle(
+            id = "blocking-03",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "Block the 2/2 with the 3/3: it eats the attacker and lives",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Grizzly Bears" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldBlock("Hill Giant", "Grizzly Bears") },
+        ),
+
+        AiPuzzle(
+            id = "blocking-04",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "Deathtouch: a 2/1 Viper trades with a 6/4 Wurm",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Ambush Viper")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldBlock("Ambush Viper", "Craw Wurm") },
+        ),
+
+        AiPuzzle(
+            id = "blocking-05",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "First strike: White Knight blocks the 2/2 and kills it for free",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "White Knight")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Grizzly Bears" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldBlock("White Knight", "Grizzly Bears") },
+        ),
+
+        AiPuzzle(
+            id = "blocking-06",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "At 3 life with one blocker, block the 6/4 — the 2/2 is survivable",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(2, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 2, "Grizzly Bears" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldBlock("Hill Giant", "Craw Wurm") },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BoardWipeTimingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BoardWipeTimingPuzzles.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+
+/**
+ * A sweeper is only good when you are behind on board.
+ *
+ * These are deliberately built on generic sweepers (Wrath of God, Day of Judgment) rather than the
+ * Bloomburrow cards `BoardWipeAdvisor` names, so the category measures the *general* mechanism.
+ * The advisor is a per-card override on top; if it is doing work, the `production` profile beats
+ * `v0` here and `PuzzleReport` shows it.
+ */
+object BoardWipeTimingPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "wipe-01",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Do not Wrath while ahead three creatures to one",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Wrath of God")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+            },
+            check = { shouldNotCast("Wrath of God") },
+        ),
+
+        AiPuzzle(
+            id = "wipe-02",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Wrath while behind zero creatures to three",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Wrath of God")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .build()
+            },
+            check = { shouldCast("Wrath of God") },
+        ),
+
+        AiPuzzle(
+            id = "wipe-03",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Do not Wrath our own two creatures away when the opponent has none",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Wrath of God")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .build()
+            },
+            check = { shouldNotCast("Wrath of God") },
+        ),
+
+        AiPuzzle(
+            id = "wipe-04",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Day of Judgment at 4 life facing nine power — the sweeper is the only out",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Day of Judgment")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(1, 4)
+                    .build()
+            },
+            check = { shouldCast("Day of Judgment") },
+        ),
+
+        AiPuzzle(
+            id = "wipe-05",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Do not trade a 6/4 and a 4/4 flier for one 2/2",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Day of Judgment")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Air Elemental")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+            },
+            check = { shouldNotCast("Day of Judgment") },
+        ),
+
+        AiPuzzle(
+            id = "wipe-06",
+            category = PuzzleCategory.BOARD_WIPE_TIMING,
+            expectation = "Sweep when the trade is one 2/2 of ours for three of theirs",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Day of Judgment")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Air Elemental")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            check = { shouldCast("Day of Judgment") },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.ai.puzzles.advanceToPriority
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * Instant timing: hold it until it does something, then actually use it.
+ *
+ * Half of these are negative controls (don't fire the trick in your own main phase) and half are
+ * positive (fire it in the window where it wins the fight). A category made only of "don't cast"
+ * puzzles would score 100% for an AI that never casts anything, which measures nothing.
+ */
+object HoldingInstantsPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "instants-01",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Hold Giant Growth in our own main phase — +3/+3 still loses to a 6/4 blocker",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Giant Growth")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .build()
+            },
+            check = { shouldNotCast("Giant Growth") },
+        ),
+
+        AiPuzzle(
+            id = "instants-02",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Giant Growth on the blocked attacker: the 2/2 becomes a 5/5 and eats the 3/3",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Giant Growth")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Grizzly Bears" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+                    .also { it.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears"))) }
+                    .advanceToPriority(1, Step.DECLARE_BLOCKERS)
+            },
+            check = {
+                shouldCast("Giant Growth")
+                shouldTarget("Grizzly Bears")
+            },
+        ),
+
+        AiPuzzle(
+            id = "instants-03",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Titanic Growth on our blocker: the 3/3 becomes a 7/7 and kills the 6/4",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withCardInHand(2, "Titanic Growth")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+                    .also { it.declareBlockers(mapOf("Hill Giant" to listOf("Craw Wurm"))) }
+                    .advanceToPriority(2, Step.DECLARE_BLOCKERS)
+            },
+            check = {
+                shouldCast("Titanic Growth")
+                shouldTarget("Hill Giant")
+            },
+        ),
+
+        AiPuzzle(
+            id = "instants-04",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Hold Fog in our own main phase — there is no combat damage to prevent",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Fog")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .build()
+            },
+            check = { shouldNotCast("Fog") },
+        ),
+
+        AiPuzzle(
+            id = "instants-05",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Fog the lethal alpha strike at 2 life",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardInHand(2, "Fog")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLifeTotal(2, 2)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 2, "Hill Giant" to 2)) }
+                    .advanceToPriority(2, Step.DECLARE_BLOCKERS)
+            },
+            check = { shouldCast("Fog") },
+        ),
+
+        AiPuzzle(
+            id = "instants-06",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Do not dump Giant Growth on the opponent's end step just because mana would be wasted",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withCardInHand(2, "Giant Growth")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+                    .advanceToPriority(2, Step.END)
+            },
+            // Probes `Strategist`'s hard-coded `passScore - 1.5` end-step discount directly: the
+            // pump wears off in cleanup, so spending it here throws the card away for nothing.
+            check = { shouldNotCast("Giant Growth") },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/LethalDetectionPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/LethalDetectionPuzzles.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * Can the AI see the kill that is already on the table?
+ *
+ * Every position here is winnable *this turn* by a line the AI is one action away from. There is
+ * no card advantage to weigh and no crack-back to fear: if it misses these, it is not counting.
+ */
+object LethalDetectionPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "lethal-01",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Alpha strike for exactly lethal into an empty board",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLifeTotal(2, 6)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackForAtLeast(6) },
+        ),
+
+        AiPuzzle(
+            id = "lethal-02",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Attack with everything: one blocker cannot stop 9 power against 6 life",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLifeTotal(2, 6)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            // Holding one back leaves at most 6 unblocked, and the blocker eats 3 of it.
+            check = { shouldAttackWithExactly("Hill Giant", "Hill Giant", "Hill Giant") },
+        ),
+
+        AiPuzzle(
+            id = "lethal-03",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Bolt the opponent for the win instead of a creature the Bolt cannot kill",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withLifeTotal(2, 3)
+                    .build()
+            },
+            // The Wurm is a 6/4: three damage bounces off it. The opponent is at 3.
+            check = {
+                shouldCast("Lightning Bolt")
+                shouldTargetOpponentFace()
+            },
+        ),
+
+        AiPuzzle(
+            id = "lethal-04",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Cast Lava Axe for exactly lethal from an empty board",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardInHand(1, "Lava Axe")
+                    .withLifeTotal(2, 5)
+                    .build()
+            },
+            check = { shouldCast("Lava Axe") },
+        ),
+
+        AiPuzzle(
+            id = "lethal-05",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Swing both Wurms for 12 into an empty board at 10 life",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withLifeTotal(2, 10)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackForAtLeast(10) },
+        ),
+
+        AiPuzzle(
+            id = "lethal-06",
+            category = PuzzleCategory.LETHAL_DETECTION,
+            expectation = "Lethal in the air: the ground blocker cannot touch either Drake",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(2, 4)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackWithExactly("Wind Drake", "Wind Drake") },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/NonCreatureValuationPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/NonCreatureValuationPuzzles.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+
+/**
+ * Does the AI see anything that is not a creature?
+ *
+ * `BoardFeatures.permanentValue` flat-values every non-creature permanent at `0.5` regardless of
+ * text, and `Strategist.heuristicTargetRank` returns `0.0` for one — so a mana rock, a repeatable
+ * tapper and an anthem are the same number, and none of them outranks nothing. This category is
+ * the plan's canary for **Phase 6 (`CardIntent`)**: it is expected to be the worst-scoring category
+ * today, and its recovery is that phase's exit criterion.
+ */
+object NonCreatureValuationPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "noncreature-01",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "Disenchant the opposing Icy Manipulator at all — it is the only artifact in play",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Disenchant")
+                    .withCardOnBattlefield(2, "Icy Manipulator")
+                    .build()
+            },
+            check = {
+                shouldCast("Disenchant")
+                shouldTarget("Icy Manipulator")
+            },
+        ),
+
+        AiPuzzle(
+            id = "noncreature-02",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "Disenchant points at their anthem, never at our own mana rock",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Disenchant")
+                    .withCardOnBattlefield(1, "Mind Stone")
+                    .withCardOnBattlefield(2, "Glorious Anthem")
+                    .build()
+            },
+            check = {
+                shouldCast("Disenchant")
+                shouldTarget("Glorious Anthem")
+                shouldNotTarget("Mind Stone")
+            },
+        ),
+
+        AiPuzzle(
+            id = "noncreature-03",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "Naturalize the opposing Banishing Light",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInHand(1, "Naturalize")
+                    .withCardOnBattlefield(2, "Banishing Light")
+                    .build()
+            },
+            check = {
+                shouldCast("Naturalize")
+                shouldTarget("Banishing Light")
+            },
+        ),
+
+        AiPuzzle(
+            id = "noncreature-04",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "Kill the repeatable tapper, not the mana rock",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Disenchant")
+                    .withCardOnBattlefield(2, "Icy Manipulator")
+                    .withCardOnBattlefield(2, "Mind Stone")
+                    .build()
+            },
+            check = {
+                shouldCast("Disenchant")
+                shouldTarget("Icy Manipulator")
+            },
+        ),
+
+        AiPuzzle(
+            id = "noncreature-05",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "The anthem pumping three creatures beats the inert artifact as a target",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Disenchant")
+                    .withCardOnBattlefield(2, "Glorious Anthem")
+                    .withCardOnBattlefield(2, "Mind Stone")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+            },
+            check = {
+                shouldCast("Disenchant")
+                shouldTarget("Glorious Anthem")
+            },
+        ),
+
+        AiPuzzle(
+            id = "noncreature-06",
+            category = PuzzleCategory.NON_CREATURE_VALUATION,
+            expectation = "Disenchant the Pacifism off our own 6/4",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Disenchant")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardAttachedTo(2, "Pacifism", "Craw Wurm")
+                    .build()
+            },
+            check = {
+                shouldCast("Disenchant")
+                shouldTarget("Pacifism")
+            },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/RaceMathPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/RaceMathPuzzles.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * Attack-vs-hold when both players are on a clock.
+ *
+ * The distinguishing feature from [LethalDetectionPuzzles] is that no line wins on the spot: every
+ * position trades this turn's damage against next turn's crack-back, which is precisely what a
+ * greedy one-ply evaluator has no machinery to weigh.
+ */
+object RaceMathPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "race-01",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "Keep the only blocker home: attacking loses to the 6/4 crack-back at 3 life",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withLifeTotal(1, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldNotAttack() },
+        ),
+
+        AiPuzzle(
+            id = "race-02",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "Attack: an empty opposing board cannot punish it, and we are the one on a clock",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLifeTotal(1, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackWithExactly("Hill Giant") },
+        ),
+
+        AiPuzzle(
+            id = "race-03",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "Send the flier, keep the ground creature home to block the 3/3",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Trained Armodon")
+                    .withLifeTotal(1, 5)
+                    .withLifeTotal(2, 5)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackWithExactly("Wind Drake") },
+        ),
+
+        AiPuzzle(
+            id = "race-04",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "Vigilance makes attacking free: Serra Angel swings and still blocks",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(1, 4)
+                    .withLifeTotal(2, 8)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackWithExactly("Serra Angel") },
+        ),
+
+        AiPuzzle(
+            id = "race-05",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "Do not attack a 2/2 into an untapped 3/3 with both players at 20",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldNotAttack() },
+        ),
+
+        AiPuzzle(
+            id = "race-06",
+            category = PuzzleCategory.RACE_MATH,
+            expectation = "The 3/3 is tapped, so the 2/2 gets in for free",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+            },
+            check = { shouldAttackWithExactly("Grizzly Bears") },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/RemovalTargetingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/RemovalTargetingPuzzles.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+
+/**
+ * Where the removal spell points.
+ *
+ * This is the category `Strategist.heuristicTargetRank` owns, plus the simulation refinement in
+ * `chooseCommittedTargets` layered on top of it. Positions are built so that the *wrong* target is
+ * the one raw creature value would pick.
+ */
+object RemovalTargetingPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "removal-01",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "Murder the 6/4, not the 2/2",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+            },
+            check = {
+                shouldCast("Murder")
+                shouldTarget("Craw Wurm")
+            },
+        ),
+
+        AiPuzzle(
+            id = "removal-02",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "Bolt the 3/3 it can kill, not the 6/4 it bounces off",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            check = {
+                shouldCast("Lightning Bolt")
+                shouldTarget("Hill Giant")
+            },
+        ),
+
+        AiPuzzle(
+            id = "removal-03",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "Do not spend removal on a creature Pacifism has already neutralized",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardAttachedTo(2, "Pacifism", "Craw Wurm")
+                    .build()
+            },
+            check = {
+                shouldCast("Murder")
+                shouldTarget("Hill Giant")
+            },
+        ),
+
+        AiPuzzle(
+            id = "removal-04",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "Removal points at the opponent's creature, never at our own bigger one",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            check = {
+                shouldCast("Murder")
+                shouldTarget("Hill Giant")
+                shouldNotTarget("Craw Wurm")
+            },
+        ),
+
+        AiPuzzle(
+            id = "removal-05",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "At 4 life, Bolt the 3/3 that is killing us rather than the opponent's face",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLifeTotal(1, 4)
+                    .build()
+            },
+            check = {
+                shouldCast("Lightning Bolt")
+                shouldTarget("Hill Giant")
+            },
+        ),
+
+        AiPuzzle(
+            id = "removal-06",
+            category = PuzzleCategory.REMOVAL_TARGETING,
+            expectation = "Kill the flier we cannot block, not the bigger creature our Giants hold off",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Air Elemental")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withLifeTotal(1, 6)
+                    .build()
+            },
+            check = {
+                shouldCast("Murder")
+                shouldTarget("Air Elemental")
+            },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/SequencingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/SequencingPuzzles.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+
+/**
+ * Which play comes first in a main phase.
+ *
+ * The probe is a single action, so these are all "of the plays available right now, which one?" —
+ * land before spell, the land that produces the colour you need, the spell that uses the mana you
+ * have.
+ */
+object SequencingPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "sequencing-01",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "Play the fourth land first — it is what makes the 4-drop castable this turn",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInHand(1, "Mountain")
+                    .withCardInHand(1, "Hill Giant")
+                    .build()
+            },
+            check = { shouldPlayLand("Mountain") },
+        ),
+
+        AiPuzzle(
+            id = "sequencing-02",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "On the last card in hand, still make the land drop",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Forest")
+                    .build()
+            },
+            // Deliberately paired with sequencing-04, which is the same decision with one more
+            // card in hand. If 04 passes and this fails, the defect is precisely
+            // `CardAdvantage.cardValue(0) = -3.0`: emptying your hand reads as a disaster, so the
+            // AI would rather hold a land forever than play it. Land drops are free.
+            check = { shouldPlayLand("Forest") },
+        ),
+
+        AiPuzzle(
+            id = "sequencing-03",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "Four lands up: cast the 3/3, not the 2/2",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInHand(1, "Gray Ogre")
+                    .build()
+            },
+            check = { shouldCast("Hill Giant") },
+        ),
+
+        AiPuzzle(
+            id = "sequencing-04",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "Develop the board rather than pass with mana available",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInHand(1, "Grizzly Bears")
+                    // A second, uncastable card so this is *not* the last-card-in-hand cliff that
+                    // sequencing-02 isolates. Same decision, one card of slack.
+                    .withCardInHand(1, "Craw Wurm")
+                    .build()
+            },
+            check = { shouldCast("Grizzly Bears") },
+        ),
+
+        AiPuzzle(
+            id = "sequencing-05",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "Anthem before combat: it turns two 2/2s into exactly lethal",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInHand(1, "Glorious Anthem")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLifeTotal(2, 6)
+                    .build()
+            },
+            check = { shouldCast("Glorious Anthem") },
+        ),
+
+        AiPuzzle(
+            id = "sequencing-06",
+            category = PuzzleCategory.SEQUENCING,
+            expectation = "Play the Mountain, not the Forest — red is the colour the hand needs",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInHand(1, "Mountain")
+                    .withCardInHand(1, "Forest")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .build()
+            },
+            check = { shouldPlayLand("Mountain") },
+        ),
+    )
+}

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -3,10 +3,12 @@
 A phased plan to make the in-game engine AI measurably stronger, on a scoreboard we trust, using
 mechanisms that generalize across the whole card catalog rather than per-card special cases.
 
-**Status:** **Phases 0 and 1 shipped** (2026-07-27) — baselines in
+**Status:** **Phases 0, 1 and 2 shipped** (2026-07-27) — baselines in
 [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md), measurement guide in
-[`docs/ai/measurement.md`](../docs/ai/measurement.md). Next up is **Phase 2, the puzzle suite**.
-Phases are individually shippable and ordered by dependency, not by appeal.
+[`docs/ai/measurement.md`](../docs/ai/measurement.md). Both scoreboards now exist: the arena
+(`just arena`) and the 48-puzzle suite (`just arena-puzzles`, **39/48 today**). Next up is
+**Phase 3, multiplayer evaluation**. Phases are individually shippable and ordered by dependency,
+not by appeal.
 
 **Related:** [`engine-performance.md`](engine-performance.md) — the CPU profile this plan's
 performance phase builds on. See "Cross-reference" below; parts of that doc are stale.
@@ -157,19 +159,25 @@ must not lose to any gauntlet member worse than 45%.
 
 ### 2. Tactical puzzle suite — the localizing signal
 
-Win rate says *that* you regressed; a puzzle says *what*. Runs in <30 s, CI-gated.
-**48 puzzles, 8 categories × 6:**
+Win rate says *that* you regressed; a puzzle says *what*. Runs in ~15 s, CI-gated.
+**48 puzzles, 8 categories × 6.** Built in Phase 2; scores are the measured 2026-07-27 baseline for
+`v0`/`production`, with the zero-weight `v0-blind` control in brackets.
 
-| Category | What it catches |
-|---|---|
-| Lethal detection | Missing an alpha strike / burn-to-face kill |
-| Blocking | Chump vs trade vs no-block; deathtouch / first strike / trample |
-| Removal targeting | Shooting the 1/1 instead of the bomb (`heuristicTargetRank`) |
-| Holding instants | Casting a combat trick in your own main phase |
-| Sequencing | Land before spell; ETB ordering; lord before creatures |
-| Board-wipe timing | Wrathing while ahead (`BoardWipeAdvisor`, currently overwritten) |
-| Race math | Attack-vs-hold when both players are on a clock |
-| **Non-creature valuation** | Ignoring an opposing O-Ring / signet / planeswalker — **expect ~0% today** |
+| Category | Baseline | What it catches |
+|---|---|---|
+| Lethal detection | 6/6 [6/6] | Missing an alpha strike / burn-to-face kill |
+| Blocking | 6/6 [6/6] | Chump vs trade vs no-block; deathtouch / first strike |
+| Removal targeting | 6/6 [0/6] | Shooting the 1/1 instead of the bomb (`heuristicTargetRank`) |
+| Holding instants | 3/6 [2/6] | Casting a combat trick in your own main phase |
+| Sequencing | 5/6 [0/6] | Land before spell; the land that unlocks the spell |
+| Board-wipe timing | 6/6 [3/6] | Wrathing while ahead |
+| Race math | 5/6 [5/6] | Attack-vs-hold when both players are on a clock |
+| **Non-creature valuation** | **2/6** [0/6] | Ignoring an opposing O-Ring / mana rock / anthem |
+
+Two readings the bracketed column forces. Lethal and blocking are carried entirely by
+`CombatAdvisor`'s seed heuristics — the blind agent matches the real one — so they are a regression
+net for *that* code, not for `BoardFeatures.kt`. And the plan's "expect ~0%" on non-creature
+valuation was close but for the wrong reason: see Phase 2's findings.
 
 ### 3. Latency
 
@@ -306,7 +314,41 @@ returns 50.0% CI [49.3%, 50.8%] against `AdvisorBenchmark`'s unpaired 46.1% — 
 
 ---
 
-### Phase 2 — Tactical puzzle suite · *3–4 d*
+### Phase 2 — Tactical puzzle suite · *3–4 d* — ✅ **DONE 2026-07-27**
+
+> **Shipped.** 48 puzzles, 8 categories × 6, in
+> `ai/src/test/kotlin/com/wingedsheep/ai/puzzles/`. `just arena-puzzles` is the gate (~15 s);
+> `just arena-puzzles-compare` runs the same suite across `v0` / `production` / `v0-blind`.
+> Per-category baseline and findings:
+> [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md#phase-2--puzzle-baselines); how to
+> write one: [`docs/ai/measurement.md`](../docs/ai/measurement.md#the-puzzle-suite).
+>
+> **Baseline: 39/48 (81%).** `v0` and `production` score identically, category for category — the
+> same "advisors are neutral" conclusion Phase 1's arena reached, from an independent measurement.
+> `v0-blind` scores 22/48, which is the suite proving it discriminates; that gap is asserted in the
+> always-on suite rather than eyeballed.
+>
+> Four corrections the build produced:
+>
+> 1. **Non-creature blindness is a *casting* failure before it is a targeting one.** The plan
+>    predicted ~0% and blamed `heuristicTargetRank`'s `else -> 0.0`. In all four failures the AI
+>    never casts the Disenchant at all: destroying an artifact is worth `permanentValue`'s flat
+>    `0.5` (+0.75 weighted) and costs a card (−1.5 weighted), so passing wins. **Phase 6's
+>    `staticPriorValue` has to clear the card-advantage cost of casting, not merely outrank a
+>    sibling target.** The two that pass are the two whose effect shows up in *creature* stats
+>    (an anthem on three bodies; Disenchanting a Pacifism off a 6/4) — so the deficit is exactly
+>    "permanents whose value is invisible in someone's P/T".
+> 2. **`CardAdvantage.cardValue(0) = -3.0` means the last card in hand is never played.**
+>    `sequencing-02` and `-04` are the same land drop one card apart; 04 passes, 02 fails. Land
+>    drops are free. One more hand-drawn constant for Phase 9.
+> 3. **A one-ply evaluator cannot see prevention.** Fog at 2 life facing lethal is passed up,
+>    because the post-simulation state has the same life totals as passing — the prevention only
+>    materializes at the damage step. It also means "hold Fog in your own main" passes for the
+>    wrong reason. A Phase 7 puzzle, not a Phase 9 one.
+> 4. **Combat is carried by `CombatAdvisor`, not the evaluator.** `v0-blind` still scores 6/6 on
+>    lethal *and* blocking. Those two categories are a regression net for `CombatAdvisor`'s seed
+>    heuristics; a `BoardFeatures.kt` change will not move them. The one combat position the
+>    evaluator owns — hold a blocker home rather than attack with everything — fails.
 
 Authored against **`ScenarioTestBase`** (`rules-engine/src/testFixtures/.../support/ScenarioTestBase.kt`,
 1562 L, already on `:ai`'s test classpath). Not scenario JSON — `manual-scenarios/` +
@@ -324,8 +366,8 @@ Files: `ai/src/test/.../puzzles/{AiPuzzle,PuzzleRunner,PuzzleSuiteTest}.kt` + `c
 - `PuzzleReport` (benchmark-gated) prints pass rate overall and per category — the number quoted
   alongside arena win rate.
 
-**Exit:** 48 puzzles committed, per-category baseline in `docs/ai/baseline-metrics.md`,
-`just arena-puzzles` runs in <30 s.
+**Exit:** ✅ 48 puzzles committed, ✅ per-category baseline in `docs/ai/baseline-metrics.md`,
+✅ `just arena-puzzles` runs in ~15 s.
 
 ---
 
@@ -568,8 +610,14 @@ add JSON for the sets we actually play, and consolidate with the duplicate store
 `CardIntent` reproduces, keeping the ones encoding genuinely card-specific tactics. A principled
 retirement criterion beats a judgment call.
 
-**Exit:** puzzle "non-creature valuation" ~0% → >70%; "removal targeting" and "holding instants" up;
-arena lower CI bound above 50%.
+**Exit:** puzzle "non-creature valuation" **2/6 → ≥5/6** (Phase 2's measured baseline, not the ~0%
+this plan guessed); "holding instants" up; arena lower CI bound above 50%.
+
+> **Phase 2 sharpened the target.** All four non-creature failures are the AI declining to *cast*
+> the Disenchant, not mis-targeting it: at flat `permanentValue = 0.5`, destroying an artifact is
+> worth +0.75 weighted and costs −1.5 of card advantage, so passing wins. `staticPriorValue` has to
+> clear the **cost of casting**, not merely outrank a sibling target. Consumer (b) — the
+> `heuristicTargetRank` fix — is necessary but on its own changes nothing.
 
 ---
 
@@ -818,13 +866,13 @@ but tanks a puzzle category, look hard before shipping.
 ## Recommended order
 
 ```
-0̶ → 1̶ → 2 → 3 → 4 → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
+0̶ → 1̶ → 2̶ → 3 → 4 → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
 ```
 
-Phases 0 and 1 are done. **Phase 5 has left the critical path** — simulation is already ~2× the
-speed the rollout budget needs, so 5a is now an independent engine-perf task and 5c is almost
-certainly not justified. Next up is **Phase 2, the puzzle suite**: the arena says *that* something
-regressed, a puzzle says *what*.
+Phases 0, 1 and 2 are done — both scoreboards exist. **Phase 5 has left the critical path** —
+simulation is already ~2× the speed the rollout budget needs, so 5a is now an independent
+engine-perf task and 5c is almost certainly not justified. Next up is **Phase 3, multiplayer
+evaluation**: 1–2 days for the highest strength-per-effort item on the list.
 
 Ranked by strength-per-effort, independent of ordering:
 
@@ -834,7 +882,7 @@ Ranked by strength-per-effort, independent of ordering:
 | 2 | **6** CardIntent | 5–7 d | Removes flat-0.5 blindness to every artifact/enchantment/PW; feeds 4 other consumers. |
 | 3 | **9** Texel tuning | 4–6 d | Replaces ~25 guessed constants with fitted ones. Cheap once the arena exists. |
 | 4 | **7** rollout evaluator | 6–9 d | Highest *ceiling*; the real lever. Costly, and worthless without the rest. |
-| 5 | **1̶ / 2** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Arena done. |
+| 5 | **1̶ / 2̶** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Both done. |
 | 6 | **4a** auto-pass filter | 3–5 d | Demoted by Phase 0: at 1.75 candidates there is little to filter. Still saves ~148 ms/game of pointless enumeration, and a rollout pays it repeatedly. |
 | 7 | **4b** DecisionBudget | 2–3 d | Enabling infrastructure. |
 | 8 | **8** determinization | 5–7 d | **Costs** strength (fairness price). Do it because search over a cheated state is search over a lie. |

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -236,3 +236,83 @@ Seat 0 (on the play) wins **46–51%** depending on the run — at 300 games it 
 was 51.0%. In BLB sealed against this AI, being on the play is close to neutral and may be slightly
 negative. It does not bias any result here (both agents sit in both seats), but it is a reminder
 that "on the play wins more" is an assumption about human play, not a property of the engine.
+
+---
+
+# Phase 2 — Puzzle baselines
+
+**Measured:** 2026-07-27, `just arena-puzzles` (the whole suite, ~15 s including Gradle startup).
+How to read one: [`measurement.md`](measurement.md#the-puzzle-suite).
+
+48 hand-authored positions, 8 categories × 6. Each asks the AI for exactly one move and asserts a
+*predicate* over it — "removal targets the 3/3 it can kill, not the 6/4 it bounces off" — never an
+exact `GameAction`.
+
+## Per-category baseline
+
+| Category | `v0` | `production` | `v0-blind` | What it catches |
+|---|---|---|---|---|
+| lethal | 6/6 | 6/6 | 6/6 | Missing an alpha strike / burn-to-face kill |
+| blocking | 6/6 | 6/6 | 6/6 | Chump vs trade vs no-block; deathtouch / first strike |
+| removal | 6/6 | 6/6 | 0/6 | Shooting the 1/1 instead of the bomb |
+| instants | 3/6 | 3/6 | 2/6 | Casting a combat trick in your own main phase |
+| sequencing | 5/6 | 5/6 | 0/6 | Land before spell; the land that unlocks the spell |
+| wipe | 6/6 | 6/6 | 3/6 | Wrathing while ahead |
+| race | 5/6 | 5/6 | 5/6 | Attack-vs-hold when both players are on a clock |
+| **noncreature** | **2/6** | **2/6** | 0/6 | Ignoring an opposing O-Ring / mana rock / anthem |
+| **total** | **39/48 (81%)** | **39/48 (81%)** | 22/48 (46%) | |
+
+`v0-blind` (every evaluation weight zeroed) is the discrimination control, the same one the arena
+uses. 22/48 versus 39/48 is the suite proving it measures something; the always-on
+`PuzzleSuiteTest` asserts that gap rather than leaving it to a manual run.
+
+## What Phase 2 found
+
+### 1. Non-creature blindness is real, and it is a *casting* failure before it is a targeting one
+
+The plan predicted ~0% here and named `heuristicTargetRank`'s `else -> 0.0` as the cause. The
+measurement is more specific: on all four failures the AI does not mis-target the Disenchant, **it
+never casts it at all**. Destroying an artifact moves `BoardPresence` by `permanentValue`'s flat
+`0.5` (weight 1.5, so +0.75) and costs a card (`CardAdvantage`, weight 1.0, −1.5 at a typical hand
+size). Passing scores higher, so the removal is held forever.
+
+That reframes Phase 6's exit criterion slightly: `staticPriorValue` has to be large enough to clear
+the *card-advantage* cost of casting, not merely to outrank a sibling target.
+
+The two that pass are the two whose effect shows up in **creature** stats, which the evaluator can
+already see: `noncreature-05` (an anthem pumping three creatures) and `noncreature-06` (Disenchant
+on a Pacifism that is holding down a 6/4). So the deficit is precisely "permanents whose value is
+not visible in someone's power and toughness."
+
+### 2. The last card in hand never gets played
+
+`sequencing-02` and `sequencing-04` are the same decision — play a land — with one card of
+difference in hand. 04 passes, 02 fails. The cause is `CardAdvantage.cardValue(0) = -3.0` against
+`cardValue(1) = 1.0`: emptying your hand reads as a 4-point disaster, which swamps the land drop's
+tempo and board gain, so the AI would rather hold its last land indefinitely. Land drops are free;
+this is a hand-drawn constant that Phase 9's logistic fit should remove.
+
+### 3. A one-ply evaluator cannot see a prevention effect
+
+`instants-05` — Fog at 2 life facing 9 power of attackers — is passed up. After the simulation
+resolves Fog, the state has the same life totals as passing did: the prevention only shows up when
+combat damage would be dealt, which is past the one-ply horizon. Fog therefore evaluates as "−1
+card" in every position, which is also why `instants-04` (hold Fog in your own main) *passes* —
+right answer, wrong reason. This is a Phase 7 rollout puzzle, not a weight-tuning one.
+
+### 4. Combat is carried by `CombatAdvisor`'s heuristics, not by the evaluator
+
+`v0-blind` scores 6/6 on lethal and 6/6 on blocking despite scoring every board identically. The
+combat categories are measuring `CombatAdvisor`'s seed heuristics, which are evaluator-independent.
+That is worth knowing before reading a future improvement: a change to `BoardFeatures.kt` will not
+move those two categories, and a change to `CombatAdvisor` will.
+
+The one combat position the evaluator does own is `race-03` (send the flier, keep the ground
+blocker home), and it fails for both — there is no model of holding a creature back at all.
+
+### 5. The card advisors are neutral here too
+
+`v0` and `production` score identically, 39/48, category for category. That is the same conclusion
+Phase 1's arena reached at 1,000 paired games (50.0%, CI [49.3%, 50.8%]), from a completely
+independent measurement. Two signals agreeing lowers the retirement bar for the 42 advisor entries
+further.

--- a/docs/ai/measurement.md
+++ b/docs/ai/measurement.md
@@ -135,3 +135,63 @@ Say these out loud rather than letting a reader assume otherwise.
   `BoardFeatures.kt` returns 0.0 with more than one opponent.
 - **Latency per budget tier.** There are no tiers until Phase 4b.
 - **Anything about a real player.** The reference opponent is another bot.
+
+---
+
+## The puzzle suite
+
+The arena tells you *that* something regressed. A puzzle tells you *what*.
+
+```bash
+just arena-puzzles              # the gate — always-on, seconds
+just arena-puzzles-compare      # the same 48 across v0 / production / v0-blind
+```
+
+48 hand-authored positions in `ai/src/test/kotlin/com/wingedsheep/ai/puzzles/`, 8 categories × 6.
+Each builds a board with `ScenarioTestBase`, asks the AI for **one** move, and asserts a predicate
+over it. Current per-category numbers: [`baseline-metrics.md`](baseline-metrics.md#phase-2--puzzle-baselines).
+
+### The gate is `KNOWN_FAILURES`, not 48/48
+
+`PuzzleSuiteTest` asserts the failing-id set **equals** a committed set. Today's AI solves 39 of 48,
+and a suite pinned to 48/48 would be red forever and therefore ignored.
+
+Equality — not "is a subset of" — is the point. It flags a regression *and* an unexpected fix:
+
+- **A new id appears** → you broke something. The report names the puzzle and prints the move.
+- **An id no longer fails** → the test goes red until you delete it from `KNOWN_FAILURES`. That is
+  the moment you want to notice, and the deletion is the evidence a phase actually landed.
+
+Each entry carries a comment naming the mechanism it is waiting on, so shrinking the set is a
+checklist for Phases 6, 7 and 9.
+
+### Writing a puzzle
+
+Put it in the right `categories/*.kt` file, give it the next id in sequence, run the suite, and add
+it to `KNOWN_FAILURES` if the AI does not solve it yet.
+
+**Assert a predicate, never an exact action.** `PuzzleMove` is the vocabulary:
+`shouldCast("Murder")`, `shouldTarget("Craw Wurm")`, `shouldAttackWithAtLeast("Wind Drake")`,
+`shouldAttackForAtLeast(6)`, `shouldBlock("Hill Giant", "Craw Wurm")`, `shouldNotBlock()`. Exact
+`GameAction` equality breaks on harmless tie-break changes and trains you to ignore the suite.
+
+Three things the runner enforces so a mis-built position cannot score as a pass:
+
+- the position must leave the AI's seat holding priority with **no pending decision**;
+- the chosen move must be **legal** — the arena found the AI proposing ~0.9 illegal actions per
+  game, and a puzzle that "passes" on a move the engine rejects measures nothing;
+- the scenario RNG is pinned (`ScenarioBuilder` otherwise seeds itself from `System.nanoTime()`).
+
+`advanceToDeclaration(seat, step)` stops where a seat is asked to declare attackers or blockers;
+`advanceToPriority(seat, step)` stops at the ordinary priority window *after* declarations, which
+is where a combat trick is cast. They differ by one window and using the wrong one is the easiest
+way to write a puzzle that measures the wrong decision.
+
+### Include positive controls
+
+Half of "holding instants" is *don't* cast the trick; the other half is *do*, in the right window.
+A category made only of "don't cast" puzzles scores 100% for an AI that never casts anything.
+`just arena-puzzles-compare`'s `v0-blind` column is the check on that: a category where the
+zero-weight agent scores as well as the real one is not measuring the evaluator. Today that is true
+of `lethal` and `blocking` — both are carried by `CombatAdvisor`'s heuristics, so they are a
+regression net for *that* code, not for `BoardFeatures.kt`.

--- a/justfile
+++ b/justfile
@@ -90,6 +90,18 @@ arena A B GAMES="300" SET="BLB" SEED="20260727":
     scripts/gradle-locked :ai:test --tests "*.ArenaBenchmark" -Dbenchmark=true -Darena=true \
         -DarenaA={{A}} -DarenaB={{B}} -DarenaGames={{GAMES}} -DarenaSet={{SET}} -DarenaSeed={{SEED}}
 
+# Run the 48-puzzle tactical suite (8 categories x 6). Seconds, not minutes: the arena says *that*
+# the AI regressed, a puzzle category says *what*. The gate is "the failing set equals
+# KNOWN_FAILURES", so an unexpected fix fails the test too. Baseline: docs/ai/baseline-metrics.md.
+[group: 'ai']
+arena-puzzles:
+    scripts/gradle-locked :ai:test --tests "*.PuzzleSuiteTest"
+
+# Same 48 puzzles across AI profiles (v0, production) with a side-by-side per-category table.
+[group: 'ai']
+arena-puzzles-compare:
+    scripts/gradle-locked :ai:test --tests "*.PuzzleComparisonBenchmark" -Dbenchmark=true
+
 # Run every agent in ai/src/test/resources/arena/gauntlet.json against every other and print the
 # full pairwise matrix plus Bradley-Terry Elo. The matrix is the deliverable — MTG agents are
 # frequently non-transitive, and a single rating erases exactly that.


### PR DESCRIPTION
Phase 2 of [`backlog/engine-ai-improvement.md`](backlog/engine-ai-improvement.md). The arena says *that* the AI regressed; a puzzle says *what*.

## What's here

48 hand-authored positions in `ai/src/test/kotlin/com/wingedsheep/ai/puzzles/`, 8 categories × 6. Each builds a board with `ScenarioTestBase`, asks the AI for exactly one move, and asserts a **predicate** over it — `shouldTarget("Hill Giant")`, `shouldAttackForAtLeast(6)`, `shouldBlock("Hill Giant", "Craw Wurm")` — never an exact `GameAction`. Exact assertions break on harmless tie-break changes and train you to ignore the suite.

```bash
just arena-puzzles           # the gate — always-on, ~10 s
just arena-puzzles-compare   # the same 48 across v0 / production / v0-blind
```

No new build wiring: `:ai` already has the engine test fixtures and `mtg-sets` on its test classpath.

## The gate is `KNOWN_FAILURES`, not 48/48

`PuzzleSuiteTest` asserts the failing-id set **equals** a committed set. Today's AI solves 39 of 48, and a suite pinned to 48/48 would be red forever and therefore ignored. Equality flags a regression *and* an unexpected fix — an id that stops failing turns the test red until you delete it, which is exactly the moment you want to notice. Each entry carries a comment naming the mechanism it waits on, so shrinking the set is a checklist for Phases 6, 7 and 9.

Three things the runner enforces so a mis-built position cannot silently score as a pass:

- the position must leave the AI's seat holding priority with **no pending decision**;
- the chosen move must be **legal** — Phase 1 found the AI proposing ~0.9 illegal actions per game, and a puzzle that "passes" on a rejected move measures nothing;
- the scenario RNG is pinned (`ScenarioBuilder` otherwise seeds itself from `System.nanoTime()`, which is not a CI gate).

## Baseline

| Category | `v0` | `production` | `v0-blind` |
|---|---|---|---|
| lethal | 6/6 | 6/6 | 6/6 |
| blocking | 6/6 | 6/6 | 6/6 |
| removal | 6/6 | 6/6 | 0/6 |
| instants | 3/6 | 3/6 | 2/6 |
| sequencing | 5/6 | 5/6 | 0/6 |
| wipe | 6/6 | 6/6 | 3/6 |
| race | 5/6 | 5/6 | 5/6 |
| **noncreature** | **2/6** | **2/6** | 0/6 |
| **total** | **39/48** | **39/48** | 22/48 |

`v0-blind` (every evaluation weight zeroed) is the discrimination control, the same one the arena uses. The always-on suite asserts the gap rather than leaving it to a manual run.

`v0` and `production` are identical category for category — the same "the BLB/ONS card advisors are measurably neutral" conclusion Phase 1's arena reached at 1,000 paired games (50.0%, CI [49.3%, 50.8%]), from a completely independent measurement.

## What it found

1. **Non-creature blindness is a *casting* failure before it is a targeting one.** The plan predicted ~0% and blamed `heuristicTargetRank`'s `else -> 0.0`. In all four failures the AI never casts the Disenchant at all: at `permanentValue`'s flat `0.5`, destroying an artifact is worth +0.75 weighted and costs −1.5 of card advantage, so passing wins. **Phase 6's `staticPriorValue` has to clear the cost of casting, not merely outrank a sibling target** — the targeting fix alone changes nothing. The two that pass are the two whose effect shows up in *creature* stats (an anthem on three bodies; Disenchanting a Pacifism off a 6/4), so the deficit is exactly "permanents whose value is invisible in someone's P/T".

2. **`CardAdvantage.cardValue(0) = -3.0` means the last card in hand is never played.** `sequencing-02` and `-04` are the same land drop one card apart; 04 passes, 02 fails. Land drops are free. One more hand-drawn constant for Phase 9.

3. **A one-ply evaluator cannot see prevention.** Fog at 2 life facing 9 power is passed up — the post-simulation state has the same life totals as passing, because prevention only materializes at the damage step. It also means "hold Fog in your own main" passes for the wrong reason. Phase 7, not Phase 9.

4. **Combat is carried by `CombatAdvisor`, not the evaluator.** `v0-blind` still scores 6/6 on lethal *and* blocking. Those categories are a regression net for `CombatAdvisor`'s seed heuristics; a `BoardFeatures.kt` change will not move them. The one combat position the evaluator owns — hold a blocker home rather than swing with everything — fails for every profile.

## Docs

- `docs/ai/baseline-metrics.md` — Phase 2 section: per-category baseline + the four findings
- `docs/ai/measurement.md` — how to read the gate, how to write a puzzle, why positive controls matter
- `backlog/engine-ai-improvement.md` — Phase 2 marked done with its corrections; Phase 6's exit criterion re-pointed at the measured baseline; next up is Phase 3

## Verification

`:ai:test` green (`just arena-puzzles` ~10 s). No `rules-engine` or SDK surface touched, so no card-SDK reference update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)