### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/backlog/cube-draft-format.md
+++ b/backlog/cube-draft-format.md
@@ -334,11 +334,11 @@ printing, per the reprint rule (`just check-card-printing "<Card>"`).
       Shang-Chi, Master of Kung Fu · M.O.D.O.K. *(legendary creatures; M.O.D.O.K. is an artifact creature)*
 - [ ] Jennifer Walters // The Sensational She-Hulk *(transforming DFC, mythic)*
 
-**DFT — Aetherdrift (11)**
-- [ ] Guidelight Optimizer · Nesting Bot · Marketback Walker *(artifact creatures)*
-- [ ] Howlsquad Heavy · Marauding Mako · Webstrike Elite *(creatures)*
-- [ ] Lumbering Worldwagon · Monument to Endurance · Perilous Snare · Repurposing Bay *(artifacts)*
-- [ ] Momentum Breaker *(enchantment)*
+**DFT — Aetherdrift (3)**
+- [x] Guidelight Optimizer · Nesting Bot · Marketback Walker *(artifact creatures)*
+- [ ] Howlsquad Heavy · Webstrike Elite *(creatures — Marauding Mako done)*
+- [ ] Monument to Endurance *(artifact — Lumbering Worldwagon, Perilous Snare, Repurposing Bay done)*
+- [x] Momentum Breaker *(enchantment)*
 
 **SPM — Marvel's Spider-Man (6)**
 - [ ] Arachne, Psionic Weaver · Carnage, Crimson Chaos *(legendary creatures)*

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LumberingWorldwagon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LumberingWorldwagon.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Lumbering Worldwagon
+ * {2}{G}
+ * Artifact — Vehicle
+ * * /4
+ * This Vehicle's power is equal to the number of lands you control.
+ * Whenever this Vehicle enters or attacks, you may search your library for a basic land card,
+ * put it onto the battlefield tapped, then shuffle.
+ * Crew 4
+ *
+ * Only power is dynamic (printed toughness stays 4), so the single-stat `dynamicPower(...)`
+ * helper applies the Layer 7b characteristic-defining ability the way Kraven, Proud Predator
+ * does — `DynamicAmounts.landsYouControl()` is the same aggregate Molimo uses for both stats.
+ *
+ * "Enters or attacks" is the repo's established two-ability idiom (Sentinel of the Nameless
+ * City, Queen's Bay Paladin, Visage of Dread): there is no single enters-or-attacks
+ * `TriggerSpec`, so [Triggers.EntersBattlefield] and [Triggers.Attacks] share one
+ * [MayEffect]-wrapped search. The "you may" is a decline of the whole search (Quirion
+ * Trailblazer), not a failure-to-find, so it wraps the pattern rather than living inside it.
+ */
+val LumberingWorldwagon = card("Lumbering Worldwagon") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Vehicle"
+    toughness = 4
+    oracleText = "This Vehicle's power is equal to the number of lands you control.\n" +
+        "Whenever this Vehicle enters or attacks, you may search your library for a basic land card, " +
+        "put it onto the battlefield tapped, then shuffle.\n" +
+        "Crew 4"
+
+    dynamicPower(DynamicAmounts.landsYouControl())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+                entersTapped = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayEffect(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand,
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD,
+                entersTapped = true
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(4))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "168"
+        artist = "Raph Lomotan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg?1783907870"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MomentumBreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MomentumBreaker.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Momentum Breaker
+ * {1}{B}
+ * Enchantment
+ * Start your engines!
+ * When this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice.
+ * Each opponent who can't discards a card.
+ * {2}, Sacrifice this enchantment: You gain life equal to your speed.
+ *
+ * The "each opponent … / each opponent who can't …" split is Entropic Battlecruiser's idiom: one
+ * [ForEachPlayerEffect] over [Player.EachOpponent] whose body is a [ConditionalEffect] evaluated
+ * per iterated opponent. Inside the loop the controller is rebound to that opponent, so
+ * `Exists(Player.You, Zone.BATTLEFIELD, CreatureOrVehicle)` asks "does *this* opponent control a
+ * creature or Vehicle" and [EffectTarget.Controller] is that opponent. Modelling it as one
+ * conditional rather than a sacrifice followed by a "did anything die" check keeps the per-player
+ * evaluation right in a multiplayer game, where opponents differ.
+ *
+ * A player who controls a creature or Vehicle has to sacrifice one — the sacrifice is mandatory and
+ * only the choice of which is theirs — so an opponent with a board never gets the discard branch.
+ *
+ * The speed payoff is a plain [DynamicAmount.Speed] over [Player.You]; a player with no speed reads
+ * as 0 (CR 702.179f), so it needs no "has speed" guard.
+ */
+val MomentumBreaker = card("Momentum Breaker") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "When this enchantment enters, each opponent sacrifices a creature or Vehicle of their " +
+        "choice. Each opponent who can't discards a card.\n" +
+        "{2}, Sacrifice this enchantment: You gain life equal to your speed."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                ConditionalEffect(
+                    condition = Exists(
+                        player = Player.You,
+                        zone = Zone.BATTLEFIELD,
+                        filter = GameObjectFilter.CreatureOrVehicle
+                    ),
+                    effect = Effects.Sacrifice(
+                        GameObjectFilter.CreatureOrVehicle,
+                        target = EffectTarget.Controller
+                    ),
+                    elseEffect = Patterns.Hand.discardCards(1, EffectTarget.Controller)
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.GainLife(DynamicAmount.Speed(Player.You))
+        description = "{2}, Sacrifice this enchantment: You gain life equal to your speed."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg?1783907891"
+        ruling(
+            "2025-02-07",
+            "If an effect needs to know what a player's speed is and that player doesn't have a speed, their speed is considered 0."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RepurposingBay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RepurposingBay.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Repurposing Bay
+ * {2}{U}
+ * Artifact
+ * {2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value
+ * equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then
+ * shuffle. Activate only as a sorcery.
+ *
+ * Cost-linked mana value, so this is the Sidisi, Regent of the Mire chain rather than
+ * [com.wingedsheep.sdk.dsl.Patterns.Library.searchLibrary] — that facade takes a static
+ * [GameObjectFilter], and there is no "mana value equals <computed>" card predicate. Target
+ * validation also runs before cost payment, so the sacrificed artifact's mana value simply isn't
+ * knowable at activation time; it has to be read at resolution.
+ *
+ * The chain mirrors what `searchLibrary(... destination = BATTLEFIELD)` expands to, with the
+ * dynamic filter spliced in after the gather:
+ *   1. gather every artifact card in your library,
+ *   2. keep those whose mana value equals the sacrificed artifact's MV + 1 — read from the cost's
+ *      sacrificed permanent via `EntityReference.Sacrificed(0)` (CR 112.7a / 608.2h; an {X} in the
+ *      sacrificed artifact's cost counts as 0, per the 2025-02-07 ruling),
+ *   3. choose up to one — `ChooseUpTo`, because searching never requires finding (CR 701.23b),
+ *   4. put it onto the battlefield, shuffle, then emit the search event so
+ *      "whenever a player searches their library" triggers see it.
+ */
+val RepurposingBay = card("Repurposing Bay") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card " +
+        "with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto " +
+        "the battlefield, then shuffle. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Artifact),
+                    storeAs = "libraryArtifacts"
+                ),
+                FilterCollectionEffect(
+                    from = "libraryArtifacts",
+                    filter = CollectionFilter.ManaValueEquals(
+                        DynamicAmount.Add(
+                            DynamicAmount.EntityProperty(
+                                EntityReference.Sacrificed(0),
+                                EntityNumericProperty.ManaValue
+                            ),
+                            DynamicAmount.Fixed(1)
+                        )
+                    ),
+                    storeMatching = "candidates"
+                ),
+                SelectFromCollectionEffect(
+                    from = "candidates",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "found"
+                ),
+                MoveCollectionEffect(
+                    from = "found",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                ),
+                ShuffleLibraryEffect(),
+                EmitLibrarySearchedEventEffect
+            )
+        )
+        description = "{2}, {T}, Sacrifice another artifact: Search your library for an artifact " +
+            "card with mana value equal to 1 plus the sacrificed artifact's mana value, put that " +
+            "card onto the battlefield, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "William Tempest"
+        flavorText = "By the end of the race, few of the Aether Rangers' vehicles resembled what they started as."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg?1783907906"
+        ruling(
+            "2025-02-07",
+            "If there's an {X} in the sacrificed artifact's mana cost, X is 0 when determining its mana value."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RocketeerBoostbuggy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RocketeerBoostbuggy.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rocketeer Boostbuggy
+ * {R}{G}
+ * Artifact — Vehicle
+ * 3/2
+ * Whenever this Vehicle attacks, create a Treasure token.
+ * Exhaust — {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.
+ * (Activate each exhaust ability only once.)
+ * Crew 1
+ *
+ * The exhaust ability animates the Vehicle **permanently** — there is no "until end of turn"
+ * clause — so it takes `Duration.Permanent` with the printed 3/2 as the base P/T, exactly as
+ * Marshals' Pathcruiser does; the +1/+1 counter then layers on top in 7d.
+ */
+val RocketeerBoostbuggy = card("Rocketeer Boostbuggy") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this Vehicle attacks, create a Treasure token. (It's an artifact with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")\n" +
+        "Exhaust — {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. " +
+        "(Activate each exhaust ability only once.)\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateTreasure(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 3,
+                toughness = 2,
+                duration = Duration.Permanent
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "Exhaust — {3}: This Vehicle becomes an artifact creature. " +
+            "Put a +1/+1 counter on it."
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg?1783907853"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThunderousVelocipede.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ThunderousVelocipede.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Thunderous Velocipede
+ * {1}{G}{G}
+ * Artifact — Vehicle
+ * 5/5
+ * Trample
+ * Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its
+ * mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.
+ * Crew 3
+ *
+ * The "if … otherwise …" split is two [EntersWithCounters] replacements whose `appliesTo` filters
+ * partition the affected set by mana value — `manaValueAtMost(4)` → 1 counter, `manaValueAtLeast(5)`
+ * → 3 counters. `EntersWithCounters.condition` is a *global* condition (Llanowar Elite's kicked
+ * check), not one that can read the entering permanent, so the mana-value test has to live in the
+ * filter, which the engine evaluates against the entering entity in `matchesEnterFilter`.
+ *
+ * `otherOnly = true` on both is the "each **other**" clause (Gev, Scaled Scorch / Metallic Mimic):
+ * the Velocipede's own entry path skips them, so it never counters itself.
+ *
+ * Tokens and other permanents with no mana cost have mana value 0, so they land in the
+ * `manaValueAtMost(4)` bucket and enter with one additional counter — correct per CR 202.3b.
+ */
+val ThunderousVelocipede = card("Thunderous Velocipede") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Trample\n" +
+        "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it " +
+        "if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters " +
+        "on it.\n" +
+        "Crew 3"
+
+    keywords(Keyword.TRAMPLE)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 1,
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.CreatureOrVehicle.youControl().manaValueAtMost(4),
+                to = Zone.BATTLEFIELD
+            )
+        )
+    )
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 3,
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.CreatureOrVehicle.youControl().manaValueAtLeast(5),
+                to = Zone.BATTLEFIELD
+            )
+        )
+    )
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "183"
+        artist = "Adrián Rodríguez Pérez"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg?1783907865"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -6132,6 +6132,141 @@
     ]
 }
 
