### PR TITLE
Add five Wilds of Eldraine cards (Torch the Tower, Ice Out, Brave the Wilds, Hearth Elemental, Picnic Ruiner)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BraveTheWilds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BraveTheWilds.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Brave the Wilds
+ * {G}
+ * Sorcery
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * If this spell was bargained, target land you control becomes a 3/3 Elemental creature with haste
+ * that's still a land.
+ * Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ *
+ * The **bargain-only target** shape (CR 702.166d, and the ruling below): the land target exists only
+ * on the bargained branch. That's the shared optional-additional-cost rail's `kickerTarget` /
+ * `kickerEffect` slots — they serve whichever mechanic declared, bargain here — so an unbargained
+ * Brave the Wilds has no targets at all and can be cast with an empty board, while a bargained one
+ * can't be cast unless a land you control is available to target.
+ *
+ * Because the branch replaces the whole effect rather than riding on it, the bargained branch has to
+ * restate the search. Per the ruling, that's exactly right: if the land is an illegal target on
+ * resolution the *entire* spell is countered, and no search happens.
+ *
+ * The animation has no duration on the card, so it's [Duration.Permanent] — the land stays a 3/3
+ * Elemental with haste for as long as it's on the battlefield. `BecomeCreature` adds the creature
+ * type and base P/T without removing land types, which is the "that's still a land" clause. No
+ * colors are set: the card doesn't make it green, so an animated Forest is still a colorless
+ * permanent.
+ */
+val BraveTheWilds = card("Brave the Wilds") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "If this spell was bargained, target land you control becomes a 3/3 Elemental creature " +
+        "with haste that's still a land.\n" +
+        "Search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+
+    bargain()
+
+    spell {
+        val searchForBasic = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+
+        effect = searchForBasic
+
+        val land = kickerTarget(
+            "target land you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.youControl())),
+        )
+        kickerEffect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = land,
+                power = 3,
+                toughness = 3,
+                keywords = setOf(Keyword.HASTE),
+                creatureTypes = setOf("Elemental"),
+                duration = Duration.Permanent,
+            ),
+            searchForBasic,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Lucas Graciano"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg?1783915084"
+
+        ruling(
+            "2023-09-01",
+            "If you bargained Brave the Wilds and the target land is an illegal target by the time " +
+                "it tries to resolve, the spell won't resolve. You won't search for a basic land " +
+                "card, and you won't shuffle."
+        )
+        ruling(
+            "2023-09-01",
+            "Some instant and sorcery spells require additional targets if they're bargained. You " +
+                "ignore those targeting requirements if those spells aren't bargained, and you " +
+                "can't bargain those spells unless you can choose the appropriate targets."
+        )
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HearthElemental.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HearthElemental.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Hearth Elemental // Stoke Genius
+ * {5}{R}
+ * Creature — Elemental
+ * 4/5
+ * This spell costs {X} less to cast, where X is the number of cards in your graveyard that are
+ * instant cards, sorcery cards, and/or have an Adventure.
+ *
+ * Adventure: Stoke Genius — {1}{R}, Sorcery — Adventure
+ * Discard your hand, then draw two cards.
+ *
+ * The reduction is a self-cast [ModifySpellCost] over
+ * [CostReductionSource.CardsInGraveyardMatchingFilter] with [Filters.InstantSorceryOrAdventure] —
+ * the "and/or" is one membership test, not three counts, so a card that is both an instant and has
+ * an Adventure is still counted once. It only ever eats generic mana, so the {R} always survives
+ * and the mana value stays 6 no matter what was paid.
+ *
+ * Crucially the reduction does **not** apply to the Adventure half: per CR 715.3 a spell cast as an
+ * Adventure has only the Adventure's characteristics, so the creature face's static ability isn't
+ * there to reduce it. Stoke Genius always costs {1}{R}. The engine gets this right for free —
+ * secondary faces price through `calculateEffectiveCostWithAlternativeBase`, which deliberately
+ * skips `SelfCast` reductions.
+ *
+ * Stoke Genius is an ordered composite: discard the whole hand *first*, then draw two, so the drawn
+ * cards are never discarded. An empty hand discards nothing and still draws two.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val HearthElemental = card("Hearth Elemental") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "This spell costs {X} less to cast, where X is the number of cards in your " +
+        "graveyard that are instant cards, sorcery cards, and/or have an Adventure."
+    power = 4
+    toughness = 5
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = Filters.InstantSorceryOrAdventure,
+                    amountPerCard = 1,
+                )
+            ),
+        )
+    }
+
+    adventure("Stoke Genius") {
+        manaCost = "{1}{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Discard your hand, then draw two cards. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                Patterns.Hand.discardHand(),
+                Effects.DrawCards(2),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1783915092"
+
+        ruling(
+            "2023-09-01",
+            "When casting a spell as an Adventure, use the alternative characteristics and ignore " +
+                "all of the card's normal characteristics. The spell's color, mana cost, mana " +
+                "value, and so on are determined by only those alternative characteristics."
+        )
+        ruling(
+            "2023-09-01",
+            "An effect may refer to a card, spell, or permanent that \"has an Adventure.\" This " +
+                "refers to a card, spell, or permanent that has an adventurer card's set of " +
+                "alternative characteristics, even if they're not being used and even if that card " +
+                "was never cast as an Adventure."
+        )
+        ruling(
+            "2023-09-01",
+            "If a spell is cast as an Adventure, its controller exiles it instead of putting it " +
+                "into its owner's graveyard as it resolves. For as long as it remains exiled, that " +
+                "player may cast it as a permanent spell."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IceOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IceOut.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Ice Out
+ * {1}{U}{U}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * This spell costs {1} less to cast if it's bargained.
+ * Counter target spell.
+ *
+ * The **cost-gate** shape of bargain (CR 702.166), same as [JohannsStopgap] and [HamletGlutton]: a
+ * `SelfCast` [ModifySpellCost] with `ReduceGeneric(1)` gated by
+ * `CostGating.OnlyIf(`[Conditions.WasBargained]`)`. The bargained cast prices at {U}{U}; the plain
+ * cast still costs {1}{U}{U}. The reduction touches only the total cost paid — Ice Out's mana value
+ * stays 3 for anything that reads it.
+ *
+ * The counter half carries no bargain gate: bargain buys a discount here, not extra effect, so the
+ * spell resolves identically either way.
+ */
+val IceOut = card("Ice Out") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "This spell costs {1} less to cast if it's bargained.\n" +
+        "Counter target spell."
+
+    bargain()
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.WasBargained),
+        )
+    }
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Olivier Bernard"
+        flavorText = "Hylda built an ice statuary from all those who couldn't understand \"go away.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg?1783915120"
+
+        ruling(
+            "2023-09-01",
+            "Bargain represents an optional additional cost. A spell cast with that additional " +
+                "cost paid is \"bargained.\""
+        )
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PicnicRuiner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/PicnicRuiner.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Picnic Ruiner // Stolen Goodies
+ * {1}{R}
+ * Creature — Goblin Rogue
+ * 2/2
+ * Whenever this creature attacks while you control a creature with power 4 or greater, this
+ * creature gains double strike until end of turn.
+ *
+ * Adventure: Stolen Goodies — {3}{G}, Sorcery — Adventure
+ * Distribute three +1/+1 counters among any number of target creatures you control.
+ *
+ * "Attacks **while** you control …" is a trigger condition, not an intervening-if: it's checked
+ * only as attackers are declared, so per the ruling below the double strike still lands even if the
+ * big creature dies in response. `triggerCondition` is exactly that gate — evaluated at detection,
+ * not again at resolution.
+ *
+ * Stolen Goodies is the divide-as-you-choose shape (CR 601.2d): the split is locked in as the spell
+ * is cast, and every chosen target must receive at least one counter — so "any number" tops out at
+ * three targets, which is what `count = 3` expresses. `minCount = 0` carries the other half of the
+ * ruling: the spell is legal with **no** targets at all, and still exiles itself so Picnic Ruiner
+ * can be cast from exile later. Counters aimed at a target that has since become illegal are simply
+ * lost; the rest of the distribution still applies.
+ *
+ * The executor splits evenly and hands the remainder to the first chosen target. For a total of
+ * three that reproduces *every* legal division — [3] on one target, [2,1] on two (ordered by which
+ * was chosen first), [1,1,1] on three — so no explicit allocation step is needed here.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val PicnicRuiner = card("Picnic Ruiner") {
+    manaCost = "{1}{R}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Goblin Rogue"
+    oracleText = "Whenever this creature attacks while you control a creature with power 4 or " +
+        "greater, this creature gains double strike until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self)
+    }
+
+    adventure("Stolen Goodies") {
+        manaCost = "{3}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Distribute three +1/+1 counters among any number of target creatures you " +
+            "control. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            target(
+                "any number of target creatures you control",
+                TargetCreature(
+                    count = 3,
+                    minCount = 0,
+                    filter = TargetFilter.CreatureYouControl,
+                ),
+            )
+            effect = Effects.DistributeCountersAmongTargets(totalCounters = 3)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "232"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1783915064"
+
+        ruling(
+            "2023-09-01",
+            "If you controlled a creature with power 4 or greater when you declared Picnic Ruiner " +
+                "as an attacker, it doesn't matter whether you still control one as its ability " +
+                "resolves. Picnic Ruiner will still gain double strike until end of turn."
+        )
+        ruling(
+            "2023-09-01",
+            "You choose how the counters will be distributed as you cast Stolen Goodies. Each " +
+                "target must receive at least one +1/+1 counter."
+        )
+        ruling(
+            "2023-09-01",
+            "If some of the creatures are illegal targets as Stolen Goodies tries to resolve, the " +
+                "original distribution of counters still applies and the counters that would have " +
+                "been put on illegal targets are lost."
+        )
+        ruling(
+            "2023-09-01",
+            "You can cast Stolen Goodies with no targets. If you do, you won't distribute any " +
+                "counters, but you'll still exile it as it resolves, and you'll still be able to " +
+                "cast Picnic Ruiner later."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TorchTheTower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TorchTheTower.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+
+/**
+ * Torch the Tower
+ * {R}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Torch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained,
+ * instead it deals 3 damage to that permanent and you scry 1.
+ * If a permanent dealt damage by Torch the Tower would die this turn, exile it instead.
+ *
+ * The spell-rider shape of bargain (CR 702.166c): the fact is read off the spell while it is still
+ * on the stack, so the payoff is gated on [Conditions.WasBargained] at resolution.
+ *
+ * "Instead" here swaps the whole damage clause, so this is a true either/or branch
+ * ([ConditionalEffect] with an `elseEffect`) rather than a base effect plus a rider — the bargained
+ * branch deals 3, not 2 + 1, which matters for damage-replacement effects that scale off the amount.
+ * The scry rides along on the bargained branch only.
+ *
+ * [MarkExileOnDeathEffect] carries the last clause. Per the WOE ruling, that replacement exiles the
+ * target if it would die this turn **for any reason**, not just from this damage — which is exactly
+ * what the marker does — so it applies unconditionally alongside either damage branch.
+ */
+val TorchTheTower = card("Torch the Tower") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Torch the Tower deals 2 damage to target creature or planeswalker. If this spell was " +
+        "bargained, instead it deals 3 damage to that permanent and you scry 1.\n" +
+        "If a permanent dealt damage by Torch the Tower would die this turn, exile it instead."
+
+    bargain()
+
+    spell {
+        val permanent = target("target creature or planeswalker", TargetCreatureOrPlaneswalker())
+        effect = Effects.Composite(
+            ConditionalEffect(
+                condition = Conditions.WasBargained,
+                effect = Effects.Composite(
+                    Effects.DealDamage(3, permanent),
+                    Effects.Scry(1),
+                ),
+                elseEffect = Effects.DealDamage(2, permanent),
+            ),
+            MarkExileOnDeathEffect(permanent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg?1783915088"
+
+        ruling(
+            "2023-09-01",
+            "Torch the Tower's last replacement effect will exile the target permanent if it would " +
+                "die this turn for any reason, not just due to lethal damage or having 0 loyalty."
+        )
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1311,6 +1311,166 @@
     ]
 }
 
+// Brave the Wilds
+{
+    "name": "Brave the Wilds",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nIf this spell was bargained, target land you control becomes a 3/3 Elemental creature with haste that's still a land.\nSearch your library for a basic land card, reveal it, put it into your hand, then shuffle.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        },
+        "kickerTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                },
+                "id": "target land you control"
+            }
+        ],
+        "kickerSpellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land you control"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "keywords": [
+                        "HASTE"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ],
+                    "duration": "Permanent"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Lucas Graciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/821b9e86-d108-42e5-b642-c5e07ab16c37.jpg?1783915084",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you bargained Brave the Wilds and the target land is an illegal target by the time it tries to resolve, the spell won't resolve. You won't search for a basic land card, and you won't shuffle."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Some instant and sorcery spells require additional targets if they're bargained. You ignore those targeting requirements if those spells aren't bargained, and you can't bargain those spells unless you can choose the appropriate targets."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Break the Spell
 {
     "name": "Break the Spell",
@@ -4501,6 +4661,112 @@
     ]
 }
 
