### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4452,6 +4452,11 @@ staticAbility {
   same, all players), `PermanentsSacrificedThisTurn(amountPerPermanent = 1)` (the count of
   permanents sacrificed this turn by *any* player — not controller-scoped — reading the
   turn-scoped `GameState.permanentsSacrificedThisTurn` counter; The Balrog, Durin's Bane),
+  `CreaturesThatAttackedThisTurn(amountPerCreature = 1)` (the count of creatures declared as
+  attackers this turn by *any* player, across every combat phase — Witchstalker Frenzy. Turn
+  *history*, from the union of each player's `PlayerAttackersThisTurnComponent.attackerIds`, not a
+  battlefield scan: an attacker that has since died still counts, which
+  `PermanentsOnBattlefieldMatching(Creature.attackedThisTurn())` would miss),
   `CardsInGraveyardMatchingFilter`, `FixedIfAnyTargetMatches`,
   `GreatestPropertyAmongPermanentsYouControl(property, filter)` — "{X} less, where X is the greatest
   `<property>` among `<filter>` you control", parameterized over `EntityNumericProperty`:
@@ -5752,6 +5757,10 @@ answer it and would silently return `false`.
   battlefield, sacrifice this enchantment" state trigger.
 - `ControlMoreCreatures` — you control more creatures than each opponent.
 - `OpponentControlsCreature` — at least one opponent has a creature.
+- `OpponentControls(filter, negate = false)` — at least one opponent controls a permanent matching
+  `filter`; the opponent-side mirror of `YouControl(filter, …)` and the general form of
+  `OpponentControlsCreature`. Existential across opponents, so it holds when *any single* opponent
+  has a match (Syr Ginger, the Meal Ender's "as long as an opponent controls a planeswalker").
 - `OpponentControlsMoreCreatures` — an opponent outpaces you.
 - `OpponentControlsMoreLands` — an opponent has more lands.
 - `OpponentHasMoreCardsInHand` — an opponent has more cards in hand than you (compares opponents' hand size to yours). Used by Beza, the Bounding Spring and Joined Researchers.

--- a/manual-scenarios/cards/f/farsight-ritual.json
+++ b/manual-scenarios/cards/f/farsight-ritual.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Farsight Ritual"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Candy Trail"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Island", "Grizzly Bears", "Hill Giant", "Island",
+      "Centaur Courser", "Island", "Savannah Lions", "Island",
+      "Island", "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": []
+}

--- a/manual-scenarios/cards/l/lich-knights-conquest.json
+++ b/manual-scenarios/cards/l/lich-knights-conquest.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Lich-Knights' Conquest"],
+    "battlefield": [
+      {"name": "Candy Trail"},
+      {"name": "Collector's Vault"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Grizzly Bears", "Hill Giant", "Centaur Courser"],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": []
+}

--- a/manual-scenarios/cards/s/syr-ginger-the-meal-ender.json
+++ b/manual-scenarios/cards/s/syr-ginger-the-meal-ender.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Syr Ginger, the Meal Ender"},
+      {"name": "Candy Trail"},
+      {"name": "Collector's Vault"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": []
+}

--- a/manual-scenarios/cards/t/talions-messenger.json
+++ b/manual-scenarios/cards/t/talions-messenger.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Island", "Grizzly Bears"],
+    "battlefield": [
+      {"name": "Talion's Messenger"},
+      {"name": "Barrow Naughty"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": []
+}

--- a/manual-scenarios/cards/w/witchstalker-frenzy.json
+++ b/manual-scenarios/cards/w/witchstalker-frenzy.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Witchstalker Frenzy"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Hill Giant"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Centaur Courser"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS", "COMBAT_DAMAGE", "POSTCOMBAT_MAIN"],
+  "player2StopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -258,6 +258,20 @@ object Conditions {
         Exists(Player.You, Zone.BATTLEFIELD, filter, negate = negate, excludeSelf = excludeSelf)
 
     /**
+     * If **an** opponent controls at least one permanent matching [filter] — the opponent-side
+     * mirror of [YouControl], generalizing [OpponentControlsCreature] to any filter.
+     *
+     * `Player.EachOpponent` is an existential across opponents, not a universal: the condition
+     * holds when *any single* opponent controls a match, which is what "as long as an opponent
+     * controls a planeswalker" (Syr Ginger, the Meal Ender) means in multiplayer.
+     */
+    fun OpponentControls(
+        filter: GameObjectFilter,
+        negate: Boolean = false
+    ): ConditionInterface =
+        Exists(Player.EachOpponent, Zone.BATTLEFIELD, filter, negate = negate)
+
+    /**
      * If you control an enchantment.
      */
     val ControlEnchantment: ConditionInterface =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -654,6 +654,31 @@ sealed interface CostReductionSource {
     ) : CostReductionSource {
         override val description: String = "the number of permanents sacrificed this turn"
     }
+
+    /**
+     * Reduces cost by [amountPerCreature] for each creature that was declared as an attacker this
+     * turn — by ANY player, not just the caster ("for each creature that attacked this turn" is
+     * not controller-scoped), and counting every combat phase this turn.
+     *
+     * The turn-history sibling of [PermanentsSacrificedThisTurn], and deliberately *not*
+     * `PermanentsOnBattlefieldMatching(Creature.attackedThisTurn())`: that reads the live
+     * battlefield, so an attacker that died in combat would stop counting. The count here is
+     * the union of every player's `PlayerAttackersThisTurnComponent.attackerIds` — the same set
+     * the engine already maintains for raid — which survives the attacker leaving the
+     * battlefield, so a trick cast after combat damage still sees the creatures that traded.
+     *
+     * Used for Witchstalker Frenzy ("This spell costs {1} less to cast for each creature that
+     * attacked this turn"). Per its ruling the reduction never touches the colored part of the
+     * cost, so it can't reduce below `{R}` — that clamping is the generic-reduction rail's, not
+     * this source's.
+     */
+    @SerialName("CreaturesThatAttackedThisTurn")
+    @Serializable
+    data class CreaturesThatAttackedThisTurn(
+        val amountPerCreature: Int = 1
+    ) : CostReductionSource {
+        override val description: String = "the number of creatures that attacked this turn"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FarsightRitual.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FarsightRitual.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Farsight Ritual
+ * {2}{U}{U}
+ * Instant
+ *
+ * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+ * Look at the top four cards of your library. If this spell was bargained, look at the top eight
+ * cards of your library instead. Put two of them into your hand and the rest on the bottom of your
+ * library in a random order.
+ *
+ * The spell-rider shape of bargain (CR 702.166c), like [ArchonsGlory] — except the payoff isn't an
+ * extra clause but a *bigger number*, so it's a [DynamicAmount.Conditional] on
+ * [Conditions.WasBargained] feeding the dig's count rather than a `ConditionalEffect` wrapping a
+ * second effect. The bargained fact is stamped on the spell as it's cast and read while the spell
+ * is still resolving.
+ *
+ * Only the look widens: `keepCount` stays a flat 2 per the WOE ruling ("You still put only two of
+ * the cards into your hand if you bargain this spell").
+ *
+ * [Patterns.Library.lookAtTopAndKeep] is the whole dig, same recipe as Sinuous Benthisaur:
+ * gather the top N off the library so the controller sees them privately (`revealed = false` — the
+ * card says "look at", not "reveal"), `ChooseExactly(2)`, kept → hand, rest → library bottom with
+ * [CardOrder.Random] for "in a random order". `ChooseExactly` caps at the collection size, so a
+ * library of fewer than two cards simply keeps everything looked at rather than deadlocking.
+ */
+val FarsightRitual = card("Farsight Ritual") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Look at the top four cards of your library. If this spell was bargained, look at the top " +
+        "eight cards of your library instead. Put two of them into your hand and the rest on the " +
+        "bottom of your library in a random order."
+
+    bargain()
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = DynamicAmount.Conditional(
+                condition = Conditions.WasBargained,
+                ifTrue = DynamicAmount.Fixed(8),
+                ifFalse = DynamicAmount.Fixed(4),
+            ),
+            keepCount = DynamicAmount.Fixed(2),
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random,
+            selectedLabel = "Put into hand",
+            remainderLabel = "Put on bottom",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "49"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg?1783915120"
+
+        ruling(
+            "2023-09-01",
+            "You still put only two of the cards into your hand if you bargain this spell."
+        )
+        ruling(
+            "2023-09-01",
+            "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+        )
+        ruling(
+            "2023-09-01",
+            "If you copy a bargained spell, the copy is also bargained."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LichKnightsConquest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/LichKnightsConquest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Lich-Knights' Conquest
+ * {4}{B}
+ * Sorcery
+ *
+ * Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards
+ * from your graveyard to the battlefield.
+ *
+ * The same sacrifice-then-spend shape as Hew the Entwood: [Effects.SacrificeAnyNumber] records what
+ * was sacrificed on the resolving effect context, and the later step reads the count back through
+ * [DynamicAmounts.permanentsSacrificedThisWay].
+ *
+ * Order matters and is load-bearing for two rulings:
+ *  - The sacrifice happens *during resolution*, not as an additional cost — so a countered
+ *    Conquest sacrifices nothing. Modelling it as the first step of the spell's own effect (rather
+ *    than `additionalCost`) is what gets that right.
+ *  - The graveyard is gathered *after* the sacrifice, so an artifact creature or enchantment
+ *    creature sacrificed to the Conquest is already in the graveyard and may be one of the cards
+ *    returned.
+ *
+ * `ChooseExactly(sacrificed)` is "return that many": mandatory, but capped at the collection size,
+ * so sacrificing more permanents than you have creature cards simply returns everything. Zero
+ * sacrifices gathers an empty selection and the spell does nothing, per "You can choose to
+ * sacrifice zero permanents".
+ *
+ * [GameObjectFilter.ArtifactEnchantmentOrToken] is the same union bargain uses — a token of any
+ * type qualifies, and an artifact *enchantment* counts once, not twice.
+ */
+val LichKnightsConquest = card("Lich-Knights' Conquest") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many " +
+        "creature cards from your graveyard to the battlefield."
+
+    spell {
+        effect = Effects.SacrificeAnyNumber(GameObjectFilter.ArtifactEnchantmentOrToken)
+            .then(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature,
+                    ),
+                    storeAs = "graveyardCreatures",
+                )
+            )
+            .then(
+                SelectFromCollectionEffect(
+                    from = "graveyardCreatures",
+                    selection = SelectionMode.ChooseExactly(
+                        DynamicAmounts.permanentsSacrificedThisWay()
+                    ),
+                    storeSelected = "returning",
+                    prompt = "Return that many creature cards from your graveyard to the battlefield",
+                )
+            )
+            .then(
+                MoveCollectionEffect(
+                    from = "returning",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true,
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "96"
+        artist = "Denis Zhbankov"
+        flavorText = "In their rotting minds, they still quest for virtue and glory."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg?1783915106"
+
+        ruling(
+            "2023-09-01",
+            "You sacrifice the artifacts, enchantments, and/or tokens as part of the resolution of " +
+                "Lich-Knights' Conquest. It isn't an additional cost. If Lich-Knights' Conquest is " +
+                "countered, you won't sacrifice anything."
+        )
+        ruling("2023-09-01", "You can choose to sacrifice zero permanents.")
+        ruling(
+            "2023-09-01",
+            "If any abilities trigger as you sacrifice permanents, those abilities won't be put " +
+                "onto the stack until after you've returned creature cards from your graveyard to " +
+                "the battlefield."
+        )
+        ruling(
+            "2023-09-01",
+            "An artifact creature or enchantment creature sacrificed to Lich-Knights' Conquest may " +
+                "be one of the cards chosen to be returned."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SyrGingerTheMealEnder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SyrGingerTheMealEnder.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Syr Ginger, the Meal Ender
+ * {2}
+ * Legendary Artifact Creature — Food Knight
+ * 3/1
+ *
+ * Syr Ginger has trample, hexproof, and haste as long as an opponent controls a planeswalker.
+ * Whenever another artifact you control is put into a graveyard from the battlefield, put a
+ * +1/+1 counter on Syr Ginger and scry 1.
+ * {2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.
+ *
+ * Three separate `staticAbility { }` blocks rather than one: a static ability is one continuous
+ * modification, and the DSL takes exactly one [com.wingedsheep.sdk.scripting.StaticAbility] per
+ * block. All three share the same [Conditions.OpponentControls] gate, so they wink in and out
+ * together as planeswalkers come and go — a condition, not a one-shot grant.
+ *
+ * The death payoff is [Triggers.leavesBattlefield] scoped to `Artifact.youControl()` with
+ * [TriggerBinding.OTHER] for "another" — Syr Ginger is itself an artifact, so without the OTHER
+ * binding sacrificing it to its own last ability would grow it on the way out. Any artifact you
+ * control counts, whether it died in combat, was sacrificed, or was destroyed; Food tokens
+ * eaten by their own ability are the intended engine.
+ *
+ * The sacrifice ability reads [DynamicAmounts.sourcePower], which is `LIVE_THEN_LKI` for
+ * [com.wingedsheep.sdk.scripting.values.EntityReference.Source]: the sacrifice is a *cost*, so
+ * Syr Ginger is already in the graveyard when the ability resolves and the read falls through to
+ * the snapshot captured at cost-payment time. That is exactly the printed ruling — "use its power
+ * from when it was last on the battlefield" — so counters accumulated by the middle ability, and
+ * any pumps, are all counted. A power of 0 or less gains no life.
+ */
+val SyrGingerTheMealEnder = card("Syr Ginger, the Meal Ender") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact Creature — Food Knight"
+    power = 3
+    toughness = 1
+    oracleText = "Syr Ginger has trample, hexproof, and haste as long as an opponent controls a " +
+        "planeswalker.\n" +
+        "Whenever another artifact you control is put into a graveyard from the battlefield, put a " +
+        "+1/+1 counter on Syr Ginger and scry 1.\n" +
+        "{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power."
+
+    staticAbility {
+        condition = Conditions.OpponentControls(GameObjectFilter.Planeswalker)
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.Self)
+    }
+
+    staticAbility {
+        condition = Conditions.OpponentControls(GameObjectFilter.Planeswalker)
+        ability = GrantKeyword(Keyword.HEXPROOF, Filters.Self)
+    }
+
+    staticAbility {
+        condition = Conditions.OpponentControls(GameObjectFilter.Planeswalker)
+        ability = GrantKeyword(Keyword.HASTE, Filters.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Patterns.Library.scry(1),
+        )
+        description = "Whenever another artifact you control is put into a graveyard from the " +
+            "battlefield, put a +1/+1 counter on Syr Ginger and scry 1."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.GainLife(DynamicAmounts.sourcePower())
+        description = "{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Michal Ivan"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg?1783915057"
+
+        ruling(
+            "2023-09-01",
+            "For Syr Ginger's last ability, use its power from when it was last on the battlefield " +
+                "to determine how much life is gained. If that power was 0 or less, you gain no life."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TalionsMessenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TalionsMessenger.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Talion's Messenger
+ * {2}{U}
+ * Creature — Faerie Noble
+ * 1/3
+ *
+ * Flying
+ * Whenever you attack with one or more Faeries, draw a card, then discard a card. When you discard
+ * a card this way, put a +1/+1 counter on target Faerie you control.
+ *
+ * [Triggers.YouAttackWithFilter] fires once per declare-attackers step, not once per attacker —
+ * "one or more Faeries" is a batch, so attacking with three Faeries loots once. The Messenger
+ * itself is a Faerie and satisfies its own trigger when it attacks.
+ *
+ * "Draw a card, then discard a card. When you discard a card this way, …" is the exact shape The
+ * Ancient One prints: a plain draw followed by a [ReflexiveTriggerEffect] whose *action* is the
+ * discard pipeline. `optional = false` because the discard is mandatory, and wrapping it as a
+ * reflexive trigger rather than a third composite step is what gets the timing and the fizzle case
+ * right — the counter is a genuine trigger that goes on the stack after the loot finishes, its
+ * target is chosen then (not at attack time), and if there was nothing to discard the reflexive
+ * trigger never fires at all.
+ *
+ * The target is [TargetPermanent] filtered to the Faerie subtype rather than [TargetFilter.Creature]:
+ * the oracle says "target Faerie you control", and Eldraine prints noncreature Faeries. Any Faerie
+ * you control is legal, not just one that attacked.
+ */
+val TalionsMessenger = card("Talion's Messenger") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Noble"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever you attack with one or more Faeries, draw a card, then discard a card. When you " +
+        "discard a card this way, put a +1/+1 counter on target Faerie you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(GameObjectFilter.Any.withSubtype("Faerie"))
+        effect = Effects.Composite(
+            Effects.DrawCards(1, EffectTarget.Controller),
+            ReflexiveTriggerEffect(
+                action = Patterns.Hand.discardCards(1),
+                optional = false,
+                reflexiveEffect = Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    1,
+                    EffectTarget.ContextTarget(0),
+                ),
+                reflexiveTargetRequirements = listOf(
+                    TargetPermanent(
+                        filter = TargetFilter.Permanent.withSubtype("Faerie").youControl()
+                    )
+                ),
+            ),
+        )
+        description = "Whenever you attack with one or more Faeries, draw a card, then discard a " +
+            "card. When you discard a card this way, put a +1/+1 counter on target Faerie you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "73"
+        artist = "Marta Nael"
+        flavorText = "\"The Kindly Lord does not issue invitations to their court lightly. " +
+            "I suggest you accept.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg?1783915114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WitchstalkerFrenzy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/WitchstalkerFrenzy.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Witchstalker Frenzy
+ * {3}{R}
+ * Instant
+ *
+ * This spell costs {1} less to cast for each creature that attacked this turn.
+ * Witchstalker Frenzy deals 5 damage to target creature.
+ *
+ * The reduction is [CostReductionSource.CreaturesThatAttackedThisTurn], a turn-history count
+ * rather than a battlefield scan. That distinction is the whole point of the card: it is a trick
+ * you cast *after* blockers or damage, when the attackers that made it cheap may already be dead.
+ * Counting `Creature.attackedThisTurn()` on the live battlefield would silently un-discount the
+ * spell exactly when it matters, so the source reads the per-player attacker sets the engine
+ * unions at each declare-attackers step instead.
+ *
+ * Both rulings fall out of the rail rather than needing card-specific handling:
+ * - Cost *reduction*, not a cost change: the mana cost and mana value stay {3}{R} / 4, so a
+ *   Witchstalker Frenzy exiled or copied by a "mana value 4 or less" effect still qualifies.
+ * - [CostModification.ReduceGenericBy] only ever eats generic mana, so however many creatures
+ *   attacked, the cost bottoms out at {R}.
+ */
+val WitchstalkerFrenzy = card("Witchstalker Frenzy") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast for each creature that attacked this turn.\n" +
+        "Witchstalker Frenzy deals 5 damage to target creature."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CreaturesThatAttackedThisTurn()
+            ),
+        )
+    }
+
+    spell {
+        val creature = target("target creature", TargetCreature())
+        effect = Effects.DealDamage(5, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Pascal Quidault"
+        flavorText = "The witchstalkers circled the armored figure, drawn to the corrupting stink " +
+            "of dark magic. Kellan and Ruby fled to the sound of savage howls and snapping jaws."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg?1783915086"
+
+        ruling(
+            "2023-09-01",
+            "Witchstalker Frenzy's first ability doesn't change its mana cost or mana value, only " +
+                "the total cost you pay. Specifically, the mana value of Witchstalker Frenzy is " +
+                "always 4."
+        )
+        ruling(
+            "2023-09-01",
+            "Witchstalker Frenzy's first ability can't reduce its cost to less than {R}."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3385,6 +3385,117 @@
     ]
 }
 
+// Farsight Ritual
+{
+    "name": "Farsight Ritual",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nLook at the top four cards of your library. If this spell was bargained, look at the top eight cards of your library instead. Put two of them into your hand and the rest on the bottom of your library in a random order.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Conditional",
+                            "condition": {
+                                "type": "CastChoiceMade",
+                                "slot": "BARGAINED"
+                            },
+                            "ifTrue": {
+                                "type": "Fixed",
+                                "amount": 8
+                            },
+                            "ifFalse": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put into hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c958257e-fa70-4fa3-90a1-0497967abef3.jpg?1783915120",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You still put only two of the cards into your hand if you bargain this spell."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Feed the Cauldron
 {
     "name": "Feed the Cauldron",
@@ -5850,6 +5961,82 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lich-Knights' Conquest
+{
+    "name": "Lich-Knights' Conquest",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sacrifice any number of artifacts, enchantments, and/or tokens. Return that many creature cards from your graveyard to the battlefield.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Sacrifice",
+                    "filter": "artifact|enchantment|token",
+                    "any": true
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "storeAs": "graveyardCreatures"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "graveyardCreatures",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": "PermanentsSacrificedThisWay"
+                    },
+                    "storeSelected": "returning",
+                    "prompt": "Return that many creature cards from your graveyard to the battlefield"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "returning",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "underOwnersControl": true
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "RARE",
+        "artist": "Denis Zhbankov",
+        "flavorText": "In their rotting minds, they still quest for virtue and glory.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59cd67d3-3327-42ad-9db1-50e2f591818c.jpg?1783915106",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You sacrifice the artifacts, enchantments, and/or tokens as part of the resolution of Lich-Knights' Conquest. It isn't an additional cost. If Lich-Knights' Conquest is countered, you won't sacrifice anything."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You can choose to sacrifice zero permanents."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If any abilities trigger as you sacrifice permanents, those abilities won't be put onto the stack until after you've returned creature cards from your graveyard to the battlefield."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "An artifact creature or enchantment creature sacrificed to Lich-Knights' Conquest may be one of the cards chosen to be returned."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -11108,6 +11295,142 @@
     ]
 }
 
+// Syr Ginger, the Meal Ender
+{
+    "name": "Syr Ginger, the Meal Ender",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact Creature — Food Knight",
+    "oracleText": "Syr Ginger has trample, hexproof, and haste as long as an opponent controls a planeswalker.\nWhenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1.\n{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Scry",
+                            "count": 1
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever another artifact you control is put into a graveyard from the battlefield, put a +1/+1 counter on Syr Ginger and scry 1."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    }
+                },
+                "descriptionOverride": "{2}, {T}, Sacrifice Syr Ginger: You gain life equal to its power."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "EachOpponent",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "EachOpponent",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "EachOpponent",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "RARE",
+        "artist": "Michal Ivan",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fbdba12-1369-41ae-b0e9-c405c0f0a2e5.jpg?1783915057",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "For Syr Ginger's last ability, use its power from when it was last on the battlefield to determine how much life is gained. If that power was 0 or less, you gain no life."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Taken by Nightmares
 {
     "name": "Taken by Nightmares",
@@ -11163,6 +11486,119 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Talion's Messenger
+{
+    "name": "Talion's Messenger",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Faerie Noble",
+    "oracleText": "Flying\nWhenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "attackerFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Faerie"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "ReflexiveTrigger",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            "optional": false,
+                            "reflexiveEffect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "reflexiveTargetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "permanent Faerie ctrl:you"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you attack with one or more Faeries, draw a card, then discard a card. When you discard a card this way, put a +1/+1 counter on target Faerie you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "RARE",
+        "artist": "Marta Nael",
+        "flavorText": "\"The Kindly Lord does not issue invitations to their court lightly. I suggest you accept.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35fb0640-5b04-4687-b863-46a8b8d36809.jpg?1783915114"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -13559,6 +13995,66 @@
             {
                 "date": "2023-09-01",
                 "text": "If a permanent has more than one Role attached to it controlled by the same player, each of those Roles except the one with the most recent timestamp is put into its owner's graveyard. This is a state-based action."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Witchstalker Frenzy
+{
+    "name": "Witchstalker Frenzy",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast for each creature that attacked this turn.\nWitchstalker Frenzy deals 5 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "CreaturesThatAttackedThisTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Pascal Quidault",
+        "flavorText": "The witchstalkers circled the armored figure, drawn to the corrupting stink of dark magic. Kellan and Ruby fled to the sound of savage howls and snapping jaws.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/649025a7-79d1-4d7c-b1db-d46bcf5a1ae2.jpg?1783915086",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Witchstalker Frenzy's first ability doesn't change its mana cost or mana value, only the total cost you pay. Specifically, the mana value of Witchstalker Frenzy is always 4."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Witchstalker Frenzy's first ability can't reduce its cost to less than {R}."
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.CommanderComponent
 import com.wingedsheep.sdk.core.CardType
@@ -441,8 +442,29 @@ class CostCalculator(
                 countBattlefieldPermanentsMatching(state, playerId, source.filter)
             is CostReductionSource.PermanentsSacrificedThisTurn ->
                 state.permanentsSacrificedThisTurn * source.amountPerPermanent
+            is CostReductionSource.CreaturesThatAttackedThisTurn ->
+                countCreaturesThatAttackedThisTurn(state) * source.amountPerCreature
         }
     }
+
+    /**
+     * The number of creatures declared as attackers this turn by any player, across every combat
+     * phase. Reads the per-player `PlayerAttackersThisTurnComponent` sets that
+     * `AttackPhaseManager` unions at each declare-attackers step, so an attacker that has since
+     * died, been exiled, or been bounced still counts — the count is turn history, not a
+     * battlefield scan. Cleared with the components at end-of-turn cleanup.
+     *
+     * A creature can only be declared as an attacker once per combat and the sets are per
+     * controller, so no de-duplication across players is needed.
+     */
+    private fun countCreaturesThatAttackedThisTurn(state: GameState): Int =
+        state.turnOrder.sumOf { playerId ->
+            state.getEntity(playerId)
+                ?.get<PlayerAttackersThisTurnComponent>()
+                ?.attackerIds
+                ?.size
+                ?: 0
+        }
 
     /**
      * Count permanents the player controls matching the filter. Iterates the projected-control

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchstalkerFrenzyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchstalkerFrenzyScenarioTest.kt
@@ -1,0 +1,176 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Witchstalker Frenzy's cost reduction — i.e. for the new
+ * `CostReductionSource.CreaturesThatAttackedThisTurn`.
+ *
+ * Oracle: "This spell costs {1} less to cast for each creature that attacked this turn."
+ *
+ * The source counts turn *history* (the union of every player's `PlayerAttackersThisTurnComponent`),
+ * not the live battlefield, and is not controller-scoped. The two tests that matter are therefore
+ * the dead attacker and the opposing attacker: a battlefield-scanning implementation would pass the
+ * plain "two attackers" case and silently fail both of those.
+ */
+class WitchstalkerFrenzyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Witchstalker Frenzy — costs {1} less per creature that attacked this turn") {
+
+            test("no creature attacked → full {3}{R} (3 generic)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Witchstalker Frenzy")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Witchstalker Frenzy"),
+                    game.player1Id,
+                )
+
+                withClue("nothing attacked, so the generic component stays at 3") {
+                    cost.genericAmount shouldBe 3
+                }
+            }
+
+            test("two creatures attacked → {1}{R} (1 generic)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Witchstalker Frenzy")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 2, "Hill Giant" to 2)
+                ).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Witchstalker Frenzy"),
+                    game.player1Id,
+                )
+
+                withClue("two attackers reduce the generic from 3 to 1") {
+                    cost.genericAmount shouldBe 1
+                }
+            }
+
+            test("an attacker that died in combat still counts") {
+                // Grizzly Bears (2/2) attacks into Hill Giant (3/3) and dies in the damage step.
+                // The card is a combat trick cast *after* damage, so this is the case that matters.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Witchstalker Frenzy")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears"))).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("the attacker traded with the blocker and is in the graveyard") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Witchstalker Frenzy"),
+                    game.player1Id,
+                )
+
+                withClue("a creature that attacked and died still discounts the spell") {
+                    cost.genericAmount shouldBe 2
+                }
+            }
+
+            test("an opponent's attackers discount the defending player's copy too") {
+                // "each creature that attacked this turn" is not controller-scoped: player 1
+                // attacks, player 2 holds the Frenzy.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Witchstalker Frenzy")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Witchstalker Frenzy"),
+                    game.player2Id,
+                )
+
+                withClue("the attacking player's creature discounts the defender's spell") {
+                    cost.genericAmount shouldBe 2
+                }
+            }
+
+            test("the reduction never eats the colored pip") {
+                // Five attackers vs a {3}{R} spell: generic bottoms out at 0, {R} survives.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Witchstalker Frenzy")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Savannah Lions", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Centaur Courser", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf(
+                        "Grizzly Bears" to 2,
+                        "Hill Giant" to 2,
+                        "Savannah Lions" to 2,
+                        "Centaur Courser" to 2,
+                    )
+                ).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Witchstalker Frenzy"),
+                    game.player1Id,
+                )
+
+                withClue("four attackers clear all 3 generic but cannot reduce below {R}") {
+                    cost.genericAmount shouldBe 0
+                    cost.colorCount[Color.RED] shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds **Farsight Ritual**, **Lich-Knights' Conquest**, **Syr Ginger, the Meal Ender**, **Talion's Messenger**, and **Witchstalker Frenzy**. WOE goes 186 → 191 of 266 (72%).

## New SDK vocabulary

Four of the five are pure composition over existing primitives. Witchstalker Frenzy needed one addition:

**`CostReductionSource.CreaturesThatAttackedThisTurn(amountPerCreature = 1)`** — the number of creatures declared as attackers this turn by *any* player, across every combat phase.

This is deliberately turn **history**, not a battlefield scan. It reads the union of each player's `PlayerAttackersThisTurnComponent.attackerIds` — the sets the engine already maintains for raid. The obvious alternative, `PermanentsOnBattlefieldMatching(Creature.attackedThisTurn())`, reads the live board, so an attacker that died in combat would stop counting — which is exactly the case the card exists for, since it's a trick you cast *after* damage. It sits next to the existing `PermanentsSacrificedThisTurn`, which is turn-scoped and not controller-scoped in the same way. One new variant, one new evaluator branch in `CostCalculator`.

Also adds **`Conditions.OpponentControls(filter)`** — the opponent-side mirror of the existing `YouControl(filter)`, generalizing `OpponentControlsCreature` to any filter for Syr Ginger's "as long as an opponent controls a planeswalker".

`docs/card-sdk-language-reference.md` updated for both.

## Card notes

- **Farsight Ritual** — bargain widens the *look*, not the keep, so the count is a `DynamicAmount.Conditional` on `WasBargained` feeding `Patterns.Library.lookAtTopAndKeep`; `keepCount` stays a flat 2 per the printed ruling ("You still put only two of the cards into your hand if you bargain this spell").
- **Lich-Knights' Conquest** — the sacrifice runs inside the spell's own effect, not as an additional cost, so a countered Conquest sacrifices nothing; and the graveyard is gathered *after* it, so an artifact creature sacrificed to the Conquest can be one of the cards returned. `ChooseExactly(sacrificed)` caps at collection size, so sacrificing more than you can reanimate just returns everything, and zero sacrifices is legal.
- **Syr Ginger, the Meal Ender** — three conditional statics sharing one gate; the "another artifact you control" trigger is `leavesBattlefield(Artifact.youControl(), GRAVEYARD, binding = OTHER)`. The sac ability reads `sourcePower()`, which is `LIVE_THEN_LKI` and falls through to the snapshot captured at cost-payment time — matching the ruling "use its power from when it was last on the battlefield".
- **Talion's Messenger** — "when you discard a card this way" is a genuine reflexive trigger (`optional = false`), so the +1/+1 counter's target is chosen *after* the loot resolves, and nothing fires if there was nothing to discard. Targets `Permanent.withSubtype("Faerie")`, not `Creature` — the oracle says "target Faerie you control" and Eldraine prints noncreature Faeries.
- **Witchstalker Frenzy** — `ReduceGenericBy` only ever eats generic mana, so the cost bottoms out at `{R}` and the mana value stays 4, both per the printed rulings.

## Verification

- `just build` green; `:rules-engine:test` re-run from scratch with `--rerun-tasks`, green.
- WOE golden re-blessed — only these five cards moved, additions only.
- `just check-card-printing` clean for all five (all canonical in WOE).
- Every mechanical field re-checked against Scryfall: mana cost, type line, P/T, rarity, collector number, artist, oracle text, image URI.
- `WitchstalkerFrenzyScenarioTest` — 5 tests covering the new cost source, including the two a battlefield scan would fail: an attacker that **died in combat** still discounting, and an **opponent's** attackers discounting the defender's copy.
- Manual `DevScenarioController` scenarios added for all five cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)