### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2357,6 +2357,7 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.ArtifactOrLand` — any artifact or land (Territory Forge).
 - `Targets.BasicLand` — any basic land.
 - `Targets.Spell` — any spell on the stack.
+- `Targets.SpellYouControl` — any spell on the stack you control, unrestricted by type (Slick Imitator's "Copy target spell you control"; a copied permanent spell resolves into a token).
 - `Targets.InstantOrSorcerySpellYouControl` — an instant or sorcery spell on the stack you control (copy-your-spell modes).
 - `Targets.CreatureSpellYouControl` — a creature spell on the stack you control (Choreographed Sparks' "Copy target creature spell you control").
 - `Targets.ActivatedOrTriggeredAbility` / `Targets.ActivatedAbility` — an ability on the stack (Stifle).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -320,6 +320,13 @@ object Targets {
     val CreatureSpellYouControl: TargetRequirement = TargetSpell(filter = TargetFilter.CreatureSpellOnStack.youControl())
 
     /**
+     * Target spell you control, of any type (e.g. Slick Imitator's "Copy target spell you
+     * control"). The unrestricted sibling of [InstantOrSorcerySpellYouControl] and
+     * [CreatureSpellYouControl].
+     */
+    val SpellYouControl: TargetRequirement = TargetSpell(filter = TargetFilter.SpellOnStack.youControl())
+
+    /**
      * Target spell you don't control.
      * In multiplayer this matches any spell controlled by an opponent.
      */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CoalstokeGearhulk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CoalstokeGearhulk.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Coalstoke Gearhulk
+ * {1}{B}{B}{R}{R}
+ * Artifact Creature — Construct
+ * 5/4
+ * Menace, deathtouch
+ * When this creature enters, put target creature card with mana value 4 or less from a graveyard
+ * onto the battlefield under your control with a finality counter on it. That creature gains
+ * menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.
+ *
+ * "With a finality counter on it" is the *entry* rider, so the counter rides along on the
+ * zone-change ([Effects.Move]'s `addCounterType`) rather than being added afterwards — a permanent
+ * that dies in the same window is still exiled instead. The same move needs an explicit
+ * `controllerOverride`: a bare move to the battlefield hands the card back to its **owner**, which
+ * is wrong the moment the target sits in an opponent's graveyard.
+ *
+ * The keyword grants use [Duration.Permanent]: the oracle text gives no duration, so they last as
+ * long as the creature is on the battlefield. The delayed exile is gated to the controller's own
+ * end step ([DelayedTriggerTiming.NEXT_END_STEP] + `fireOnPlayer = You`) — "your next end step"
+ * still means this turn's if it hasn't begun yet.
+ */
+val CoalstokeGearhulk = card("Coalstoke Gearhulk") {
+    manaCost = "{1}{B}{B}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "Menace, deathtouch\n" +
+        "When this creature enters, put target creature card with mana value 4 or less from a " +
+        "graveyard onto the battlefield under your control with a finality counter on it. That " +
+        "creature gains menace, deathtouch, and haste. At the beginning of your next end step, " +
+        "exile that creature."
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.MENACE, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val reanimated = target(
+            "target creature card with mana value 4 or less in a graveyard",
+            TargetObject(filter = TargetFilter.CreatureInGraveyard.manaValueAtMost(4))
+        )
+        effect = Effects.Composite(
+            Effects.Move(
+                reanimated,
+                Zone.BATTLEFIELD,
+                controllerOverride = EffectTarget.Controller,
+                addCounterType = CounterType.FINALITY
+            ),
+            Effects.GrantKeyword(Keyword.MENACE, reanimated, Duration.Permanent),
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, reanimated, Duration.Permanent),
+            Effects.GrantKeyword(Keyword.HASTE, reanimated, Duration.Permanent),
+            CreateDelayedTriggerEffect(
+                step = Step.END,
+                effect = Effects.Exile(reanimated),
+                timing = DelayedTriggerTiming.NEXT_END_STEP,
+                fireOnPlayer = EffectTarget.PlayerRef(Player.You)
+            )
+        )
+        description = "When this creature enters, put target creature card with mana value 4 or " +
+            "less from a graveyard onto the battlefield under your control with a finality " +
+            "counter on it. That creature gains menace, deathtouch, and haste. At the beginning " +
+            "of your next end step, exile that creature."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "198"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg?1783907861"
+        ruling(
+            "2025-02-07",
+            "Finality counters work on any permanent, not only creatures. If a permanent with a " +
+                "finality counter on it would be put into a graveyard from the battlefield, exile " +
+                "it instead."
+        )
+        ruling("2025-02-07", "Multiple finality counters on a single permanent are redundant.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GasGuzzler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GasGuzzler.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Gas Guzzler
+ * {B}
+ * Creature — Vampire Rogue
+ * 2/1
+ * Start your engines!
+ * This creature enters tapped.
+ * Max speed — {B}, Sacrifice another creature or Vehicle: Draw a card.
+ *
+ * "Another creature or Vehicle" is [Costs.SacrificeAnother] over
+ * [GameObjectFilter.CreatureOrVehicle] — the Vehicle half matches by subtype, so an uncrewed
+ * (noncreature) Vehicle is a legal sacrifice.
+ */
+val GasGuzzler = card("Gas Guzzler") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Rogue"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "This creature enters tapped.\n" +
+        "Max speed — {B}, Sacrifice another creature or Vehicle: Draw a card."
+    power = 2
+    toughness = 1
+
+    startYourEngines()
+
+    replacementEffect(EntersTapped())
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(
+                Costs.Mana("{B}"),
+                Costs.SacrificeAnother(GameObjectFilter.CreatureOrVehicle)
+            )
+            effect = Effects.DrawCards(1)
+            description = "{B}, Sacrifice another creature or Vehicle: Draw a card"
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Yohann Schepacz"
+        flavorText = "Gastal's vampires took fuel from the dead."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg?1783907896"
+        ruling("2025-02-07", "A player \"has max speed\" if their speed is 4.")
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalThrillroller.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GastalThrillroller.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gastal Thrillroller
+ * {2}{R}
+ * Artifact — Vehicle
+ * 4/2
+ * Trample, haste
+ * When this Vehicle enters, it becomes an artifact creature until end of turn.
+ * Crew 2
+ * {2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality
+ * counter on it. Activate only as a sorcery.
+ *
+ * The enters trigger self-animates to the Vehicle's own printed 4/2 (the convention Rocketeer
+ * Boostbuggy uses) — the permanent is already an artifact, so only CREATURE is added, and the
+ * trample/haste it prints carry over for the turn it's alive.
+ *
+ * The recursion ability is activated from the graveyard ([Zone.GRAVEYARD]) and pairs
+ * [Effects.PutOntoBattlefield] with a finality counter, the same shape as Relentless X-ATM092.
+ */
+val GastalThrillroller = card("Gastal Thrillroller") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Trample, haste\n" +
+        "When this Vehicle enters, it becomes an artifact creature until end of turn.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)\n" +
+        "{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a " +
+        "finality counter on it. Activate only as a sorcery."
+    power = 4
+    toughness = 2
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 4,
+            toughness = 2,
+            duration = Duration.EndOfTurn
+        )
+        description = "When this Vehicle enters, it becomes an artifact creature until end of turn."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.DiscardCard)
+        effect = Effects.Composite(
+            Effects.PutOntoBattlefield(EffectTarget.Self),
+            Effects.AddCounters(Counters.FINALITY, 1, EffectTarget.Self)
+        )
+        activateFromZone = Zone.GRAVEYARD
+        timing = TimingRule.SorcerySpeed
+        description = "{2}{R}, Discard a card: Return this card from your graveyard to the " +
+            "battlefield with a finality counter on it"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "129"
+        artist = "Caio Monteiro"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg?1783907881"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LootThePathfinder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LootThePathfinder.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Loot, the Pathfinder
+ * {2}{G}{U}{R}
+ * Legendary Creature — Beast Noble
+ * 2/4
+ * Double strike, vigilance, haste
+ * Exhaust — {G}, {T}: Add three mana of any one color.
+ * Exhaust — {U}, {T}: Draw three cards.
+ * Exhaust — {R}, {T}: Loot deals 3 damage to any target.
+ *
+ * Each exhaust ability is once per object (`isExhaust`); all three share the {T} symbol, so in
+ * practice only one fires per untap step unless Loot is untapped again.
+ */
+val LootThePathfinder = card("Loot, the Pathfinder") {
+    manaCost = "{2}{G}{U}{R}"
+    colorIdentity = "GRU"
+    typeLine = "Legendary Creature — Beast Noble"
+    oracleText = "Double strike, vigilance, haste\n" +
+        "Exhaust — {G}, {T}: Add three mana of any one color. (Activate each exhaust ability only once.)\n" +
+        "Exhaust — {U}, {T}: Draw three cards.\n" +
+        "Exhaust — {R}, {T}: Loot deals 3 damage to any target."
+    power = 2
+    toughness = 4
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.VIGILANCE, Keyword.HASTE)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        isExhaust = true
+        effect = Effects.AddAnyColorMana(3)
+        // Adds mana, targets nothing — a mana ability (CR 605.1a), so it uses the stack-free
+        // timing rule. Pit Automaton's "exhaust ability that isn't a mana ability" rider only
+        // makes sense if this one is flagged as one.
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        isExhaust = true
+        effect = Effects.DrawCards(3)
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        isExhaust = true
+        val t = target("target", AnyTarget())
+        effect = Effects.DealDamage(3, t)
+    }
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "212"
+        artist = "Ernanda Souza"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg?1783907856"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SlickImitator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SlickImitator.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slick Imitator
+ * {1}{U}
+ * Creature — Ooze
+ * 1/3
+ * Start your engines!
+ * Max speed — {1}, Sacrifice this creature: Copy target spell you control. You may choose new
+ * targets for the copy.
+ *
+ * The copy is unrestricted by spell type, so it can duplicate a permanent spell — the copy
+ * resolves into a token, which [Effects.CopyTargetSpell] already handles.
+ */
+val SlickImitator = card("Slick Imitator") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Ooze"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — {1}, Sacrifice this creature: Copy target spell you control. You may choose " +
+        "new targets for the copy. (A copy of a permanent spell becomes a token.)"
+    power = 1
+    toughness = 3
+
+    startYourEngines()
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+            val spell = target("target spell you control", Targets.SpellYouControl)
+            effect = Effects.CopyTargetSpell(spell)
+            // `maxSpeed { }` prepends "Max speed — "; the auto-rendered label would otherwise
+            // read the bound variable name mid-sentence.
+            description = "{1}, Sacrifice this creature: Copy target spell you control"
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Xabi Gaztelua"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg?1783907902"
+        ruling("2025-02-07", "A player \"has max speed\" if their speed is 4.")
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2164,6 +2164,121 @@
     ]
 }
 