+// Lumbering Worldwagon
+{
+    "name": "Lumbering Worldwagon",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "This Vehicle's power is equal to the number of lands you control.\nWhenever this Vehicle enters or attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nCrew 4",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            }
+        },
+        "toughness": 4
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "RARE",
+        "artist": "Raph Lomotan",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f989c59-7b2a-4036-9ea2-cd0c7e85c15b.jpg?1783907870"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Magmakin Artillerist
 {
     "name": "Magmakin Artillerist",
@@ -6776,6 +6911,125 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Momentum Breaker
+{
+    "name": "Momentum Breaker",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice. Each opponent who can't discards a card.\n{2}, Sacrifice this enchantment: You gain life equal to your speed.",
+    "keywords": [
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "Exists",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": "creature|Vehicle"
+                            }
+                        },
+                        "then": {
+                            "type": "ForceSacrifice",
+                            "filter": "creature|Vehicle",
+                            "target": "Controller"
+                        },
+                        "otherwise": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": "Speed"
+                },
+                "descriptionOverride": "{2}, Sacrifice this enchantment: You gain life equal to your speed."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38513b53-384f-45e7-9905-80dd2c3c4918.jpg?1783907891",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an effect needs to know what a player's speed is and that player doesn't have a speed, their speed is considered 0."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -8231,6 +8485,116 @@
     ]
 }
 
