### PR TITLE
Engine AI Phase 4: branching factor + decision budget

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
 import com.wingedsheep.ai.engine.evaluation.*
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.core.Step
@@ -33,13 +34,26 @@ class AIPlayer(
     private val simulator: GameSimulator,
     private val evaluator: BoardEvaluator,
     private val strategist: Strategist,
-    private val responder: DecisionResponder
+    private val responder: DecisionResponder,
+    /**
+     * Phase 4a. Skip enumeration entirely on priority windows that
+     * [MeaningfulActionFilter.canAutoPassWithoutEnumerating] can decide from the state alone.
+     */
+    private val useMeaningfulFilter: Boolean = false,
 ) {
     /**
      * Choose the best action from the current legal actions.
      * Returns the [GameAction] to submit to the [ActionProcessor].
+     *
+     * The fast path matters more than it looks. Phase 0 measured **76.2% of priority windows
+     * offering zero candidates** while still paying ~0.40 ms to enumerate and find that out —
+     * ~148 ms per game of pure waste, and a cost a rollout would pay again on every one of the
+     * ~20-30 windows it crosses.
      */
     fun chooseAction(state: GameState): GameAction {
+        if (useMeaningfulFilter && MeaningfulActionFilter.canAutoPassWithoutEnumerating(state, playerId)) {
+            return PassPriority(playerId)
+        }
         val legalActions = simulator.getLegalActions(state, playerId)
         return chooseFrom(state, legalActions).action
     }
@@ -163,7 +177,11 @@ class AIPlayer(
             val simulator = GameSimulator(cardRegistry)
             val evaluator = profile.evaluationWeights.toEvaluator()
             val combatAdvisor = CombatAdvisor(simulator, evaluator, cardRegistry, advisorRegistry)
-            val responder = DecisionResponder(simulator, evaluator, advisorRegistry = advisorRegistry)
+            val responder = DecisionResponder(
+                simulator, evaluator,
+                advisorRegistry = advisorRegistry,
+                budgetPolicy = profile.budgetPolicy,
+            )
 
             // Wire up the decision resolver so simulations can resolve non-trivial
             // decisions (modal spells, gift choices, etc.) instead of returning
@@ -176,8 +194,15 @@ class AIPlayer(
                 playerId = playerId,
                 simulator = simulator,
                 evaluator = evaluator,
-                strategist = Strategist(simulator, evaluator, combatAdvisor = combatAdvisor, advisorRegistry = advisorRegistry),
-                responder = responder
+                strategist = Strategist(
+                    simulator, evaluator,
+                    combatAdvisor = combatAdvisor,
+                    advisorRegistry = advisorRegistry,
+                    useMeaningfulFilter = profile.useMeaningfulFilter,
+                    budgetPolicy = profile.budgetPolicy,
+                ),
+                responder = responder,
+                useMeaningfulFilter = profile.useMeaningfulFilter,
             )
         }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -3,6 +3,9 @@ package com.wingedsheep.ai.engine
 import com.wingedsheep.ai.engine.advisor.CardAdvisorModule
 import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
 import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
+import com.wingedsheep.ai.engine.budget.BudgetPolicy
+import com.wingedsheep.ai.engine.budget.LegacyBudgetPolicy
+import com.wingedsheep.ai.engine.budget.TieredBudgetPolicy
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.ai.engine.evaluation.BoardPresence
 import com.wingedsheep.ai.engine.evaluation.CardAdvantage
@@ -77,6 +80,23 @@ data class AiProfile(
     val advisorModules: List<CardAdvisorModule> = emptyList(),
     /** Leaf-evaluation weights. See [EvaluationWeights]. */
     val evaluationWeights: EvaluationWeights = EvaluationWeights.DEFAULT,
+    /**
+     * Phase 4a: only propose actions the AI can actually take, and skip windows where it has
+     * none.
+     *
+     * Routes candidate generation and whole-window skipping through
+     * [com.wingedsheep.engine.legalactions.MeaningfulActionFilter] — the same rules the client's
+     * auto-pass uses — and fixes the Strategist's target filling to fill the slots it can instead
+     * of abandoning a spell whose *optional* slot happens to be empty. Off for [LEGACY_V0]:
+     * the second half is a plain bug fix, but the reference opponent has to stay frozen or every
+     * number published against it silently rebases.
+     */
+    val useMeaningfulFilter: Boolean = false,
+    /**
+     * Phase 4b. How much search one decision may spend. [LegacyBudgetPolicy] is today's
+     * constants with no global deadline.
+     */
+    val budgetPolicy: BudgetPolicy = LegacyBudgetPolicy,
 ) {
     companion object {
         /**
@@ -100,6 +120,16 @@ data class AiProfile(
         val PRODUCTION = AiProfile(
             id = "production",
             advisorModules = listOf(BloomburrowAdvisorModule(), OnslaughtAdvisorModule()),
+        )
+
+        /**
+         * Everything Phase 4 added, on top of [LEGACY_V0]: the meaningful-action filter and the
+         * four-tier decision budget at its nominal sizes. The arena agent `v0-phase4`.
+         */
+        val PHASE4 = AiProfile(
+            id = "v0-phase4",
+            useMeaningfulFilter = true,
+            budgetPolicy = TieredBudgetPolicy(),
         )
     }
 }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.ai.engine
 
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
+import com.wingedsheep.ai.engine.budget.DecisionBudget
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.core.DeclareBlockers
@@ -31,7 +32,13 @@ class CombatAdvisor(
     private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry()
 ) {
     companion object {
-        /** Max engine simulations for blocking local search. Keeps decision time bounded. */
+        /**
+         * Max engine simulations for blocking local search — now a **floor**, not a ceiling.
+         *
+         * `DecisionBudget` derives the real allowance from the tier, and combat declaration is
+         * always CRITICAL, so combat never gets less search than it did before Phase 4. This
+         * constant is what `SearchAllowances.LEGACY` and every sub-NORMAL tier resolve to.
+         */
         const val MAX_BLOCK_SIMULATIONS = 10
     }
 
@@ -68,7 +75,8 @@ class CombatAdvisor(
     fun chooseAttackers(
         state: GameState,
         legalAction: LegalAction,
-        playerId: EntityId
+        playerId: EntityId,
+        budget: DecisionBudget = DecisionBudget.legacy(),
     ): GameAction {
         val projected = state.projectedState
         val validAttackers = legalAction.validAttackers ?: emptyList()
@@ -211,9 +219,8 @@ class CombatAdvisor(
             other != playerId && projected.getBattlefieldControlledBy(other).any { projected.isCreature(it) }
         }
         if (state.step == Step.DECLARE_ATTACKERS && enemyControlsCreature) {
-            val deadline = System.currentTimeMillis() + 1000
             improveAttackViaLocalSearch(
-                state, playerId, opponentId, validAttackers, mandatory.toSet(), seedMap, deadline
+                state, playerId, opponentId, validAttackers, mandatory.toSet(), seedMap, budget
             )
         }
 
@@ -239,7 +246,8 @@ class CombatAdvisor(
         state: GameState,
         legalAction: LegalAction,
         playerId: EntityId,
-        useSimulation: Boolean = false
+        useSimulation: Boolean = false,
+        budget: DecisionBudget = DecisionBudget.legacy(),
     ): GameAction {
         val projected = state.projectedState
         val validBlockers = legalAction.validBlockers ?: emptyList()
@@ -280,7 +288,7 @@ class CombatAdvisor(
         val bestMap = if (useSimulation) {
             improveViaLocalSearch(
                 state, projected, playerId, attackers, validBlockers,
-                mandatoryBlockerIds, seedMap
+                mandatoryBlockerIds, seedMap, budget
             )
         } else {
             seedMap
@@ -400,7 +408,9 @@ class CombatAdvisor(
      * Each candidate is then validated via full engine simulation to catch triggers,
      * replacement effects, and keyword interactions that math alone would miss.
      *
-     * Caps at [MAX_BLOCK_SIMULATIONS] total simulations to keep decision time bounded.
+     * Caps at `budget.allowances.blockSimulations` total simulations to keep decision time
+     * bounded — [MAX_BLOCK_SIMULATIONS] is that allowance's floor, so blocking never searches
+     * less than it did before the budget existed.
      */
     private fun improveViaLocalSearch(
         state: GameState,
@@ -409,15 +419,17 @@ class CombatAdvisor(
         attackers: List<EntityId>,
         validBlockers: List<EntityId>,
         mandatoryBlockerIds: Set<EntityId>,
-        seedMap: MutableMap<EntityId, List<EntityId>>
+        seedMap: MutableMap<EntityId, List<EntityId>>,
+        budget: DecisionBudget,
     ): MutableMap<EntityId, List<EntityId>> {
         var currentPlan = seedMap.toMutableMap()
         var currentScore = evaluateBlockingPlan(state, playerId, currentPlan) ?: return currentPlan
-        var simulationsLeft = MAX_BLOCK_SIMULATIONS
+        var simulationsLeft = budget.allowances.blockSimulations
+        val deadline = budget.combatDeadlineNanos
 
         val maxIterations = 2
         for (iteration in 1..maxIterations) {
-            if (simulationsLeft <= 0) break
+            if (simulationsLeft <= 0 || System.nanoTime() > deadline) break
 
             val mutations = generateBlockMutations(
                 state, projected, attackers, validBlockers,
@@ -428,7 +440,7 @@ class CombatAdvisor(
             var bestScore = currentScore
 
             for (mutation in mutations) {
-                if (simulationsLeft <= 0) break
+                if (simulationsLeft <= 0 || System.nanoTime() > deadline) break
                 simulationsLeft--
                 val score = evaluateBlockingPlan(state, playerId, mutation) ?: continue
                 if (score > bestScore) {
@@ -1051,8 +1063,9 @@ class CombatAdvisor(
         validAttackers: List<EntityId>,
         mandatoryAttackers: Set<EntityId>,
         attackerMap: MutableMap<EntityId, EntityId>,
-        deadline: Long
+        budget: DecisionBudget,
     ) {
+        val deadline = budget.combatDeadlineNanos
         // Baseline: use current board evaluation. Attack plans must beat this.
         val noAttackScore = evaluateAttackPlan(state, playerId, opponentId, emptyMap())
             ?: evaluator.evaluate(state, state.projectedState, playerId)
@@ -1068,15 +1081,15 @@ class CombatAdvisor(
             currentScore = noAttackScore
         }
 
-        val maxIterations = 3
+        val maxIterations = budget.allowances.attackSearchIterations
         for (iteration in 1..maxIterations) {
-            if (System.currentTimeMillis() > deadline) break
+            if (System.nanoTime() > deadline) break
             var bestMutation: Map<EntityId, EntityId>? = null
             var bestScore = currentScore
 
             // Mutation 1: Add each non-attacking creature
             for (attacker in validAttackers) {
-                if (System.currentTimeMillis() > deadline) break
+                if (System.nanoTime() > deadline) break
                 if (attacker in attackerMap) continue
                 val mutation = attackerMap.toMutableMap()
                 mutation[attacker] = opponentId
@@ -1089,7 +1102,7 @@ class CombatAdvisor(
 
             // Mutation 2: Remove each non-mandatory attacker
             for (attacker in attackerMap.keys.toList()) {
-                if (System.currentTimeMillis() > deadline) break
+                if (System.nanoTime() > deadline) break
                 if (attacker in mandatoryAttackers) continue
                 val mutation = attackerMap.toMutableMap()
                 mutation.remove(attacker)

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -2,6 +2,9 @@ package com.wingedsheep.ai.engine
 
 import com.wingedsheep.ai.engine.advisor.AdvisorDecisionContext
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
+import com.wingedsheep.ai.engine.budget.BudgetPolicy
+import com.wingedsheep.ai.engine.budget.DecisionBudget
+import com.wingedsheep.ai.engine.budget.LegacyBudgetPolicy
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.ai.engine.evaluation.BoardPresence
 import com.wingedsheep.engine.core.*
@@ -21,11 +24,19 @@ import com.wingedsheep.sdk.model.EntityId
  * simulates each option. For larger spaces, it uses MTG-aware heuristics.
  *
  * Card-specific overrides are checked first via [CardAdvisorRegistry].
+ *
+ * **On the decision budget:** every scan in here is already bounded to at most ~11 simulations by
+ * construction (a yes/no is 2, a colour is 5, a number is sampled to 11, targets are pre-ranked and
+ * truncated), which is at or below what even [com.wingedsheep.ai.engine.budget.BudgetTier.ROUTINE]
+ * allows. The one place a budget can genuinely bind is the target pre-rank cut, so that is the one
+ * place it is wired. Threading it through the other twenty responders would be plumbing that
+ * changes no number.
  */
 class DecisionResponder(
     private val simulator: GameSimulator,
     private val evaluator: BoardEvaluator,
-    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry()
+    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry(),
+    private val budgetPolicy: BudgetPolicy = LegacyBudgetPolicy,
 ) {
     fun respond(state: GameState, decision: PendingDecision, playerId: EntityId): DecisionResponse {
         // Try card-specific advisor first
@@ -48,7 +59,8 @@ class DecisionResponder(
 
         // Fall through to generic logic
         return when (decision) {
-            is ChooseTargetsDecision -> respondTargets(state, decision, playerId)
+            is ChooseTargetsDecision ->
+                respondTargets(state, decision, playerId, budgetPolicy.budgetForDecision(state, playerId))
             is SelectCardsDecision -> respondSelectCards(state, decision, playerId)
             is YesNoDecision -> respondYesNo(state, decision, playerId)
             is BatchYesNoDecision -> respondBatchYesNo(state, decision, playerId)
@@ -90,19 +102,20 @@ class DecisionResponder(
     private fun respondTargets(
         state: GameState,
         decision: ChooseTargetsDecision,
-        playerId: EntityId
+        playerId: EntityId,
+        budget: DecisionBudget,
     ): DecisionResponse {
+        val maxCandidates = budget.allowances.targetCandidates
         if (decision.targetRequirements.size == 1) {
             val req = decision.targetRequirements.first()
             val targets = decision.legalTargets[req.index] ?: return cancelOrFirst(decision)
             if (targets.isEmpty()) return cancelOrFirst(decision)
 
             // For small target pools, simulate each; for large pools, use heuristics then simulate top candidates
-            val candidates = if (targets.size <= 8) {
+            val candidates = if (targets.size <= maxCandidates) {
                 targets
             } else {
-                // Pre-rank by heuristic, then simulate top 8
-                targets.sortedByDescending { targetHeuristic(state, it, playerId) }.take(8)
+                targets.sortedByDescending { targetHeuristic(state, it, playerId) }.take(maxCandidates)
             }
 
             val best = pickBestBySimulation(state, candidates, playerId) { target ->
@@ -127,7 +140,7 @@ class DecisionResponder(
             if (targets.isEmpty()) {
                 req.index to emptyList()
             } else {
-                val best = pickBestBySimulation(state, targets.take(8), playerId) { target ->
+                val best = pickBestBySimulation(state, targets.take(maxCandidates), playerId) { target ->
                     TargetsResponse(decision.id, mapOf(req.index to listOf(target)))
                 }
                 // For optional targets, compare best pick against skipping

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -2,11 +2,15 @@ package com.wingedsheep.ai.engine
 
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
 import com.wingedsheep.ai.engine.advisor.CastContext
+import com.wingedsheep.ai.engine.budget.BudgetPolicy
+import com.wingedsheep.ai.engine.budget.DecisionBudget
+import com.wingedsheep.ai.engine.budget.LegacyBudgetPolicy
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.ai.engine.evaluation.BoardPresence
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
 import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -36,7 +40,19 @@ class Strategist(
     private val simulator: GameSimulator,
     private val evaluator: BoardEvaluator,
     private val combatAdvisor: CombatAdvisor = CombatAdvisor(simulator, evaluator),
-    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry()
+    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry(),
+    /**
+     * Phase 4a: only propose actions the AI can actually take.
+     *
+     * Two halves. Candidates come from [MeaningfulActionFilter] instead of the ad-hoc
+     * `affordable && !isManaAbility` filter, so a spell whose mandatory target slot is empty stops
+     * being a candidate; and [fillableRequirements] fills the slots it *can* rather than
+     * abandoning the whole spell. Together they close the "889 of 945 rejected actions were
+     * `CastSpell: No valid targets available`" finding Phase 1 quantified and left open.
+     */
+    private val useMeaningfulFilter: Boolean = false,
+    /** Phase 4b. How much search each decision may spend. */
+    private val budgetPolicy: BudgetPolicy = LegacyBudgetPolicy,
 ) {
     fun chooseAction(
         state: GameState,
@@ -48,31 +64,32 @@ class Strategist(
         // returns a single DeclareAttackers/DeclareBlockers with an empty default map).
         val combatAction = legalActions.find { it.actionType == "DeclareAttackers" || it.actionType == "DeclareBlockers" }
         if (combatAction != null) {
-            return handleCombatDeclaration(state, combatAction, playerId)
+            val budget = budgetPolicy.budgetFor(state, playerId, listOf(combatAction))
+            return handleCombatDeclaration(state, combatAction, playerId, budget)
         }
 
         if (legalActions.size == 1) return legalActions.first()
 
         val pass = legalActions.find { it.actionType == "PassPriority" }
-        val affordable = expandXCostAbilities(
-            state,
-            preferKickerVariants(
-                legalActions.filter { it.affordable && !it.isManaAbility && it.actionType != "PassPriority" }
-            ),
-            playerId
-        )
+        val affordable = expandXCostAbilities(state, preferKickerVariants(candidatesFrom(legalActions)), playerId)
 
         if (affordable.isEmpty()) return pass ?: legalActions.first()
 
+        val budget = budgetPolicy.budgetFor(state, playerId, affordable)
+
         // ── 1-ply scoring of all candidates ──
         val passScore = if (pass != null) {
-            evaluate1Ply(state, pass, playerId)
+            evaluate1Ply(state, pass, playerId, budget = budget)
         } else {
             evaluator.evaluate(state, state.projectedState, playerId)
         }
 
-        val scored = affordable.map { action ->
-            action to evaluate1Ply(state, action, playerId, passScore)
+        // The anytime contract: the first candidate is always scored, and the budget only cuts the
+        // tail short. `maxByOrNull` over a partial list is still a valid (if worse) answer.
+        val scored = mutableListOf<Pair<LegalAction, Double>>()
+        for (action in affordable) {
+            scored += action to evaluate1Ply(state, action, playerId, passScore, budget)
+            if (budget.expired()) break
         }
 
         // On the opponent's end step, unspent mana is about to be wasted.
@@ -91,7 +108,7 @@ class Strategist(
             // AI sees the real resolved board, including effects already on the stack.
             val chosen = best.first
             if (chosen.requiresTargets) {
-                chosen.copy(action = chooseCommittedTargets(state, chosen, playerId))
+                chosen.copy(action = chooseCommittedTargets(state, chosen, playerId, budget))
             } else {
                 chosen
             }
@@ -100,27 +117,48 @@ class Strategist(
         }
     }
 
+    /**
+     * The candidate actions worth scoring.
+     *
+     * Mana abilities are excluded either way: activating one on its own is never the AI's move —
+     * mana is produced as part of paying for something, by the engine's own auto-tap.
+     */
+    private fun candidatesFrom(legalActions: List<LegalAction>): List<LegalAction> =
+        if (useMeaningfulFilter) {
+            MeaningfulActionFilter.filterMeaningful(legalActions).filter { it.affordable && !it.isManaAbility }
+        } else {
+            legalActions.filter { it.affordable && !it.isManaAbility && it.actionType != "PassPriority" }
+        }
+
     private fun handleCombatDeclaration(
         state: GameState,
         legalAction: LegalAction,
-        playerId: EntityId
+        playerId: EntityId,
+        budget: DecisionBudget,
     ): LegalAction {
         val action = when (legalAction.actionType) {
-            "DeclareAttackers" -> combatAdvisor.chooseAttackers(state, legalAction, playerId)
-            "DeclareBlockers" -> combatAdvisor.chooseBlockers(state, legalAction, playerId, useSimulation = true)
+            "DeclareAttackers" -> combatAdvisor.chooseAttackers(state, legalAction, playerId, budget)
+            "DeclareBlockers" ->
+                combatAdvisor.chooseBlockers(state, legalAction, playerId, useSimulation = true, budget = budget)
             else -> legalAction.action
         }
         return legalAction.copy(action = action)
     }
 
-    private fun evaluate1Ply(state: GameState, action: LegalAction, playerId: EntityId, passScore: Double? = null): Double {
+    private fun evaluate1Ply(
+        state: GameState,
+        action: LegalAction,
+        playerId: EntityId,
+        passScore: Double? = null,
+        budget: DecisionBudget = DecisionBudget.legacy(),
+    ): Double {
         // For targeted spells, fill in the best target by simulation before scoring. Without a
         // target the CastSpellHandler rejects the action ("No valid targets") and the spell always
         // scores the same as passing; with only a *heuristic* target, an ability whose ideal target
         // is already taken by something on the stack (e.g. a second "can't block" when the first is
         // still resolving) would be scored at that redundant target and look worthless — so the AI
         // would never play it. Scoring at the best target makes the action's real upside visible.
-        val simulationAction = chooseCommittedTargets(state, action, playerId)
+        val simulationAction = chooseCommittedTargets(state, action, playerId, budget)
         val result = simulator.simulate(state, simulationAction)
         val defaultScore = evaluator.evaluate(result.state, result.state.projectedState, playerId)
 
@@ -164,8 +202,7 @@ class Strategist(
         // AI re-picks it forever — an infinite loop.
         val baseAction = action.action
         if (targetsAlreadyFilled(baseAction) != false) return action.action
-        val targetInfos = targetInfosFor(action) ?: return action.action
-        if (targetInfos.any { it.validTargets.isEmpty() }) return action.action
+        val targetInfos = fillableRequirements(action) ?: return action.action
 
         val chosenTargets = targetInfos.map { info ->
             val best = info.validTargets.maxByOrNull { heuristicTargetRank(state, it, playerId) }
@@ -184,22 +221,26 @@ class Strategist(
      * at the same creature: while the first is still on the stack the heuristic sees that creature
      * at full value and re-picks it, but a simulation that resolves both effects shows re-hitting it
      * gains nothing over neutralizing a second, still-able blocker (which [BoardPresence] now prices
-     * lower). Requirements are resolved greedily — others held at their heuristic best — and only the
-     * top [MAX_TARGET_CANDIDATES] candidates per requirement are simulated to bound cost. Falls back
-     * to [resolveTargetsForSimulation] when the action carries no usable target metadata.
+     * lower). Requirements are resolved greedily — others held at their heuristic best — and only
+     * the top `budget.allowances.targetCandidates` per requirement are simulated to bound cost. A
+     * budget below [com.wingedsheep.ai.engine.budget.BudgetTier.NORMAL] skips the refinement
+     * entirely and keeps the heuristic pick: this loop is the most expensive thing a routine
+     * priority window can pay for. Falls back to [resolveTargetsForSimulation] when the action
+     * carries no usable target metadata.
      */
     private fun chooseCommittedTargets(
         state: GameState,
         action: LegalAction,
-        playerId: EntityId
+        playerId: EntityId,
+        budget: DecisionBudget = DecisionBudget.legacy(),
     ): com.wingedsheep.engine.core.GameAction {
         val baseAction = action.action
         if (targetsAlreadyFilled(baseAction) != false) return baseAction
-        val targetInfos = targetInfosFor(action)
-            ?: return resolveTargetsForSimulation(state, action, playerId)
-        if (targetInfos.any { it.validTargets.isEmpty() }) {
+        if (!budget.allowances.refineTargetsBySimulation) {
             return resolveTargetsForSimulation(state, action, playerId)
         }
+        val targetInfos = fillableRequirements(action)
+            ?: return resolveTargetsForSimulation(state, action, playerId)
 
         // Heuristic baseline for every requirement, then refine each one by simulation.
         val chosenTargets = targetInfos.map { info ->
@@ -209,10 +250,11 @@ class Strategist(
         }.toMutableList()
 
         for (i in targetInfos.indices) {
+            if (budget.expired()) break
             val info = targetInfos[i]
             val candidates = info.validTargets
                 .sortedByDescending { heuristicTargetRank(state, it, playerId) }
-                .take(MAX_TARGET_CANDIDATES)
+                .take(budget.allowances.targetCandidates)
             if (candidates.size <= 1) continue
             val best = candidates.maxByOrNull { candidate ->
                 val trial = chosenTargets.toMutableList()
@@ -235,6 +277,39 @@ class Strategist(
             is ActivateAbility -> baseAction.targets.isNotEmpty()
             else -> null
         }
+
+    /**
+     * The target requirements the AI will actually fill, or null when it cannot build a legal
+     * target list at all and should leave the action's targets alone.
+     *
+     * Targets are submitted as one **flat** list, which the engine slices back into requirements
+     * by their max counts (`TargetValidator.validateTargets`). An unfilled slot can therefore only
+     * ever be a trailing one — there is no way to say "requirement 0 got nothing, requirement 1
+     * got this".
+     *
+     * That mattered more than it sounds. V0 bails on the *whole spell* the moment any requirement
+     * has no legal target, and then submits no targets at all, which the engine rejects with "No
+     * valid targets available" — Phase 1 measured that as ~0.9 rejected actions per game, 889 of
+     * 945 rejections. The shape behind almost all of them is an **optional** trailing slot:
+     * Conduct Electricity's "up to one target creature token" with no token on the board makes the
+     * AI decline to target the mandatory creature either.
+     *
+     * Behind [useMeaningfulFilter] with the rest of "only propose actions you can actually take" —
+     * not because the old behaviour is defensible, but because `AiProfile.LEGACY_V0` is the
+     * permanent reference opponent that every published number is quoted against, and quietly
+     * making it stronger would silently rebase months of arena results.
+     */
+    private fun fillableRequirements(action: LegalAction): List<TargetInfo>? {
+        val all = targetInfosFor(action) ?: return null
+        val fillable = all.takeWhile { it.validTargets.isNotEmpty() }
+        if (fillable.size == all.size) return all
+        if (!useMeaningfulFilter) return null
+        val unfilled = all.drop(fillable.size)
+        // A mandatory slot with no legal target means the spell cannot be cast at all, and a
+        // later slot that *does* have targets cannot be reached past a skipped one.
+        if (unfilled.any { it.minTargets > 0 || it.validTargets.isNotEmpty() }) return null
+        return fillable
+    }
 
     /** Normalize an action's target metadata into requirements (multi-target or single-target). */
     private fun targetInfosFor(action: LegalAction): List<TargetInfo>? =
@@ -468,9 +543,6 @@ class Strategist(
     }
 
     private companion object {
-        /** Cap on candidate targets simulated per requirement when committing a targeted action. */
-        const val MAX_TARGET_CANDIDATES = 8
-
         /** Cap on the number of X values an X-cost ability is expanded into (keeps the highest). */
         const val MAX_X_CANDIDATES = 5
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/budget/BudgetPolicy.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/budget/BudgetPolicy.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.ai.engine.budget
+
+import com.wingedsheep.ai.engine.lifePoolsOf
+import com.wingedsheep.ai.engine.sidesFor
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Decides how much thought one decision is worth.
+ *
+ * Lives on `AiProfile`, so a profile is what an arena run is actually measuring: `just arena
+ * v0-budget-100 v0-budget-3000` is two agents differing in nothing but this.
+ */
+interface BudgetPolicy {
+    /**
+     * The budget for a priority window.
+     *
+     * @param meaningfulActions the candidate list *after* the meaningful-action filter, or the raw
+     *   affordable candidates when the filter is off. Empty means the AI is about to pass.
+     */
+    fun budgetFor(state: GameState, playerId: EntityId, meaningfulActions: List<LegalAction>): DecisionBudget
+
+    /**
+     * The budget for answering a [com.wingedsheep.engine.core.PendingDecision].
+     *
+     * Separate from [budgetFor] because a decision has no candidate list to size a tier from, and
+     * because it is never skippable: the engine is blocked mid-resolution until it is answered, so
+     * there is no [BudgetTier.TRIVIAL] equivalent.
+     */
+    fun budgetForDecision(state: GameState, playerId: EntityId): DecisionBudget
+}
+
+/**
+ * No tiering: every decision gets today's constants and no global deadline.
+ *
+ * This is what `AiProfile.LEGACY_V0` runs, and it must stay bit-identical to the pre-Phase-4 AI —
+ * `FrozenBaselineTest` hashes V0's action stream precisely so that a refactor cannot quietly move
+ * the permanent reference opponent.
+ */
+object LegacyBudgetPolicy : BudgetPolicy {
+    override fun budgetFor(
+        state: GameState,
+        playerId: EntityId,
+        meaningfulActions: List<LegalAction>,
+    ): DecisionBudget = DecisionBudget.legacy()
+
+    override fun budgetForDecision(state: GameState, playerId: EntityId): DecisionBudget =
+        DecisionBudget.legacy()
+
+    override fun toString(): String = "legacy"
+}
+
+/**
+ * The four-tier policy from `backlog/engine-ai-improvement.md` §4b.
+ *
+ * | Tier | When |
+ * |---|---|
+ * | TRIVIAL | Nothing meaningful to choose between — the AI is passing regardless |
+ * | ROUTINE | An opponent's-turn window with no immediate threat; upkeep, draw, end step |
+ * | NORMAL | Our main phase, or a response to something on the stack |
+ * | CRITICAL | Combat declaration, or either side within one swing of lethal |
+ *
+ * Two entries from the plan's table are **not** implemented and are deliberately not faked:
+ * "sweeper castable or on the stack" and "a real counterspell window" both need to know what a card
+ * *does*, which is Phase 6's `CardIntent`. Guessing them from a mana cost would put the most
+ * expensive tier on the wrong windows, which is worse than leaving them at NORMAL.
+ *
+ * @param normalMillis size of the [BudgetTier.NORMAL] tier. Every other tier scales off it in the
+ *   published ratio (1:10 routine, 5:2 critical), which is what makes `ArenaBudgetScalingTest`'s
+ *   "the same agent at 100 / 1000 / 3000 ms" a single-parameter sweep.
+ */
+class TieredBudgetPolicy(
+    val normalMillis: Long = BudgetTier.NORMAL.millis,
+) : BudgetPolicy {
+
+    override fun budgetFor(
+        state: GameState,
+        playerId: EntityId,
+        meaningfulActions: List<LegalAction>,
+    ): DecisionBudget {
+        val tier = tierFor(state, playerId, meaningfulActions)
+        val millis = millisFor(tier)
+        return DecisionBudget(tier, SearchAllowances.forMillis(millis), millis)
+    }
+
+    override fun budgetForDecision(state: GameState, playerId: EntityId): DecisionBudget {
+        val tier = if (someoneIsInLethalRange(state, playerId)) BudgetTier.CRITICAL else BudgetTier.NORMAL
+        val millis = millisFor(tier)
+        return DecisionBudget(tier, SearchAllowances.forMillis(millis), millis)
+    }
+
+    fun millisFor(tier: BudgetTier): Long = when (tier) {
+        BudgetTier.TRIVIAL -> 0
+        BudgetTier.ROUTINE -> normalMillis / 10
+        BudgetTier.NORMAL -> normalMillis
+        BudgetTier.CRITICAL -> normalMillis * 5 / 2
+    }
+
+    fun tierFor(
+        state: GameState,
+        playerId: EntityId,
+        meaningfulActions: List<LegalAction>,
+    ): BudgetTier {
+        if (meaningfulActions.isEmpty()) return BudgetTier.TRIVIAL
+
+        // Combat declaration is always CRITICAL, so combat never gets *less* time than it has
+        // today — the risk register's "combat's 1 s cap fights the global budget" line.
+        if (meaningfulActions.any {
+                it.actionType == "DeclareAttackers" || it.actionType == "DeclareBlockers"
+            }
+        ) {
+            return BudgetTier.CRITICAL
+        }
+
+        if (someoneIsInLethalRange(state, playerId)) return BudgetTier.CRITICAL
+
+        // Something is on the stack and we are choosing whether to answer it.
+        if (state.stack.isNotEmpty()) return BudgetTier.NORMAL
+
+        val isMyTurn = state.isActiveTurnFor(playerId)
+        if (isMyTurn && (state.step == Step.PRECOMBAT_MAIN || state.step == Step.POSTCOMBAT_MAIN)) {
+            return BudgetTier.NORMAL
+        }
+
+        return BudgetTier.ROUTINE
+    }
+
+    override fun toString(): String = "tiered(${normalMillis}ms)"
+
+    /**
+     * Is either side one combat step away from dying?
+     *
+     * A deliberately crude proxy — the total power of a side's untapped creatures against the
+     * smallest life pool facing it — because it runs at every priority window. It over-triggers
+     * (blockers exist; not every creature can attack) and that is the safe direction: the cost of a
+     * false CRITICAL is one slow decision, the cost of a false ROUTINE is a missed lethal.
+     */
+    private fun someoneIsInLethalRange(state: GameState, playerId: EntityId): Boolean {
+        val sides = state.sidesFor(playerId) ?: return false
+        val myLife = state.lifePoolsOf(sides.mine).minOrNull() ?: return false
+        val myPower = untappedPowerOf(state, sides.mine)
+        return sides.opponents.any { opponent ->
+            val theirLife = state.lifePoolsOf(opponent).minOrNull() ?: return@any false
+            val theirPower = untappedPowerOf(state, opponent)
+            theirPower >= myLife || myPower >= theirLife
+        }
+    }
+
+    private fun untappedPowerOf(state: GameState, side: List<EntityId>): Int {
+        val projected = state.projectedState
+        return side.sumOf { player ->
+            projected.getBattlefieldControlledBy(player).sumOf { entityId ->
+                if (!projected.isCreature(entityId)) return@sumOf 0
+                if (state.getEntity(entityId)?.get<TappedComponent>() != null) return@sumOf 0
+                (projected.getPower(entityId) ?: 0).coerceAtLeast(0)
+            }
+        }
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/budget/DecisionBudget.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/budget/DecisionBudget.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.ai.engine.budget
+
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * How much thinking a single decision is worth.
+ *
+ * The millisecond figures are the ones agreed in `backlog/engine-ai-improvement.md`. They are the
+ * *nominal* size of a tier, not a stopwatch the search races: see [SearchAllowances] for why the
+ * work a tier buys is counted, not timed.
+ */
+enum class BudgetTier(val millis: Long) {
+    /** One legal action, or the window is auto-passable. The AI shouldn't be thinking at all. */
+    TRIVIAL(0),
+
+    /** An opponent's-turn window with no immediate threat; upkeep, draw, end step. */
+    ROUTINE(200),
+
+    /** Our main phase with meaningful actions. Most decisions. */
+    NORMAL(2_000),
+
+    /** Combat declaration; either player in lethal range; a sweeper or a real counterspell window. */
+    CRITICAL(5_000);
+}
+
+/**
+ * What a budget buys, expressed as **work**, not wall clock.
+ *
+ * A wall clock is the obvious way to spend a time budget and the wrong one here. The arena's whole
+ * value rests on reruns at the same seed producing the same games — `ArenaHarnessTest` asserts
+ * identical outcomes at 8 threads and at 1 — and a search that stops when the clock runs out
+ * produces a different move under load than it does idle. So a tier is converted, once, into a
+ * count of simulations the search may spend, and [DecisionBudget.deadlineNanos] is left as a hard
+ * safety stop that a healthy decision never reaches.
+ *
+ * The numbers at [NORMAL_MILLIS] are exactly today's hardcoded constants, which is what makes
+ * `AiProfile.LEGACY_V0` reproducible: `forMillis(2_000) == LEGACY`.
+ */
+data class SearchAllowances(
+    /** Candidate targets simulated per target requirement. `Strategist.MAX_TARGET_CANDIDATES`. */
+    val targetCandidates: Int,
+    /** Whether committed targets are refined by simulation at all, or left at the heuristic pick. */
+    val refineTargetsBySimulation: Boolean,
+    /** Engine simulations the blocking local search may spend. `CombatAdvisor.MAX_BLOCK_SIMULATIONS`. */
+    val blockSimulations: Int,
+    /** Improvement rounds the attack local search may run. */
+    val attackSearchIterations: Int,
+    /** Wall-clock cap on the combat local searches specifically. Today's hardcoded 1000 ms. */
+    val combatSearchMillis: Long,
+) {
+    companion object {
+        /** The tier the allowances are calibrated against. */
+        val NORMAL_MILLIS: Long = BudgetTier.NORMAL.millis
+
+        /**
+         * Today's behaviour, constant for constant. `AiProfile.LEGACY_V0` must keep producing
+         * exactly this or `FrozenBaselineTest` fails, which is the point of that test.
+         */
+        val LEGACY = SearchAllowances(
+            targetCandidates = 8,
+            refineTargetsBySimulation = true,
+            blockSimulations = 10,
+            attackSearchIterations = 3,
+            combatSearchMillis = 1_000,
+        )
+
+        /**
+         * Scale [LEGACY] to a tier of [millis].
+         *
+         * Linear in the budget, then clamped: `blockSimulations` keeps 10 as a **floor** (the plan
+         * is explicit that combat must never get *less* search than it has today), and every
+         * allowance has a ceiling so a pathological budget can't turn one decision into a
+         * multi-second stall. Below [BudgetTier.NORMAL] the simulation-refined target pick is
+         * dropped entirely — it is the single most expensive thing a routine window pays for, at
+         * up to `targetCandidates` simulations per requirement.
+         */
+        fun forMillis(millis: Long): SearchAllowances {
+            if (millis <= 0) return TRIVIAL_ALLOWANCES
+            val scale = millis.toDouble() / NORMAL_MILLIS
+            return SearchAllowances(
+                targetCandidates = scaled(LEGACY.targetCandidates, scale, floor = 1, ceiling = 32),
+                refineTargetsBySimulation = millis >= NORMAL_MILLIS,
+                blockSimulations = scaled(LEGACY.blockSimulations, scale, floor = 10, ceiling = 80),
+                attackSearchIterations = scaled(LEGACY.attackSearchIterations, scale, floor = 1, ceiling = 12),
+                combatSearchMillis = millis,
+            )
+        }
+
+        /** Nothing is searched; every consumer falls back to its heuristic seed. */
+        val TRIVIAL_ALLOWANCES = SearchAllowances(
+            targetCandidates = 1,
+            refineTargetsBySimulation = false,
+            blockSimulations = 0,
+            attackSearchIterations = 0,
+            combatSearchMillis = 0,
+        )
+
+        private fun scaled(base: Int, scale: Double, floor: Int, ceiling: Int): Int =
+            min(ceiling, max(floor, (base * scale).roundToInt()))
+    }
+}
+
+/**
+ * The time and work one decision may spend.
+ *
+ * Created per decision by a [BudgetPolicy] and threaded from `AIPlayer` down through `Strategist`,
+ * `CombatAdvisor` and `DecisionResponder`. Every consumer must honour the **anytime contract**:
+ * have a valid answer after its first iteration, so an expired budget degrades the move rather
+ * than failing to produce one.
+ */
+class DecisionBudget(
+    val tier: BudgetTier,
+    val allowances: SearchAllowances,
+    /** Nominal size of this budget in milliseconds. [UNBOUNDED_MILLIS] means "no wall-clock stop". */
+    val millis: Long,
+    private val startNanos: Long = System.nanoTime(),
+) {
+    /** Hard wall-clock stop. A healthy decision finishes long before this; see [SearchAllowances]. */
+    val deadlineNanos: Long =
+        if (millis >= UNBOUNDED_MILLIS) Long.MAX_VALUE else startNanos + millis * NANOS_PER_MILLI
+
+    /** Deadline for the combat local searches, which have always had their own tighter cap. */
+    val combatDeadlineNanos: Long =
+        min(deadlineNanos, startNanos + allowances.combatSearchMillis * NANOS_PER_MILLI)
+
+    fun expired(): Boolean = deadlineNanos != Long.MAX_VALUE && System.nanoTime() >= deadlineNanos
+
+    fun remainingMs(): Long =
+        if (deadlineNanos == Long.MAX_VALUE) Long.MAX_VALUE
+        else max(0L, (deadlineNanos - System.nanoTime()) / NANOS_PER_MILLI)
+
+    /** Milliseconds spent since this budget was opened. For latency reporting. */
+    fun elapsedMs(): Long = (System.nanoTime() - startNanos) / NANOS_PER_MILLI
+
+    override fun toString(): String = "DecisionBudget($tier, ${millis}ms, $allowances)"
+
+    companion object {
+        private const val NANOS_PER_MILLI = 1_000_000L
+
+        /** Sentinel for "the wall clock never stops this decision". */
+        const val UNBOUNDED_MILLIS = Long.MAX_VALUE / NANOS_PER_MILLI
+
+        /**
+         * The budget `AiProfile.LEGACY_V0` runs on: today's constants, and no global deadline —
+         * only the combat searches have ever had one, at 1000 ms.
+         */
+        fun legacy(): DecisionBudget =
+            DecisionBudget(BudgetTier.NORMAL, SearchAllowances.LEGACY, UNBOUNDED_MILLIS)
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.ai.engine.AiProfile
 import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
 import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
+import com.wingedsheep.ai.engine.budget.TieredBudgetPolicy
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.EntityId
 
@@ -53,6 +54,28 @@ object ArenaAgents {
             id = "v0-blind",
             evaluationWeights = EvaluationWeights.BLIND,
         )),
+        // ── Phase 4 ──
+        // The meaningful-action filter alone. `just arena v0 v0-meaningful 1000` is the phase's
+        // exit criterion: at ≥50% the filter costs nothing, and if it *loses* it is discarding a
+        // real option and has found a bug for free.
+        ArenaAgent("v0-meaningful", AiProfile.LEGACY_V0.copy(
+            id = "v0-meaningful",
+            useMeaningfulFilter = true,
+        )),
+        // The decision budget alone, at four sizes. `ArenaBudgetScalingTest` plays these against
+        // each other: strength must be monotone in the budget, or the search is making noise.
+        ArenaAgent("v0-budget-100", budgetAgent(100)),
+        ArenaAgent("v0-budget-1000", budgetAgent(1_000)),
+        ArenaAgent("v0-budget-2000", budgetAgent(2_000)),
+        ArenaAgent("v0-budget-3000", budgetAgent(3_000)),
+        // Both, at the nominal budget sizes — what Phase 4 proposes to ship.
+        ArenaAgent("v0-phase4", AiProfile.PHASE4),
+    )
+
+    /** `v0` with nothing changed but the size of a [TieredBudgetPolicy]'s NORMAL tier. */
+    private fun budgetAgent(normalMillis: Long): AiProfile = AiProfile.LEGACY_V0.copy(
+        id = "v0-budget-$normalMillis",
+        budgetPolicy = TieredBudgetPolicy(normalMillis),
     )
 
     private val byName: Map<String, ArenaAgent> = all.associateBy { it.name }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaBudgetScalingTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaBudgetScalingTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.ai.arena
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * **The safety net for every search this plan adds after Phase 4.**
+ *
+ * The same agent, differing in nothing but the size of its `DecisionBudget`, played against itself
+ * at 100 / 1000 / 3000 ms. Strength must be **monotone in the budget**. If it isn't, the search is
+ * generating noise rather than signal, and the right response is to fix the leaf evaluator (Phases
+ * 6 and 9) before stacking more samples on top of it — not to add rollouts (Phase 7).
+ *
+ * Built now, before rollouts exist, precisely so it is already calibrated when they land.
+ *
+ * ```
+ * just arena-budget-scaling 300
+ * ```
+ *
+ * The reported number is the **paired win share** of the bigger budget over the smaller, so 0.5 is
+ * parity and the monotonicity claim is "every ladder rung is at or above 0.5". At the small game
+ * counts this is normally run at, read the interval, not the point estimate: three runs of 300
+ * games have interval half-widths around ±6%, so a rung at 0.48 is not a violation and a run that
+ * puts a whole interval *below* parity is.
+ *
+ * A structural note that matters for reading the numbers: `SearchAllowances` converts a budget into
+ * a **count of simulations**, not a stopwatch, so a rung is reproducible and a busy machine cannot
+ * change the answer. See that class for why.
+ */
+class ArenaBudgetScalingTest : FunSpec({
+
+    val enabled = System.getProperty("arenaBudgetScaling") == "true"
+    val games = System.getProperty("arenaGames")?.toIntOrNull() ?: 300
+    val seed = System.getProperty("arenaSeed")?.toLongOrNull() ?: ArenaConfig.DEFAULT_SEED
+    val setCode = System.getProperty("arenaSet") ?: "BLB"
+    val threads = System.getProperty("arenaThreads")?.toIntOrNull()
+        ?: Runtime.getRuntime().availableProcessors()
+
+    /**
+     * The ladder, smallest budget first. Each rung is played as `bigger vs smaller`, so a healthy
+     * result is a win share at or above 0.5 on every rung.
+     */
+    val ladder = listOf("v0-budget-100", "v0-budget-1000", "v0-budget-3000")
+
+    test("budget scaling: strength is monotone in the decision budget").config(enabled = enabled) {
+        println("=== BUDGET SCALING: ${ladder.joinToString(" < ")} — $games games per rung, seed $seed ===")
+        println("    Each rung is `bigger vs smaller`; parity is 50%. A rung whose whole interval")
+        println("    sits below 50% means more search made the agent worse.")
+        println()
+
+        val rungs = ladder.zipWithNext().map { (smaller, bigger) ->
+            val config = ArenaConfig(
+                agentA = ArenaAgents.resolve(bigger),
+                agentB = ArenaAgents.resolve(smaller),
+                games = games, seed = seed, setCode = setCode, threads = threads,
+            )
+            println("--- $bigger vs $smaller ---")
+            Arena.run(config).also { print(ArenaReport.summary(it)) }
+        }
+
+        // The end-to-end rung too: the extremes should separate more than any single step does.
+        val endToEnd = Arena.run(
+            ArenaConfig(
+                agentA = ArenaAgents.resolve(ladder.last()),
+                agentB = ArenaAgents.resolve(ladder.first()),
+                games = games, seed = seed, setCode = setCode, threads = threads,
+            )
+        )
+        println("--- ${ladder.last()} vs ${ladder.first()} (end to end) ---")
+        print(ArenaReport.summary(endToEnd))
+
+        println()
+        println("=== MONOTONICITY ===")
+        (rungs + endToEnd).forEach { run ->
+            val stats = run.stats
+            val verdict = if (stats.pairWinShareCi.high < 0.5) "VIOLATION" else "ok"
+            println(
+                "  ${stats.agentA} vs ${stats.agentB}: ${pct(stats.pairWinShare)} " +
+                    "CI [${pct(stats.pairWinShareCi.low)}, ${pct(stats.pairWinShareCi.high)}] — $verdict"
+            )
+        }
+
+        // Only a *whole interval* below parity is a failure. A point estimate under 50% at 300
+        // games is inside the noise, and failing on it would train everyone to ignore this test.
+        val violations = (rungs + endToEnd)
+            .filter { it.stats.pairWinShareCi.high < 0.5 }
+            .map { "${it.stats.agentA} loses to ${it.stats.agentB} (${pct(it.stats.pairWinShare)})" }
+        violations shouldBe emptyList()
+    }
+
+    /**
+     * The always-on half: the ladder is real, its rungs are ordered, and the agents differ in
+     * nothing but the budget. Cheap enough to run on every `:ai:test`, and it is what stops the
+     * benchmark above from silently measuring two identical agents.
+     */
+    test("budget ladder agents differ only in budget size, in increasing order") {
+        val profiles = ladder.map { ArenaAgents.resolve(it).profile }
+        profiles.map { it.copy(id = "", budgetPolicy = profiles.first().budgetPolicy) }
+            .distinct().size shouldBe 1
+        profiles.map { it.budgetPolicy.toString() } shouldBe
+            listOf("tiered(100ms)", "tiered(1000ms)", "tiered(3000ms)")
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/AutoPassParityTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/AutoPassParityTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.view.LegalActionEnricher
+import com.wingedsheep.engine.view.asPriorityAction
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+/**
+ * The Phase 4a regression net: the auto-pass rules must mean the same thing on both sides of the
+ * engine/DTO seam, and the enumeration-skipping fast path must never disagree with the full check.
+ *
+ * `AutoPassManager` used to own these rules over the client DTO `LegalActionInfo`, which is why the
+ * AI could not call them. They now live in [MeaningfulActionFilter] over engine `LegalAction`s, and
+ * `AutoPassManager` adapts the DTO and delegates. Two things could silently break as a result, and
+ * this test is here for both:
+ *
+ * 1. **The adapter drifts.** `LegalActionEnricher` is a lossy projection — if it ever stopped
+ *    carrying (say) `holdPriority` or `validBlockers`, the client would start stopping in different
+ *    places from the AI and nothing else would notice.
+ * 2. **The fast path over-fires.** [MeaningfulActionFilter.canAutoPassWithoutEnumerating] decides
+ *    a whole priority window from the state alone. It is only sound if it is a strict subset of the
+ *    full verdict, and that claim is an argument about which `when` branches ignore their action
+ *    list — exactly the kind of argument a later edit invalidates.
+ *
+ * The corpus is real: two full seeded AI-vs-AI games, every priority window either player reaches.
+ */
+class AutoPassParityTest : FunSpec({
+
+    val set = MtgSetCatalog.requireByCode("BLB")
+    val registry = CardRegistry().apply {
+        register(set.cards)
+        register(set.basicLands)
+    }
+    val enricher = LegalActionEnricher(ManaSolver(registry), registry)
+
+    /** One captured priority window: the state, whose priority it is, and what they may do. */
+    data class Window(val state: GameState, val playerId: EntityId, val actions: List<LegalAction>)
+
+    /**
+     * Play a seeded AI-vs-AI game, capturing every priority window on the way through.
+     *
+     * A cut-down `TableGameRunner`: the arena's runner returns an outcome, not the states, and the
+     * point here is the states.
+     */
+    fun harvest(seed: Long, maxActions: Int = 1_200): List<Window> {
+        val processor = ActionProcessor(registry)
+        val enumerator = LegalActionEnumerator.create(registry)
+        val deck = buildSeededSealedDeck(set.cards, Random(seed))
+        val init = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = listOf(PlayerConfig("Seat0", deck), PlayerConfig("Seat1", deck)),
+                skipMulligans = true,
+                startingPlayerIndex = 0,
+                seed = seed,
+            )
+        )
+        val ai = init.state.turnOrder.associateWith { AIPlayer.create(registry, it, AiProfile.LEGACY_V0) }
+
+        var state = init.state
+        val windows = mutableListOf<Window>()
+        var actions = 0
+        while (!state.gameOver && actions < maxActions) {
+            val decision = state.pendingDecision
+            if (decision != null) {
+                val response = ai.getValue(decision.playerId).respondToDecision(state, decision)
+                val result = processor.process(state, SubmitDecision(decision.playerId, response)).result
+                if (result.error != null) break
+                state = result.state
+                actions++
+                continue
+            }
+            val priorityPlayer = state.priorityPlayerId ?: break
+            val legalActions = enumerator.enumerate(state, priorityPlayer, EnumerationMode.ACTIONS_ONLY)
+            windows += Window(state, priorityPlayer, legalActions)
+
+            val result = processor.process(state, ai.getValue(priorityPlayer).chooseAction(state)).result
+            val next = if (result.error != null) {
+                processor.process(state, safeFallbackAction(state, priorityPlayer, enumerator)).result
+            } else {
+                result
+            }
+            if (next.error != null || next.state === state) break
+            state = next.state
+            actions++
+        }
+        return windows
+    }
+
+    val corpus = listOf(20260728L, 20260729L).flatMap { harvest(it) }
+
+    test("the corpus is big and varied enough to mean something") {
+        corpus.size shouldBeGreaterThan 300
+        // Both verdicts must occur, or "identical on every window" is a vacuous claim.
+        val verdicts = corpus.map { MeaningfulActionFilter.shouldAutoPass(it.state, it.playerId, it.actions, cardRegistry = registry) }
+        verdicts.count { it } shouldBeGreaterThan 20
+        verdicts.count { !it } shouldBeGreaterThan 20
+    }
+
+    test("the DTO and the engine action agree on what is meaningful") {
+        val mismatches = corpus.mapNotNull { window ->
+            val fromEngine = MeaningfulActionFilter.filterMeaningful(window.actions).map { it.description }
+            val fromDto = enricher.enrich(window.actions, window.state, window.playerId)
+                .filter { MeaningfulActionFilter.isMeaningful(it.asPriorityAction()) }
+                .map { it.description }
+            if (fromEngine == fromDto) null else {
+                "turn ${window.state.turnNumber} ${window.state.step}: engine=$fromEngine dto=$fromDto"
+            }
+        }
+        mismatches.shouldBeEmpty()
+    }
+
+    test("the DTO and the engine action reach the same auto-pass verdict") {
+        val mismatches = corpus.mapNotNull { window ->
+            val fromEngine = MeaningfulActionFilter.autoPassVerdict(
+                window.state, window.playerId, window.actions, cardRegistry = registry
+            )
+            val fromDto = MeaningfulActionFilter.autoPassVerdict(
+                window.state, window.playerId,
+                enricher.enrich(window.actions, window.state, window.playerId).map { it.asPriorityAction() },
+                cardRegistry = registry
+            )
+            if (fromEngine == fromDto) null else {
+                "turn ${window.state.turnNumber} ${window.state.step}: engine=$fromEngine dto=$fromDto"
+            }
+        }
+        mismatches.shouldBeEmpty()
+    }
+
+    test("the enumeration-free fast path never contradicts the full verdict") {
+        val violations = corpus.filter { window ->
+            MeaningfulActionFilter.canAutoPassWithoutEnumerating(window.state, window.playerId) &&
+                !MeaningfulActionFilter.shouldAutoPass(
+                    window.state, window.playerId, window.actions, cardRegistry = registry
+                )
+        }.map { "turn ${it.state.turnNumber} ${it.state.step}: fast path passes, full check stops" }
+        violations.shouldBeEmpty()
+    }
+
+    test("the fast path fires on a real share of windows — otherwise it is not worth having") {
+        val skippable = corpus.count {
+            MeaningfulActionFilter.canAutoPassWithoutEnumerating(it.state, it.playerId)
+        }
+        println(
+            "enumeration-free windows: $skippable / ${corpus.size} " +
+                "(${skippable * 100 / corpus.size}%) — quoted in docs/ai/baseline-metrics.md"
+        )
+        // Phase 0 measured 76.2% of windows offering zero candidates. The fast path is a strict
+        // subset of that (it declines every window whose verdict depends on the hand), so a third
+        // is the bar: below that the enumeration saving would not pay for the check.
+        withClue("only $skippable of ${corpus.size} windows were skippable without enumerating") {
+            (skippable * 3 > corpus.size) shouldBe true
+        }
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/budget/BudgetPolicyTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/budget/BudgetPolicyTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.ai.engine.budget
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Which window gets which tier.
+ *
+ * The tier assignment is where a budget can be *wrong* rather than merely small: a lethal window
+ * mis-tiered as ROUTINE drops the simulation-refined target pick at the exact moment it matters.
+ */
+class BudgetPolicyTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Grizzly Bears",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2, toughness = 2,
+    )
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(listOf(bear))
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    fun castAction(playerId: EntityId) = LegalAction(
+        action = PassPriority(playerId),
+        actionType = "CastSpell",
+        description = "Cast something",
+    )
+
+    val policy = TieredBudgetPolicy()
+
+    test("nothing meaningful to choose between is TRIVIAL") {
+        val d = driver()
+        policy.tierFor(d.state, d.player1, emptyList()) shouldBe BudgetTier.TRIVIAL
+    }
+
+    test("a combat declaration is always CRITICAL") {
+        val d = driver()
+        val declare = LegalAction(
+            action = DeclareAttackers(d.player1, emptyMap()),
+            actionType = "DeclareAttackers",
+            description = "Declare attackers",
+        )
+        policy.tierFor(d.state, d.player1, listOf(declare)) shouldBe BudgetTier.CRITICAL
+    }
+
+    test("our own main phase is NORMAL while nobody is threatening lethal") {
+        val d = driver()
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        policy.tierFor(d.state, d.player1, listOf(castAction(d.player1))) shouldBe BudgetTier.NORMAL
+    }
+
+    test("an opponent's quiet upkeep is ROUTINE") {
+        val d = driver()
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // player2 is not the active player, and their window is not a main phase.
+        policy.tierFor(d.state, d.player2, listOf(castAction(d.player2))) shouldBe BudgetTier.ROUTINE
+    }
+
+    test("a board that can kill somebody this turn promotes even a quiet window to CRITICAL") {
+        val d = driver()
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        repeat(4) {
+            val attacker = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+            d.removeSummoningSickness(attacker)
+        }
+        d.replaceState(d.state.withLifeTotal(d.player2, 8)) // 4 x 2 power >= 8 life
+        policy.tierFor(d.state, d.player2, listOf(castAction(d.player2))) shouldBe BudgetTier.CRITICAL
+    }
+
+    test("the legacy policy never tiers at all") {
+        val d = driver()
+        LegacyBudgetPolicy.budgetFor(d.state, d.player1, emptyList()).allowances shouldBe
+            SearchAllowances.LEGACY
+        LegacyBudgetPolicy.budgetForDecision(d.state, d.player1).allowances shouldBe
+            SearchAllowances.LEGACY
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/budget/DecisionBudgetTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/budget/DecisionBudgetTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.ai.engine.budget
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.shouldBe
+
+/**
+ * The budget arithmetic — the part that has to be right for `ArenaBudgetScalingTest` to mean
+ * anything, and the part that has to be *unchanged* for `AiProfile.LEGACY_V0` to stay the frozen
+ * reference opponent.
+ */
+class DecisionBudgetTest : FunSpec({
+
+    test("the NORMAL tier reproduces today's search counts exactly") {
+        // If this ever fails, the permanent reference opponent has moved and every published
+        // arena number is measured against a different baseline than it claims.
+        //
+        // The one field that deliberately differs is the combat wall clock: v0 pins it at 1000 ms
+        // regardless, while a tiered budget hands combat the whole tier (and combat is always
+        // CRITICAL, so it is 5000 ms in practice — more than v0, never less).
+        SearchAllowances.forMillis(BudgetTier.NORMAL.millis)
+            .copy(combatSearchMillis = SearchAllowances.LEGACY.combatSearchMillis) shouldBe
+            SearchAllowances.LEGACY
+    }
+
+    test("allowances are monotone in the budget") {
+        val ladder = listOf(100L, 500L, 1_000L, 2_000L, 3_000L, 5_000L).map { SearchAllowances.forMillis(it) }
+        ladder.zipWithNext().forEach { (smaller, bigger) ->
+            bigger.targetCandidates shouldBeGreaterThanOrEqualTo smaller.targetCandidates
+            bigger.blockSimulations shouldBeGreaterThanOrEqualTo smaller.blockSimulations
+            bigger.attackSearchIterations shouldBeGreaterThanOrEqualTo smaller.attackSearchIterations
+            bigger.combatSearchMillis shouldBeGreaterThanOrEqualTo smaller.combatSearchMillis
+        }
+    }
+
+    test("blocking search never drops below its pre-budget floor") {
+        // The risk register's "combat's 1 s cap fights the global budget" line: MAX_BLOCK_SIMULATIONS
+        // is a floor now, so even the smallest tier searches blocking as hard as v0 did.
+        listOf(1L, 50L, 100L, 200L, 2_000L, 10_000L).forEach { millis ->
+            SearchAllowances.forMillis(millis).blockSimulations shouldBeGreaterThanOrEqualTo 10
+        }
+    }
+
+    test("below NORMAL the simulation-refined target pick is dropped, at and above it is kept") {
+        SearchAllowances.forMillis(BudgetTier.ROUTINE.millis).refineTargetsBySimulation shouldBe false
+        SearchAllowances.forMillis(BudgetTier.NORMAL.millis).refineTargetsBySimulation shouldBe true
+        SearchAllowances.forMillis(BudgetTier.CRITICAL.millis).refineTargetsBySimulation shouldBe true
+    }
+
+    test("a legacy budget never expires, but still caps the combat searches at 1000 ms") {
+        val budget = DecisionBudget.legacy()
+        budget.expired().shouldBeFalse()
+        budget.deadlineNanos shouldBe Long.MAX_VALUE
+        // The combat deadline is a real deadline even when the global one isn't — that is exactly
+        // the pre-Phase-4 arrangement, where only `improveAttackViaLocalSearch` had a stopwatch.
+        (budget.combatDeadlineNanos < Long.MAX_VALUE) shouldBe true
+    }
+
+    test("an already-elapsed budget reports expired rather than negative time") {
+        val budget = DecisionBudget(
+            BudgetTier.ROUTINE, SearchAllowances.forMillis(1), millis = 1,
+            startNanos = System.nanoTime() - 1_000_000_000L,
+        )
+        budget.expired() shouldBe true
+        budget.remainingMs() shouldBe 0L
+    }
+
+    test("a tiered policy scales every tier off its NORMAL size") {
+        val policy = TieredBudgetPolicy(normalMillis = 1_000)
+        policy.millisFor(BudgetTier.TRIVIAL) shouldBe 0L
+        policy.millisFor(BudgetTier.ROUTINE) shouldBe 100L
+        policy.millisFor(BudgetTier.NORMAL) shouldBe 1_000L
+        policy.millisFor(BudgetTier.CRITICAL) shouldBe 2_500L
+        // The default reproduces the plan's published table.
+        val default = TieredBudgetPolicy()
+        BudgetTier.entries.forEach { default.millisFor(it) shouldBe it.millis }
+    }
+
+    test("a policy names itself, because an arena report identifies an agent by it") {
+        LegacyBudgetPolicy.toString() shouldBe "legacy"
+        TieredBudgetPolicy(3_000).toString() shouldBe "tiered(3000ms)"
+    }
+})

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -3,13 +3,14 @@
 A phased plan to make the in-game engine AI measurably stronger, on a scoreboard we trust, using
 mechanisms that generalize across the whole card catalog rather than per-card special cases.
 
-**Status:** **Phases 0, 1, 2 and 3 shipped** (Phase 3 on 2026-07-28) — baselines in
+**Status:** **Phases 0, 1, 2, 3 and 4 shipped** (Phase 4 on 2026-07-28) — baselines in
 [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md), measurement guide in
-[`docs/ai/measurement.md`](../docs/ai/measurement.md). Three scoreboards now exist: the arena
-(`just arena`), the 48-puzzle suite (`just arena-puzzles`, **39/48 today**) and the multiplayer pod
-arena (`just arena-pod`). Next up is **Phase 4, branching factor + budget** — or **Phase 6,
-CardIntent**, which is the highest strength-per-effort item left. Phases are individually shippable
-and ordered by dependency, not by appeal.
+[`docs/ai/measurement.md`](../docs/ai/measurement.md). Four scoreboards now exist: the arena
+(`just arena`), the 48-puzzle suite (`just arena-puzzles`, **39/48 today**), the multiplayer pod
+arena (`just arena-pod`) and the budget-scaling ladder (`just arena-budget-scaling`, **monotone**).
+Next up is **Phase 6, CardIntent** — the highest strength-per-effort item left, and the first one
+that is meant to move the win rate rather than enable it. Phases are individually shippable and
+ordered by dependency, not by appeal.
 
 **Related:** [`engine-performance.md`](engine-performance.md) — the CPU profile this plan's
 performance phase builds on. See "Cross-reference" below; parts of that doc are stale.
@@ -451,7 +452,63 @@ an exact-mirror / clean-game / discrimination harness in the always-on suite, �
 
 ---
 
-### Phase 4 — Branching factor + budget · *5–8 d*
+### Phase 4 — Branching factor + budget · *5–8 d* — ✅ **DONE 2026-07-28**
+
+> **Shipped.** `rules-engine/.../legalactions/MeaningfulActionFilter.kt` owns the auto-pass rules;
+> `AutoPassManager` adapts the DTO and delegates. `ai/.../engine/budget/{DecisionBudget,BudgetPolicy}.kt`
+> carries the four tiers, threaded through `AIPlayer` → `Strategist` → `CombatAdvisor` →
+> `DecisionResponder` and switched by `AiProfile.useMeaningfulFilter` / `.budgetPolicy`. New
+> scoreboard: `just arena-budget-scaling`. Numbers and findings:
+> [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md#phase-4--branching-factor--budget);
+> how to read the ladder: [`docs/ai/measurement.md`](../docs/ai/measurement.md#the-budget-scaling-ladder).
+>
+> **Baselines: `v0-meaningful` 51.3% CI [49.8%, 52.7%] and `v0-phase4` 50.8% CI [49.4%, 52.2%]**
+> over 1,000 paired games each — neutral, which is the result enabling infrastructure should
+> produce. The exit criterion was ≥50% precisely because a filtered agent that *loses* is
+> discarding a real option; it does not lose. **The budget-scaling ladder is monotone with every
+> rung's lower CI bound above parity** (1000 vs 100: 55.7% [52.7%, 58.7%] · 3000 vs 1000: 54.0%
+> [51.0%, 57.0%] · end to end: 55.3% [52.0%, 59.0%]) — the safety net is calibrated and passing
+> before rollouts exist, which was the whole point of building it now.
+>
+> Five corrections the build produced:
+>
+> 1. **Phase 1's illegal-action finding was a targeting bug, not a filtering one — and it is now
+>    fixed.** 889 of 945 rejections were `CastSpell: No valid targets available`, and the
+>    meaningful-action filter turned out not to be the cause. `Strategist` abandoned target
+>    selection for the *whole spell* whenever *any* requirement had no legal target, then submitted
+>    an untargeted cast. Almost every case is an **optional** trailing slot — Conduct Electricity's
+>    "up to one target creature token" with no token on the board makes the AI decline to target the
+>    mandatory creature either. `fillableRequirements` fills what it can. Measured: **36 → 0** over
+>    200 mirror games.
+> 2. **`validTargets` cannot see a multi-requirement spell's second slot.** It only ever mirrors the
+>    first requirement, so "targeted spell with no legal target" passed a spell whose second
+>    *mandatory* slot was empty. `PriorityAction.hasUnfillableTargetRequirement` asks the real
+>    question, and the client's auto-pass gets the fix too — it was stopping players on spells they
+>    could not cast.
+> 3. **A budget must be spent as work, not wall clock.** `SearchAllowances` converts a tier into a
+>    count of simulations once; the millisecond figure is a hard safety stop only. A stopwatch would
+>    have made every arena run irreproducible and `ArenaHarnessTest`'s "identical at 8 threads and
+>    at 1" assertion flaky — and it is why the arena's 3.5-minute 1,000-game gate survives Phase 4b
+>    intact, contrary to Phase 1's warning that shipping a budget would make the arena expensive.
+> 4. **The plan's threading list was one module too long.** Every scan in `DecisionResponder` is
+>    already bounded to ≤11 simulations by construction, at or below what even ROUTINE allows. The
+>    budget is wired into the one place it can bind (the target pre-rank cut) and deliberately not
+>    into the other twenty responders.
+> 5. **Two CRITICAL triggers from the table are not implemented, on purpose.** "Sweeper castable"
+>    and "a real counterspell window" both need to know what a card *does* — Phase 6's `CardIntent`.
+>    Guessing from a mana cost would put the most expensive tier on the wrong windows.
+>
+> **`LEGACY_V0` is untouched.** Both halves are behind profile flags, including the target-filling
+> bug fix — not because the old behaviour is defensible, but because quietly strengthening the
+> permanent reference opponent would silently rebase every number published against it.
+> `FrozenBaselineTest` would not have caught it: its frozen game is all-vanilla Portal, which has no
+> multi-requirement spell.
+>
+> **The branching-factor exit criterion was dropped, as Phase 0 predicted.** "Down 30–50%" was
+> written against an assumed ~8 candidates; the real figure is 1.75, and `filterMeaningful` has
+> almost nothing left to cut. The delivered win is `canAutoPassWithoutEnumerating`: **40% of
+> priority windows are now decided without calling the enumerator at all** (measured over 884 real
+> windows by `AutoPassParityTest`, which prints the figure).
 
 #### 4a. Port the meaningful-action filter down into the engine
 
@@ -490,6 +547,12 @@ honour it.
 > written against an assumed ~8. The win is entirely `shouldAutoPass`: 76.2% of windows already
 > yield zero candidates and still pay `enumerate` (0.40 ms) first, which is ~148 ms per game of pure
 > waste and is paid again on every rollout crossing. Scope 4a as "skip the enumeration".
+>
+> **As built,** that became a third entry point, `canAutoPassWithoutEnumerating`, which decides a
+> window from the **state alone** — the other two still need the enumerated list. It fires on 40%
+> of windows rather than 76.2%, because it declines every window whose verdict depends on what the
+> player is holding, and `AutoPassParityTest` holds it to being a strict subset of the full verdict
+> over a corpus of real windows.
 
 #### 4b. `DecisionBudget`
 
@@ -511,9 +574,9 @@ so combat never gets *less* time than today.
 **Anytime contract:** every consumer must have a valid answer after its first iteration. Enforced
 structurally by Phase 7's sequential halving.
 
-**Exit:** branching factor down 30–50%; `just arena v0 v0-meaningful 1000` ≥50% — if the filtered
-agent *loses*, the filter is discarding a real option and you've found a bug for free;
-`ArenaBudgetScalingTest` running.
+**Exit:** ~~branching factor down 30–50%~~ (unreachable at 1.75 candidates — replaced by "40% of
+priority windows decided without enumerating"); ✅ `just arena v0 v0-meaningful 1000` = 51.3%,
+CI [49.8%, 52.7%]; ✅ `ArenaBudgetScalingTest` running **and monotone**.
 
 ---
 
@@ -933,15 +996,15 @@ but tanks a puzzle category, look hard before shipping.
 ## Recommended order
 
 ```
-0̶ → 1̶ → 2̶ → 3̶ → 4 → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
+0̶ → 1̶ → 2̶ → 3̶ → 4̶ → 6 → 7 → 8 → 9 → 10        (5a runs alongside, on its own schedule)
 ```
 
-Phases 0–3 are done — all three scoreboards exist and the evaluator is no longer one-eyed at a pod
-table. **Phase 5 has left the critical path** — simulation is already ~2× the speed the rollout
-budget needs, so 5a is now an independent engine-perf task and 5c is almost certainly not justified.
-Next up is **Phase 6, CardIntent** — now the highest strength-per-effort item left — with **Phase 4**
-(branching factor + budget) as the alternative if you would rather land the enabling infrastructure
-first. Phase 6 does not depend on Phase 4.
+Phases 0–4 are done — all four scoreboards exist, the evaluator is no longer one-eyed at a pod
+table, and the budget ladder is calibrated and monotone before any rollout depends on it.
+**Phase 5 has left the critical path** — simulation is already ~2× the speed the rollout budget
+needs, so 5a is now an independent engine-perf task and 5c is almost certainly not justified.
+Next up is **Phase 6, CardIntent** — the highest strength-per-effort item left, and the first phase
+since 3 that is meant to move a win rate rather than enable one.
 
 Ranked by strength-per-effort, independent of ordering:
 
@@ -952,8 +1015,8 @@ Ranked by strength-per-effort, independent of ordering:
 | 2 | **9** Texel tuning | 4–6 d | Replaces ~25 guessed constants with fitted ones. Cheap once the arena exists. |
 | 3 | **7** rollout evaluator | 6–9 d | Highest *ceiling*; the real lever. Costly, and worthless without the rest. |
 | 4 | **1̶ / 2̶** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Both done. |
-| 5 | **4a** auto-pass filter | 3–5 d | Demoted by Phase 0: at 1.75 candidates there is little to filter. Still saves ~148 ms/game of pointless enumeration, and a rollout pays it repeatedly. |
-| 6 | **4b** DecisionBudget | 2–3 d | Enabling infrastructure. |
+| — | **4̶a** auto-pass filter | 3–5 d | **Done.** Demoted by Phase 0 and rescoped to "skip the enumeration": 40% of priority windows now never call the enumerator. Also closed Phase 1's 889-of-945 illegal-action finding, which turned out to be a targeting bug. |
+| — | **4̶b** DecisionBudget | 2–3 d | **Done.** Enabling infrastructure, and it measures like it — neutral in the arena, monotone in the scaling ladder. |
 | 7 | **8** determinization | 5–7 d | **Costs** strength (fairness price). Do it because search over a cheated state is search over a lie. |
 | 8 | **5a** hoist O(n²) scans | 3–5 d | Demoted by Phase 0: no longer needed for rollouts. Still a standing engine win — `findAvailableManaSources` was 59% inclusive. |
 | — | **5c** persistent collections | 4–6 d | **Drop** unless a fresh profile demands it. Phase 0 measured throughput at ~2× the required rate. |
@@ -969,17 +1032,17 @@ two phases' worth of assumed work.
 
 | Risk | Detection | Mitigation |
 |---|---|---|
-| **Search makes the AI slower AND weaker** | `ArenaBudgetScalingTest` — strength must be monotone in budget | Build it in Phase 4, *before* rollouts. Non-monotone ⇒ rollouts are noise; fix the leaf evaluator (6, 9) before adding samples |
+| ~~**Search makes the AI slower AND weaker**~~ | `ArenaBudgetScalingTest` — strength must be monotone in budget | **Instrument built and calibrated in Phase 4, before rollouts exist, and it passes**: 55.7% / 54.0% / 55.3% up the ladder, every lower CI bound above parity. Still the standing gate for Phase 7 — non-monotone ⇒ rollouts are noise, and the fix is the leaf evaluator (6, 9), not more samples |
 | **Determinization dip read as a regression** | Certain to happen | Named in advance; Phase 8's bar is "still beats V0", not "beats the cheating version" |
 | **Overfitting to self-play** | Held-out set + gauntlet + puzzles | ≥3 collecting agents; hold out by game *and* by set; arena is the arbiter, not log-loss |
 | **Non-transitive strength** | Full pairwise matrix, not just Elo | Must beat V0 *and* previous version; lose to no gauntlet member worse than 45% |
-| **Combat's 1 s cap fights the global budget** | Blocking puzzle category; per-tier latency logging | Combat declaration is always CRITICAL; keep `MAX_BLOCK_SIMULATIONS = 10` as a floor, not a ceiling |
+| ~~**Combat's 1 s cap fights the global budget**~~ | Blocking puzzle category; `DecisionBudgetTest` | **Closed in Phase 4b** — combat declaration is always CRITICAL and `MAX_BLOCK_SIMULATIONS = 10` is a floor on every tier, asserted directly, so combat can never search *less* than it did before the budget existed |
 | **`GameSimulator.isResolving` / `decisionResolver` thread-safety** | Nondeterminism across arena reruns at the same seed | One `AIPlayer` per *seat* per game, never shared. `ArenaHarnessTest` asserts identical outcomes at 8 threads and at 1 — **green as of Phase 1**, so the AI is deterministic today. `PlayoutEngine` must own its own processor when Phase 7 lands |
 | **A pod result is read against 50%** | Certain to happen — every other number in this plan is | The null is **1/teams**: 33% at `ffa3`, 25% at `ffa4`, 50% at `2hg`. `ArenaReport.podSummary` prints the null on the same line as the win share and states it in the verdict sentence |
 | **A multiplayer harness trusts `GameState.turnNumber`** | Used to read every pod game as wedged after the first elimination | `turnNumber` was a round counter that only advanced for `turnOrder.first()`, who may be dead. **Closed**: it counts player turns now, so it is a sound clock at any table size (`backlog/multiplayer.md`) |
 | **Persistent collections break persisted sessions / committed replays** | `GameStateSerializationFormatStabilityTest` golden JSON | Serializers delegate to standard `MapSerializer`/`ListSerializer` ⇒ byte-identical wire format |
 | **`CardInstantiator` extraction produces malformed cards** | `DeterminizerInvariantsTest` + full engine suite | Reuse `GameInitializer`'s own construction path, don't hand-roll |
-| ~~**Arena wall-clock makes the merge gate unaffordable**~~ | Measured in Phase 1 | **Not a risk today** — 1,000 games is 3.5 min, because no `DecisionBudget` exists yet. Re-opens in Phase 4b: re-measure before shipping a budget, and only then consider a reduced-budget arena mode |
+| ~~**Arena wall-clock makes the merge gate unaffordable**~~ | Measured in Phase 1, re-measured in Phase 4b | **Closed.** 1,000 games is still ~3.5 min *with* a budget, because `SearchAllowances` spends a tier as a count of simulations rather than as wall clock. The reduced-budget arena mode was never needed and was not built |
 | ~~**`AiProfile.LEGACY_V0` silently drifts**~~ | `FrozenBaselineTest` golden action-stream hash | **Closed in Phase 1** — one fixed all-vanilla Portal game, SHA-256 over the action stream. All-vanilla so the hash tracks *AI* behaviour, not every card that ships |
 | ~~**`respondBudgetModal` zero-cost infinite loop**~~ | Arena stuck-game detector | **Closed in Phase 0** — free modes are taken once; regression test committed |
 | ~~**`Searcher.kt`'s `Double.MIN_VALUE/2` gets accidentally revived**~~ | — | **Closed in Phase 0** — file deleted rather than repaired |

--- a/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
@@ -39,7 +39,7 @@ tasks.withType<Test>().configureEach {
     // and `just arena-gauntlet` reach the test JVM. Both recipes also pass -Dbenchmark=true, which
     // is what relaxes TestHangGuard for a run that legitimately takes half an hour.
     for (prop in listOf(
-        "arena", "arenaGauntlet", "arenaPod", "arenaTable", "arenaA", "arenaB",
+        "arena", "arenaGauntlet", "arenaPod", "arenaBudgetScaling", "arenaTable", "arenaA", "arenaB",
         "arenaGames", "arenaSeed", "arenaSet", "arenaMaxTurns", "arenaThreads",
     )) {
         System.getProperty(prop)?.let { systemProperty(prop, it) }

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -437,3 +437,131 @@ is built from `state.getBattlefield()` only, so `getController` on a *player* en
 and the player branch therefore always takes the `else` arm and returns **−5.0**. Every burn spell
 ranks its own controller and its opponent identically badly. Phase 6 should fix this when it
 rewrites the function's `else -> 0.0`.
+
+---
+
+# Phase 4 — Branching factor + budget
+
+**Measured:** 2026-07-28, Phase 4. Same hardware as above.
+
+```bash
+just arena v0 v0-meaningful 1000     # the filter alone
+just arena v0 v0-phase4 1000         # filter + tiered budget — what the phase proposes to ship
+just arena-budget-scaling 300        # the monotonicity ladder
+just arena-pod ffa3 v0-phase4 v0 150 # pod crash check
+```
+
+## Agent baselines
+
+| Matchup | Win share for A | CI | Games | Verdict |
+|---|---|---|---|---|
+| `v0-meaningful` vs `v0` | 51.3% | [49.8%, 52.7%] | 1,000 | neutral — spans parity |
+| `v0-phase4` vs `v0` | 50.8% | [49.4%, 52.2%] | 1,000 | neutral — spans parity |
+| `v0-phase4` vs a field of `v0` (`ffa3`) | 30.0% | [25.3%, 34.7%] | 150 | neutral — spans the 33.3% null |
+
+**Phase 4 is enabling infrastructure and it measures like it.** Neither agent is a demonstrated
+improvement, and neither is a regression — which is the result the phase was designed to produce.
+The exit criterion was `just arena v0 v0-meaningful 1000` **≥50%**, phrased that way precisely
+because a filtered agent that *loses* is discarding a real option. It does not lose.
+
+## Budget scaling — the safety net, and it passes
+
+`just arena-budget-scaling 300`. The same agent, differing in nothing but the size of its
+`DecisionBudget`, played against itself. **Strength is monotone in the budget, with every rung's
+lower CI bound above parity:**
+
+| Rung | Win share for the bigger budget | CI |
+|---|---|---|
+| 1000 ms vs 100 ms | 55.7% | [52.7%, 58.7%] |
+| 3000 ms vs 1000 ms | 54.0% | [51.0%, 57.0%] |
+| 3000 ms vs 100 ms (end to end) | 55.3% | [52.0%, 59.0%] |
+
+This is the single most important number in the phase. It says the search the AI already has
+converts *more thinking* into *more winning*, so when Phase 7 stacks rollouts on top of it there is
+a calibrated instrument that will notice if that stops being true. Note the end-to-end rung is not
+larger than the first: returns diminish above ~1 s, and the three runs share decks and seeds, so
+they are correlated — read the ladder as "monotone", not as "linear".
+
+**Allowances are counted, not timed.** `SearchAllowances` converts a budget into a number of
+simulations once, and the wall clock is only a hard safety stop. A stopwatch-driven search would
+have made the arena non-reproducible and `ArenaHarnessTest`'s "identical at 8 threads and at 1"
+assertion flaky, which would have cost more than it bought.
+
+## Enumeration skipping — what 4a actually saves
+
+Phase 0 re-scoped 4a from "shrink the candidate list" (there are only 1.75 candidates to shrink) to
+"skip the enumeration". `MeaningfulActionFilter.canAutoPassWithoutEnumerating` decides a whole
+priority window from the state alone, without calling `LegalActionEnumerator.enumerate` at all.
+
+Measured over 884 real priority windows from two full AI-vs-AI games (`AutoPassParityTest`, which
+prints the figure): **40% of windows are decided without enumerating.** That is below Phase 0's
+76.2% "windows offering zero candidates" because the fast path deliberately declines every window
+whose verdict depends on what the player is holding — both main phases, both combat declarations,
+first-strike damage, end of combat, and the opponent's end step. At ~0.40 ms per `enumerate` and
+~380 windows per game, it is ~60 ms per game today, and a Phase 7 rollout would have paid it again
+on every window it crossed.
+
+## What Phase 4 found
+
+### 1. The Phase 1 illegal-action finding was a *targeting* bug, not a filtering one
+
+Phase 1 measured the AI proposing ~0.9 illegal actions per game, **889 of 945 being exactly
+`CastSpell: No valid targets available`**, and left it open. The meaningful-action filter was the
+obvious suspect and it turned out not to be the cause at all.
+
+The actual mechanism: `Strategist.resolveTargetsForSimulation` and `chooseCommittedTargets` both
+opened with `if (targetInfos.any { it.validTargets.isEmpty() }) return action.action` — abandoning
+target selection for the **whole spell** the moment *any* requirement had no legal target, and then
+submitting an untargeted cast that the engine rejects. Almost every instance is an **optional**
+trailing slot. Conduct Electricity is "destroy target creature" *and* "up to one target creature
+token"; with no token on the board the AI declines to target the mandatory creature either, and
+throws the card away on a rejection.
+
+`Strategist.fillableRequirements` now fills the slots it can. Targets are submitted as one flat list
+that `TargetValidator` slices back by max counts, so an unfilled slot can only ever be a trailing
+one — the function returns null (old behaviour) when a mandatory slot is empty, or when a *later*
+slot has targets that a skipped one would displace.
+
+Measured effect, mirror matches over 200 games: **`No valid targets available` 36 → 0.** Only 10
+`Not enough mana` rejections remain, a separate bug.
+
+It is behind `AiProfile.useMeaningfulFilter` rather than applied unconditionally. Not because the
+old behaviour is defensible, but because `LEGACY_V0` is the permanent reference opponent and quietly
+strengthening it would silently rebase every number ever published against it. `FrozenBaselineTest`
+would not have caught this: its frozen game is all-vanilla Portal, which has no multi-requirement
+spell.
+
+### 2. `validTargets` cannot see a multi-requirement spell's second slot
+
+The same neighbourhood, a different consumer. `LegalAction.validTargets` and
+`LegalActionInfo.validTargets` only ever mirror the *first* target requirement, so the obvious
+"targeted spell with no legal target" test passes a two-requirement spell whose second mandatory
+slot is empty — an action the engine will reject.
+
+`PriorityAction.hasUnfillableTargetRequirement` asks the real question (any **mandatory**
+requirement with no legal target), and both the AI's candidate filter and the client's auto-pass now
+use it. The client half is a UX fix in its own right: it was stopping the player on spells they
+could not cast.
+
+### 3. The "next stop point" button used a weaker notion of "meaningful" than the stop itself
+
+`GameSession` computed `hasMeaningfulActions` inline as "not PassPriority, and not a plain mana
+ability" — which counts unaffordable spells and zero-target spells that the actual stop decision
+discards. So the Pass button could promise a stop that never arrived. It now calls
+`AutoPassManager.getMeaningfulActions`, the same code path the stop uses.
+
+### 4. Threading a budget through `DecisionResponder` would have changed no number
+
+The plan lists `DecisionResponder` in the budget's threading chain. Every scan in it is already
+bounded by construction — a yes/no is 2 simulations, a colour is 5, a number is sampled to 11,
+targets are pre-ranked and truncated to 8 — which is at or below what even the ROUTINE tier allows.
+The budget is wired into the one place it can bind (the target pre-rank cut) and deliberately not
+into the other twenty responders.
+
+### 5. Two tiers from the plan's table are not implemented, on purpose
+
+`BudgetPolicy`'s CRITICAL tier fires on combat declaration and on either side being within one
+swing of lethal. The plan also lists "sweeper castable or on the stack" and "a real counterspell
+window". Both need to know what a card *does* — Phase 6's `CardIntent` — and guessing them from a
+mana cost would put the most expensive tier on the wrong windows, which is worse than leaving those
+windows at NORMAL.

--- a/docs/ai/measurement.md
+++ b/docs/ai/measurement.md
@@ -36,10 +36,14 @@ just arena A B [GAMES] [SET] [SEED]
 | Publish | 3,000 | 10 min | ±0.4 pp |
 
 Wall clock is measured on an 8-core M1 Pro at ~5 games/sec. **This is ~100× cheaper than the plan
-assumed**, because the plan budgeted a 2 s `DecisionBudget` that does not exist yet; today the AI
-spends ~1.6 s of wall clock on a whole game. When Phase 4b lands a real budget, re-measure this
-table before promising anyone a 1,000-game gate — it is the budget, not the game count, that makes
-an arena expensive.
+assumed**, because the plan budgeted a 2 s `DecisionBudget` spent as wall clock; today the AI spends
+~1.6 s on a whole game.
+
+**Phase 4b's budget did not change that, by design.** A `DecisionBudget` is converted once into a
+*count* of simulations (`SearchAllowances`) and the millisecond figure is only a hard safety stop —
+so a 2,000 ms NORMAL tier costs what its allowances cost, not two seconds. A stopwatch-driven search
+would have made every arena run irreproducible and `ArenaHarnessTest`'s "identical at 8 threads and
+at 1" assertion flaky. The table above still holds with `v0-phase4` on both seats.
 
 Agents are named in `ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt`:
 
@@ -50,6 +54,9 @@ Agents are named in `ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt`:
 | `production` | what a player actually faces: BLB + ONS card advisors |
 | `blb-advisors` / `ons-advisors` | v0 plus one advisor module |
 | `v0-blind` | all evaluation weights zero. Not playable — it is the harness's own control |
+| `v0-meaningful` | v0 + the Phase 4a meaningful-action filter and target-filling fix |
+| `v0-budget-100` … `-3000` | v0 + a `TieredBudgetPolicy` at that NORMAL-tier size. The scaling ladder |
+| `v0-phase4` | both halves of Phase 4 — the filter plus the tiered budget at nominal sizes |
 
 Results land in `benchmarks/arena/<timestamp>-<a>-vs-<b>/` (gitignored): `results.csv` is one row
 per game, `summary.md` is the report below.
@@ -133,8 +140,31 @@ Say these out loud rather than letting a reader assume otherwise.
   but it means the arena tests symmetric matchups only.
 - **Multiplayer.** `just arena` is two seats and always will be — the paired swap has no meaning at
   a bigger table. Pods have their own harness; see [the pod arena](#the-pod-arena) below.
-- **Latency per budget tier.** There are no tiers until Phase 4b.
+- **Wall-clock latency per budget tier.** There are tiers as of Phase 4b, but they are spent as
+  simulation counts, not milliseconds — so "p95 latency at CRITICAL" is not something a
+  reproducible arena can report. Measure it in production instead.
 - **Anything about a real player.** The reference opponent is another bot.
+
+---
+
+## The budget-scaling ladder
+
+```
+just arena-budget-scaling [GAMES] [SET] [SEED]
+```
+
+The same agent, differing in nothing but the size of its `DecisionBudget`, played against itself at
+100 / 1000 / 3000 ms. Four matchups, so budget 4× `GAMES`.
+
+**Read it as one claim: strength must be monotone in the budget.** If it isn't, the search is
+generating noise rather than signal, and the fix is a better leaf evaluator (Phases 6 and 9), not
+more samples — adding rollouts on top of a search that gets worse with more thinking is how you
+spend a week making the AI slower *and* weaker. That is why this ladder was built in Phase 4,
+before any rollouts exist: it needs to be calibrated before it is needed.
+
+The test fails only when a rung's **whole interval** sits below parity. A point estimate under 50%
+at 300 games per rung is inside the noise, and failing on it would train everyone to ignore the
+test. Current numbers: [`baseline-metrics.md`](baseline-metrics.md#budget-scaling--the-safety-net-and-it-passes).
 
 ---
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
@@ -1,47 +1,35 @@
 package com.wingedsheep.gameserver.priority
 
+import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.combat.BlockingComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
-import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.engine.view.LegalActionInfo
+import com.wingedsheep.engine.view.asPriorityAction
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
 
 /**
- * Arena-style auto-pass manager that implements intelligent priority passing.
+ * The client-facing half of Arena-style priority passing: *should this player be prompted*, and
+ * *where will the game stop next* if they don't act.
  *
- * This follows the 4 Rules of Arena-style Instants:
+ * The rules themselves live in [MeaningfulActionFilter] in the rules engine, because the AI and the
+ * gym hold engine `LegalAction`s and never build a [LegalActionInfo]. This class adapts the DTO,
+ * delegates the decision, and logs the reason. What stays here is presentation: the "Pass to
+ * Combat" button label and the step lookahead that computes it.
  *
- * ## Rule 1: The "Meaningful Action" Filter
- * Filters out actions that shouldn't stop the game:
- * - Mana abilities are invisible (don't count for stopping)
- * - Zero-target spells are invisible (if requiresTargets but no validTargets)
- * - Counterspells only visible if stack is non-empty
+ * The rules, in short (full detail on [MeaningfulActionFilter]):
  *
- * ## Rule 2: The "Opponent's Turn" Compression
- * When it's the opponent's turn:
- * - Upkeep/Draw: AUTO-PASS
- * - Main Phase: STOP if you have instant-speed responses
- * - Combat (Start/Attackers): STOP (crucial window for tapping/killing attackers)
- * - End Step: STOP if you have instant-speed responses (golden rule for control players)
- *
- * ## Rule 3: The "My Turn" Optimization
- * When it's your own turn:
- * - Upkeep/Draw: AUTO-PASS
- * - Combat: STOP (for combat tricks like Giant Growth)
- *
- * ## Rule 4: The Stack Response
- * - If YOUR spell/ability is on top of the stack: AUTO-PASS (let opponent respond)
- * - If OPPONENT's permanent spell is on top and you have no responses: AUTO-PASS (auto-resolve)
- * - If OPPONENT's non-permanent spell or ability is on top: STOP (so you can see what they're doing)
+ * 1. **Meaningful-action filter** — mana abilities, zero-target spells and unaffordable casts don't
+ *    stop the game.
+ * 2. **Opponent's-turn compression** — upkeep/draw pass; main phases, combat windows and the end
+ *    step stop when you have an instant-speed response; declare blockers stops when you can block.
+ * 3. **Your-turn optimization** — you stop at your main phases and at declare attackers.
+ * 4. **Stack response** — your own object on top auto-passes; an opponent's non-permanent spell or
+ *    ability stops.
  */
 class AutoPassManager(
     /**
@@ -54,63 +42,6 @@ class AutoPassManager(
 ) {
 
     private val logger = LoggerFactory.getLogger(AutoPassManager::class.java)
-
-    companion object {
-        /** Combat steps the engine auto-skips when no creatures are attacking (CR 508.8) */
-        private val COMBAT_STEPS_SKIPPED_WITHOUT_ATTACKERS = setOf(
-            Step.DECLARE_BLOCKERS,
-            Step.FIRST_STRIKE_COMBAT_DAMAGE,
-            Step.COMBAT_DAMAGE
-        )
-
-        /**
-         * Every action type that represents casting a spell, across *all* cost paths. The
-         * enumerators emit a distinct `actionType` per cost variant (a plain cast, each modal
-         * shape, and every alternative cost — flashback, harmonize, warp, evoke/impending/granted
-         * via [CastWithAlternativeCost], kicker, conspire, a free cast, morph). The auto-pass
-         * logic must treat them all as "a spell you can cast"; missing one (e.g. Sneak, which is
-         * only ever a `CastWithAlternativeCost`) makes the client speed past the window where it's
-         * legal. The server only sends legal actions, so any of these present means the player can
-         * actually cast it now.
-         */
-        val SPELL_CAST_ACTION_TYPES = setOf(
-            "CastSpell",
-            "CastSpellMode",
-            "CastSpellModal",
-            "CastWithAlternativeCost",
-            "CastWithFlashback",
-            "CastWithHarmonize",
-            "CastWithWarp",
-            "CastWithKicker",
-            // Gift (CR 702.174a) — the "promise a gift" twin of a normal cast.
-            "CastWithGift",
-            "CastWithConspire",
-            "CastWithoutPayingManaCost",
-            "CastFaceDown",
-        )
-
-        /** Spell casts plus the activated / special abilities that count as instant-speed responses. */
-        val INSTANT_RESPONSE_ACTION_TYPES = SPELL_CAST_ACTION_TYPES + setOf(
-            "ActivateAbility",
-            "CycleCard",
-            "TypecycleCard",
-            "PlotCard",
-            "ForetellCard",
-            // Crew is an activated ability (CR 702.122a) with no timing restriction, so it can be
-            // activated any time you have priority (CR 117.1b) — making it a valid instant-speed
-            // response (e.g. crewing during the opponent's declare-attackers window). Saddle is
-            // sorcery-speed and deliberately absent.
-            "CrewVehicle",
-        )
-    }
-
-    /**
-     * True if this action is an instant-speed response — a spell the player can cast or an
-     * ability they can activate right now — with a legal target if it needs one.
-     */
-    private fun LegalActionInfo.isInstantSpeedResponse(): Boolean =
-        actionType in INSTANT_RESPONSE_ACTION_TYPES &&
-            (!requiresTargets || !validTargets.isNullOrEmpty())
 
     /**
      * Determines if the player with priority should automatically pass.
@@ -128,511 +59,24 @@ class AutoPassManager(
         opponentTurnStops: Set<Step> = emptySet(),
         stopsMode: Boolean = false
     ): Boolean {
-        // If player doesn't have priority, can't pass
-        if (state.priorityPlayerId != playerId) {
-            return false
-        }
-
-        // If there's a pending decision, never auto-pass
-        if (state.pendingDecision != null) {
-            return false
-        }
-
-        // Get meaningful actions (Rule 1) - needed for stack response check
-        val meaningfulActions = getMeaningfulActions(legalActions, state)
-
-        // Rule 4: Stack Response - Check who controls the top of the stack
-        // - If YOUR spell/ability is on top → AUTO-PASS (let opponent respond)
-        // - If OPPONENT's spell/ability is on top → STOP (so you can see what they're doing)
-        if (state.stack.isNotEmpty()) {
-            val topOfStack = state.stack.last() // Stack is LIFO, last = top
-            val topController = getStackItemController(state, topOfStack)
-
-            if (topController == playerId) {
-                // Our own spell/ability is on top - auto-pass to let opponent respond,
-                // unless an available action has holdPriority set (e.g., copy-spell abilities)
-                val shouldHold = meaningfulActions.any { it.holdPriority }
-                if (shouldHold) {
-                    logger.debug("STOP: Own spell/ability on top of stack but player has holdPriority action")
-                    return false
-                }
-                logger.debug("AUTO-PASS: Own spell/ability on top of stack")
-                return true
-            } else {
-                // Opponent's item on top.
-                // Persistent yield (backlog §C): the player explicitly asked to stop being stopped
-                // by this ability, so auto-pass even though it's an opponent's object — an opt-in
-                // per-ability override of the usual "stop on opponent's stack item" rule. A
-                // holdPriority action (a response the player deliberately lined up) still wins, and
-                // this is one more pass reason layered on top of the meaningful-action filter, not
-                // a replacement for it.
-                val topContainer = state.getEntity(topOfStack)
-                val yieldedIdentity = topContainer?.get<TriggeredAbilityOnStackComponent>()?.abilityIdentity
-                    ?: topContainer?.get<ActivatedAbilityOnStackComponent>()?.abilityIdentity
-                if (yieldedIdentity != null &&
-                    state.isYieldingTo(playerId, yieldedIdentity) &&
-                    meaningfulActions.none { it.holdPriority }
-                ) {
-                    logger.debug("AUTO-PASS: Yielded to opponent's ability $yieldedIdentity")
-                    return true
-                }
-
-                // In Stops mode: always stop on opponent's stack items (regardless of type)
-                if (stopsMode) {
-                    logger.debug("STOP (Stops mode): Opponent's spell/ability on stack")
-                    return false
-                }
-
-                // Auto mode: check what type it is
-                val container = state.getEntity(topOfStack)
-                val cardComponent = container?.get<CardComponent>()
-                val isPermanentSpell = container?.get<SpellOnStackComponent>()?.let {
-                    isPermanentSpell(cardComponent, it)
-                } ?: false
-                val isAura = cardComponent?.isAura ?: false
-
-                if (isPermanentSpell && !isAura) {
-                    // Non-aura permanent spells (creatures, artifacts, non-aura enchantments, planeswalkers):
-                    // Auto-pass if we have no meaningful instant-speed responses.
-                    // Auras are excluded because they target, and the opponent should see what's being targeted.
-                    val hasResponses = meaningfulActions.any { it.actionType in INSTANT_RESPONSE_ACTION_TYPES }
-                    if (!hasResponses) {
-                        logger.debug("AUTO-PASS: Opponent's permanent spell on stack, no responses")
-                        return true
-                    }
-                }
-
-                // Non-permanent spells (instants/sorceries) and abilities: always stop
-                logger.debug("STOP: Opponent's spell/ability on stack")
-                return false
-            }
-        }
-
-        // Determine if this is our turn or opponent's turn. Team-aware (CR 805/810): in a shared
-        // Two-Headed Giant turn BOTH teammates are "on their turn", so the non-active-player
-        // teammate still stops in their own main phase instead of being auto-passed as if it were
-        // the opponents' turn. Reduces to `activePlayerId == playerId` in a non-team game.
-        val isMyTurn = state.isActiveTurnFor(playerId)
-
-        // Check per-step stop overrides (only when stack is empty, which it is at this point)
-        val relevantStops = if (isMyTurn) myTurnStops else opponentTurnStops
-        if (state.step in relevantStops) {
-            logger.debug("STOP: Per-step stop override set for ${state.step}")
-            return false
-        }
-
-        // Stops mode: stop at combat damage step when creatures are attacking you
-        if (stopsMode && !isMyTurn && (state.step == Step.COMBAT_DAMAGE || state.step == Step.FIRST_STRIKE_COMBAT_DAMAGE)) {
-            val hasAttackers = state.getBattlefield().any { entityId ->
-                state.getEntity(entityId)?.get<AttackingComponent>() != null
-            }
-            if (hasAttackers) {
-                logger.debug("STOP (Stops mode): Combat damage step with attackers")
-                return false
-            }
-        }
-
-        // Never auto-pass the active player's own main phases
-        if (isMyTurn && (state.step == Step.PRECOMBAT_MAIN || state.step == Step.POSTCOMBAT_MAIN)) {
-            logger.debug("STOP: My main phase (always stop)")
-            return false
-        }
-
-        // If no meaningful actions, auto-pass
-        if (meaningfulActions.isEmpty()) {
-            logger.debug("AUTO-PASS: No meaningful actions available")
-            return true
-        }
-
-        // Special handling for DECLARE_BLOCKERS on your own turn.
-        // After the opponent declares blockers, you may want to cast combat tricks
-        // (like Giant Growth) before damage. On opponent's turn, this is handled
-        // by shouldAutoPassOnOpponentTurn which only stops if you have blockers.
-        if (state.step == Step.DECLARE_BLOCKERS && isMyTurn) {
-            val hasInstantSpeedResponses = meaningfulActions.any { it.isInstantSpeedResponse() }
-
-            if (hasInstantSpeedResponses) {
-                logger.debug("STOP: Declare blockers step (have instant-speed responses)")
-                return false
-            }
-        }
-
-        // On opponent's declare attackers, auto-pass if they didn't attack — nothing to respond to
-        if (!isMyTurn && state.step == Step.DECLARE_ATTACKERS) {
-            val hasAttackers = state.getBattlefield().any { entityId ->
-                state.getEntity(entityId)?.get<AttackingComponent>() != null
-            }
-            if (!hasAttackers) {
-                logger.debug("AUTO-PASS: Opponent's declare attackers (no attackers declared)")
-                return true
-            }
-        }
-
-        return if (isMyTurn) {
-            shouldAutoPassOnMyTurn(state.step, meaningfulActions)
-        } else {
-            shouldAutoPassOnOpponentTurn(state.step, meaningfulActions)
-        }
+        val verdict = MeaningfulActionFilter.autoPassVerdict(
+            state = state,
+            playerId = playerId,
+            legalActions = legalActions.map { it.asPriorityAction() },
+            myTurnStops = myTurnStops,
+            opponentTurnStops = opponentTurnStops,
+            stopsMode = stopsMode,
+            cardRegistry = cardRegistry,
+        )
+        logger.debug(verdict.reason)
+        return verdict.autoPass
     }
 
     /**
-     * Rule 1: Filter legal actions to only "meaningful" actions that should stop the game.
+     * Filter legal actions to only the "meaningful" ones that should stop the game.
      */
-    private fun getMeaningfulActions(
-        legalActions: List<LegalActionInfo>,
-        state: GameState
-    ): List<LegalActionInfo> {
-        return legalActions.filter { action ->
-            // PassPriority is never meaningful (it's the default)
-            if (action.actionType == "PassPriority") {
-                return@filter false
-            }
-
-            // Mana abilities are invisible - they don't stop the game
-            // Exception: mana abilities with sacrifice costs (e.g., Skirk Prospector)
-            // are meaningful because sacrificing a creature is a significant game action
-            if (action.isManaAbility) {
-                val hasSacrificeCost = action.additionalCostInfo?.costType == "SacrificePermanent"
-                if (!hasSacrificeCost) {
-                    return@filter false
-                }
-            }
-
-            // DeclareAttackers is meaningful if there are valid attackers
-            if (action.actionType == "DeclareAttackers") {
-                val hasValidAttackers = !action.validAttackers.isNullOrEmpty()
-                return@filter hasValidAttackers
-            }
-
-            // DeclareBlockers is meaningful only if there are valid blockers
-            if (action.actionType == "DeclareBlockers") {
-                val hasValidBlockers = !action.validBlockers.isNullOrEmpty()
-                return@filter hasValidBlockers
-            }
-
-            // PlayLand is always meaningful when available
-            if (action.actionType == "PlayLand") {
-                return@filter true
-            }
-
-            // For spells that require targets, check if they have valid targets
-            if (action.requiresTargets) {
-                val hasValidTargets = !action.validTargets.isNullOrEmpty()
-                if (!hasValidTargets) {
-                    // Zero-target spell - invisible
-                    return@filter false
-                }
-            }
-
-            // ActivateAbility (non-mana) is meaningful
-            if (action.actionType == "ActivateAbility") {
-                return@filter true
-            }
-
-            // A spell cast (any cost path) is meaningful only if the player can afford it.
-            // (Regular spells are only added when affordable, but companion actions for
-            // cycling/morph cards can be added with isAffordable=false.)
-            if (action.actionType in SPELL_CAST_ACTION_TYPES) {
-                return@filter action.isAffordable
-            }
-
-            // Cycling/typecycling is meaningful only if the player can afford it
-            if (action.actionType == "CycleCard" || action.actionType == "TypecycleCard" ||
-                action.actionType == "PlotCard" || action.actionType == "ForetellCard") {
-                return@filter action.isAffordable
-            }
-
-            // Crewing a Vehicle is meaningful only if there's enough untapped power to pay the
-            // crew cost (otherwise there's nothing to stop for).
-            if (action.actionType == "CrewVehicle") {
-                return@filter action.isAffordable
-            }
-
-            // Other actions are meaningful by default
-            true
-        }
-    }
-
-    /**
-     * Rule 3: Determine auto-pass behavior on your own turn (TRUE Arena-style).
-     *
-     * Arena is VERY aggressive about auto-passing on your own turn. You only stop at:
-     * - Main phases (to play lands and spells)
-     * - Declare attackers (to declare attacks)
-     *
-     * EVERYTHING ELSE auto-passes, even if you have instant-speed actions available.
-     * If you want to act at other times, you need Full Control or manual stops.
-     *
-     * This matches how Arena actually works - it speeds through your turn so you can
-     * play your main phase cards and attack, then quickly passes to opponent's turn.
-     */
-    private fun shouldAutoPassOnMyTurn(
-        step: Step,
-        meaningfulActions: List<LegalActionInfo>
-    ): Boolean {
-        return when (step) {
-            // Main Phases - STOP (this is where you play lands and cast spells)
-            Step.PRECOMBAT_MAIN, Step.POSTCOMBAT_MAIN -> {
-                logger.debug("STOP: My main phase")
-                false
-            }
-
-            // Declare Attackers - STOP only if we still need to declare attacks
-            // Once attackers are confirmed, auto-pass to let opponent declare blockers.
-            Step.DECLARE_ATTACKERS -> {
-                val needsToDeclare = meaningfulActions.any { it.actionType == "DeclareAttackers" }
-                if (needsToDeclare) {
-                    logger.debug("STOP: My declare attackers step (need to declare)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: My declare attackers step (already declared)")
-                    true
-                }
-            }
-
-            // EVERYTHING ELSE - AUTO-PASS (Arena-style aggressive passing)
-            // This includes: upkeep, draw, begin combat, declare blockers (after opponent blocks),
-            // first strike damage, combat damage, end combat, end step, cleanup
-            Step.UPKEEP, Step.DRAW -> {
-                logger.debug("AUTO-PASS: My upkeep/draw step")
-                true
-            }
-
-            Step.BEGIN_COMBAT -> {
-                logger.debug("AUTO-PASS: My begin combat")
-                true
-            }
-
-            Step.DECLARE_BLOCKERS -> {
-                val hasResponses = meaningfulActions.any { it.isInstantSpeedResponse() }
-                if (hasResponses) {
-                    logger.debug("STOP: My declare blockers step (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: My declare blockers step (no responses, moving to damage)")
-                    true
-                }
-            }
-
-            Step.FIRST_STRIKE_COMBAT_DAMAGE -> {
-                val hasResponses = meaningfulActions.any { it.isInstantSpeedResponse() }
-                if (hasResponses) {
-                    logger.debug("STOP: My first strike damage step (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: My first strike damage step (no responses)")
-                    true
-                }
-            }
-
-            Step.COMBAT_DAMAGE, Step.END_COMBAT -> {
-                logger.debug("AUTO-PASS: My combat damage/end combat")
-                true
-            }
-
-            Step.END -> {
-                logger.debug("AUTO-PASS: My end step")
-                true
-            }
-
-            Step.CLEANUP, Step.UNTAP -> {
-                logger.debug("AUTO-PASS: Cleanup/Untap")
-                true
-            }
-        }
-    }
-
-    /**
-     * Rule 2: Determine auto-pass behavior on opponent's turn (TRUE Arena-style).
-     *
-     * Arena is very aggressive about auto-passing on opponent's turn too.
-     * You only stop when you actually need to make a blocking decision.
-     * Having instants in hand doesn't mean you stop at every phase.
-     *
-     * - Upkeep/Draw: AUTO-PASS
-     * - Main: STOP if you have instant-speed responses
-     * - Begin Combat: AUTO-PASS
-     * - Declare Attackers (after declaration): STOP if you have instant-speed responses
-     * - Declare Blockers: STOP if you have blockers or instant-speed actions
-     * - Combat Damage: AUTO-PASS
-     * - End Step: AUTO-PASS (use per-step stop override to hold here)
-     */
-    private fun shouldAutoPassOnOpponentTurn(
-        step: Step,
-        meaningfulActions: List<LegalActionInfo>
-    ): Boolean {
-        // Check if we have blockers available
-        val hasBlockers = meaningfulActions.any { it.actionType == "DeclareBlockers" && !it.validBlockers.isNullOrEmpty() }
-
-        // Check if we have instant-speed responses (spells/abilities, not blockers)
-        val hasInstantSpeedResponses = meaningfulActions.any { it.isInstantSpeedResponse() }
-
-        return when (step) {
-            // Beginning Phase - auto-pass
-            Step.UPKEEP, Step.DRAW -> {
-                logger.debug("AUTO-PASS: Opponent's upkeep/draw")
-                true
-            }
-
-            // Main Phases - STOP if we have instant-speed responses
-            // (like Arena stopping at begin combat / end step, but also catching
-            // the case where the opponent does nothing on main phase and we could act)
-            Step.PRECOMBAT_MAIN, Step.POSTCOMBAT_MAIN -> {
-                if (hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's main phase (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's main phase (no responses)")
-                    true
-                }
-            }
-
-            // Begin Combat - AUTO-PASS (Arena-style)
-            Step.BEGIN_COMBAT -> {
-                logger.debug("AUTO-PASS: Opponent's begin combat (Arena-style)")
-                true
-            }
-
-            // Declare Attackers (after declaration) - STOP if we have instant-speed responses.
-            // This is the priority window after attackers are declared (CR 508.2) where
-            // the defending player can cast instants/activate abilities before blockers.
-            Step.DECLARE_ATTACKERS -> {
-                if (hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's declare attackers (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's declare attackers (no responses)")
-                    true
-                }
-            }
-
-            // Declare Blockers - STOP if we have creatures that can block OR
-            // instant-speed actions we can actually perform (combat tricks, cycling with mana, etc.)
-            // The server only sends legal actions, so having them in meaningfulActions
-            // means the player can actually pay for them.
-            Step.DECLARE_BLOCKERS -> {
-                if (hasBlockers || hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's declare blockers (have ${if (hasBlockers) "blockers" else "instant-speed responses"})")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's declare blockers (no blockers or responses)")
-                    true
-                }
-            }
-
-            // First Strike Damage - STOP if we have instant-speed responses
-            Step.FIRST_STRIKE_COMBAT_DAMAGE -> {
-                if (hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's first strike damage step (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's first strike damage step (no responses)")
-                    true
-                }
-            }
-
-            // Combat Damage - AUTO-PASS (no meaningful priority window to hold for here)
-            Step.COMBAT_DAMAGE -> {
-                logger.debug("AUTO-PASS: Opponent's combat damage")
-                true
-            }
-
-            // End Combat - STOP if we have instant-speed responses. This is a real priority
-            // window (CR 511.1) where the defending player can still act — and it's the *only*
-            // window for abilities restricted to it (e.g. Desert's "{T}: deals 1 damage to
-            // target attacking creature. Activate only during the end of combat step."), whose
-            // targets (still-attacking creatures) also vanish once the step ends (CR 511.3).
-            // Mirrors the END step / declare-attackers / first-strike handling above.
-            Step.END_COMBAT -> {
-                if (hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's end combat step (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's end combat step (no responses)")
-                    true
-                }
-            }
-
-            // End Step - STOP if we have instant-speed responses
-            Step.END -> {
-                if (hasInstantSpeedResponses) {
-                    logger.debug("STOP: Opponent's end step (have instant-speed responses)")
-                    false
-                } else {
-                    logger.debug("AUTO-PASS: Opponent's end step (no responses)")
-                    true
-                }
-            }
-
-            // Cleanup - no priority normally
-            Step.CLEANUP, Step.UNTAP -> {
-                logger.debug("AUTO-PASS: Cleanup/Untap")
-                true
-            }
-        }
-    }
-
-    /**
-     * Check if the player has any instant-speed responses available.
-     * Used for stack response checking.
-     */
-    fun hasInstantSpeedResponses(legalActions: List<LegalActionInfo>): Boolean {
-        return legalActions.any { action ->
-            // Exclude mana abilities (unless they have a sacrifice cost)
-            (!action.isManaAbility || action.additionalCostInfo?.costType == "SacrificePermanent") &&
-            // Must be a spell cast or activatable ability (not land play or combat action)
-            action.isInstantSpeedResponse()
-        }
-    }
-
-    /**
-     * Whether a spell on the stack is a permanent spell, respecting the actually-cast face.
-     *
-     * Split-layout cards (Omen, Adventure, MDFC — CR 709 / 715) keep their *base* characteristics
-     * (a creature) in [CardComponent] even when cast as their instant/sorcery face. Casting the
-     * instant/sorcery face stamps [SpellOnStackComponent.faceIndex]; resolving the type from that
-     * face (like [com.wingedsheep.engine.mechanics.stack.StackResolver] does) is what keeps the
-     * spell off the "permanent spell → auto-resolve" path, so the opponent still stops and sees it
-     * on the stack. Falls back to the base type line when there's no cast face or no registry.
-     */
-    private fun isPermanentSpell(cardComponent: CardComponent?, spell: SpellOnStackComponent): Boolean {
-        if (cardComponent == null) return false
-        val faceTypeLine = spell.faceIndex?.let { idx ->
-            cardRegistry?.getCard(cardComponent.name)?.cardFaces?.getOrNull(idx)?.typeLine
-        }
-        return faceTypeLine?.isPermanent ?: cardComponent.isPermanent
-    }
-
-    /**
-     * Get the controller of a stack item.
-     * Checks various component types since abilities use different components than spells.
-     */
-    private fun getStackItemController(state: GameState, entityId: EntityId): EntityId? {
-        val container = state.getEntity(entityId) ?: return null
-
-        // Check for activated ability
-        container.get<ActivatedAbilityOnStackComponent>()?.let {
-            return it.controllerId
-        }
-
-        // Check for triggered ability
-        container.get<TriggeredAbilityOnStackComponent>()?.let {
-            return it.controllerId
-        }
-
-        // Check for spell (uses casterId)
-        container.get<SpellOnStackComponent>()?.let {
-            return it.casterId
-        }
-
-        // Fall back to ControllerComponent (for permanents that somehow end up here)
-        container.get<ControllerComponent>()?.let {
-            return it.playerId
-        }
-
-        return null
-    }
-
+    fun getMeaningfulActions(legalActions: List<LegalActionInfo>): List<LegalActionInfo> =
+        legalActions.filter { MeaningfulActionFilter.isMeaningful(it.asPriorityAction()) }
 
     /**
      * Calculates the next step/phase where the game will stop for this player.
@@ -657,7 +101,7 @@ class AutoPassManager(
         }
 
         val currentStep = state.step
-        // Team-aware (see the stop-decision above): a Two-Headed Giant teammate shares the turn.
+        // Team-aware (see [MeaningfulActionFilter]): a Two-Headed Giant teammate shares the turn.
         val isMyTurn = state.isActiveTurnFor(playerId)
 
         // Special combat damage labels when there are attacking creatures
@@ -705,7 +149,7 @@ class AutoPassManager(
             step = nextStep
 
             // Skip combat steps that the engine auto-skips when there are no attackers (CR 508.8)
-            if (!hasAttackers && step in COMBAT_STEPS_SKIPPED_WITHOUT_ATTACKERS) {
+            if (!hasAttackers && step in MeaningfulActionFilter.COMBAT_STEPS_SKIPPED_WITHOUT_ATTACKERS) {
                 continue
             }
 
@@ -739,7 +183,7 @@ class AutoPassManager(
     }
 
     /**
-     * Simplified version of shouldAutoPassOnMyTurn for calculating next stop point.
+     * Simplified version of the my-turn rules for calculating the next stop point.
      * Arena-style: Only stop at main phases, declare attackers, and first strike damage
      * (when player has meaningful actions) on your own turn.
      */
@@ -756,7 +200,7 @@ class AutoPassManager(
     }
 
     /**
-     * Simplified version of shouldAutoPassOnOpponentTurn for calculating next stop point.
+     * Simplified version of the opponent's-turn rules for calculating the next stop point.
      * Arena-style: Very aggressive auto-passing, only stop at declare blockers, declare attackers
      * (if have responses), and end step.
      */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -897,10 +897,10 @@ class GameSession(
         val priorityHolder = state.priorityPlayerId
         val isActorForPriority = priorityHolder != null && state.actorFor(priorityHolder) == playerId
         val nextStopPoint = if (isActorForPriority && playerMode != PriorityMode.FULL_CONTROL) {
-            val hasMeaningfulActions = legalActions.any { action ->
-                action.actionType != "PassPriority" &&
-                (!action.isManaAbility || action.additionalCostInfo?.costType == "SacrificePermanent")
-            }
+            // The same notion of "meaningful" the stop decision itself uses — otherwise the
+            // button can promise a stop (say, at the opponent's end step for a spell we can't
+            // actually pay for) that never arrives.
+            val hasMeaningfulActions = autoPassManager.getMeaningfulActions(legalActions).isNotEmpty()
             autoPassManager.getNextStopPoint(state, playerId, hasMeaningfulActions, myTurnStops = playerOverrides.myTurnStops, opponentTurnStops = playerOverrides.opponentTurnStops, stopsMode = playerMode == PriorityMode.STOPS)
         } else {
             null

--- a/justfile
+++ b/justfile
@@ -120,6 +120,14 @@ arena-gauntlet GAMES="200" SET="BLB" SEED="20260727":
     scripts/gradle-locked :ai:test --tests "*.ArenaBenchmark" -Dbenchmark=true -DarenaGauntlet=true \
         -DarenaGames={{GAMES}} -DarenaSet={{SET}} -DarenaSeed={{SEED}}
 
+# Play the same agent against itself at 100 / 1000 / 3000 ms of decision budget. Strength must be
+# MONOTONE in the budget; if it isn't, the search is generating noise and the fix is a better leaf
+# evaluator (phases 6 and 9), not more samples. Runs four matchups, so budget 4x GAMES.
+[group: 'ai']
+arena-budget-scaling GAMES="300" SET="BLB" SEED="20260727":
+    scripts/gradle-locked :ai:test --tests "*.ArenaBudgetScalingTest" -Dbenchmark=true \
+        -DarenaBudgetScaling=true -DarenaGames={{GAMES}} -DarenaSet={{SET}} -DarenaSeed={{SEED}}
+
 # Clean build artifacts
 [group: 'build']
 clean:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -13,13 +13,13 @@ import com.wingedsheep.sdk.model.EntityId
  */
 data class LegalAction(
     val action: GameAction,
-    val actionType: String,
+    override val actionType: String,
     val description: String,
     val affordable: Boolean = true,
 
     // Targeting
-    val validTargets: List<EntityId>? = null,
-    val requiresTargets: Boolean = false,
+    override val validTargets: List<EntityId>? = null,
+    override val requiresTargets: Boolean = false,
     /**
      * Maximum number of targets the player may pick for the *first* requirement. Always the
      * resolved cap — i.e. [TargetInfo.maxTargets] of that requirement — never the
@@ -68,10 +68,10 @@ data class LegalAction(
     val xConstrainsTargetCount: Boolean = false,
 
     // Combat
-    val validAttackers: List<EntityId>? = null,
+    override val validAttackers: List<EntityId>? = null,
     val mandatoryAttackers: List<EntityId>? = null,
     val validAttackTargets: List<EntityId>? = null,
-    val validBlockers: List<EntityId>? = null,
+    override val validBlockers: List<EntityId>? = null,
     val blockerMaxBlockCounts: Map<EntityId, Int>? = null,
     val mandatoryBlockerAssignments: Map<EntityId, List<EntityId>>? = null,
 
@@ -107,7 +107,7 @@ data class LegalAction(
     val harmonizeCreatures: List<HarmonizeCreatureData>? = null,
 
     // Mana abilities
-    val isManaAbility: Boolean = false,
+    override val isManaAbility: Boolean = false,
     val requiresManaColorChoice: Boolean = false,
     /**
      * Constrained set of colors the ability can produce, when known.
@@ -151,8 +151,16 @@ data class LegalAction(
     val modalEnumeration: ModalLegalEnumeration? = null,
 
     // When true, prevents auto-pass whenever this action is available
-    val holdPriority: Boolean = false
-)
+    override val holdPriority: Boolean = false
+) : PriorityAction {
+    /** [PriorityAction]'s name for [affordable]. The DTO calls the same thing `isAffordable`. */
+    override val isAffordableAction: Boolean get() = affordable
+
+    override val additionalCostType: String? get() = additionalCostInfo?.costType
+
+    override val hasUnfillableTargetRequirement: Boolean
+        get() = targetRequirements?.any { it.minTargets > 0 && it.validTargets.isEmpty() } ?: false
+}
 
 /**
  * Per-mode enumeration data for a choose-N modal spell.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/MeaningfulActionFilter.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/MeaningfulActionFilter.kt
@@ -1,0 +1,535 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The minimal shape of a legal action that the meaningful-action and auto-pass rules read.
+ *
+ * Two types answer these questions: the engine's own [LegalAction] and the server DTO
+ * `LegalActionInfo` the client is sent. Both live in this module, but only one of them may be
+ * changed freely — the DTO is a wire contract — so [LegalAction] implements this directly and the
+ * DTO is adapted by `LegalActionInfo.asPriorityAction()` (in the `view` package, which already
+ * depends on this one).
+ */
+interface PriorityAction {
+    val actionType: String
+    val requiresTargets: Boolean
+    val validTargets: List<EntityId>?
+    val validAttackers: List<EntityId>?
+    val validBlockers: List<EntityId>?
+    val isManaAbility: Boolean
+    val holdPriority: Boolean
+
+    /** Whether the player can actually pay for this action right now. */
+    val isAffordableAction: Boolean
+
+    /** [AdditionalCostData.costType], flattened so the DTO's parallel type can answer it too. */
+    val additionalCostType: String?
+
+    /**
+     * True when some **mandatory** target requirement has no legal target, so the action cannot
+     * legally be taken however the player fills the rest in.
+     *
+     * Not the same question as [validTargets] being empty. That field only ever mirrors the
+     * *first* requirement, so a two-requirement spell ("destroy target creature and target
+     * artifact") whose second slot is empty reads as perfectly castable through it — and the
+     * engine then rejects the cast with "No valid targets available". Phase 1's arena measured
+     * that rejection at ~0.9 per game, 889 of 945 rejections, and this is its shape.
+     *
+     * An *optional* requirement (`minTargets == 0`) with no legal targets is fine and does not
+     * count: the player simply picks none.
+     */
+    val hasUnfillableTargetRequirement: Boolean
+}
+
+/**
+ * Why a priority window was (or was not) auto-passed.
+ *
+ * The reason is not decoration: the game-server logs it at debug level, and it is the only way to
+ * tell "auto-passed because nothing was meaningful" from "auto-passed because our own spell is on
+ * top of the stack" when a player reports the game speeding past a window they wanted.
+ */
+data class AutoPassVerdict(val autoPass: Boolean, val reason: String)
+
+/**
+ * Arena-style priority rules — which actions are worth stopping for, and which whole priority
+ * windows can be skipped outright.
+ *
+ * This used to live in `game-server`'s `AutoPassManager` over the client DTO, which meant the AI
+ * and the gym could not call it: both hold engine [LegalAction]s and never build a DTO. The rules
+ * are engine rules — nothing here is presentation — so they live here and `AutoPassManager`
+ * delegates. One source of truth: a window the client speeds past and a window the AI thinks about
+ * are now decided by the same code.
+ *
+ * Three entry points, in increasing order of how much they save:
+ *
+ * - [isMeaningful] / [filterMeaningful] — shrink a candidate list. Drops `PassPriority`, mana
+ *   abilities without a sacrifice cost, targeted spells with no legal targets, unaffordable
+ *   casts/cycles/crews, and empty combat declarations.
+ * - [autoPassVerdict] — decide a whole window from the enumerated actions. The AI can return
+ *   `PassPriority` without scoring anything.
+ * - [canAutoPassWithoutEnumerating] — decide a whole window from the **state alone**, so the
+ *   caller never pays for `LegalActionEnumerator.enumerate` at all. This is the one that matters
+ *   for search: Phase 0 measured 76.2% of priority windows offering zero candidates while still
+ *   paying ~0.40 ms to find that out, and a rollout crosses ~20-30 windows per playout.
+ *
+ * The third is a strict subset of the second by construction — it fires only on the
+ * (turn, step) combinations where [autoPassVerdict] ignores the action list entirely — and
+ * `AutoPassParityTest` holds that invariant over a corpus of real game states.
+ */
+object MeaningfulActionFilter {
+
+    /**
+     * Every action type that represents casting a spell, across *all* cost paths. The enumerators
+     * emit a distinct `actionType` per cost variant (a plain cast, each modal shape, and every
+     * alternative cost — flashback, harmonize, warp, evoke/impending/granted via
+     * `CastWithAlternativeCost`, kicker, conspire, a free cast, morph). The auto-pass logic must
+     * treat them all as "a spell you can cast"; missing one (e.g. Sneak, which is only ever a
+     * `CastWithAlternativeCost`) makes the client speed past the window where it's legal. Only
+     * legal actions are ever passed in, so any of these present means the player can act now.
+     */
+    val SPELL_CAST_ACTION_TYPES = setOf(
+        "CastSpell",
+        "CastSpellMode",
+        "CastSpellModal",
+        "CastWithAlternativeCost",
+        "CastWithFlashback",
+        "CastWithHarmonize",
+        "CastWithWarp",
+        "CastWithKicker",
+        // Gift (CR 702.174a) — the "promise a gift" twin of a normal cast.
+        "CastWithGift",
+        "CastWithConspire",
+        "CastWithoutPayingManaCost",
+        "CastFaceDown",
+    )
+
+    /** Spell casts plus the activated / special abilities that count as instant-speed responses. */
+    val INSTANT_RESPONSE_ACTION_TYPES = SPELL_CAST_ACTION_TYPES + setOf(
+        "ActivateAbility",
+        "CycleCard",
+        "TypecycleCard",
+        "PlotCard",
+        "ForetellCard",
+        // Crew is an activated ability (CR 702.122a) with no timing restriction, so it can be
+        // activated any time you have priority (CR 117.1b) — making it a valid instant-speed
+        // response (e.g. crewing during the opponent's declare-attackers window). Saddle is
+        // sorcery-speed and deliberately absent.
+        "CrewVehicle",
+    )
+
+    /** Combat steps the engine auto-skips when no creatures are attacking (CR 508.8). */
+    val COMBAT_STEPS_SKIPPED_WITHOUT_ATTACKERS = setOf(
+        Step.DECLARE_BLOCKERS,
+        Step.FIRST_STRIKE_COMBAT_DAMAGE,
+        Step.COMBAT_DAMAGE,
+    )
+
+    /**
+     * Steps on the player's **own** turn where [autoPassVerdict] passes no matter what actions are
+     * available — the basis of [canAutoPassWithoutEnumerating]. Derived from
+     * [shouldAutoPassOnMyTurn]: every branch there that ignores its `meaningfulActions` argument.
+     */
+    private val UNCONDITIONAL_PASS_ON_MY_TURN = setOf(
+        Step.UNTAP, Step.UPKEEP, Step.DRAW,
+        Step.BEGIN_COMBAT, Step.COMBAT_DAMAGE, Step.END_COMBAT,
+        Step.END, Step.CLEANUP,
+    )
+
+    /** The same, on an opponent's turn. Derived from [shouldAutoPassOnOpponentTurn]. */
+    private val UNCONDITIONAL_PASS_ON_OPPONENT_TURN = setOf(
+        Step.UNTAP, Step.UPKEEP, Step.DRAW,
+        Step.BEGIN_COMBAT, Step.COMBAT_DAMAGE, Step.CLEANUP,
+    )
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rule 1: the meaningful-action filter
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** Whether this action is worth stopping the game — or scoring — for. */
+    fun isMeaningful(action: PriorityAction): Boolean {
+        // PassPriority is never meaningful (it's the default).
+        if (action.actionType == "PassPriority") return false
+
+        // Mana abilities are invisible — they don't stop the game. Exception: a mana ability with
+        // a sacrifice cost (Skirk Prospector) is a real game action.
+        if (action.isManaAbility && action.additionalCostType != "SacrificePermanent") return false
+
+        // Combat declarations are meaningful only when there is something to declare.
+        if (action.actionType == "DeclareAttackers") return !action.validAttackers.isNullOrEmpty()
+        if (action.actionType == "DeclareBlockers") return !action.validBlockers.isNullOrEmpty()
+
+        // A land drop is always meaningful when it's offered.
+        if (action.actionType == "PlayLand") return true
+
+        // A targeted spell that cannot be legally targeted is invisible — casting it isn't
+        // possible. Both shapes count: the single-requirement one whose `validTargets` is empty,
+        // and the multi-requirement one with an unfillable mandatory slot.
+        if (action.requiresTargets && action.validTargets.isNullOrEmpty()) return false
+        if (action.hasUnfillableTargetRequirement) return false
+
+        // A non-mana activated ability is meaningful.
+        if (action.actionType == "ActivateAbility") return true
+
+        // Everything with a cost is meaningful only if it can be paid. (Regular spells are only
+        // enumerated when affordable, but companion actions for cycling/morph cards are added
+        // with isAffordable = false.)
+        if (action.actionType in SPELL_CAST_ACTION_TYPES ||
+            action.actionType == "CycleCard" || action.actionType == "TypecycleCard" ||
+            action.actionType == "PlotCard" || action.actionType == "ForetellCard" ||
+            action.actionType == "CrewVehicle"
+        ) {
+            return action.isAffordableAction
+        }
+
+        return true
+    }
+
+    /** [isMeaningful] over a list, preserving the caller's own action type. */
+    fun <T : PriorityAction> filterMeaningful(actions: List<T>): List<T> = actions.filter(::isMeaningful)
+
+    private fun PriorityAction.isInstantSpeedResponse(): Boolean =
+        actionType in INSTANT_RESPONSE_ACTION_TYPES &&
+            (!requiresTargets || !validTargets.isNullOrEmpty())
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // The whole-window decision
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /** [autoPassVerdict]'s boolean, for callers that don't want the reason. */
+    fun shouldAutoPass(
+        state: GameState,
+        playerId: EntityId,
+        legalActions: List<PriorityAction>,
+        myTurnStops: Set<Step> = emptySet(),
+        opponentTurnStops: Set<Step> = emptySet(),
+        stopsMode: Boolean = false,
+        cardRegistry: CardRegistry? = null,
+    ): Boolean = autoPassVerdict(
+        state, playerId, legalActions, myTurnStops, opponentTurnStops, stopsMode, cardRegistry
+    ).autoPass
+
+    /**
+     * Should the player holding priority pass without being asked?
+     *
+     * @param myTurnStops / [opponentTurnStops] per-step stop overrides a human player configured.
+     *   The AI passes neither.
+     * @param stopsMode the human "Stops" priority mode, which is more conservative than "Auto".
+     * @param cardRegistry resolves the actually-cast face of a split-layout spell on the stack
+     *   (CR 709/715). Null falls back to the base card's type line — fine for a single-face test,
+     *   but production must supply it so an Omen/Adventure instant face isn't mistaken for the
+     *   permanent face and auto-resolved past.
+     */
+    fun autoPassVerdict(
+        state: GameState,
+        playerId: EntityId,
+        legalActions: List<PriorityAction>,
+        myTurnStops: Set<Step> = emptySet(),
+        opponentTurnStops: Set<Step> = emptySet(),
+        stopsMode: Boolean = false,
+        cardRegistry: CardRegistry? = null,
+    ): AutoPassVerdict {
+        if (state.priorityPlayerId != playerId) return STOP_NO_PRIORITY
+        if (state.pendingDecision != null) return STOP_PENDING_DECISION
+
+        val meaningfulActions = legalActions.filter(::isMeaningful)
+
+        // ── Rule 4: the stack response ──
+        if (state.stack.isNotEmpty()) {
+            return stackVerdict(state, playerId, meaningfulActions, stopsMode, cardRegistry)
+        }
+
+        // Team-aware (CR 805/810): in a shared Two-Headed Giant turn BOTH teammates are "on their
+        // turn", so the non-active teammate still stops in their own main phase instead of being
+        // auto-passed as if it were the opponents' turn. Reduces to `activePlayerId == playerId`
+        // in a game without teams.
+        val isMyTurn = state.isActiveTurnFor(playerId)
+
+        val relevantStops = if (isMyTurn) myTurnStops else opponentTurnStops
+        if (state.step in relevantStops) {
+            return AutoPassVerdict(false, "STOP: Per-step stop override set for ${state.step}")
+        }
+
+        if (stopsMode && !isMyTurn &&
+            (state.step == Step.COMBAT_DAMAGE || state.step == Step.FIRST_STRIKE_COMBAT_DAMAGE) &&
+            hasAttackers(state)
+        ) {
+            return AutoPassVerdict(false, "STOP (Stops mode): Combat damage step with attackers")
+        }
+
+        // Never auto-pass the active player's own main phases.
+        if (isMyTurn && (state.step == Step.PRECOMBAT_MAIN || state.step == Step.POSTCOMBAT_MAIN)) {
+            return AutoPassVerdict(false, "STOP: My main phase (always stop)")
+        }
+
+        if (meaningfulActions.isEmpty()) return PASS_NOTHING_MEANINGFUL
+
+        // On your own declare-blockers step, after the opponent has blocked, you may still want a
+        // combat trick before damage. (On the opponent's turn this is handled below, which stops
+        // for blockers too.)
+        if (state.step == Step.DECLARE_BLOCKERS && isMyTurn &&
+            meaningfulActions.any { it.isInstantSpeedResponse() }
+        ) {
+            return AutoPassVerdict(false, "STOP: Declare blockers step (have instant-speed responses)")
+        }
+
+        // On the opponent's declare attackers, pass if they didn't attack — nothing to respond to.
+        if (!isMyTurn && state.step == Step.DECLARE_ATTACKERS && !hasAttackers(state)) {
+            return PASS_NO_ATTACKERS_DECLARED
+        }
+
+        return if (isMyTurn) {
+            shouldAutoPassOnMyTurn(state.step, meaningfulActions)
+        } else {
+            shouldAutoPassOnOpponentTurn(state.step, meaningfulActions)
+        }
+    }
+
+    /**
+     * Can this priority window be passed **without enumerating legal actions at all**?
+     *
+     * True only where [autoPassVerdict] would return `autoPass = true` for *any* action list, so a
+     * caller may substitute this for the full check and never pay for enumeration. The guarantee is
+     * one-directional: this returning false says nothing, and the caller must then enumerate.
+     *
+     * Deliberately excludes every window whose verdict depends on what the player is holding —
+     * both main phases, both combat declarations, first-strike damage, end of combat, and the
+     * opponent's end step. It also requires an empty stack (a non-empty one routes through the
+     * stack rules, which read `holdPriority`) and no stop overrides, which is why the human-facing
+     * server never calls it.
+     */
+    fun canAutoPassWithoutEnumerating(state: GameState, playerId: EntityId): Boolean {
+        if (state.priorityPlayerId != playerId) return false
+        if (state.pendingDecision != null) return false
+        if (state.stack.isNotEmpty()) return false
+
+        val isMyTurn = state.isActiveTurnFor(playerId)
+        val unconditional =
+            if (isMyTurn) UNCONDITIONAL_PASS_ON_MY_TURN else UNCONDITIONAL_PASS_ON_OPPONENT_TURN
+        if (state.step in unconditional) return true
+
+        // The one action-independent window left: the opponent declared attackers and there are
+        // none, so there is nothing to respond to. Cheap — `getBattlefield()` is memoized.
+        return !isMyTurn && state.step == Step.DECLARE_ATTACKERS && !hasAttackers(state)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rule 4: the stack response
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private fun stackVerdict(
+        state: GameState,
+        playerId: EntityId,
+        meaningfulActions: List<PriorityAction>,
+        stopsMode: Boolean,
+        cardRegistry: CardRegistry?,
+    ): AutoPassVerdict {
+        val topOfStack = state.stack.last() // Stack is LIFO, last = top
+        val topController = stackItemController(state, topOfStack)
+
+        if (topController == playerId) {
+            // Our own spell/ability is on top — pass and let the opponent respond, unless an
+            // available action asked to hold priority (e.g. a copy-spell ability).
+            return if (meaningfulActions.any { it.holdPriority }) {
+                STOP_OWN_STACK_ITEM_BUT_HOLDING
+            } else {
+                PASS_OWN_STACK_ITEM
+            }
+        }
+
+        // Persistent yield: the player explicitly asked to stop being stopped by this ability, so
+        // pass even though it's an opponent's object. A holdPriority action — a response they
+        // deliberately lined up — still wins.
+        val topContainer = state.getEntity(topOfStack)
+        val yieldedIdentity = topContainer?.get<TriggeredAbilityOnStackComponent>()?.abilityIdentity
+            ?: topContainer?.get<ActivatedAbilityOnStackComponent>()?.abilityIdentity
+        if (yieldedIdentity != null &&
+            state.isYieldingTo(playerId, yieldedIdentity) &&
+            meaningfulActions.none { it.holdPriority }
+        ) {
+            return AutoPassVerdict(true, "AUTO-PASS: Yielded to opponent's ability $yieldedIdentity")
+        }
+
+        // Stops mode: always stop on an opponent's stack item, whatever it is.
+        if (stopsMode) return STOP_STOPS_MODE_OPPONENT_STACK
+
+        val cardComponent = topContainer?.get<CardComponent>()
+        val isPermanentSpell = topContainer?.get<SpellOnStackComponent>()?.let {
+            isPermanentSpell(cardComponent, it, cardRegistry)
+        } ?: false
+        // Auras are excluded: they target, and the opponent should see what is being targeted.
+        val isAura = cardComponent?.isAura ?: false
+
+        if (isPermanentSpell && !isAura &&
+            meaningfulActions.none { it.actionType in INSTANT_RESPONSE_ACTION_TYPES }
+        ) {
+            return PASS_OPPONENT_PERMANENT_SPELL
+        }
+
+        return STOP_OPPONENT_STACK_ITEM
+    }
+
+    /**
+     * Whether a spell on the stack is a permanent spell, respecting the actually-cast face.
+     *
+     * Split-layout cards (Omen, Adventure, MDFC — CR 709 / 715) keep their *base* characteristics
+     * (a creature) in [CardComponent] even when cast as their instant/sorcery face. Resolving the
+     * type from the cast face, as `StackResolver` does, is what keeps such a spell off the
+     * "permanent spell → auto-resolve" path.
+     */
+    private fun isPermanentSpell(
+        cardComponent: CardComponent?,
+        spell: SpellOnStackComponent,
+        cardRegistry: CardRegistry?,
+    ): Boolean {
+        if (cardComponent == null) return false
+        val faceTypeLine = spell.faceIndex?.let { idx ->
+            cardRegistry?.getCard(cardComponent.name)?.cardFaces?.getOrNull(idx)?.typeLine
+        }
+        return faceTypeLine?.isPermanent ?: cardComponent.isPermanent
+    }
+
+    /** Controller of a stack item. Abilities and spells carry different components. */
+    private fun stackItemController(state: GameState, entityId: EntityId): EntityId? {
+        val container = state.getEntity(entityId) ?: return null
+        container.get<ActivatedAbilityOnStackComponent>()?.let { return it.controllerId }
+        container.get<TriggeredAbilityOnStackComponent>()?.let { return it.controllerId }
+        container.get<SpellOnStackComponent>()?.let { return it.casterId }
+        return container.get<ControllerComponent>()?.playerId
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rules 2 and 3: per-step compression
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Rule 3 — your own turn. Arena is very aggressive here: you stop at main phases and at
+     * declare attackers, and speed through everything else unless a combat trick is live.
+     *
+     * Every branch that ignores [meaningfulActions] is listed in [UNCONDITIONAL_PASS_ON_MY_TURN];
+     * keep the two in step.
+     */
+    private fun shouldAutoPassOnMyTurn(
+        step: Step,
+        meaningfulActions: List<PriorityAction>,
+    ): AutoPassVerdict = when (step) {
+        Step.PRECOMBAT_MAIN, Step.POSTCOMBAT_MAIN ->
+            AutoPassVerdict(false, "STOP: My main phase")
+
+        // Stop only while we still need to declare. Once attackers are confirmed, pass so the
+        // opponent can declare blockers.
+        Step.DECLARE_ATTACKERS ->
+            if (meaningfulActions.any { it.actionType == "DeclareAttackers" }) {
+                AutoPassVerdict(false, "STOP: My declare attackers step (need to declare)")
+            } else {
+                AutoPassVerdict(true, "AUTO-PASS: My declare attackers step (already declared)")
+            }
+
+        Step.DECLARE_BLOCKERS -> respondOrPass(
+            meaningfulActions,
+            "My declare blockers step",
+            passSuffix = "no responses, moving to damage",
+        )
+
+        Step.FIRST_STRIKE_COMBAT_DAMAGE -> respondOrPass(
+            meaningfulActions, "My first strike damage step",
+        )
+
+        Step.UPKEEP, Step.DRAW -> AutoPassVerdict(true, "AUTO-PASS: My upkeep/draw step")
+        Step.BEGIN_COMBAT -> AutoPassVerdict(true, "AUTO-PASS: My begin combat")
+        Step.COMBAT_DAMAGE, Step.END_COMBAT ->
+            AutoPassVerdict(true, "AUTO-PASS: My combat damage/end combat")
+        Step.END -> AutoPassVerdict(true, "AUTO-PASS: My end step")
+        Step.CLEANUP, Step.UNTAP -> AutoPassVerdict(true, "AUTO-PASS: Cleanup/Untap")
+    }
+
+    /**
+     * Rule 2 — an opponent's turn. You stop where you can actually act: a main phase or an end
+     * step with a response, the post-declaration combat windows, and blockers.
+     *
+     * Every branch that ignores [meaningfulActions] is listed in
+     * [UNCONDITIONAL_PASS_ON_OPPONENT_TURN]; keep the two in step.
+     */
+    private fun shouldAutoPassOnOpponentTurn(
+        step: Step,
+        meaningfulActions: List<PriorityAction>,
+    ): AutoPassVerdict = when (step) {
+        Step.UPKEEP, Step.DRAW -> AutoPassVerdict(true, "AUTO-PASS: Opponent's upkeep/draw")
+
+        Step.PRECOMBAT_MAIN, Step.POSTCOMBAT_MAIN ->
+            respondOrPass(meaningfulActions, "Opponent's main phase")
+
+        Step.BEGIN_COMBAT ->
+            AutoPassVerdict(true, "AUTO-PASS: Opponent's begin combat (Arena-style)")
+
+        // The priority window after attackers are declared (CR 508.2), where the defending player
+        // can act before blockers.
+        Step.DECLARE_ATTACKERS ->
+            respondOrPass(meaningfulActions, "Opponent's declare attackers")
+
+        // Stop if we have creatures that can block OR an instant-speed action we can pay for.
+        Step.DECLARE_BLOCKERS -> {
+            val hasBlockers = meaningfulActions.any {
+                it.actionType == "DeclareBlockers" && !it.validBlockers.isNullOrEmpty()
+            }
+            if (hasBlockers) {
+                AutoPassVerdict(false, "STOP: Opponent's declare blockers (have blockers)")
+            } else {
+                respondOrPass(meaningfulActions, "Opponent's declare blockers", passSuffix = "no blockers or responses")
+            }
+        }
+
+        Step.FIRST_STRIKE_COMBAT_DAMAGE ->
+            respondOrPass(meaningfulActions, "Opponent's first strike damage step")
+
+        Step.COMBAT_DAMAGE -> AutoPassVerdict(true, "AUTO-PASS: Opponent's combat damage")
+
+        // A real priority window (CR 511.1) — and the *only* one for abilities restricted to it
+        // (a Desert's "Activate only during the end of combat step"), whose targets also vanish
+        // once the step ends (CR 511.3).
+        Step.END_COMBAT -> respondOrPass(meaningfulActions, "Opponent's end combat step")
+
+        Step.END -> respondOrPass(meaningfulActions, "Opponent's end step")
+
+        Step.CLEANUP, Step.UNTAP -> AutoPassVerdict(true, "AUTO-PASS: Cleanup/Untap")
+    }
+
+    private fun respondOrPass(
+        meaningfulActions: List<PriorityAction>,
+        window: String,
+        passSuffix: String = "no responses",
+    ): AutoPassVerdict =
+        if (meaningfulActions.any { it.isInstantSpeedResponse() }) {
+            AutoPassVerdict(false, "STOP: $window (have instant-speed responses)")
+        } else {
+            AutoPassVerdict(true, "AUTO-PASS: $window ($passSuffix)")
+        }
+
+    private fun hasAttackers(state: GameState): Boolean = state.getBattlefield().any { entityId ->
+        state.getEntity(entityId)?.get<AttackingComponent>() != null
+    }
+
+    // Verdicts with no interpolated detail, hoisted so the hot path allocates nothing.
+    private val STOP_NO_PRIORITY = AutoPassVerdict(false, "STOP: Player does not hold priority")
+    private val STOP_PENDING_DECISION = AutoPassVerdict(false, "STOP: A decision is pending")
+    private val PASS_NOTHING_MEANINGFUL = AutoPassVerdict(true, "AUTO-PASS: No meaningful actions available")
+    private val PASS_NO_ATTACKERS_DECLARED =
+        AutoPassVerdict(true, "AUTO-PASS: Opponent's declare attackers (no attackers declared)")
+    private val PASS_OWN_STACK_ITEM = AutoPassVerdict(true, "AUTO-PASS: Own spell/ability on top of stack")
+    private val STOP_OWN_STACK_ITEM_BUT_HOLDING =
+        AutoPassVerdict(false, "STOP: Own spell/ability on top of stack but player has holdPriority action")
+    private val STOP_STOPS_MODE_OPPONENT_STACK =
+        AutoPassVerdict(false, "STOP (Stops mode): Opponent's spell/ability on stack")
+    private val PASS_OPPONENT_PERMANENT_SPELL =
+        AutoPassVerdict(true, "AUTO-PASS: Opponent's permanent spell on stack, no responses")
+    private val STOP_OPPONENT_STACK_ITEM = AutoPassVerdict(false, "STOP: Opponent's spell/ability on stack")
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionInfoPriorityView.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionInfoPriorityView.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.legalactions.PriorityAction
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Adapts the client-facing [LegalActionInfo] to [PriorityAction], the shape
+ * [com.wingedsheep.engine.legalactions.MeaningfulActionFilter] reads.
+ *
+ * A wrapper rather than `LegalActionInfo : PriorityAction`: the DTO is a wire contract serialized
+ * straight to the client, and two of the interface's members (`isAffordableAction`,
+ * `additionalCostType`) would have to be added as derived properties, which Jackson would then
+ * publish as new JSON fields. This costs one small object per legal action, once per priority
+ * window, on the server path only.
+ */
+fun LegalActionInfo.asPriorityAction(): PriorityAction = LegalActionInfoPriorityView(this)
+
+private class LegalActionInfoPriorityView(private val info: LegalActionInfo) : PriorityAction {
+    override val actionType: String get() = info.actionType
+    override val requiresTargets: Boolean get() = info.requiresTargets
+    override val validTargets: List<EntityId>? get() = info.validTargets
+    override val validAttackers: List<EntityId>? get() = info.validAttackers
+    override val validBlockers: List<EntityId>? get() = info.validBlockers
+    override val isManaAbility: Boolean get() = info.isManaAbility
+    override val holdPriority: Boolean get() = info.holdPriority
+    override val isAffordableAction: Boolean get() = info.isAffordable
+    override val additionalCostType: String? get() = info.additionalCostInfo?.costType
+    override val hasUnfillableTargetRequirement: Boolean
+        get() = info.targetRequirements?.any { it.minTargets > 0 && it.validTargets.isEmpty() } ?: false
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/MeaningfulActionFilterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/MeaningfulActionFilterTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The meaningful-action rules, exercised directly.
+ *
+ * [MeaningfulActionFilter.isMeaningful] is a pure function of an action's shape, so it needs no
+ * game state — which is exactly why it is worth pinning here rather than only through the
+ * game-server's much heavier `AutoPassManagerTest`. The whole-window rules that *do* need state are
+ * covered by that suite (it drives `AutoPassManager`, which delegates here) and by
+ * `AutoPassParityTest` in `:ai`.
+ */
+class MeaningfulActionFilterTest : FunSpec({
+
+    fun action(
+        type: String,
+        affordable: Boolean = true,
+        manaAbility: Boolean = false,
+        costType: String? = null,
+        requiresTargets: Boolean = false,
+        validTargets: List<EntityId>? = null,
+        validAttackers: List<EntityId>? = null,
+        validBlockers: List<EntityId>? = null,
+        unfillableRequirement: Boolean = false,
+    ) = object : PriorityAction {
+        override val actionType = type
+        override val requiresTargets = requiresTargets
+        override val validTargets = validTargets
+        override val validAttackers = validAttackers
+        override val validBlockers = validBlockers
+        override val isManaAbility = manaAbility
+        override val holdPriority = false
+        override val isAffordableAction = affordable
+        override val additionalCostType = costType
+        override val hasUnfillableTargetRequirement = unfillableRequirement
+    }
+
+    val someone = EntityId("permanent-1")
+
+    test("passing priority is never a candidate") {
+        MeaningfulActionFilter.isMeaningful(action("PassPriority")) shouldBe false
+    }
+
+    test("a plain mana ability is invisible, but one with a sacrifice cost is not") {
+        MeaningfulActionFilter.isMeaningful(action("ActivateAbility", manaAbility = true)) shouldBe false
+        MeaningfulActionFilter.isMeaningful(
+            action("ActivateAbility", manaAbility = true, costType = "SacrificePermanent")
+        ) shouldBe true
+    }
+
+    test("a targeted spell with no legal target is not a candidate") {
+        // The Phase 1 arena measured 889 of 945 rejected AI actions as exactly this shape:
+        // `CastSpell: No valid targets available`, roughly one per game.
+        MeaningfulActionFilter.isMeaningful(
+            action("CastSpell", requiresTargets = true, validTargets = emptyList())
+        ) shouldBe false
+        MeaningfulActionFilter.isMeaningful(
+            action("CastSpell", requiresTargets = true, validTargets = listOf(someone))
+        ) shouldBe true
+    }
+
+    test("a multi-requirement spell with an unfillable mandatory slot is not a candidate") {
+        // The shape the flat `validTargets` field cannot see: "destroy target creature and target
+        // artifact" with a legal creature but no artifact on the board. `validTargets` mirrors
+        // requirement 0 and looks perfectly castable, and the engine then rejects the cast.
+        MeaningfulActionFilter.isMeaningful(
+            action(
+                "CastSpell", requiresTargets = true,
+                validTargets = listOf(someone), unfillableRequirement = true,
+            )
+        ) shouldBe false
+    }
+
+    test("an unaffordable cast, cycle or crew is not a candidate") {
+        listOf("CastSpell", "CastWithFlashback", "CycleCard", "ForetellCard", "CrewVehicle").forEach { type ->
+            MeaningfulActionFilter.isMeaningful(action(type, affordable = false)) shouldBe false
+            MeaningfulActionFilter.isMeaningful(action(type, affordable = true)) shouldBe true
+        }
+    }
+
+    test("every cast action type is recognised as a spell cast") {
+        // Missing one here is the bug that makes the client speed past a window where a card with
+        // an alternative cost is legal — Sneak is only ever a CastWithAlternativeCost.
+        MeaningfulActionFilter.SPELL_CAST_ACTION_TYPES.forEach { type ->
+            MeaningfulActionFilter.isMeaningful(action(type, affordable = false)) shouldBe false
+        }
+        (MeaningfulActionFilter.SPELL_CAST_ACTION_TYPES - MeaningfulActionFilter.INSTANT_RESPONSE_ACTION_TYPES)
+            .shouldBe(emptySet())
+    }
+
+    test("a combat declaration is meaningful only when there is something to declare") {
+        MeaningfulActionFilter.isMeaningful(action("DeclareAttackers", validAttackers = emptyList())) shouldBe false
+        MeaningfulActionFilter.isMeaningful(action("DeclareAttackers", validAttackers = listOf(someone))) shouldBe true
+        MeaningfulActionFilter.isMeaningful(action("DeclareBlockers", validBlockers = emptyList())) shouldBe false
+        MeaningfulActionFilter.isMeaningful(action("DeclareBlockers", validBlockers = listOf(someone))) shouldBe true
+    }
+
+    test("a land drop is always meaningful") {
+        MeaningfulActionFilter.isMeaningful(action("PlayLand")) shouldBe true
+    }
+
+    test("filterMeaningful preserves the caller's own action type and order") {
+        val actions = listOf(
+            action("PassPriority"),
+            action("PlayLand"),
+            action("CastSpell", affordable = false),
+            action("ActivateAbility"),
+        )
+        MeaningfulActionFilter.filterMeaningful(actions).map { it.actionType } shouldBe
+            listOf("PlayLand", "ActivateAbility")
+    }
+})


### PR DESCRIPTION
Phase 4 of [`backlog/engine-ai-improvement.md`](backlog/engine-ai-improvement.md). Enabling infrastructure — and it measures like it: **neutral in the arena, monotone in the new scaling ladder.**

## 4a — the auto-pass rules move down into the engine

`AutoPassManager` owned a complete Arena-style implementation of the priority rules, but over the client DTO `LegalActionInfo` — so `:ai` and `:gym`, which hold engine `LegalAction`s and never build a DTO, could not call it. Those are engine rules; nothing in them is presentation. They now live in `rules-engine/.../legalactions/MeaningfulActionFilter.kt`, and `AutoPassManager` adapts the DTO and delegates. What stays in game-server is the "Pass to Combat" button label and the step lookahead that computes it.

Three entry points, in increasing order of what they save:

- `isMeaningful` / `filterMeaningful` — shrink a candidate list.
- `autoPassVerdict` — decide a whole window from the enumerated actions.
- `canAutoPassWithoutEnumerating` — decide a whole window from the **state alone**, so `LegalActionEnumerator.enumerate` is never called.

The third is the one Phase 0 re-scoped this sub-phase toward. The plan's original "branching factor down 30–50%" was written against an assumed ~8 candidates; the real figure is 1.75, so there is almost nothing left to filter. **40% of priority windows are now decided without enumerating** (measured over 884 real windows), and a Phase 7 rollout would have paid that cost again on every one of the ~20–30 windows it crosses.

## 4b — `DecisionBudget`

Four tiers (TRIVIAL / ROUTINE / NORMAL / CRITICAL), threaded through `AIPlayer` → `Strategist` → `CombatAdvisor` → `DecisionResponder`, selected by `AiProfile.budgetPolicy`.

**One deliberate deviation from the plan: a tier is spent as *work*, not wall clock.** `SearchAllowances` converts a budget into a count of simulations once, and the millisecond figure is only a hard safety stop. A stopwatch-driven search produces a different move under load than it does idle, which would make every arena run irreproducible and `ArenaHarnessTest`'s "identical at 8 threads and at 1" assertion flaky. It is also why the 1,000-game merge gate is still ~3.5 minutes *with* a budget, contrary to Phase 1's warning that shipping one would make the arena expensive.

`MAX_BLOCK_SIMULATIONS = 10` becomes a **floor** on every tier, and combat declaration is always CRITICAL, so combat can never search less than it did before.

## The safety net, built before it is needed

`ArenaBudgetScalingTest` (`just arena-budget-scaling`) plays the same agent against itself at 100 / 1000 / 3000 ms. If strength is not monotone in the budget, the search is generating noise, and the fix is a better leaf evaluator (Phases 6 and 9), not more samples. **It passes:**

| Rung | Win share for the bigger budget | CI |
|---|---|---|
| 1000 vs 100 ms | 55.7% | [52.7%, 58.7%] |
| 3000 vs 1000 ms | 54.0% | [51.0%, 57.0%] |
| 3000 vs 100 ms | 55.3% | [52.0%, 59.0%] |

## Closes Phase 1's open illegal-action finding

Phase 1 measured the AI proposing ~0.9 illegal actions per game, **889 of 945 being exactly `CastSpell: No valid targets available`**, and left it open. The meaningful-action filter was the obvious suspect and turned out not to be the cause at all.

`Strategist` abandoned target selection for the **whole spell** the moment *any* requirement had no legal target, then submitted an untargeted cast the engine rejects. Almost every instance is an **optional** trailing slot — Conduct Electricity is "destroy target creature" *and* "up to one target creature token"; with no token on the board the AI declines to target the mandatory creature either and throws the card away. `fillableRequirements` fills the slots it can.

**Measured: 36 → 0 over 200 mirror games.** Relatedly, `validTargets` only ever mirrors the *first* target requirement, so `hasUnfillableTargetRequirement` asks the real question — which fixes the client too, where auto-pass was stopping players on spells they could not cast.

## `LEGACY_V0` is untouched

Both halves are behind `AiProfile` flags, **including the bug fix**. Not because the old behaviour is defensible, but because `LEGACY_V0` is the permanent reference opponent and quietly strengthening it would silently rebase every number ever published against it. `FrozenBaselineTest` would not have caught this on its own: its frozen game is all-vanilla Portal, which has no multi-requirement spell.

## Numbers

| Matchup | Win share for A | CI | Games |
|---|---|---|---|
| `v0-meaningful` vs `v0` | 51.3% | [49.8%, 52.7%] | 1,000 |
| `v0-phase4` vs `v0` | 50.8% | [49.4%, 52.2%] | 1,000 |
| `v0-phase4` vs a field of `v0` (`ffa3`) | 30.0% | [25.3%, 34.7%] (null 33.3%) | 150 |

Neither is a demonstrated improvement, and neither is a regression — the result enabling infrastructure should produce. The exit criterion was `≥50%` precisely because a filtered agent that *loses* is discarding a real option.

## Verification

`:rules-engine:test`, `:ai:test` and `:game-server:test` all green, including `FrozenBaselineTest`, the 600-assertion `AutoPassManagerTest` (unchanged, now exercising the delegated rules) and the puzzle suite at an unchanged **39/48**.

New always-on tests: `MeaningfulActionFilterTest`, `AutoPassParityTest` (DTO/engine parity + the fast-path subset invariant over 884 real windows), `DecisionBudgetTest`, `BudgetPolicyTest`.

Full findings: [`docs/ai/baseline-metrics.md`](docs/ai/baseline-metrics.md#phase-4--branching-factor--budget) · how to read the ladder: [`docs/ai/measurement.md`](docs/ai/measurement.md#the-budget-scaling-ladder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)