+// Coalstoke Gearhulk
+{
+    "name": "Coalstoke Gearhulk",
+    "manaCost": "{1}{B}{B}{R}{R}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Menace, deathtouch\nWhen this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card with mana value 4 or less in a graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "controllerOverride": "Controller",
+                            "addCounterType": "FINALITY"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card with mana value 4 or less in a graveyard"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "DEATHTOUCH",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card with mana value 4 or less in a graveyard"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card with mana value 4 or less in a graveyard"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature card with mana value 4 or less in a graveyard"
+                                },
+                                "destination": "Exile"
+                            },
+                            "timing": "NextEndStep",
+                            "fireOnPlayer": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=4",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card with mana value 4 or less in a graveyard"
+                },
+                "descriptionOverride": "When this creature enters, put target creature card with mana value 4 or less from a graveyard onto the battlefield under your control with a finality counter on it. That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile that creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "MYTHIC",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73431628-b9b0-41e6-8e9b-8a090939b0c1.jpg?1783907861",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Finality counters work on any permanent, not only creatures. If a permanent with a finality counter on it would be put into a graveyard from the battlefield, exile it instead."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Multiple finality counters on a single permanent are redundant."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Collision Course
 {
     "name": "Collision Course",
@@ -3749,6 +3864,94 @@
     ]
 }
 