+// Repurposing Bay
+{
+    "name": "Repurposing Bay",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact"
+                            },
+                            "storeAs": "libraryArtifacts"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "libraryArtifacts",
+                            "filter": {
+                                "type": "ManaValueEquals",
+                                "value": {
+                                    "type": "Add",
+                                    "left": {
+                                        "type": "EntityProperty",
+                                        "entity": "Sacrificed",
+                                        "numericProperty": "ManaValue"
+                                    },
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "storeMatching": "candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{2}, {T}, Sacrifice another artifact: Search your library for an artifact card with mana value equal to 1 plus the sacrificed artifact's mana value, put that card onto the battlefield, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "William Tempest",
+        "flavorText": "By the end of the race, few of the Aether Rangers' vehicles resembled what they started as.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cf1ace1-b7f5-4bd9-a494-ee7cb6c1f854.jpg?1783907906",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If there's an {X} in the sacrificed artifact's mana cost, X is 0 when determining its mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ride's End
 {
     "name": "Ride's End",
@@ -8729,6 +9093,100 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Rocketeer Boostbuggy
+{
+    "name": "Rocketeer Boostbuggy",
+    "manaCost": "{R}{G}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever this Vehicle attacks, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nExhaust — {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {3}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c80c91e-dd3d-4c7b-89e4-bfb253eeaee2.jpg?1783907853",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 
@@ -10574,6 +11032,62 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "GREEN"
+    ]
+}
+
+// Thunderous Velocipede
+{
+    "name": "Thunderous Velocipede",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "otherOnly": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature|Vehicle mv<=4 ctrl:you",
+                    "to": "Battlefield"
+                }
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 3,
+                "otherOnly": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature|Vehicle mv>=5 ctrl:you",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "MYTHIC",
+        "artist": "Adrián Rodríguez Pérez",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98a79557-8ed6-4d9a-b4e1-cece05664984.jpg?1783907865"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftGearworksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftGearworksScenarioTest.kt
@@ -1,0 +1,442 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Five Aetherdrift cards whose behaviour the card snapshot can't prove, because each one leans on
+ * an engine path rather than on the shape of its own script:
+ *
+ * | Card | Under test |
+ * |---|---|
+ * | Thunderous Velocipede | two `EntersWithCounters` replacements partitioned by the *entering* permanent's mana value |
+ * | Repurposing Bay | a library search whose mana-value filter is read from the artifact sacrificed to pay the cost |
+ * | Momentum Breaker | "each opponent sacrifices … each opponent who can't discards" evaluated per opponent |
+ * | Rocketeer Boostbuggy | an exhaust ability that animates a Vehicle permanently, and refuses a second activation |
+ * | Lumbering Worldwagon | a characteristic-defining power that tracks lands, plus its enters/attacks search |
+ */
+class AetherdriftGearworksScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Thunderous Velocipede") {
+
+            test("a cheap creature enters with one extra counter, an expensive one with three") {
+                val game = velocipedeGame(handCards = listOf("Grizzly Bears", "Craw Wurm"))
+
+                game.castAndResolve(1, "Grizzly Bears")
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Grizzly Bears is mana value 2, so the 'four or less' clause applies") {
+                    game.plusCounters(bears) shouldBe 1
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+
+                game.castAndResolve(1, "Craw Wurm")
+                val wurm = game.findPermanent("Craw Wurm")!!
+                withClue("Craw Wurm is mana value 6, so the 'otherwise' clause gives three") {
+                    game.plusCounters(wurm) shouldBe 3
+                    game.state.projectedState.getPower(wurm) shouldBe 9
+                    game.state.projectedState.getToughness(wurm) shouldBe 7
+                }
+            }
+
+            test("a Vehicle counts too, and the Velocipede never counters itself") {
+                val game = velocipedeGame(handCards = listOf("Rover Blades"))
+
+                val velocipede = game.findPermanent("Thunderous Velocipede")!!
+                withClue("'Each *other* …' — the Velocipede's own entry skipped both replacements") {
+                    game.plusCounters(velocipede) shouldBe 0
+                }
+
+                game.castAndResolve(1, "Rover Blades")
+                val blades = game.findPermanent("Rover Blades")!!
+                withClue("Rover Blades is a mana value 3 Vehicle, not a creature — still one counter") {
+                    game.plusCounters(blades) shouldBe 1
+                }
+            }
+
+            test("an opponent's creature is untouched") {
+                val game = velocipedeGame(
+                    handCards = emptyList(),
+                    opponentHand = listOf("Grizzly Bears"),
+                    activePlayer = 2
+                )
+
+                game.castAndResolve(2, "Grizzly Bears")
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("The replacement is scoped to creatures and Vehicles *you* control") {
+                    game.plusCounters(bears) shouldBe 0
+                }
+            }
+        }
+
+        context("Repurposing Bay") {
+
+            test("the search is filtered to one plus the sacrificed artifact's mana value") {
+                val game = bayGame()
+                val bauble = game.findPermanent("Grim Bauble")!!
+
+                game.activateBay()
+                val sacrifice = game.getPendingDecision() as SelectCardsDecision
+                withClue("The cost sacrifices another artifact — the Bay itself isn't offered") {
+                    sacrifice.options.map { game.cardName(it) }.toSet() shouldBe
+                        setOf("Grim Bauble", "Aetherjacket")
+                }
+                game.selectCards(listOf(bauble))
+                game.settle()
+
+                val search = game.getPendingDecision() as SelectCardsDecision
+                withClue("Grim Bauble is mana value 1, so only a mana value 2 artifact qualifies") {
+                    search.options.map { game.cardName(it) } shouldBe listOf("Burner Rocket")
+                }
+                withClue("Searching never requires finding (CR 701.23b)") {
+                    search.minSelections shouldBe 0
+                }
+
+                game.selectCards(search.options.take(1))
+                game.settle()
+
+                withClue("The found artifact arrives on the battlefield, the Bauble is in the yard") {
+                    game.isOnBattlefield("Burner Rocket") shouldBe true
+                    game.isInGraveyard(1, "Grim Bauble") shouldBe true
+                }
+            }
+
+            test("sacrificing a costlier artifact moves the window up") {
+                val game = bayGame()
+                val jacket = game.findPermanent("Aetherjacket")!!
+
+                game.activateBay()
+                game.selectCards(listOf(jacket))
+                game.settle()
+
+                val search = game.getPendingDecision() as SelectCardsDecision
+                withClue("Aetherjacket is mana value 3, so the window is mana value 4") {
+                    search.options.map { game.cardName(it) } shouldBe listOf("Racers' Scoreboard")
+                }
+            }
+        }
+
+        context("Momentum Breaker") {
+
+            test("an opponent with a board sacrifices rather than discards") {
+                val game = breakerGame(
+                    opponentBattlefield = listOf("Grizzly Bears"),
+                    opponentHand = listOf("Hill Giant", "Craw Wurm")
+                )
+
+                game.castAndResolve(1, "Momentum Breaker")
+                game.settle()
+
+                withClue("They control a creature, so the sacrifice branch runs") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Sacrificing means they never reach 'each opponent who can't'") {
+                    game.handSize(2) shouldBe 2
+                }
+            }
+
+            test("an opponent with an empty board discards instead") {
+                val game = breakerGame(
+                    opponentBattlefield = emptyList(),
+                    opponentHand = listOf("Hill Giant", "Craw Wurm")
+                )
+
+                game.castAndResolve(1, "Momentum Breaker")
+
+                val discard = game.getPendingDecision() as SelectCardsDecision
+                withClue("The discard is the opponent's own choice, from their own hand") {
+                    discard.playerId shouldBe game.player2Id
+                    discard.options.map { game.cardName(it) }.toSet() shouldBe
+                        setOf("Hill Giant", "Craw Wurm")
+                }
+                game.selectCards(discard.options.take(1))
+                game.settle()
+
+                withClue("No creature or Vehicle to give up — the fallback discard fires") {
+                    game.handSize(2) shouldBe 1
+                    game.graveyardSize(2) shouldBe 1
+                }
+            }
+
+            test("a Vehicle satisfies the sacrifice even though it isn't a creature") {
+                val game = breakerGame(
+                    opponentBattlefield = listOf("Burner Rocket"),
+                    opponentHand = listOf("Hill Giant")
+                )
+
+                game.castAndResolve(1, "Momentum Breaker")
+                game.settle()
+
+                withClue("'a creature or Vehicle' — an uncrewed Vehicle still counts") {
+                    game.isInGraveyard(2, "Burner Rocket") shouldBe true
+                    game.handSize(2) shouldBe 1
+                }
+            }
+
+            test("the sacrifice outlet pays out the controller's speed") {
+                val game = breakerGame(
+                    opponentBattlefield = listOf("Grizzly Bears"),
+                    opponentHand = emptyList()
+                )
+                game.castAndResolve(1, "Momentum Breaker")
+                game.settle()
+
+                withClue("Start your engines! set an unset speed to 1 (CR 702.179b)") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.activateBreakerOutlet()
+                game.settle()
+
+                withClue("You gain life equal to your speed — 1 at starting speed") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 1
+                }
+                withClue("The enchantment was sacrificed as a cost") {
+                    game.isInGraveyard(1, "Momentum Breaker") shouldBe true
+                }
+            }
+        }
+
+        context("Rocketeer Boostbuggy") {
+
+            test("the exhaust ability animates it for good, and only ever fires once") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Rocketeer Boostbuggy")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val buggy = game.findPermanent("Rocketeer Boostbuggy")!!
+                withClue("An uncrewed Vehicle is not a creature") {
+                    game.state.projectedState.isCreature(buggy) shouldBe false
+                }
+
+                game.activateExhaust("Rocketeer Boostbuggy", buggy)
+                game.settle()
+
+                withClue("No 'until end of turn' clause — the animation is permanent") {
+                    game.state.projectedState.isCreature(buggy) shouldBe true
+                }
+                withClue("3/2 plus the +1/+1 counter it put on itself") {
+                    game.plusCounters(buggy) shouldBe 1
+                    game.state.projectedState.getPower(buggy) shouldBe 4
+                    game.state.projectedState.getToughness(buggy) shouldBe 3
+                }
+
+                val second = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = buggy,
+                        abilityId = game.exhaustAbilityId("Rocketeer Boostbuggy")
+                    )
+                )
+                withClue("Exhaust — activate each exhaust ability only once") {
+                    (second.error != null) shouldBe true
+                }
+            }
+        }
+
+        context("Lumbering Worldwagon") {
+
+            test("its power tracks the lands you control and its enters trigger fetches a basic") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Lumbering Worldwagon")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                repeat(4) { builder.withCardInLibrary(1, "Forest") }
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castAndResolve(1, "Lumbering Worldwagon")
+                withClue("'You may search' asks first — the whole search can be declined") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.settle()
+
+                val search = game.getPendingDecision() as SelectCardsDecision
+                withClue("Only basic lands are offered") {
+                    search.options.map { game.cardName(it) }.toSet() shouldBe setOf("Forest")
+                }
+                game.selectCards(search.options.take(1))
+                game.settle()
+
+                val wagon = game.findPermanent("Lumbering Worldwagon")!!
+                withClue("Three Forests were out, the trigger fetched a fourth") {
+                    game.findAllPermanents("Forest").size shouldBe 4
+                }
+                withClue("Power is the land count; toughness stays the printed 4") {
+                    game.state.projectedState.getPower(wagon) shouldBe 4
+                    game.state.projectedState.getToughness(wagon) shouldBe 4
+                }
+            }
+        }
+    }
+
+    // ---- board setups -------------------------------------------------------------------------
+
+    /** Player 1's precombat main with the Velocipede already out and seven Forests for casting. */
+    private fun velocipedeGame(
+        handCards: List<String>,
+        opponentHand: List<String> = emptyList(),
+        activePlayer: Int = 1
+    ): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Thunderous Velocipede")
+            .withLandsOnBattlefield(1, "Forest", 10)
+            .withLandsOnBattlefield(2, "Forest", 10)
+        handCards.forEach { builder.withCardInHand(1, it) }
+        opponentHand.forEach { builder.withCardInHand(2, it) }
+        stockLibraries(builder)
+        return builder
+            .withActivePlayer(activePlayer)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    /**
+     * Repurposing Bay plus two sacrificeable artifacts of different mana values (Grim Bauble 1,
+     * Aetherjacket 3), and a library holding one artifact at each of mana value 2, 3 and 4 so the
+     * cost-linked filter has something to discriminate between.
+     */
+    private fun bayGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Repurposing Bay")
+            .withCardOnBattlefield(1, "Grim Bauble")
+            .withCardOnBattlefield(1, "Aetherjacket")
+            .withLandsOnBattlefield(1, "Island", 4)
+            .withCardInLibrary(1, "Burner Rocket")
+            .withCardInLibrary(1, "Rover Blades")
+            .withCardInLibrary(1, "Racers' Scoreboard")
+        repeat(6) { builder.withCardInLibrary(2, "Grizzly Bears") }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    /** Momentum Breaker in hand with the mana to cast it; the opponent's board and hand are set up. */
+    private fun breakerGame(
+        opponentBattlefield: List<String>,
+        opponentHand: List<String>
+    ): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Momentum Breaker")
+            .withLandsOnBattlefield(1, "Swamp", 4)
+        opponentBattlefield.forEach { builder.withCardOnBattlefield(2, it) }
+        opponentHand.forEach { builder.withCardInHand(2, it) }
+        stockLibraries(builder)
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    private fun stockLibraries(builder: ScenarioBuilder) {
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+
+    // ---- drivers ------------------------------------------------------------------------------
+
+    /** Cast [cardName] from [playerNumber]'s hand, auto-pay, and let it resolve. */
+    private fun TestGame.castAndResolve(playerNumber: Int, cardName: String) {
+        val cast = castSpell(playerNumber, cardName)
+        withClue("Casting $cardName failed: ${cast.error}") { cast.error shouldBe null }
+        settle()
+    }
+
+    private fun TestGame.activateBay() {
+        val abilityId = cardRegistry.getCard("Repurposing Bay")!!.script.activatedAbilities.single().id
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = findPermanent("Repurposing Bay")!!,
+                abilityId = abilityId
+            )
+        )
+        withClue("Activation failed: ${result.error}") { result.error shouldBe null }
+        settle()
+    }
+
+    private fun TestGame.exhaustAbilityId(cardName: String): AbilityId =
+        cardRegistry.getCard(cardName)!!.script.activatedAbilities.single { it.isExhaust }.id
+
+    private fun TestGame.activateExhaust(cardName: String, sourceId: EntityId) {
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = sourceId,
+                abilityId = exhaustAbilityId(cardName)
+            )
+        )
+        withClue("Activation failed: ${result.error}") { result.error shouldBe null }
+        settle()
+    }
+
+    private fun TestGame.activateBreakerOutlet() {
+        val abilityId = cardRegistry.getCard("Momentum Breaker")!!.script.activatedAbilities.single().id
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = findPermanent("Momentum Breaker")!!,
+                abilityId = abilityId
+            )
+        )
+        withClue("Activation failed: ${result.error}") { result.error shouldBe null }
+        settle()
+    }
+
+    /**
+     * Drain mana prompts and the stack until the game is idle or waiting on a decision the test
+     * itself has to answer. Auto-paying inline keeps the tests about the cards, not about mana.
+     */
+    private fun TestGame.settle() {
+        var guard = 0
+        while (guard++ < 30) {
+            if (getPendingDecision() is SelectManaSourcesDecision) {
+                submitManaSourcesAutoPay()
+                continue
+            }
+            if (hasPendingDecision()) return
+            if (state.stack.isEmpty()) return
+            resolveStack()
+        }
+    }
+
+    private fun TestGame.plusCounters(entityId: EntityId): Int {
+        val counters = state.getEntity(entityId)?.get<CountersComponent>() ?: return 0
+        return counters.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+    }
+
+    private fun TestGame.cardName(id: EntityId): String? =
+        state.getEntity(id)?.get<CardComponent>()?.name
+}