+// Hearth Elemental
+{
+    "name": "Hearth Elemental",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsInstant",
+                                        "IsSorcery",
+                                        "HasAdventure"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8f5f102-cc75-4cee-a117-4bdaaf86c2e9.jpg?1783915092",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "When casting a spell as an Adventure, use the alternative characteristics and ignore all of the card's normal characteristics. The spell's color, mana cost, mana value, and so on are determined by only those alternative characteristics."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "An effect may refer to a card, spell, or permanent that \"has an Adventure.\" This refers to a card, spell, or permanent that has an adventurer card's set of alternative characteristics, even if they're not being used and even if that card was never cast as an Adventure."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it as a permanent spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Stoke Genius",
+            "manaCost": "{1}{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Discard your hand, then draw two cards. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "discardedHand"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discardedHand",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // High Fae Negotiator
 {
     "name": "High Fae Negotiator",
@@ -4904,6 +5170,84 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Ice Out
+{
+    "name": "Ice Out",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nThis spell costs {1} less to cast if it's bargained.\nCounter target spell.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "CastChoiceMade",
+                        "slot": "BARGAINED"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Olivier Bernard",
+        "flavorText": "Hylda built an ice statuary from all those who couldn't understand \"go away.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88ffafda-c852-497a-8156-4f759cdf3693.jpg?1783915120",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Bargain represents an optional additional cost. A spell cast with that additional cost paid is \"bargained.\""
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -7212,6 +7556,91 @@
                         }
                     ]
                 }