+// Gas Guzzler
+{
+    "name": "Gas Guzzler",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Vampire Rogue",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nThis creature enters tapped.\nMax speed — {B}, Sacrifice another creature or Vehicle: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|Vehicle",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — {B}, Sacrifice another creature or Vehicle: Draw a card"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Yohann Schepacz",
+        "flavorText": "Gastal's vampires took fuel from the dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4db3a28c-e4b4-4b18-8d56-e3842184d105.jpg?1783907896",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gastal Blockbuster
 {
     "name": "Gastal Blockbuster",
@@ -3958,6 +4161,102 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Gastal Thrillroller
+{
+    "name": "Gastal Thrillroller",
+    "manaCost": "{2}{R}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Trample, haste\nWhen this Vehicle enters, it becomes an artifact creature until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)\n{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this Vehicle enters, it becomes an artifact creature until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{2}{R}, Discard a card: Return this card from your graveyard to the battlefield with a finality counter on it"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "RARE",
+        "artist": "Caio Monteiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8b1762b-ff03-4312-afcc-cb6b5f280ade.jpg?1783907881"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5998,6 +6297,141 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Loot, the Pathfinder
+{
+    "name": "Loot, the Pathfinder",
+    "manaCost": "{2}{G}{U}{R}",
+    "typeLine": "Legendary Creature — Beast Noble",
+    "oracleText": "Double strike, vigilance, haste\nExhaust — {G}, {T}: Add three mana of any one color. (Activate each exhaust ability only once.)\nExhaust — {U}, {T}: Draw three cards.\nExhaust — {R}, {T}: Loot deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "VIGILANCE",
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "restrictions": [
+                    "Once"
+                ],
+                "isManaAbility": true,
+                "isExhaust": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "isExhaust": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "Once"
+                ],
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "MYTHIC",
+        "artist": "Ernanda Souza",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33c59c04-4c0b-4a60-826e-3a7757d0b2a2.jpg?1783907856",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "BLUE"
     ]
 }
 
@@ -9988,6 +10422,93 @@
         "artist": "Elizabeth Peiró",
         "flavorText": "Garima was delighted to finally test out her design. The amazing views were a bonus.",
         "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bc9c501-098d-4560-9826-329b05689e0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Slick Imitator
+{
+    "name": "Slick Imitator",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — {1}, Sacrifice this creature: Copy target spell you control. You may choose new targets for the copy. (A copy of a permanent spell becomes a token.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CopyTargetSpell",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target spell you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "ctrl:you",
+                            "zone": "Stack"
+                        },
+                        "id": "target spell you control"
+                    }
+                ],
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Max speed — {1}, Sacrifice this creature: Copy target spell you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Xabi Gaztelua",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e86ef50-4939-4e7c-853d-438f0f3e0411.jpg?1783907902",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoalstokeGearhulkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoalstokeGearhulkScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Coalstoke Gearhulk — "When this creature enters, put target creature card with mana value 4 or
+ * less from a graveyard onto the battlefield under your control with a finality counter on it.
+ * That creature gains menace, deathtouch, and haste. At the beginning of your next end step, exile
+ * that creature."
+ *
+ * Five chained effects behind one trigger, so the parts that can silently go wrong are:
+ *
+ * - the target reads **a** graveyard, not only yours;
+ * - mana value 4 or less actually restricts the candidate set;
+ * - the finality counter rides along on the zone change rather than being bolted on afterwards;
+ * - the three keyword grants land on the *reanimated* creature, not on the Gearhulk;
+ * - the delayed trigger fires on the controller's own end step and exiles that creature.
+ */
+class CoalstokeGearhulkScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("reanimates an opponent's creature under your control, with a finality counter and the three keywords") {
+            val game = gearhulkGame()
+            val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+
+            game.castSpell(1, "Coalstoke Gearhulk").error shouldBe null
+            game.autoPayIfAsked()
+            game.resolveStack()
+
+            withClue("The enters trigger asks for its target") {
+                game.hasPendingDecision() shouldBe true
+            }
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            withClue("It left the opponent's graveyard for the battlefield") {
+                game.findPermanent("Grizzly Bears") shouldNotBe null
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+            }
+            val reanimated = game.findPermanent("Grizzly Bears")!!
+            withClue("\"under your control\" — the caster controls it, not its owner") {
+                game.state.getEntity(reanimated)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+            }
+            withClue("It entered with the finality counter") {
+                game.state.getEntity(reanimated)?.get<CountersComponent>()
+                    ?.getCount(CounterType.FINALITY) shouldBe 1
+            }
+            withClue("Menace, deathtouch and haste are granted to the reanimated creature") {
+                val projected = game.state.projectedState
+                projected.hasKeyword(reanimated, Keyword.MENACE) shouldBe true
+                projected.hasKeyword(reanimated, Keyword.DEATHTOUCH) shouldBe true
+                projected.hasKeyword(reanimated, Keyword.HASTE) shouldBe true
+            }
+        }
+
+        test("the delayed trigger exiles the reanimated creature at your end step") {
+            val game = gearhulkGame()
+            val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+
+            game.castSpell(1, "Coalstoke Gearhulk").error shouldBe null
+            game.autoPayIfAsked()
+            game.resolveStack()
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            withClue("Still around during the turn it was reanimated") {
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            withClue("Exiled at the beginning of the controller's end step — not put into a graveyard") {
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isInExile(2, "Grizzly Bears") shouldBe true
+            }
+        }
+
+        test("a creature card with mana value 5 is not a legal target") {
+            val game = gearhulkGame(graveyardCreature = "Serra Angel")
+
+            game.castSpell(1, "Coalstoke Gearhulk").error shouldBe null
+            game.autoPayIfAsked()
+            game.resolveStack()
+
+            withClue("Serra Angel costs {3}{W}{W} — mana value 5, above the trigger's ceiling, so " +
+                "the trigger has no legal target and is removed rather than pausing for one") {
+                game.hasPendingDecision() shouldBe false
+                game.isInGraveyard(2, "Serra Angel") shouldBe true
+            }
+        }
+    }
+
+    /**
+     * Coalstoke Gearhulk in hand with exactly {1}{B}{B}{R}{R} available, and one creature card
+     * sitting in the *opponent's* graveyard.
+     */
+    private fun gearhulkGame(graveyardCreature: String = "Grizzly Bears"): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Coalstoke Gearhulk")
+            .withLandsOnBattlefield(1, "Swamp", 3)
+            .withLandsOnBattlefield(1, "Mountain", 2)
+            .withCardInGraveyard(2, graveyardCreature)
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+
+    /** Submit auto-pay if the engine paused for a mana-source decision. */
+    private fun TestGame.autoPayIfAsked() {
+        if (getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+            submitManaSourcesAutoPay()
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickImitatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlickImitatorScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Slick Imitator — "Max speed — {1}, Sacrifice this creature: Copy target spell you control. You
+ * may choose new targets for the copy."
+ *
+ * The card is the first user of `Targets.SpellYouControl`, the type-unrestricted sibling of
+ * `Targets.InstantOrSorcerySpellYouControl` / `Targets.CreatureSpellYouControl`. What that new
+ * requirement has to get right:
+ *
+ * - a **permanent** spell you control is a legal target (the copy resolves into a token, CR 707.10f);
+ * - "you control" actually excludes an opponent's spell;
+ * - the max-speed gate still keeps the ability off the action list below speed 4.
+ */
+class SlickImitatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("copies your own creature spell on the stack; the copy resolves as a token") {
+            val game = imitatorGame(maxSpeed = true)
+
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.autoPayIfAsked()
+            val bearsSpell = game.spellOnStack("Grizzly Bears")
+
+            val activate = game.activateImitator(bearsSpell)
+            withClue("Your own creature spell is a legal target: ${activate.error}") {
+                activate.error shouldBe null
+            }
+            game.autoPayIfAsked()
+            game.resolveStack()
+
+            val bears = game.findAllPermanents("Grizzly Bears")
+            withClue("The original and its copy both resolved — found ${bears.size}") {
+                bears.size shouldBe 2
+            }
+            withClue("A copy of a permanent spell becomes a token") {
+                bears.count { game.state.getEntity(it)?.has<TokenComponent>() == true } shouldBe 1
+            }
+            withClue("Slick Imitator sacrificed itself to pay the cost") {
+                game.findPermanent("Slick Imitator") shouldBe null
+                game.isInGraveyard(1, "Slick Imitator") shouldBe true
+            }
+        }
+
+        test("an opponent's spell is not a legal target") {
+            // The opponent's turn — a creature spell is sorcery-speed, so only they can cast one.
+            val game = imitatorGame(maxSpeed = true, activePlayer = 2)
+
+            // Opponent casts, then passes so player 1 holds priority with their spell on the stack.
+            game.castSpell(2, "Grizzly Bears").error shouldBe null
+            game.autoPayIfAsked()
+            game.execute(PassPriority(game.player2Id))
+            val bearsSpell = game.spellOnStack("Grizzly Bears")
+
+            val activate = game.activateImitator(bearsSpell)
+            withClue("\"target spell you control\" must reject the opponent's spell: ${activate.error}") {
+                activate.error shouldNotBe null
+            }
+        }
+
+        test("the ability is gated behind max speed") {
+            val game = imitatorGame(maxSpeed = false)
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.autoPayIfAsked()
+            val bearsSpell = game.spellOnStack("Grizzly Bears")
+
+            val activate = game.activateImitator(bearsSpell)
+            withClue("Speed is 1 from its own \"Start your engines!\", not 4: ${activate.error}") {
+                game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                activate.error shouldNotBe null
+            }
+        }
+    }
+
+    private fun imitatorGame(maxSpeed: Boolean, activePlayer: Int = 1): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Slick Imitator", summoningSickness = false)
+            .withLandsOnBattlefield(1, "Forest", 4)
+            .withLandsOnBattlefield(2, "Forest", 3)
+            .withCardInHand(1, "Grizzly Bears")
+            .withCardInHand(2, "Grizzly Bears")
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        val game = builder
+            .withActivePlayer(activePlayer)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        if (maxSpeed) {
+            game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+        }
+        return game
+    }
+
+    /** The single stack object with the given card name. */
+    private fun TestGame.spellOnStack(name: String): EntityId =
+        state.stack.single { id: EntityId ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    /** Activate Slick Imitator's single (max-speed-gated) activated ability at [spell]. */
+    private fun TestGame.activateImitator(spell: EntityId): ExecutionResult {
+        val imitator = findPermanent("Slick Imitator")!!
+        val abilityId = cardRegistry.getCard("Slick Imitator")!!.script.activatedAbilities.single().id
+        return execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = imitator,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Spell(spell))
+            )
+        )
+    }
+
+    /** Submit auto-pay if the engine paused for a mana-source decision. */
+    private fun TestGame.autoPayIfAsked() {
+        if (getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+            submitManaSourcesAutoPay()
+        }
+    }
+}