### PR DESCRIPTION
Implements five more Aetherdrift cards, taking DFT from 189/276 to 194/276. All five compose existing SDK primitives — no new engine vocabulary.

| Card | | |
|---|---|---|
| **Lumbering Worldwagon** | {2}{G} | Artifact — Vehicle */4, rare |
| **Rocketeer Boostbuggy** | {R}{G} | Artifact — Vehicle 3/2, uncommon |
| **Thunderous Velocipede** | {1}{G}{G} | Artifact — Vehicle 5/5, mythic |
| **Repurposing Bay** | {2}{U} | Artifact, rare |
| **Momentum Breaker** | {1}{B} | Enchantment, uncommon |

## Modelling notes

**Thunderous Velocipede** — "enters with an additional +1/+1 counter if its mana value is 4 or less, otherwise three" is two `EntersWithCounters` replacements whose `appliesTo` filters partition the affected set (`manaValueAtMost(4)` / `manaValueAtLeast(5)`). `EntersWithCounters.condition` is a *global* condition (Llanowar Elite's kicked check) and can't read the entering permanent, so the mana-value test lives in the filter — which `matchesEnterFilter` evaluates against the entering entity. Tokens read as mana value 0 and land in the ≤4 bucket, per CR 202.3b.

**Repurposing Bay** — the search filter depends on the mana value of the artifact sacrificed to pay the cost, and target validation runs before cost payment, so this is the Sidisi, Regent of the Mire resolution-time chain rather than `Patterns.Library.searchLibrary` (whose filter is static). Gather → `CollectionFilter.ManaValueEquals(Sacrificed(0).ManaValue + 1)` → `ChooseUpTo(1)` → battlefield → shuffle → emit the search event.

**Momentum Breaker** — "each opponent sacrifices … each opponent who can't discards" is Entropic Battlecruiser's idiom: one `ForEachPlayerEffect` over `EachOpponent` whose body is a `ConditionalEffect`. The controller is rebound per iteration, so the branch is decided separately for each opponent rather than once for the table.

**Lumbering Worldwagon** — "enters or attacks" is the repo's two-triggered-ability idiom (Sentinel of the Nameless City, Queen's Bay Paladin); there is no single enters-or-attacks `TriggerSpec`. Power is a `dynamicPower(DynamicAmounts.landsYouControl())` CDA with the printed toughness left at 4.

**Rocketeer Boostbuggy** — the exhaust ability has no "until end of turn" clause, so it animates with `Duration.Permanent` (Marshals' Pathcruiser).

## Tests

`AetherdriftGearworksScenarioTest` — 11 tests over the five behaviours the card snapshot can't prove: the mana-value partition (including a Vehicle, an opponent's creature, and the Velocipede not countering itself), the cost-linked search window at two different sacrifice costs, all three Momentum Breaker branches plus the speed payout, the exhaust animation and its once-only restriction, and the Worldwagon's land-tracking power.

`just test` passes. `just check-card-printing` confirms all five are canonical in their earliest real printing. Also refreshed the stale DFT block in `backlog/cube-draft-format.md` — six of its eleven entries were already implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)