### PR TITLE
Count player turns in GameState.turnNumber, not rounds

### DIFF
--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/FrozenBaselineTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/FrozenBaselineTest.kt
@@ -76,7 +76,14 @@ class FrozenBaselineTest : FunSpec({
         /**
          * Blessed 2026-07-27 against `AiProfile.LEGACY_V0` as pinned in Phase 1: seat 1 wins on
          * turn 10, life -8 / 16. Re-bless only for the reasons listed in this class's KDoc.
+         *
+         * Re-blessed 2026-07-28 for the turn-numbering change (`GameState.turnNumber` counts player
+         * turns rather than rounds). **`LEGACY_V0` did not move.** The stream's only turn-number
+         * carrier is its trailing `END|turns=` record, so the same game now hashes differently while
+         * every action in it is identical — verified by re-running both turn-numbering schemes with
+         * that record's turn count elided: both produced `8ae37a73f24d4e42`. The game itself is
+         * unchanged down to the outcome: seat 1 still wins at life -8 / 16, on what is now turn 20.
          */
-        private const val GOLDEN_HASH = "506577c26cba1a9c"
+        private const val GOLDEN_HASH = "d7d1bf75e6eb1a33"
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/PodArena.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/PodArena.kt
@@ -34,10 +34,9 @@ data class PodArenaConfig(
     val seed: Long = ArenaConfig.DEFAULT_SEED,
     val setCode: String = "BLB",
     /**
-     * Cap in **rounds**, not player turns — `GameState.turnNumber` only increments when the first
-     * seat starts a turn (`TurnManager.startTurn`), so one unit here is [TableSetup.seats] player
-     * turns. Default 30 rather than the head-to-head 50: a four-seat round is four turns of real
-     * play, and 30 rounds is already 120 of them.
+     * Cap in turns **per seat**, so one unit here is [TableSetup.seats] player turns. Default 30
+     * rather than the head-to-head 50: every seat's turn is a turn of real play, and 30 per seat is
+     * already 90-120 of them at this table.
      */
     val maxTurns: Int = DEFAULT_MAX_TURNS,
     /** Per-game runaway backstop. See [TableGameRunner.DEFAULT_MAX_ACTIONS]. */
@@ -52,8 +51,8 @@ data class PodArenaConfig(
 
     companion object {
         /**
-         * 30 rounds, against the head-to-head arena's 50. `maxTurns` is a round count and a pod
-         * round is [TableSetup.seats] player turns, so 30 is already 90-120 turns of real play.
+         * 30 turns per seat, against the head-to-head arena's 50 — at [TableSetup.seats] seats
+         * that is already 90-120 turns of real play.
          */
         const val DEFAULT_MAX_TURNS = 30
     }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/PodArenaHarnessTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/PodArenaHarnessTest.kt
@@ -102,7 +102,7 @@ class PodArenaHarnessTest : FunSpec({
         withClue("${setup.id}: $illegalActions") { illegalActions.keys.shouldBeEmpty() }
         withClue("${setup.id}: $exception") { exception shouldBe null }
         withClue("${setup.id} wedged: $drawReason") {
-            val hitACap = listOf("maxTurns", "maxPlayerTurns", "maxActions").any { drawReason.startsWith(it) }
+            val hitACap = listOf("maxTurns", "maxActions").any { drawReason.startsWith(it) }
             (drawReason.isEmpty() || hitACap) shouldBe true
         }
     }
@@ -114,10 +114,11 @@ class PodArenaHarnessTest : FunSpec({
     }
 
     test("a four-player pod plays past its first elimination to a real finish, clean") {
-        // The path that matters here: once a seat is knocked out, `GameState.turnNumber` stops
-        // advancing (TurnManager only bumps it for turnOrder.first()), and a harness that measures
-        // progress by it declares a healthy three-way endgame wedged. This test is that regression
-        // net — before the runner counted player-turn handovers instead, it failed with `stuck`.
+        // The path that matters here is the endgame after a seat is knocked out. `turnNumber` used
+        // to be a round counter that only advanced for `turnOrder.first()` — and turnOrder keeps
+        // eliminated players — so it froze the moment the opening seat died and a harness measuring
+        // progress by it declared a healthy three-way endgame wedged. This test is that regression
+        // net: it failed with `stuck` before the fix.
         val game = soloGame(TableSetup.FFA4, maxTurns = 30)
         game.shouldRunClean()
         withClue("did not finish: ${game.drawReason}") { game.completed shouldBe true }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/TableGameRunner.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/TableGameRunner.kt
@@ -139,16 +139,15 @@ object TableGameRunner {
     /**
      * Wedge detection: this many actions without the turn passing to another player.
      *
-     * `AIBenchmark`'s version counts actions without a **`GameState.turnNumber`** change, and that
-     * measure does not survive a pod. `turnNumber` is a *round* counter — `TurnManager.startTurn`
-     * only increments it when `turnOrder.first()` begins a turn — and `turnOrder` keeps eliminated
-     * players, so **once the first seat is knocked out `turnNumber` never advances again** and a
-     * perfectly healthy three-way endgame reads as wedged forever. Counting player-turn handovers
-     * instead is format-independent.
+     * `GameState.turnNumber` counts player turns, so it is a sound clock here — it advances on every
+     * turn regardless of seat count or who has been eliminated. (It was a *round* counter until the
+     * turn-number fix, which froze outright once the opening seat was knocked out and made every
+     * healthy three-way endgame read as wedged forever; this detector counted handovers itself to
+     * dodge that.)
      *
-     * 300 per player turn is deliberately looser than the old 300 per round (two player turns in a
-     * duel): a false "stuck" silently discards a real result, which is worse than taking a few
-     * hundred extra actions to notice a genuine wedge.
+     * 300 per player turn is deliberately looser than 300 per round (two player turns in a duel):
+     * a false "stuck" silently discards a real result, which is worse than taking a few hundred
+     * extra actions to notice a genuine wedge.
      */
     private const val STUCK_ACTIONS_PER_TURN = 300
 
@@ -171,6 +170,7 @@ object TableGameRunner {
         seed: Long,
         groupId: Int,
         rotation: Int,
+        /** Cap in turns *per seat* — a duel gets `2 * maxTurns` player turns, a four-pod `4 *`. */
         maxTurns: Int = 50,
         maxActions: Int = DEFAULT_MAX_ACTIONS,
         /** Hash every action and decision into [TableGameOutcome.actionStreamHash]. Off by
@@ -211,22 +211,20 @@ object TableGameRunner {
         var actionCount = 0
         val illegalActions = mutableMapOf<String, Int>()
         var lastActivePlayer: EntityId? = null
-        var playerTurns = 0
         var lastProgressAction = 0
         var drawReason = ""
         var exception: String? = null
-        // `maxTurns` stays a round count so the head-to-head numbers keep their meaning, but the
-        // hard cap has to be in player turns — see STUCK_ACTIONS_PER_TURN on why `turnNumber` is
-        // not a reliable clock. In a duel `turnNumber < maxTurns` always trips first, so this is a
-        // backstop there and the real terminator in a pod that has lost its first seat.
+        // `maxTurns` is a cap in turns *per seat*, so a duel and a four-player pod get the same
+        // number of turns each and the head-to-head numbers keep their historical meaning.
+        // `GameState.turnNumber` counts player turns, hence the multiply.
         val maxPlayerTurns = maxTurns * setup.seats
         val stream = if (recordActionStream) MessageDigest.getInstance("SHA-256") else null
         fun record(entry: String) = stream?.update(entry.toByteArray(Charsets.UTF_8))
 
         val duration = measureTime {
             try {
-                while (!state.gameOver && state.turnNumber < maxTurns &&
-                    playerTurns < maxPlayerTurns && actionCount < maxActions
+                while (!state.gameOver && state.turnNumber < maxPlayerTurns &&
+                    actionCount < maxActions
                 ) {
                     if (actionCount - lastProgressAction > STUCK_ACTIONS_PER_TURN) {
                         drawReason = "stuck(turn=${state.turnNumber},step=${state.step.name})"
@@ -234,7 +232,6 @@ object TableGameRunner {
                     }
                     if (state.activePlayerId != lastActivePlayer) {
                         lastActivePlayer = state.activePlayerId
-                        playerTurns++
                         lastProgressAction = actionCount
                     }
 
@@ -284,7 +281,6 @@ object TableGameRunner {
                 if (!state.gameOver && drawReason.isEmpty()) {
                     drawReason = when {
                         actionCount >= maxActions -> "maxActions($maxActions)"
-                        playerTurns >= maxPlayerTurns -> "maxPlayerTurns($maxPlayerTurns)"
                         else -> "maxTurns($maxTurns)"
                     }
                 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AdvisorBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AdvisorBenchmark.kt
@@ -161,7 +161,8 @@ private data class GameResultAdvisor(
 
 private fun playAdvisorGame(
     registry: CardRegistry, deck1: Deck, deck2: Deck, id: Int,
-    advisedIsP1: Boolean, maxTurns: Int = 50
+    // maxTurns counts player turns (`GameState.turnNumber`), so 100 is 50 turns each.
+    advisedIsP1: Boolean, maxTurns: Int = 100
 ): GameResultAdvisor {
     val processor = ActionProcessor(registry)
     val initializer = GameInitializer(registry)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/GameBenchmark.kt
@@ -53,7 +53,7 @@ class GameBenchmark : FunSpec({
 
         val runtime = Runtime.getRuntime()
 
-        log("=== BENCHMARK: $numGames games on $cores threads (random sealed decks, maxTurns=50) ===")
+        log("=== BENCHMARK: $numGames games on $cores threads (random sealed decks, maxTurns=100) ===")
         log("CSV output: ${csvFile.absolutePath}")
 
         val wallTime = measureTime {
@@ -64,7 +64,7 @@ class GameBenchmark : FunSpec({
                     if (i <= 10 || i % 10 == 0) {
                         log("  [Game $i] started [${deckSummary(deck1)} vs ${deckSummary(deck2)}]")
                     }
-                    playGame(registry, deck1, deck2, i, maxTurns = 50) { turn, p1Life, p2Life, actions ->
+                    playGame(registry, deck1, deck2, i, maxTurns = 100) { turn, p1Life, p2Life, actions ->
                         if (i <= 10 && turn % 5 == 0) {
                             log("  [Game $i] turn $turn: P1=$p1Life P2=$p2Life ($actions actions)")
                         }
@@ -159,7 +159,8 @@ private fun deckSummary(deck: Deck): String {
 }
 
 private fun playGame(
-    registry: CardRegistry, deck1: Deck, deck2: Deck, id: Int, maxTurns: Int = 50,
+    // maxTurns counts player turns (`GameState.turnNumber`), so 100 is 50 turns each.
+    registry: CardRegistry, deck1: Deck, deck2: Deck, id: Int, maxTurns: Int = 100,
     onTurn: (turn: Int, p1Life: Int, p2Life: Int, actions: Int) -> Unit = { _, _, _, _ -> }
 ): GameResult {
     val processor = ActionProcessor(registry)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/RandomActionBenchmark.kt
@@ -51,7 +51,7 @@ class RandomActionBenchmark : FunSpec({
                 completionService.submit {
                     val deck1 = buildRandomSealedDeck(allCards)
                     val deck2 = buildRandomSealedDeck(allCards)
-                    playRandomGame(registry, deck1, deck2, maxTurns = 50).also {
+                    playRandomGame(registry, deck1, deck2, maxTurns = 100).also {
                         val n = finished.incrementAndGet()
                         if (n <= 5 || n % 10 == 0 || n == numGames) {
                             println("  [${n}/${numGames}] ${it.turns} turns, ${it.actions} actions, ${it.durationMs}ms, ${it.winner}")
@@ -120,7 +120,8 @@ private data class RandomGameResult(
  * Play a game using purely random legal actions. No AI evaluation at all.
  */
 private fun playRandomGame(
-    registry: CardRegistry, deck1: Deck, deck2: Deck, maxTurns: Int = 50
+    // maxTurns counts player turns (`GameState.turnNumber`), so 100 is 50 turns each.
+    registry: CardRegistry, deck1: Deck, deck2: Deck, maxTurns: Int = 100
 ): RandomGameResult {
     val processor = ActionProcessor(registry)
     val enumerator = LegalActionEnumerator.create(registry)

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SimulationThroughputBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SimulationThroughputBenchmark.kt
@@ -163,7 +163,8 @@ private fun measureGame(
     deck1: Deck,
     deck2: Deck,
     seed: Long,
-    maxTurns: Int = 50
+    // Turns per player, not rounds — `GameState.turnNumber` counts player turns.
+    maxTurns: Int = 100
 ): ThroughputSample {
     val processor = ActionProcessor(registry)
     val enumerator = LegalActionEnumerator.create(registry)

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -412,13 +412,14 @@ Files: `ai/src/test/.../puzzles/{AiPuzzle,PuzzleRunner,PuzzleSuiteTest}.kt` + `c
 >    member's own `LifeTotalComponent` is never written again after setup. `LifeDifferential` read it
 >    directly, so for half the table the life differential was **frozen at the starting 30 for the
 >    whole game**. Everything now reads `state.lifeTotal()` and values a side per *life pool*.
-> 3. **`GameState.turnNumber` stops advancing after the first elimination.** `TurnManager.startTurn`
->    only increments it for `turnOrder.first()`, and `turnOrder` keeps eliminated players — so a pod
->    plays on for twenty more turns at "turn 16". The arena's wedge detector and length cap both keyed
->    on it and declared every healthy three-way endgame stuck; they now count player-turn handovers.
->    **The engine-side consequence is not fixed and is not an AI question**: delayed triggers and
->    every other `turnNumber + 1` reading of "next turn" inherit the same freeze. That belongs in
->    `backlog/multiplayer.md`.
+> 3. **`GameState.turnNumber` stopped advancing after the first elimination.**
+>    `TurnManager.startTurn` only incremented it for `turnOrder.first()`, and `turnOrder` keeps
+>    eliminated players — so a pod played on for twenty more turns at "turn 16". The arena's wedge
+>    detector and length cap both keyed on it and declared every healthy three-way endgame stuck.
+>    **Fixed in the engine since**: `turnNumber` now counts player turns, so it advances on every
+>    turn at any table size and the harness reads it directly again. The same freeze had reached
+>    delayed triggers and every other `turnNumber + 1` reading of "next turn" — see
+>    `backlog/multiplayer.md` for that half.
 > 4. **No `AiProfile` flag, deliberately.** In 1v1 the new code is bit-identical by construction (one
 >    opposing side of one player, short-circuited before the fold), which `FrozenBaselineTest` and the
 >    unchanged 39/48 puzzle score both confirm. In multiplayer the old behaviour was a bug, not a
@@ -975,7 +976,7 @@ two phases' worth of assumed work.
 | **Combat's 1 s cap fights the global budget** | Blocking puzzle category; per-tier latency logging | Combat declaration is always CRITICAL; keep `MAX_BLOCK_SIMULATIONS = 10` as a floor, not a ceiling |
 | **`GameSimulator.isResolving` / `decisionResolver` thread-safety** | Nondeterminism across arena reruns at the same seed | One `AIPlayer` per *seat* per game, never shared. `ArenaHarnessTest` asserts identical outcomes at 8 threads and at 1 — **green as of Phase 1**, so the AI is deterministic today. `PlayoutEngine` must own its own processor when Phase 7 lands |
 | **A pod result is read against 50%** | Certain to happen — every other number in this plan is | The null is **1/teams**: 33% at `ffa3`, 25% at `ffa4`, 50% at `2hg`. `ArenaReport.podSummary` prints the null on the same line as the win share and states it in the verdict sentence |
-| **A multiplayer harness trusts `GameState.turnNumber`** | Every pod game reads as wedged after the first elimination | `turnNumber` only advances for `turnOrder.first()`, who may be dead. Count player-turn handovers. **Closed for the arena in Phase 3**; still open for engine code that reads "next turn" as `turnNumber + 1` (`backlog/multiplayer.md`) |
+| **A multiplayer harness trusts `GameState.turnNumber`** | Used to read every pod game as wedged after the first elimination | `turnNumber` was a round counter that only advanced for `turnOrder.first()`, who may be dead. **Closed**: it counts player turns now, so it is a sound clock at any table size (`backlog/multiplayer.md`) |
 | **Persistent collections break persisted sessions / committed replays** | `GameStateSerializationFormatStabilityTest` golden JSON | Serializers delegate to standard `MapSerializer`/`ListSerializer` ⇒ byte-identical wire format |
 | **`CardInstantiator` extraction produces malformed cards** | `DeterminizerInvariantsTest` + full engine suite | Reuse `GameInitializer`'s own construction path, don't hand-roll |
 | ~~**Arena wall-clock makes the merge gate unaffordable**~~ | Measured in Phase 1 | **Not a risk today** — 1,000 games is 3.5 min, because no `DecisionBudget` exists yet. Re-opens in Phase 4b: re-measure before shipping a budget, and only then consider a reduced-budget arena mode |

--- a/backlog/multiplayer.md
+++ b/backlog/multiplayer.md
@@ -181,14 +181,28 @@ The built-in AI kept an explicitly 1v1 `soleOpponent` helper in the `ai` module.
 opposing team instead of the first opponent in turn order. `just arena-pod` plays FFA and 2HG games.
 See "AI pod players" below.
 
-> **Open engine question that came out of that work: `GameState.turnNumber` stops advancing after
-> the first elimination.** `TurnManager.startTurn` increments it only when
-> `playerId == state.turnOrder.first()`, and `turnOrder` retains eliminated players — so once seat 0
-> is out, a pod plays another twenty turns at the same `turnNumber`. Everything that reads
-> `turnNumber + 1` as "next turn" inherits the freeze: delayed triggers
-> (`CreateDelayedTriggerExecutor`), `ExileTopCardMayPlayFreeExecutor`, `StackResolver`'s
-> `notBeforeTurn`. Fixing it is a rules change with replay and client-display consequences, so it
-> wants its own phase rather than a drive-by.
+> **Engine question that came out of that work, now resolved: `GameState.turnNumber` used to stop
+> advancing after the first elimination.** It was a *round* counter — `TurnManager.startTurn`
+> incremented it only when `playerId == state.turnOrder.first()` — and `turnOrder` retains
+> eliminated players, so once seat 0 was out a pod played another twenty turns at the same
+> `turnNumber`. **`turnNumber` now counts player turns**: every turn that begins gets the next
+> number, so a four-player pod's opening round is turns 1-4 and nothing freezes.
+>
+> That also fixed two things the round counter got wrong independently of elimination. Every
+> `turnNumber + 1` read of "next turn" (`CreateDelayedTriggerExecutor`, `StackResolver`'s rebound
+> `notBeforeTurn`, `ExileTopCardMayPlayFreeExecutor`) meant "next *round*", firing a full cycle
+> late in a pod; and every `stamp == turnNumber` read of "this turn" (graveyard and exile entry
+> stamps) matched a whole round, so a creature that died on an opponent's turn counted as having
+> died on yours. The seat-index arithmetic that `resolveStepTurn` used to compensate with is gone —
+> the floor is `turnNumber` or `turnNumber + 1`, and `CleanupPhaseManager`'s controller check picks
+> the turn, which is what makes it survive skipped turns, extra turns and eliminated seats.
+>
+> Fallout, absorbed in the same change: the client's turn indicator now counts player turns
+> (`Turn 5` where it read `Turn 3`, matching MTGO/Arena); `match_results.turn_count` and the gym's
+> `turnNumber` observation change units the same way; and arena/benchmark turn caps are now read as
+> turns *per seat* (`TableGameRunner` multiplies by seat count), so their effective horizons are
+> unchanged. Replays re-simulate from the input stream, so old replays still play back — only the
+> displayed number moves.
 
 The riskiest work, done first, while everything is still verifiable against the existing 2-player test corpus.
 

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -402,25 +402,22 @@ starting 30 for the whole game**.
 
 `MultiplayerEvaluationTest` asserts each of these as a positive claim rather than describing them.
 
-### 2. `GameState.turnNumber` stops advancing after the first elimination
+### 2. `GameState.turnNumber` stopped advancing after the first elimination — fixed since
 
-`TurnManager.startTurn` increments `turnNumber` only when `playerId == state.turnOrder.first()`, and
-`turnOrder` keeps eliminated players. So in a pod, the moment seat 0 is knocked out, **`turnNumber`
-never changes again** — the game plays on for another twenty turns at "turn 16".
+As measured, `TurnManager.startTurn` incremented `turnNumber` only when
+`playerId == state.turnOrder.first()`, and `turnOrder` keeps eliminated players. So in a pod, the
+moment seat 0 was knocked out, **`turnNumber` never changed again** — the game played on for another
+twenty turns at "turn 16". The arena's wedge detector and length cap both keyed on it and declared
+every healthy three-way endgame stuck.
 
-This is not an AI bug and Phase 3 did not change it, but anything that drives multiplayer games has
-to know about it:
+This was never an AI bug. `turnNumber` now counts **player turns**, so it advances on every turn at
+any table size and the harness reads it directly again. See `backlog/multiplayer.md` for the engine
+side — the same freeze reached delayed triggers and everything else that read `turnNumber + 1` as
+"next turn".
 
-- The arena's wedge detector (`actionCount` since the last `turnNumber` change) declared every
-  healthy three-way endgame stuck. It now counts **player-turn handovers**.
-- A game-length cap of `turnNumber < maxTurns` never trips after an elimination. There is now a
-  player-turn cap alongside it.
-- Anything in the engine that reasons about "next turn" as `turnNumber + 1` — delayed triggers,
-  `ExileTopCardMayPlayFreeExecutor`, `CreateDelayedTriggerExecutor` — inherits the same freeze. That
-  is a real rules question for multiplayer and belongs in `backlog/multiplayer.md`, not here.
-
-Also worth knowing before writing any pod harness: even *before* an elimination, one `turnNumber` at
-a four-seat table is four player turns, so a per-round action budget tuned on duels is ~4× too tight.
+One thing that survives the fix and is still worth knowing before writing a pod harness: a pod turn
+costs more actions than a duel turn, because the Strategist simulates every candidate against three
+or four growing boards. An action budget tuned on duels is too tight regardless of the clock.
 
 ### 3. `ThreatAssessment` has a ~130-point cliff at "opponent has no creatures"
 

--- a/docs/ai/measurement.md
+++ b/docs/ai/measurement.md
@@ -194,19 +194,20 @@ or four growing boards, and the Strategist simulates every candidate against all
 uncapped mirror spends minutes per game proving what a few hundred actions already proved. Full
 length pod games are what `just arena-pod` is for.
 
-### Two traps this harness had to work around
+### One trap this harness had to work around
 
-Both are real engine behaviours, not harness bugs, and anything else that drives multiplayer games
-will hit them:
+A real engine behaviour, not a harness bug, and anything else that drives multiplayer games will hit
+it: **a pod turn costs more actions than a duel turn.** Three or four growing boards mean the
+Strategist's per-decision cost grows with the table, so a flat "300 actions without a turn change
+means stuck" threshold tuned on duels fires on a pod game that is making perfectly good progress.
+`STUCK_ACTIONS_PER_TURN` is deliberately loose for that reason.
 
-1. **`GameState.turnNumber` is a round counter that stops advancing after the first elimination.**
-   `TurnManager.startTurn` only increments it when `turnOrder.first()` begins a turn, and
-   `turnOrder` keeps eliminated players — so once seat 0 is knocked out it never moves again. Any
-   progress detector or length cap keyed on it declares a healthy three-way endgame wedged forever.
-   The runner counts player-turn handovers instead.
-2. **A pod round costs several turns' worth of actions.** Even before an elimination, one
-   `turnNumber` at a four-seat table is four player turns, so a flat "300 actions without a turn
-   change means stuck" threshold fires on a game that is making perfectly good progress.
+A second trap is now gone: `GameState.turnNumber` used to be a *round* counter that
+`TurnManager.startTurn` only incremented for `turnOrder.first()`. Since `turnOrder` keeps eliminated
+players, it froze the moment seat 0 was knocked out, and any progress detector or length cap keyed
+on it declared a healthy three-way endgame wedged forever. It now counts player turns, so it is a
+sound clock at any table size. Note the unit when reading caps: `maxTurns` in the arena config is
+turns **per seat**, which `TableGameRunner` multiplies by the seat count.
 
 ---
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3029,9 +3029,7 @@ work for abilities-on-stack (which carry no `CardComponent`).
   strips it when the card leaves the graveyard, so a later arrival by a different route
   doesn't carry the earlier claim. The component carries no turn number —
   `BeginningPhaseManager` wipes it from every entity at each turn's untap step, which is what
-  gives both predicates MTG-correct per-turn semantics (the engine's `state.turnNumber`
-  increments per round, not per active player, so a turn-number comparison would be wrong in
-  multiplayer). Used by Abyssal Harvester (FDN) and by Samwise the Stouthearted / Lobelia
+  gives both predicates their per-turn semantics. Used by Abyssal Harvester (FDN) and by Samwise the Stouthearted / Lobelia
   Sackville-Baggins (LTR) respectively — pair with `GameObjectFilter.Creature` or `Permanent`
   on a graveyard-zone `TargetFilter`. Both are false in battlefield-projection / untap /
   trigger-gating contexts (the component only lives on graveyard cards). Note that a card the

--- a/docs/engine-server-interface.md
+++ b/docs/engine-server-interface.md
@@ -56,7 +56,7 @@ Tracks the temporal state of the game.
 
 ```kotlin
 data class TurnInfo(
-    val turnNumber: Int,
+    val turnNumber: Int,            // Counts player turns: seat A's turn 1, seat B's turn 2, …
     val activePlayerId: EntityId,   // Whose turn is it?
     val priorityPlayerId: EntityId, // Who can act *right now*?
     val phase: Phase,               // e.g., COMBAT

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/benchmark/AIBenchmark.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/benchmark/AIBenchmark.kt
@@ -79,7 +79,7 @@ class AIBenchmark : FunSpec({
 
     val benchmarkEnabled = System.getProperty("benchmark") == "true"
     val numGames = System.getProperty("benchmarkGames")?.toIntOrNull() ?: 10
-    val maxTurns = System.getProperty("benchmarkMaxTurns")?.toIntOrNull() ?: 50
+    val maxTurns = System.getProperty("benchmarkMaxTurns")?.toIntOrNull() ?: 100
 
     fun playerConfig(prefix: String): PlayerType {
         val type = System.getProperty("${prefix}Type") ?: "engine"

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/CompactReplaySizeBenchmark.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/CompactReplaySizeBenchmark.kt
@@ -68,7 +68,7 @@ class CompactReplaySizeBenchmark : ScenarioTestBase() {
                 session.keepHand(p1)
                 session.keepHand(p2)
 
-                val outcome = playRandomGame(session, enumerator, rng, maxTurns = 40)
+                val outcome = playRandomGame(session, enumerator, rng, maxTurns = 80)
 
                 val setup = session.getReplaySetup()
                 if (setup == null) {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
@@ -69,7 +69,7 @@ class ReplayDivergenceReproTest : ScenarioTestBase() {
                 session.keepHand(p1)
                 session.keepHand(p2)
 
-                playRandomGame(session, enumerator, rng, maxTurns = 25)
+                playRandomGame(session, enumerator, rng, maxTurns = 50)
 
                 val setup = session.getReplaySetup() ?: continue
                 val liveFinal = session.getStateForTesting()

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -281,8 +281,8 @@ sealed interface StatePredicate {
      * `ZoneTransitionService` on every arrival in a graveyard, and stripped when the card
      * leaves the graveyard so a later arrival by a different route does not carry the
      * earlier "from battlefield" claim. It carries no turn number — `BeginningPhaseManager`
-     * wipes it from every entity during the untap step of each turn, giving both predicates
-     * MTG-correct per-turn semantics independent of the engine's per-round `state.turnNumber`.
+     * wipes it from every entity during the untap step of each turn, which is what gives both
+     * predicates their per-turn semantics.
      *
      * Pair with `CardPredicate.IsPermanent` (or any other card-predicate constraint)
      * to express the full Samwise / Lobelia filter.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -855,9 +855,8 @@ class CleanupPhaseManager(
         // Skip permanent ones (used by "for as long as it remains exiled" effects)
         // For expiresAfterTurn: keep alive until that turn number's end step
         // Also clear ExileEntryTurnComponent so "exiled with [granter] this turn" effects
-        // (e.g. Maralen, Fae Ascendant) reset between turns. The engine's turnNumber only
-        // increments per round, not per active player, so simply comparing turn numbers
-        // would let an exile entry leak across the opponent's turn.
+        // (e.g. Maralen, Fae Ascendant) reset between turns — "this turn" is over once this
+        // cleanup runs, so the stamp has served its purpose either way.
         for ((entityId, container) in newState.entities) {
             val playFree = container.get<PlayWithoutPayingCostComponent>()
             val removePlayFree = playFree != null && !playFree.permanent
@@ -877,12 +876,13 @@ class CleanupPhaseManager(
         }
 
         // Expire non-permanent may-play permissions whose duration has elapsed.
-        // `turnNumber` is round-based (it increments only when the starting player begins a
-        // new turn), so it can't distinguish the controller's turn from the opponent's within
-        // the same round. A permission that should last "until the end of your next turn" must
-        // therefore only expire at the cleanup of the *controller's own* turn — otherwise the
-        // non-starting player would lose it at the end of the starting player's turn in the
-        // target round, one turn early (Burning Curiosity, Sizzling Changeling).
+        // `expiresAfterTurn` is a *floor*, not the exact turn: a permission that lasts "until the
+        // end of your next turn" expires at the cleanup of the first turn the *controller* takes at
+        // or after it. Hence the `activePlayerId == controller` half of the check — dropping it
+        // would expire the grant at the end of whichever opponent's turn happened to come first,
+        // one or more turns early (Burning Curiosity, Sizzling Changeling). Pairing a floor with
+        // the controller guard is also what makes this survive skipped turns, extra turns and
+        // eliminated seats; see ExileTopCardMayPlayFreeExecutor.resolveStepTurn.
         if (newState.mayPlayPermissions.isNotEmpty()) {
             newState = newState.copy(
                 mayPlayPermissions = newState.mayPlayPermissions.filterNot { permission ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -94,13 +94,16 @@ class TurnManager(
      * Start a new turn for a player.
      */
     fun startTurn(state: GameState, playerId: EntityId): ExecutionResult {
-        // Turn number increments when the first player starts a new turn
-        // It stays the same when the second player starts their turn within the same round
-        val newTurnNumber = if (playerId == state.turnOrder.first()) {
-            state.turnNumber + 1
-        } else {
-            state.turnNumber
-        }
+        // [GameState.turnNumber] counts player turns, so every turn that begins gets the next
+        // number — a four-player pod's opening round is turns 1..4, and an extra turn (CR 500.7)
+        // is a turn of its own. The game's *first* turn doesn't come through here (GameInitializer
+        // seeds turnNumber = 1 directly), so this is only ever a transition into a later turn.
+        //
+        // This used to increment only for `turnOrder.first()`, making it a round counter. That made
+        // `turnNumber + 1` mean "next round" rather than "next turn" for delayed triggers, and it
+        // froze outright once the opening seat was eliminated — turnOrder keeps eliminated players,
+        // so nothing ever matched the boundary again and a pod played on at a fixed turn number.
+        val newTurnNumber = state.turnNumber + 1
 
         var newState = state.copy(
             activePlayerId = playerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -103,7 +103,10 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             resolved
         }
 
-        // The earliest turn this delayed trigger may fire, derived from effect.timing:
+        // The earliest turn this delayed trigger may fire, derived from effect.timing. Because
+        // GameState.turnNumber counts player turns, `+ 1` means "not this turn" — the very next
+        // turn any player takes qualifies. Narrowing that to a particular player's turn is
+        // fireOnPlayer's job, not this floor's.
         //  - NEXT_END_STEP ("at the beginning of your next end step"): fires at the next
         //    upcoming end step on the controller's turn. If we're still before the end step
         //    on the controller's current turn, that end step qualifies — don't skip to the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardMayPlayFreeExecutor.kt
@@ -196,44 +196,33 @@ class GrantMayPlayFromExileExecutor : EffectExecutor<GrantMayPlayFromExileEffect
     }
 
     /**
-     * Resolve which turn's cleanup will mark "the controller's next [step]" given the
-     * current step and active player. The cleanup-driven removal is coarse — it runs once
-     * per turn at cleanup — so we map any step in the turn to that turn's cleanup.
+     * Resolve the earliest turn whose cleanup may mark "the controller's next [step]", given the
+     * current step and active player. The cleanup-driven removal is coarse — it runs once per turn
+     * at cleanup — so we map any step in the turn to that turn's cleanup.
      *
-     * The returned value is a *round* number, because [GameState.turnNumber] is round-based —
-     * it increments only when the starting player begins a new turn, so every player's turn
-     * within a round shares the same number. The cleanup expiry check disambiguates which
-     * player's turn it is by also requiring `activePlayerId == controllerId`; this function
-     * therefore only has to name the round in which the controller's next matching turn falls.
-     * Counting *player-turns* until the controller's turn (and adding them to a round-based
-     * number) over-counts whenever the grant happens on an opponent's turn — the bug that let
-     * "until your next end step" leak an extra full turn when a creature died on the opponent's
-     * turn (Shadow Urchin).
+     * This is a *floor*, not an exact turn: the expiry check in [CleanupPhaseManager] also requires
+     * `activePlayerId == controllerId`, so the permission dies at the cleanup of the first turn the
+     * controller actually takes at or after this number. That pairing is what keeps the answer right
+     * across skipped turns, extra turns and eliminated seats — none of which a turn count computed
+     * from seat positions would survive.
+     *
+     * So the whole question is only ever "does the current turn still count?": if it does, this
+     * turn's cleanup is the deadline; otherwise the deadline is the controller's next turn, which is
+     * some turn strictly after this one. Since [GameState.turnNumber] counts player turns, that is
+     * just `turnNumber + 1`.
      */
     private fun resolveStepTurn(
         state: GameState,
         controllerId: EntityId,
         expiry: MayPlayExpiry.UntilControllerStep
     ): Int {
-        val turnOrder = state.turnOrder
-        val playerIndex = turnOrder.indexOf(controllerId)
-        val activeIndex = turnOrder.indexOf(state.activePlayerId)
-
-        val onControllerTurn = playerIndex == activeIndex
-        val targetStep = expiry.step
-        val targetReachedThisTurn = state.step.ordinal >= targetStep.ordinal
+        val onControllerTurn = state.activePlayerId == controllerId
+        val targetReachedThisTurn = state.step.ordinal >= expiry.step.ordinal
         val thisTurnStillCounts = onControllerTurn && expiry.includeCurrentTurn && !targetReachedThisTurn
 
-        return when {
-            // This turn's matching step still counts — expire at this turn's cleanup.
-            thisTurnStillCounts -> state.turnNumber
-            // Controller's own turn, but this turn no longer counts — their next turn is next round.
-            onControllerTurn -> state.turnNumber + 1
-            // Opponent's turn: the controller still takes a turn *this* round if they come later in
-            // turn order; otherwise they already went and their next turn is in the next round.
-            playerIndex > activeIndex -> state.turnNumber
-            else -> state.turnNumber + 1
-        }
+        // This turn's matching step still counts — expire at this turn's cleanup. Otherwise the
+        // controller's next turn is the deadline, and every later turn number qualifies as a floor.
+        return if (thisTurnStillCounts) state.turnNumber else state.turnNumber + 1
     }
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -40,7 +40,18 @@ data class GameState(
     /** Zone contents - maps zone keys to lists of entity IDs */
     val zones: Map<ZoneKey, List<EntityId>> = emptyMap(),
 
-    /** Current turn number (starts at 0, becomes 1 when first player's turn starts) */
+    /**
+     * Current turn number, counting **player turns** — every turn the game begins gets its own
+     * number, including extra turns (CR 500.7) and every seat's turn in a multiplayer pod. Starts
+     * at 0 and becomes 1 when the first player's turn starts, so in a four-player pod the opening
+     * round is turns 1, 2, 3, 4 and the second round is 5, 6, 7, 8.
+     *
+     * This is deliberately *not* a round counter. `turnNumber + 1` is read across the engine as
+     * "the next turn" (delayed triggers, rebound, may-play expiries) and `stamp == turnNumber` as
+     * "this turn" (graveyard/exile entry stamps) — both of which are only true of a per-turn count.
+     * A round counter also stops advancing entirely once the first seat is eliminated, because the
+     * seat that used to mark the round boundary never takes another turn.
+     */
     val turnNumber: Int = 0,
 
     /** ID of the player whose turn it is */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiplayerSmokeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/MultiplayerSmokeTest.kt
@@ -34,8 +34,9 @@ import io.kotest.matchers.shouldBe
  * N-player correct once the single-opponent context is gone. A four-player game
  * initializes, priority round-trips through all four seats, a full turn cycle hands
  * the turn to the next player in turn order, [GameState.getOpponents] excludes lost
- * players, an `EachOpponent` effect fans out to all three opponents, and
- * [Player.DefendingPlayer] resolves per CR 802.2a from the attack assignment.
+ * players, an `EachOpponent` effect fans out to all three opponents,
+ * [Player.DefendingPlayer] resolves per CR 802.2a from the attack assignment, and
+ * [GameState.turnNumber] keeps counting turns after a seat is eliminated.
  */
 class MultiplayerSmokeTest : FunSpec({
 
@@ -134,6 +135,77 @@ class MultiplayerSmokeTest : FunSpec({
         playersSeenWithPriority shouldBe players.toSet()
         // The next turn belongs to the next player in turn order.
         state.activePlayerId shouldBe players[1]
+    }
+
+    test("turnNumber counts player turns and keeps advancing after a seat is eliminated") {
+        val (initial, players) = initFourPlayerGame()
+        val registry = CardRegistry().also { it.register(vanilla) }
+        val processor = ActionProcessor(registry)
+
+        /** Drive the game with pass-everything play until the turn leaves [from]. */
+        fun advanceOneTurn(start: GameState, from: EntityId): GameState {
+            var state = start
+            var safety = 0
+            while (state.activePlayerId == from && !state.gameOver) {
+                check(++safety < 500) { "turn never advanced (stuck at step ${state.step})" }
+
+                val pending = state.pendingDecision
+                if (pending is com.wingedsheep.engine.core.SelectCardsDecision) {
+                    val response = com.wingedsheep.engine.core.CardsSelectedResponse(
+                        pending.id, pending.options.take(pending.minSelections)
+                    )
+                    val result = processor.process(
+                        state, com.wingedsheep.engine.core.SubmitDecision(pending.playerId, response)
+                    ).result
+                    check(result.isSuccess || result.isPaused) { "discard failed: ${result.error}" }
+                    state = result.newState
+                    continue
+                }
+
+                val prio = state.priorityPlayerId ?: break
+                val action = when {
+                    state.step == Step.DECLARE_ATTACKERS &&
+                        state.activePlayerId == prio &&
+                        state.getEntity(prio)?.has<AttackersDeclaredThisCombatComponent>() != true ->
+                        DeclareAttackers(prio, emptyMap())
+                    state.step == Step.DECLARE_BLOCKERS && state.pendingDecision == null &&
+                        state.activePlayerId != prio -> DeclareBlockers(prio, emptyMap())
+                    else -> PassPriority(prio)
+                }
+                val result = processor.process(state, action).result
+                check(result.isSuccess || result.isPaused) { "action $action failed: ${result.error}" }
+                state = result.newState
+            }
+            return state
+        }
+
+        // The opening turn is turn 1, and every seat's turn gets its own number — this is a turn
+        // count, not a round count.
+        var state = initial
+        state.turnNumber shouldBe 1
+        state = advanceOneTurn(state, players[0])
+        state.activePlayerId shouldBe players[1]
+        state.turnNumber shouldBe 2
+
+        // Knock out seat 0 — the seat a round counter keyed its boundary on. `turnOrder` keeps
+        // eliminated players, so it would never come round again and the counter would freeze here
+        // for the rest of the game.
+        state = state.updateEntity(players[0]) { c ->
+            c.with(PlayerLostComponent(LossReason.CONCESSION))
+        }
+
+        state = advanceOneTurn(state, players[1])
+        state.activePlayerId shouldBe players[2]
+        state.turnNumber shouldBe 3
+
+        state = advanceOneTurn(state, players[2])
+        state.activePlayerId shouldBe players[3]
+        state.turnNumber shouldBe 4
+
+        // Wrapping past the eliminated seat is just another turn.
+        state = advanceOneTurn(state, players[3])
+        state.activePlayerId shouldBe players[1]
+        state.turnNumber shouldBe 5
     }
 
     test("an EachOpponent life-loss effect hits all three opponents and not the controller") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdditionalCombatPhaseTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdditionalCombatPhaseTest.kt
@@ -52,9 +52,9 @@ class AdditionalCombatPhaseTest : FunSpec({
      * postcombat main phase right after the natural one emits its own StepChangedEvent).
      */
     fun GameTestDriver.recordStepsThroughTurn(maxRounds: Int = 400): List<Step> {
-        // `turnNumber` is a round counter (it only bumps when the first player starts a turn), so it
-        // is shared by both players' turns within a round. Bound the recording to the *active
-        // player's* turn instead, stopping as soon as the turn passes to the opponent.
+        // Bound the recording to the *active player's* turn, stopping as soon as the turn passes to
+        // the opponent — an inserted extra combat phase is part of the same turn, so watching the
+        // active player is what distinguishes "still this turn" from "the turn ended".
         val startPlayer = activePlayer
         val startStep = currentStep
         val firstEventIndex = events.size

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningCuriosityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningCuriosityTest.kt
@@ -20,11 +20,10 @@ import io.kotest.matchers.shouldBe
  * top three cards instead. Until the end of your next turn, you may play those cards.
  *
  * Regression guard for "until the end of your next turn" when the controller is NOT the starting
- * player. `GameState.turnNumber` is round-based — it only increments when the starting player
- * begins a new turn — so two players share a turn number within a round. The expiry must be gated
+ * player. The permission records a turn *floor* ("not this turn"), so the expiry must also be gated
  * on the *controller's own* turn; otherwise the non-starting player loses the permission at the end
- * of the starting player's turn in the target round, one full turn too early, and can no longer
- * play the exiled land on their next turn (the reported bug).
+ * of whichever opponent's turn comes first, one full turn too early, and can no longer play the
+ * exiled land on their next turn (the reported bug).
  */
 class BurningCuriosityTest : FunSpec({
 
@@ -88,7 +87,7 @@ class BurningCuriosityTest : FunSpec({
         val land = exiled.first()
         driver.state.mayPlayPermissions.any { land in it.cardIds } shouldBe true
 
-        // Advance through P1's next turn (same round number as P2's next turn) into P2's next turn.
+        // Advance through P1's next turn into P2's next turn — the one the window must cover.
         advanceToNextTurnMain(driver)
         driver.state.activePlayerId shouldBe p1
         advanceToNextTurnMain(driver)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaralenFaeAscendantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaralenFaeAscendantScenarioTest.kt
@@ -346,9 +346,8 @@ class MaralenFaeAscendantScenarioTest : ScenarioTestBase() {
                 game.getClientState(1).cards[turn1Cheap]
                     ?.playableFromExile shouldBe true
 
-                // End P1's turn → P2's turn. Even though the engine reuses turnNumber
-                // across both players within a round, "exiled this turn" must not leak
-                // into the opponent's turn — the entry's eligibility expires at cleanup.
+                // End P1's turn → P2's turn. "Exiled this turn" must not leak into the
+                // opponent's turn — the entry's eligibility expires at cleanup.
                 game.passUntilPhase(Phase.ENDING, Step.END)
                 game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OneRingToRuleThemAllScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OneRingToRuleThemAllScenarioTest.kt
@@ -68,10 +68,16 @@ class OneRingToRuleThemAllScenarioTest : FunSpec({
         }
     }
 
-    fun GameTestDriver.advanceToMain(targetRound: Int) {
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `GameState.turnNumber` counts player turns, and these are duels where
+     * the two seats alternate, so the starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
         var guard = 0
-        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 600) {
-            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 600) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
             when {
                 state.pendingDecision != null -> autoResolveDecision()
                 state.priorityPlayerId != null -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RediscoverTheWayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RediscoverTheWayScenarioTest.kt
@@ -54,10 +54,16 @@ class RediscoverTheWayScenarioTest : FunSpec({
         }
     }
 
-    fun GameTestDriver.advanceToMain(targetRound: Int) {
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `GameState.turnNumber` counts player turns, and these are duels where
+     * the two seats alternate, so the starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
         var guard = 0
-        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
-            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
             when {
                 state.pendingDecision != null -> autoResolveDecision()
                 state.priorityPlayerId != null -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowUrchinTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShadowUrchinTest.kt
@@ -20,10 +20,10 @@ import io.kotest.matchers.shouldBe
  *
  * Regression guard for the reported bug: when the counter-bearing creature dies during the
  * OPPONENT's turn, "until your next end step" must close at the controller's own next end step — not
- * a full turn later. The expiry is driven by the cleanup step, and `GameState.turnNumber` is
- * round-based (it only increments when the starting player begins a new turn), so counting
- * player-turns until the controller's turn over-counted whenever the grant happened on an opponent's
- * turn, leaking the may-play window across an extra turn ("second turn from then still playable").
+ * a full turn later. The expiry is driven by the cleanup step, and the turn it records is only a
+ * floor: trying to compute the controller's exact next turn from seat positions over-counted
+ * whenever the grant happened on an opponent's turn, leaking the may-play window across an extra
+ * turn ("second turn from then still playable").
  */
 class ShadowUrchinTest : FunSpec({
 
@@ -39,9 +39,9 @@ class ShadowUrchinTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
     }
 
-    // P1 is the starting player; P2 controls Shadow Urchin. P2 sits *after* P1 in the round, so when
-    // Shadow Urchin dies on P1's turn, P2's next end step is still this same round — the case the old
-    // round-based math pushed a full turn too late.
+    // P1 is the starting player; P2 controls Shadow Urchin. When Shadow Urchin dies on P1's turn,
+    // P2's own next end step is the very next turn — the case that seat-index arithmetic over the
+    // old round counter pushed a full turn too late.
     test("may-play window closes at the controller's own next end step when granted on the opponent's turn") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SizzlingChangelingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SizzlingChangelingTest.kt
@@ -23,9 +23,9 @@ import io.kotest.matchers.shouldBe
  *
  * Regression guard for "until the end of your next turn": the exiled card must stay playable
  * through the controller's *next* turn (a land via PlayLand and a nonland spell via CastSpell),
- * and the permission must expire only after that turn. Note `GameState.turnNumber` is round-based
- * — it increments when the starting player begins a new turn, not per player-turn — so in a duel
- * the controller's next turn is exactly turnNumber + 1.
+ * and the permission must expire only after that turn. The permission's `expiresAfterTurn` is a
+ * floor (`turnNumber + 1` — "not this turn"); which turn it actually closes on is decided by the
+ * controller half of the cleanup check, so a duel and a pod behave the same way.
  */
 class SizzlingChangelingTest : FunSpec({
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SozinsCometScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SozinsCometScenarioTest.kt
@@ -66,8 +66,7 @@ class SozinsCometScenarioTest : FunSpec({
     /**
      * Advance play from the current (my) turn to my next precombat main phase.
      *
-     * Each iteration ends the current turn and stops at the *following* turn's precombat main
-     * (turnNumber is round-based — it increments only when the starting player begins a turn), so
+     * Each iteration ends the current turn and stops at the *following* turn's precombat main, so
      * the loop exits precisely on my own main phase in a later turn. Ending each iteration on
      * `PRECOMBAT_MAIN` (rather than looping to END and only afterwards advancing to a main) is what
      * keeps it from overshooting onto the opponent's turn.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastRoninScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastRoninScenarioTest.kt
@@ -47,10 +47,16 @@ class TheLastRoninScenarioTest : FunSpec({
         }
     }
 
-    fun GameTestDriver.advanceToMain(targetRound: Int) {
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `GameState.turnNumber` counts player turns, and these are duels where
+     * the two seats alternate, so the starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
         var guard = 0
-        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
-            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
             when {
                 state.pendingDecision != null -> autoResolveDecision()
                 state.priorityPlayerId != null -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderOfUnityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThunderOfUnityTest.kt
@@ -38,10 +38,10 @@ import io.kotest.matchers.shouldBe
  * and fired for *every* permanent that entered (opponents' permanents, lands, the Saga itself,
  * etc.). The "does NOT ping" tests below are the regression guard for that bug.
  *
- * Note on turn numbers: `GameState.turnNumber` is the round number (both players' turns within a
- * round share it — see `TurnManager.startTurn`), so the controller's Saga gains a lore counter on
- * rounds 1/2/3 → chapter I is round 1, chapter II is round 2, chapter III is round 3 (after which
- * the Saga is sacrificed).
+ * Note on turn numbers: the Saga's lore counters run on its *controller's* turns, so chapter I is
+ * the controller's first turn, II their second and III their third (after which the Saga is
+ * sacrificed). `GameState.turnNumber` counts player turns, so in this duel those are turns 1/3/5 —
+ * the `advanceToMain` helper below does that conversion.
  */
 class ThunderOfUnityTest : FunSpec({
 
@@ -97,10 +97,16 @@ class ThunderOfUnityTest : FunSpec({
      * Stops the instant we enter that step, so any Saga chapter trigger queued by the lore-counter
      * turn-based action is still sitting on the stack (resolve it with [resolveStack]).
      */
-    fun GameTestDriver.advanceToMain(targetRound: Int) {
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `GameState.turnNumber` counts player turns, and these are duels where
+     * the two seats alternate, so the starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
         var guard = 0
-        while (!(state.turnNumber == targetRound && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
-            if (state.gameOver) throw AssertionError("Game ended while advancing to round $targetRound")
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
             when {
                 state.pendingDecision != null -> autoResolveDecision()
                 state.priorityPlayerId != null -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeSagasScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeSagasScenarioTest.kt
@@ -77,8 +77,13 @@ class WoeSagasScenarioTest : FunSpec({
         }
     }
 
-    /** Advance to the given turn's precombat main phase through the real game flow. */
-    fun GameTestDriver.advanceToMain(targetTurn: Int) {
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `GameState.turnNumber` counts player turns, and this is a duel where
+     * the two seats alternate, so the starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
         var guard = 0
         while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
             if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")


### PR DESCRIPTION
## The freeze

`turnNumber` was a **round** counter: `TurnManager.startTurn` incremented it only when
`turnOrder.first()` began a turn. `turnOrder` retains eliminated players, so the seat marking the
round boundary never came round again once it was knocked out — a pod played another twenty turns at
"turn 16". The arena's wedge detector and length cap both keyed on it and declared every healthy
three-way endgame stuck.

It now counts **player turns**: every turn that begins gets the next number, so a four-player pod's
opening round is turns 1-4 and nothing can freeze it.

## Two things the round counter got wrong anyway

Independently of elimination, in any pod:

- Every `turnNumber + 1` read of "next turn" meant "next *round*", firing a full cycle late — delayed
  triggers (`CreateDelayedTriggerExecutor`), rebound (`StackResolver`), may-play expiries.
- Every `stamp == turnNumber` read of "this turn" matched a whole round, so a creature that died on
  an opponent's turn counted as having died on yours (graveyard and exile entry stamps).

`resolveStepTurn`'s seat-index arithmetic goes away with it. The floor is now `turnNumber` or
`turnNumber + 1`, and `CleanupPhaseManager`'s controller check picks the actual turn. That pairing —
a floor plus a controller guard — is what survives skipped turns, extra turns and eliminated seats,
none of which a turn count derived from seat positions can.

## Fallout, absorbed here

- **Client display** counts player turns: `Turn 5` where it read `Turn 3`. That matches MTGO/Arena.
- **`match_results.turn_count`** and the gym's `turnNumber` observation change units the same way.
- **Arena/benchmark caps** are now read as turns *per seat* (`TableGameRunner` multiplies by seat
  count), so effective horizons are unchanged. `TableGameRunner` also drops the `playerTurns`
  counter it kept purely to dodge the freeze, and `PodArenaHarnessTest`'s post-elimination pod test
  stays as the regression net.
- **Replays** re-simulate from the input stream, so old replays still play back — only the displayed
  number moves.

## FrozenBaselineTest re-bless

`LEGACY_V0` did **not** move. The action stream's only turn-number carrier is its trailing
`END|turns=` record. Re-running both turn-numbering schemes with that count elided produced
`8ae37a73f24d4e42` either way, so every action in the game is identical. Same game, same outcome
(seat 1 wins at life -8/16), renumbered from turn 10 to turn 20.

## Verification

`just test-rules`, `just test-ai`, `just test-server`, `just test-gym`, `just test-gym-server`,
`just test-gym-trainer`, `just check` — all green. New coverage in `MultiplayerSmokeTest`: a
four-player game's `turnNumber` advances 1→2→3→4→5 across a mid-game elimination, including the wrap
past the dead seat.

Closes the open engine question in `backlog/multiplayer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)