### PR DESCRIPTION
Five Aetherdrift cards, picked to span the set's mechanics without needing new engine capability. DFT goes **194/276 → 199/276**.

| Card | | What it leans on |
|---|---|---|
| **Loot, the Pathfinder** | `{2}{G}{U}{R}` mythic | three exhaust abilities |
| **Slick Imitator** | `{1}{U}` uncommon | start your engines! + max-speed copy |
| **Gas Guzzler** | `{B}` rare | start your engines! + `EntersTapped` + max-speed sac ability |
| **Gastal Thrillroller** | `{2}{R}` rare Vehicle | self-animate, crew 2, graveyard-activated recursion |
| **Coalstoke Gearhulk** | `{1}{B}{B}{R}{R}` mythic | reanimate + finality counter + delayed exile |

### Notes

- **Loot's `{G}, {T}` ability is flagged as a mana ability.** It adds mana and targets nothing (CR 605.1a). Pit Automaton's "exhaust ability that isn't a mana ability" rider only reads correctly if this one is.
- **Slick Imitator's copy is unrestricted by spell type**, so a permanent spell you control is a legal target and its copy resolves into a token (CR 707.10f) — already handled by `CopyTargetSpellEffect`.
- **Gastal Thrillroller's enters trigger animates to its own printed 4/2**, the convention Rocketeer Boostbuggy already uses. The permanent is already an artifact, so only `CREATURE` is added.
- **Coalstoke's finality counter rides along on the zone change** (`Move`'s `addCounterType`) rather than being added afterwards, so a permanent that dies in the same window is still exiled.