+            }
+        }
+    ]
+}
+
+// Picnic Ruiner
+{
+    "name": "Picnic Ruiner",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "Whenever this creature attacks while you control a creature with power 4 or greater, this creature gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "UNCOMMON",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66485c3e-3b21-4db4-ac12-af04e35b49b1.jpg?1783915064",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you controlled a creature with power 4 or greater when you declared Picnic Ruiner as an attacker, it doesn't matter whether you still control one as its ability resolves. Picnic Ruiner will still gain double strike until end of turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You choose how the counters will be distributed as you cast Stolen Goodies. Each target must receive at least one +1/+1 counter."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If some of the creatures are illegal targets as Stolen Goodies tries to resolve, the original distribution of counters still applies and the counters that would have been put on illegal targets are lost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You can cast Stolen Goodies with no targets. If you do, you won't distribute any counters, but you'll still exile it as it resolves, and you'll still be able to cast Picnic Ruiner later."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Stolen Goodies",
+            "manaCost": "{3}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Distribute three +1/+1 counters among any number of target creatures you control. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "DistributeCountersAmongTargets",
+                    "totalCounters": 3
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 3,
+                        "minCount": 0,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "any number of target creatures you control"
+                    }
+                ]
             }
         }
     ]
@@ -11545,6 +11974,115 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Torch the Tower
+{
+    "name": "Torch the Tower",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "BARGAINED"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature or planeswalker"
+                                }
+                            },
+                            {
+                                "type": "Scry",
+                                "count": 1
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature or planeswalker"
+                        }
+                    }
+                },
+                {
+                    "type": "MarkExileOnDeath",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3d6027c-813f-46df-95b4-e2e305a67620.jpg?1783915088",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Torch the Tower's last replacement effect will exile the target permanent if it would die this turn for any reason, not just due to lethal damage or having 0 loyalty."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Implements five more Wilds of Eldraine cards. WOE goes from 181/266 to 186/266 (70%).

All five build on existing SDK primitives — no engine or SDK changes, so the only non-card file touched is the re-blessed WOE card snapshot (additions only).

## Cards

**Torch the Tower** — {R} Instant, common (#153)
Bargain. 2 damage to target creature or planeswalker; bargained it deals 3 instead and you scry 1. `ConditionalEffect` with an `elseEffect`, since "instead" swaps the whole damage clause rather than adding to it. The last line rides `MarkExileOnDeathEffect` unconditionally — per the WOE ruling it exiles the target if it would die this turn *for any reason*, not just from this damage.

**Ice Out** — {1}{U}{U} Instant, common (#54)
Bargain, `{1}` cheaper when bargained, counter target spell. The cost-gate shape: `ModifySpellCost(SelfCast, ReduceGeneric(1), CostGating.OnlyIf(Conditions.WasBargained))`, same as Johann's Stopgap. Mana value stays 3.

**Brave the Wilds** — {G} Sorcery, common (#165)
The bargain-only-target shape (CR 702.166d): the land target exists only on the bargained branch, so an unbargained cast has no targets at all and a bargained one can't be cast without a land to point at. Modelled with the shared optional-additional-cost rail's `kickerTarget` / `kickerEffect` slots. The animation is `Duration.Permanent` — no duration is printed on the card. Because the branch replaces the whole effect, the bargained branch restates the basic-land search, which matches the ruling that an illegal land target counters the entire spell (no search, no shuffle).

**Hearth Elemental // Stoke Genius** — {5}{R} Creature — Elemental 4/5, uncommon (#136)
Self-cast reduction over `CardsInGraveyardMatchingFilter(InstantSorceryOrAdventure)` — the "and/or" is one membership test, so a card that is both an instant and has an Adventure counts once. Notably the reduction does **not** apply to the Adventure half (CR 715.3): secondary faces price through `calculateEffectiveCostWithAlternativeBase`, which deliberately skips `SelfCast` reductions, so Stoke Genius always costs {1}{R}.

**Picnic Ruiner // Stolen Goodies** — {1}{R} Creature — Goblin Rogue 2/2, uncommon (#232)
"Attacks **while** you control …" is a `triggerCondition`, not an intervening-if — checked only as attackers are declared, so the double strike survives the big creature dying in response (confirmed by ruling). Stolen Goodies distributes three +1/+1 counters with `count = 3, minCount = 0`: three is the real ceiling because each target needs at least one counter, and zero targets is explicitly legal (the card still exiles itself so the creature can be cast later). The executor's even-split-remainder-to-first rule reproduces every legal division of three, so no separate allocation step is needed.

## Verification

- `just build` green (compile + all module tests).
- `just check-card-printing` clean for all five — each is canonical in WOE, its earliest real printing.
- Every field re-checked against Scryfall: mana cost, type line, P/T, rarity, collector number, artist, color identity, flavor text, and image URI (all four `image_uris.normal` verified HTTP 200).
- WOE card snapshot re-blessed; the diff is 538 lines, all additions, only these five cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)