### SDK

One addition: `Targets.SpellYouControl`, the type-unrestricted sibling of `Targets.InstantOrSorcerySpellYouControl` / `Targets.CreatureSpellYouControl`, composed from filters that already existed. Catalogued in `docs/card-sdk-language-reference.md` in the same change.

### Bug caught by the tests

Coalstoke's scenario test caught a real one: a bare `Effects.Move(target, Zone.BATTLEFIELD)` hands the card back to its **owner**, so reanimating out of an opponent's graveyard handed the creature *to the opponent*. Fixed with an explicit `controllerOverride = EffectTarget.Controller`.

### Verification

- `just test` — full suite green
- `just rebless-cards` — only the five new cards moved in the DFT golden, additions only
- `just check-card-printing` — all five canonical in DFT, their earliest real printing
- Every field (name, mana cost, type line, oracle text, P/T, rarity, collector number, artist) re-verified against Scryfall; all five image URLs return 200
- Scenario tests for the two riskiest compositions: `CoalstokeGearhulkScenarioTest` (3 tests), `SlickImitatorScenarioTest` (3 tests)

### Considered and dropped

**Lightwheel Enhancements** was in the original five and got swapped for Gas Guzzler. Its "Max speed — You may cast this card from your graveyard" needs a self-scoped cast permission that *functions in the graveyard*; every existing `MayCastFromGraveyard` is a battlefield-resident permanent granting the permission by filter, and `maxSpeed { }` gates statics through `ConditionalStaticAbility` in the layer system, which only reads battlefield permanents. That's `add-feature` work, not a card.

Same reason ruled out Kolodin, Triumph Caster and Alacrian Armory: "that Vehicle becomes an artifact creature" on an *arbitrary* Vehicle needs a P/T-preserving animate, and `BecomeCreature` requires explicit P/T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)