### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GuidelightPathmaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/GuidelightPathmaker.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Guidelight Pathmaker — Aetherdrift #206
+ * {4}{W}{U} · Artifact — Vehicle · 6/5
+ *
+ * Vigilance
+ * When this Vehicle enters, you may search your library for an artifact card and reveal it. Put it
+ * onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. If you
+ * search your library this way, shuffle.
+ * Crew 2
+ *
+ * The destination depends on what was found, so this can't be `Patterns.Library.searchLibrary`
+ * (one fixed destination). It is an inline Gather → Select → branch pipeline instead: the found
+ * card is revealed, then `ifNotEmpty(found, filter = manaValueAtMost(2))` routes it to the
+ * battlefield and the `orElse` branch to hand. A declined "up to one" (or an artifact-less library)
+ * leaves the collection empty, so both branches move nothing and only the shuffle runs.
+ *
+ * The outer [MayEffect] is the "you may search" — per the card's 2025-02-07 Oracle update the
+ * shuffle only happens if you *choose* to search, which is exactly why the shuffle sits inside the
+ * may rather than after it.
+ */
+val GuidelightPathmaker = card("Guidelight Pathmaker") {
+    manaCost = "{4}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Vigilance\n" +
+        "When this Vehicle enters, you may search your library for an artifact card and reveal it. " +
+        "Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your " +
+        "hand. If you search your library this way, shuffle.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 6
+    toughness = 5
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Effects.Pipeline {
+                val searchable = gather(
+                    CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Artifact),
+                )
+                val found = chooseUpTo(1, from = searchable, prompt = "Search for an artifact card")
+                reveal(found)
+                ifNotEmpty(found, filter = GameObjectFilter.Any.manaValueAtMost(2)) {
+                    move(found, CardDestination.ToZone(Zone.BATTLEFIELD))
+                } orElse {
+                    toHand(found)
+                }
+                run(ShuffleLibraryEffect())
+                run(EmitLibrarySearchedEventEffect)
+            },
+        )
+        description = "When this Vehicle enters, you may search your library for an artifact card " +
+            "and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, " +
+            "put it into your hand. If you search your library this way, shuffle."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "206"
+        artist = "Stephan Martiniere"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg?1783907857"
+        ruling(
+            "2025-02-07",
+            "Guidelight Pathmaker has received an update to its Oracle text. Specifically, you'll " +
+                "only shuffle if you choose to search your library.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OutpaceOblivion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OutpaceOblivion.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+
+/**
+ * Outpace Oblivion — Aetherdrift #139
+ * {2}{R} · Enchantment
+ *
+ * Start your engines!
+ * When this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.
+ * {2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed.
+ *
+ * "Each player who doesn't have max speed" is the per-player evaluation Momentum Breaker uses:
+ * one [ForEachPlayerEffect] over [Player.Each] whose body is a [ConditionalEffect]. Inside the
+ * loop the controller is rebound to the iterated player, so `Not(HasMaxSpeed(Player.You))` asks
+ * about *that* player and [EffectTarget.Controller] is that player — which keeps the check right
+ * in multiplayer and includes Outpace Oblivion's own controller, exactly as printed.
+ *
+ * Whether a player has max speed is checked as the ability resolves, one iteration at a time; the
+ * damage can't change anyone's speed (speed only rises, on your own turn, when an opponent loses
+ * life — CR 702.179d), so the sequential iteration matches the simultaneous printed damage.
+ *
+ * The enchantment is already in the graveyard when the ability resolves (it was sacrificed to pay
+ * the cost), so the damage comes from its last-known information — the engine's default source
+ * handling for a sacrificed cost, no explicit `damageSource` needed.
+ */
+val OutpaceOblivion = card("Outpace Oblivion") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "When this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.\n" +
+        "{2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "up to one target creature or planeswalker",
+            TargetCreatureOrPlaneswalker(optional = true),
+        )
+        effect = Effects.DealDamage(5, t)
+        description = "When this enchantment enters, it deals 5 damage to up to one target " +
+            "creature or planeswalker."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                ConditionalEffect(
+                    condition = Conditions.Not(Conditions.HasMaxSpeed(Player.You)),
+                    effect = Effects.DealDamage(2, EffectTarget.Controller),
+                ),
+            ),
+        )
+        description = "{2}, Sacrifice this enchantment: It deals 2 damage to each player who " +
+            "doesn't have max speed."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg?1783907878"
+        ruling(
+            "2025-02-07",
+            "If an effect needs to know what a player's speed is and that player doesn't have a " +
+                "speed, their speed is considered 0.",
+        )
+        ruling("2025-02-07", "A player \"has max speed\" if their speed is 4.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PossessionEngine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PossessionEngine.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Possession Engine — Aetherdrift #54
+ * {3}{U}{U} · Artifact — Vehicle · 5/5
+ *
+ * When this Vehicle enters, gain control of target creature an opponent controls for as long as
+ * you control this Vehicle. That creature can't attack or block for as long as you control this
+ * Vehicle.
+ * Crew 3
+ *
+ * Both halves share the one target and the one duration, so both are
+ * [Duration.WhileYouControlSource] anchored to the Vehicle — not `WhileSourceOnBattlefield`. That
+ * distinction is the whole point of the wording: if an opponent steals Possession Engine, "you
+ * control this Vehicle" stops being true and the stolen creature goes home *and* regains its
+ * ability to attack and block, where a battlefield-scoped duration would leave the creature
+ * parked under the wrong player until the Vehicle died.
+ *
+ * The durations are one-way (CR 611.2b): once the Vehicle changes controller or leaves, both
+ * effects end for good and regaining it does not restart them — which also means the two halves
+ * can never drift apart.
+ */
+val PossessionEngine = card("Possession Engine") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "When this Vehicle enters, gain control of target creature an opponent controls " +
+        "for as long as you control this Vehicle. That creature can't attack or block for as long " +
+        "as you control this Vehicle.\n" +
+        "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 5
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val stolen = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        val whileControlled = Duration.WhileYouControlSource("this Vehicle")
+        effect = Effects.Composite(
+            Effects.GainControl(stolen, whileControlled),
+            Effects.CantAttackOrBlock(stolen, whileControlled),
+        )
+        description = "When this Vehicle enters, gain control of target creature an opponent " +
+            "controls for as long as you control this Vehicle. That creature can't attack or " +
+            "block for as long as you control this Vehicle."
+    }
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Leroy Steinmann"
+        flavorText = "\"Here's a tip: If your ride needs souls for fuel, make sure to always keep one handy.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg?1783907906"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RoadsideBlowout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RoadsideBlowout.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Roadside Blowout — Aetherdrift #58
+ * {2}{U} · Sorcery
+ *
+ * This spell costs {2} less to cast if it targets a permanent with mana value 1.
+ * Return target creature or Vehicle an opponent controls to its owner's hand.
+ * Draw a card.
+ *
+ * Same shape as Ride's End: the lone "creature or Vehicle" target is itself the permanent the
+ * discount inspects, so [CostReductionSource.FixedIfAnyTargetMatches] over a mana-value-1
+ * permanent filter resolves at cast time once the target is announced (CR 601.2f).
+ * Per the 2025-02-07 ruling, a permanent whose mana cost contains {X} has X = 0 there — that
+ * falls out of the engine's stored mana value, which is already the on-battlefield value.
+ *
+ * The draw is not conditional on the bounce resolving: if the target becomes illegal the whole
+ * spell fizzles, but a target that is still legal and simply cannot be moved still leaves the
+ * draw intact, so the two effects sit in a plain [Effects.Composite].
+ */
+val RoadsideBlowout = card("Roadside Blowout") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {2} less to cast if it targets a permanent with mana value 1.\n" +
+        "Return target creature or Vehicle an opponent controls to its owner's hand.\n" +
+        "Draw a card."
+
+    spell {
+        val t = target(
+            "target creature or Vehicle an opponent controls",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.CreatureOrVehicle.opponentControls()),
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(t),
+            Effects.DrawCards(1),
+        )
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 2,
+                    filter = GameObjectFilter.Permanent.manaValue(1),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Michele Giorgi"
+        flavorText = "\"In cases of extreme emergency, just wing it.\"\n—Rocketeer safety manual, full text"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg?1783907905"
+        ruling("2025-02-07", "If there's an {X} in a permanent's mana cost, X is 0 when determining its mana value.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TheSpeedDemon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TheSpeedDemon.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Speed Demon — Aetherdrift #105
+ * {3}{B}{B} · Legendary Creature — Demon · 5/5
+ *
+ * Flying, trample
+ * Start your engines!
+ * At the beginning of your end step, you draw X cards and lose X life, where X is your speed.
+ *
+ * X is a plain [DynamicAmount.Speed] over [Player.You]. Speed can only change via the inherent
+ * speed trigger (an opponent losing life during your turn, CR 702.179d), so drawing the cards
+ * can't move it between the two halves and reading it twice matches the single printed X. A
+ * controller with no speed reads as 0 (CR 702.179f) — which can't happen while The Speed Demon
+ * itself is on the battlefield, since start your engines! sets speed to 1 as a state-based action,
+ * but does fall out correctly if the trigger somehow resolves after it has left.
+ */
+val TheSpeedDemon = card("The Speed Demon") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Demon"
+    oracleText = "Flying, trample\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "At the beginning of your end step, you draw X cards and lose X life, where X is your speed."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Composite(
+            Effects.DrawCards(DynamicAmount.Speed(Player.You)),
+            Effects.LoseLife(DynamicAmount.Speed(Player.You), EffectTarget.Controller),
+        )
+        description = "At the beginning of your end step, you draw X cards and lose X life, " +
+            "where X is your speed."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "105"
+        artist = "Helge C. Balzer"
+        flavorText = "Caution is for those who falter."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg?1783907890"
+        ruling(
+            "2025-02-07",
+            "If an effect needs to know what a player's speed is and that player doesn't have a " +
+                "speed, their speed is considered 0.",
+        )
+        ruling(
+            "2025-02-07",
+            "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something " +
+                "that happens as a state-based action as soon as you control a permanent with the " +
+                "ability. Notably, this includes gaining control of a permanent with the ability " +
+                "that another player controls.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -5216,6 +5216,115 @@
     ]
 }
 
+// Guidelight Pathmaker
+{
+    "name": "Guidelight Pathmaker",
+    "manaCost": "{4}{W}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Vigilance\nWhen this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. If you search your library this way, shuffle.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "artifact"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected1",
+                                "prompt": "Search for an artifact card"
+                            },
+                            {
+                                "type": "RevealCollection",
+                                "from": "selected1"
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "selected1",
+                                "ifNotEmpty": {
+                                    "type": "MoveCollection",
+                                    "from": "selected1",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                },
+                                "ifEmpty": {
+                                    "type": "MoveCollection",
+                                    "from": "selected1",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    }
+                                },
+                                "filter": "mv<=2"
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this Vehicle enters, you may search your library for an artifact card and reveal it. Put it onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. If you search your library this way, shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "UNCOMMON",
+        "artist": "Stephan Martiniere",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2e00cd7-925e-4bab-b064-c96aa2935f8c.jpg?1783907857",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Guidelight Pathmaker has received an update to its Oracle text. Specifically, you'll only shuffle if you choose to search your library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Guidelight Synergist
 {
     "name": "Guidelight Synergist",
@@ -7985,6 +8094,116 @@
     ]
 }
 
+// Outpace Oblivion
+{
+    "name": "Outpace Oblivion",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhen this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.\n{2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed.",
+    "keywords": [
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature or planeswalker"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetCreatureOrPlaneswalker",
+                    "optional": true,
+                    "id": "up to one target creature or planeswalker"
+                },
+                "descriptionOverride": "When this enchantment enters, it deals 5 damage to up to one target creature or planeswalker."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "Not",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": "Speed",
+                                    "operator": "EQ",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Controller"
+                        }
+                    }
+                },
+                "descriptionOverride": "{2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c22e415f-636f-4394-9b21-600ab720ac98.jpg?1783907878",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an effect needs to know what a player's speed is and that player doesn't have a speed, their speed is considered 0."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pacesetter Paragon
 {
     "name": "Pacesetter Paragon",
@@ -8408,6 +8627,100 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Possession Engine
+{
+    "name": "Possession Engine",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainControl",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            },
+                            "duration": {
+                                "type": "WhileYouControlSource",
+                                "sourceDescription": "this Vehicle"
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "CantAttack",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature an opponent controls"
+                                    },
+                                    "duration": {
+                                        "type": "WhileYouControlSource",
+                                        "sourceDescription": "this Vehicle"
+                                    }
+                                },
+                                {
+                                    "type": "CantBlockTargetCreatures",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature an opponent controls"
+                                    },
+                                    "duration": {
+                                        "type": "WhileYouControlSource",
+                                        "sourceDescription": "this Vehicle"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "descriptionOverride": "When this Vehicle enters, gain control of target creature an opponent controls for as long as you control this Vehicle. That creature can't attack or block for as long as you control this Vehicle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "RARE",
+        "artist": "Leroy Steinmann",
+        "flavorText": "\"Here's a tip: If your ride needs souls for fuel, make sure to always keep one handy.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f206b0a1-50d8-4d53-850d-fb15fd328267.jpg?1783907906"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -9527,6 +9840,75 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Roadside Blowout
+{
+    "name": "Roadside Blowout",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {2} less to cast if it targets a permanent with mana value 1.\nReturn target creature or Vehicle an opponent controls to its owner's hand.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle an opponent controls"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|Vehicle ctrl:opponent"
+                },
+                "id": "target creature or Vehicle an opponent controls"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 2,
+                        "filter": "permanent mv=1"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Michele Giorgi",
+        "flavorText": "\"In cases of extreme emergency, just wing it.\"\n—Rocketeer safety manual, full text",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6153a76-56f7-46ee-bba5-b62c0143388a.jpg?1783907905",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If there's an {X} in a permanent's mana cost, X is 0 when determining its mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -11380,6 +11762,70 @@
         "rarity": "MYTHIC",
         "artist": "Michele Giorgi",
         "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cbb7b4e-bd32-44a0-9396-16738c5e4381.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// The Speed Demon
+{
+    "name": "The Speed Demon",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Demon",
+    "oracleText": "Flying, trample\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nAt the beginning of your end step, you draw X cards and lose X life, where X is your speed.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE",
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": "Speed"
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": "Speed",
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, you draw X cards and lose X life, where X is your speed."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "MYTHIC",
+        "artist": "Helge C. Balzer",
+        "flavorText": "Caution is for those who falter.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62242a80-0444-4a0e-a868-97eabcc77648.jpg?1783907890",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an effect needs to know what a player's speed is and that player doesn't have a speed, their speed is considered 0."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something that happens as a state-based action as soon as you control a permanent with the ability. Notably, this includes gaining control of a permanent with the ability that another player controls."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuidelightPathmakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuidelightPathmakerScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Guidelight Pathmaker (DFT #206).
+ *
+ * Guidelight Pathmaker {4}{W}{U} — Artifact — Vehicle 6/5
+ * Vigilance
+ * When this Vehicle enters, you may search your library for an artifact card and reveal it. Put it
+ * onto the battlefield if its mana value is 2 or less. Otherwise, put it into your hand. If you
+ * search your library this way, shuffle.
+ * Crew 2
+ *
+ * The load-bearing claim is the **branch on the found card's mana value**: one search, two
+ * destinations. Grim Bauble ({B}, mana value 1) must land on the battlefield; Rover Blades ({3},
+ * mana value 3) must land in hand. The third case is the "you may" — declining must move nothing.
+ */
+class GuidelightPathmakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Guidelight Pathmaker") {
+
+            test("a mana value 2 or less artifact goes onto the battlefield") {
+                val game = pathmakerGame()
+                val bauble = game.findCardsInLibrary(1, "Grim Bauble").single()
+
+                game.castSpell(1, "Guidelight Pathmaker").error shouldBe null
+                game.resolveStack()
+
+                withClue("the trigger should first ask whether to search") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true).error shouldBe null
+                game.selectCards(listOf(bauble)).error shouldBe null
+                game.resolveStack()
+
+                withClue("mana value 1 ≤ 2, so it enters the battlefield") {
+                    game.isOnBattlefield("Grim Bauble") shouldBe true
+                    game.isInHand(1, "Grim Bauble") shouldBe false
+                }
+            }
+
+            test("an artifact with mana value 3 or more goes to hand instead") {
+                val game = pathmakerGame()
+                val blades = game.findCardsInLibrary(1, "Rover Blades").single()
+
+                game.castSpell(1, "Guidelight Pathmaker").error shouldBe null
+                game.resolveStack()
+                game.answerYesNo(true).error shouldBe null
+                game.selectCards(listOf(blades)).error shouldBe null
+                game.resolveStack()
+
+                withClue("mana value 3 > 2, so it goes to hand, not the battlefield") {
+                    game.isInHand(1, "Rover Blades") shouldBe true
+                    game.isOnBattlefield("Rover Blades") shouldBe false
+                }
+            }
+
+            test("declining the search moves nothing") {
+                val game = pathmakerGame()
+                val librarySizeBefore = game.librarySize(1)
+
+                game.castSpell(1, "Guidelight Pathmaker").error shouldBe null
+                game.resolveStack()
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Vehicle still entered") {
+                    game.isOnBattlefield("Guidelight Pathmaker") shouldBe true
+                }
+                withClue("but no card left the library and neither artifact reached hand or battlefield") {
+                    game.librarySize(1) shouldBe librarySizeBefore
+                    game.isInHand(1, "Grim Bauble") shouldBe false
+                    game.isInHand(1, "Rover Blades") shouldBe false
+                    game.isOnBattlefield("Grim Bauble") shouldBe false
+                    game.isOnBattlefield("Rover Blades") shouldBe false
+                }
+            }
+        }
+    }
+
+    /** Pathmaker in hand, six lands to cast it, and one cheap + one expensive artifact to find. */
+    private fun pathmakerGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Guidelight Pathmaker")
+            .withLandsOnBattlefield(1, "Plains", 3)
+            .withLandsOnBattlefield(1, "Island", 3)
+            .withCardInLibrary(1, "Grim Bauble")
+            .withCardInLibrary(1, "Rover Blades")
+        repeat(6) { builder.withCardInLibrary(2, "Grizzly Bears") }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutpaceOblivionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutpaceOblivionScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Outpace Oblivion (DFT #139).
+ *
+ * Outpace Oblivion {2}{R} — Enchantment
+ * Start your engines!
+ * When this enchantment enters, it deals 5 damage to up to one target creature or planeswalker.
+ * {2}, Sacrifice this enchantment: It deals 2 damage to each player who doesn't have max speed.
+ *
+ * The load-bearing claim is that "each player who doesn't have max speed" is evaluated **per
+ * player**: the `ForEachPlayer(Each)` loop rebinds the controller each iteration, so the max-speed
+ * gate asks about that player rather than about the ability's controller. Getting that wrong is
+ * invisible in the common case — it only shows up when the two players' speeds differ, which is
+ * exactly what these tests set up. The sacrifice is a cost, so the damage also has to survive its
+ * own source having already left the battlefield.
+ */
+class OutpaceOblivionScenarioTest : ScenarioTestBase() {
+
+    private val sacrificeAbilityId
+        get() = cardRegistry.getCard("Outpace Oblivion")!!.script.activatedAbilities.single().id
+
+    init {
+        context("Outpace Oblivion") {
+
+            test("start your engines! puts its controller on the board at speed 1") {
+                val game = oblivionGame()
+
+                withClue("CR 704.5z sets speed to 1 as soon as you control the permanent") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+                withClue("each player tracks speed separately — the opponent still has none") {
+                    game.state.speed(game.player2Id) shouldBe Speed.NONE
+                }
+            }
+
+            test("the sacrifice ability skips the player at max speed and hits the one who isn't") {
+                val game = oblivionGame()
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val controllerLifeBefore = game.getLifeTotal(1)
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                game.activateSacrifice()
+
+                withClue("the controller has max speed, so they take nothing") {
+                    game.getLifeTotal(1) shouldBe controllerLifeBefore
+                }
+                withClue("the opponent has no speed (0 ≠ 4), so they take 2") {
+                    game.getLifeTotal(2) shouldBe opponentLifeBefore - 2
+                }
+            }
+
+            test("it hits its own controller too when they are below max speed") {
+                val game = oblivionGame()
+                game.state = SpeedService.set(game.state, game.player2Id, Speed.MAX, "test").first
+
+                val controllerLifeBefore = game.getLifeTotal(1)
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                game.activateSacrifice()
+
+                withClue("the controller sits at speed 1, so the symmetric damage includes them") {
+                    game.getLifeTotal(1) shouldBe controllerLifeBefore - 2
+                }
+                withClue("the opponent is at max speed and is spared") {
+                    game.getLifeTotal(2) shouldBe opponentLifeBefore
+                }
+            }
+
+            test("with nobody at max speed it hits both players") {
+                val game = oblivionGame()
+                val controllerLifeBefore = game.getLifeTotal(1)
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                game.activateSacrifice()
+
+                game.getLifeTotal(1) shouldBe controllerLifeBefore - 2
+                game.getLifeTotal(2) shouldBe opponentLifeBefore - 2
+            }
+        }
+    }
+
+    private fun TestGame.activateSacrifice() {
+        val oblivion = findPermanent("Outpace Oblivion")!!
+        val result = execute(
+            ActivateAbility(playerId = player1Id, sourceId = oblivion, abilityId = sacrificeAbilityId),
+        )
+        withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+        resolveStack()
+        withClue("the enchantment was sacrificed to pay the cost") {
+            isOnBattlefield("Outpace Oblivion") shouldBe false
+        }
+    }
+
+    /** Outpace Oblivion already on the battlefield, with two Mountains for the {2} activation. */
+    private fun oblivionGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Outpace Oblivion")
+            .withLandsOnBattlefield(1, "Mountain", 2)
+        repeat(6) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        // Built in the upkeep and advanced, so the CR 704.5z start-your-engines state-based action
+        // has actually run by the time a test reads anyone's speed.
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PossessionEngineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PossessionEngineScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Possession Engine (DFT #54).
+ *
+ * Possession Engine {3}{U}{U} — Artifact — Vehicle 5/5
+ * When this Vehicle enters, gain control of target creature an opponent controls for as long as
+ * you control this Vehicle. That creature can't attack or block for as long as you control this
+ * Vehicle.
+ * Crew 3
+ *
+ * The load-bearing claim is the shared `WhileYouControlSource` duration: the steal *and* the
+ * combat lock must both end the moment the Vehicle stops being yours, rather than lingering (the
+ * `WhileSourceOnBattlefield` failure mode) or expiring at cleanup (the `EndOfTurn` default on
+ * `Effects.CantAttackOrBlock`, which would silently free the creature after one turn).
+ */
+class PossessionEngineScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Possession Engine") {
+
+            test("the enters trigger steals the creature and locks it out of combat") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Possession Engine")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the opponent starts with their own creature") {
+                    game.state.getEntity(bears)!!.get<ControllerComponent>()!!.playerId shouldBe game.player2Id
+                }
+
+                game.castSpell(1, "Possession Engine").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger should pause to choose a target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("control moved to the Vehicle's controller") {
+                    projected.getController(bears) shouldBe game.player1Id
+                }
+                withClue("and the creature can neither attack nor block") {
+                    projected.cantAttack(bears) shouldBe true
+                    projected.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("both halves last past end of turn — the lock is not an until-end-of-turn effect") {
+                val game = stealGame()
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                val projected = game.state.projectedState
+                withClue("cleanup must not undo a 'for as long as you control this Vehicle' effect") {
+                    projected.getController(bears) shouldBe game.player1Id
+                    projected.cantAttack(bears) shouldBe true
+                    projected.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("destroying the Vehicle hands the creature back and lifts the combat lock") {
+                val game = stealGame(extraLands = 2)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val engine = game.findPermanent("Possession Engine")!!
+
+                // Skycrash (DFT) — "Destroy target artifact." Aimed at our own Vehicle, which is
+                // the cheapest way to make "you control this Vehicle" stop being true.
+                game.castSpell(1, "Skycrash", engine).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Vehicle is gone") {
+                    game.isOnBattlefield("Possession Engine") shouldBe false
+                }
+
+                val projected = game.state.projectedState
+                withClue("the duration ended, so control reverts to the owner") {
+                    projected.getController(bears) shouldBe game.player2Id
+                }
+                withClue("and the creature can attack and block again") {
+                    projected.cantAttack(bears) shouldBe false
+                    projected.cantBlock(bears) shouldBe false
+                }
+            }
+        }
+    }
+
+    /** A game in which Possession Engine has already resolved and stolen the opposing Grizzly Bears. */
+    private fun stealGame(extraLands: Int = 0): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Possession Engine")
+            .withLandsOnBattlefield(1, "Island", 5)
+            .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+        if (extraLands > 0) {
+            builder.withCardInHand(1, "Skycrash")
+            builder.withLandsOnBattlefield(1, "Mountain", extraLands)
+        }
+        repeat(6) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        val bears = game.findPermanent("Grizzly Bears")!!
+        game.castSpell(1, "Possession Engine")
+        game.resolveStack()
+        game.selectTargets(listOf(bears))
+        game.resolveStack()
+        return game
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoadsideBlowoutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoadsideBlowoutScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Roadside Blowout (DFT #58).
+ *
+ * Roadside Blowout {2}{U} — Sorcery
+ * This spell costs {2} less to cast if it targets a permanent with mana value 1.
+ * Return target creature or Vehicle an opponent controls to its owner's hand.
+ * Draw a card.
+ *
+ * The load-bearing claim is the conditional discount: with exactly one Island available the spell
+ * is castable *only* if the chosen target has mana value 1, so each test's ability to pay is the
+ * assertion. Engine Rat ({B}, mana value 1) unlocks it; Grizzly Bears ({1}{G}, mana value 2)
+ * does not.
+ */
+class RoadsideBlowoutScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Roadside Blowout") {
+
+            test("targeting a mana value 1 permanent costs {U} and still bounces and draws") {
+                val game = blowoutGame(islands = 1)
+                val rat = game.findPermanent("Engine Rat")!!
+                val handBefore = game.handSize(1)
+
+                val result = game.castSpell(1, "Roadside Blowout", rat)
+                withClue("the {2} discount should make one Island enough: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the creature went back to its owner's hand") {
+                    game.isOnBattlefield("Engine Rat") shouldBe false
+                    game.isInHand(2, "Engine Rat") shouldBe true
+                }
+                withClue("Blowout left hand (-1 for itself, +1 for the draw)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("targeting a mana value 2 permanent gets no discount") {
+                val game = blowoutGame(islands = 1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.castSpell(1, "Roadside Blowout", bears)
+                withClue("mana value 2 doesn't match the filter, so {2}{U} is unpayable off one Island") {
+                    result.error shouldNotBe null
+                }
+                withClue("nothing happened") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("with full mana it happily targets a mana value 2 permanent") {
+                val game = blowoutGame(islands = 3)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.castSpell(1, "Roadside Blowout", bears)
+                withClue("paying the printed {2}{U}: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+            }
+        }
+    }
+
+    /** Blowout in hand, [islands] Islands, and both a mana value 1 and a mana value 2 opposing creature. */
+    private fun blowoutGame(islands: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Roadside Blowout")
+            .withLandsOnBattlefield(1, "Island", islands)
+            .withCardOnBattlefield(2, "Engine Rat", summoningSickness = false)
+            .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+        repeat(6) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSpeedDemonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSpeedDemonScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Speed Demon (DFT #105).
+ *
+ * The Speed Demon {3}{B}{B} — Legendary Creature — Demon 5/5
+ * Flying, trample
+ * Start your engines!
+ * At the beginning of your end step, you draw X cards and lose X life, where X is your speed.
+ *
+ * The load-bearing claim is that X reads the *controller's* speed at resolution, so the draw and
+ * the life loss scale together and move in lockstep with the speed track — 1 card / 1 life fresh
+ * off start your engines!, 4 / 4 at max speed.
+ */
+class TheSpeedDemonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Speed Demon") {
+
+            test("draws and loses one at the starting speed its own keyword confers") {
+                val game = demonGame()
+                withClue("start your engines! put the controller at speed 1") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                game.handSize(1) shouldBe handBefore + 1
+                game.getLifeTotal(1) shouldBe lifeBefore - 1
+            }
+
+            test("scales to four cards and four life at max speed") {
+                val game = demonGame()
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("X is your speed, so both halves read 4") {
+                    game.handSize(1) shouldBe handBefore + 4
+                    game.getLifeTotal(1) shouldBe lifeBefore - 4
+                }
+            }
+
+            test("the opponent's end step is not yours") {
+                val game = demonGame()
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                // Run out player 1's turn, then stop in player 2's end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                val handAfterOwnTurn = game.handSize(1)
+                val lifeAfterOwnTurn = game.getLifeTotal(1)
+                withClue("the controller's own end step did fire") {
+                    handAfterOwnTurn shouldBe handBefore + 1
+                    lifeAfterOwnTurn shouldBe lifeBefore - 1
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                withClue("\"your end step\" must not fire on the opponent's turn") {
+                    game.handSize(1) shouldBe handAfterOwnTurn
+                    game.getLifeTotal(1) shouldBe lifeAfterOwnTurn
+                }
+            }
+        }
+    }
+
+    /** The Speed Demon on the battlefield in the controller's precombat main phase. */
+    private fun demonGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "The Speed Demon", summoningSickness = false)
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        // Built in the upkeep and advanced, so the CR 704.5z start-your-engines state-based action
+        // has run before any test reads a speed.
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+}


### PR DESCRIPTION
Five Aetherdrift cards, all composed from existing SDK vocabulary — no new effects, triggers, or static abilities.

| Card | Cost | Notes |
|---|---|---|
| **Roadside Blowout** | `{2}{U}` Sorcery | `CostReductionSource.FixedIfAnyTargetMatches` on a mana-value-1 permanent — Ride's End's shape. |
| **Guidelight Pathmaker** | `{4}{W}{U}` Vehicle 6/5 | One search, two destinations. |
| **Outpace Oblivion** | `{2}{R}` Enchantment | Start your engines! + a symmetric max-speed-gated burn. |
| **Possession Engine** | `{3}{U}{U}` Vehicle 5/5 | Steal + combat lock under one shared duration. |
| **The Speed Demon** | `{3}{B}{B}` Legendary Demon 5/5 | End-step draw/lose X off `DynamicAmount.Speed`. |

### The load-bearing bits

- **Guidelight Pathmaker** can't use `Patterns.Library.searchLibrary` — that has one fixed destination, and the card routes on the found card's mana value. It's an inline `Effects.Pipeline` instead: gather → `chooseUpTo(1)` → `reveal` → `ifNotEmpty(found, filter = manaValueAtMost(2)) { move(battlefield) } orElse { toHand(found) }`. The shuffle sits **inside** the `MayEffect`, per the card's 2025-02-07 Oracle update ("you'll only shuffle if you choose to search your library").
- **Outpace Oblivion**'s "each player who doesn't have max speed" is a `ForEachPlayer(Player.Each)` loop whose body is gated on `Not(HasMaxSpeed(Player.You))`. The loop rebinds `controllerId` per iteration, so the gate asks about *that* player — a bug that's invisible until the two players' speeds differ.
- **Possession Engine** uses `Duration.WhileYouControlSource` for **both** halves, not `WhileSourceOnBattlefield` (which would leave a stolen creature parked under the wrong player if the Vehicle itself got stolen) and not the `EndOfTurn` default on `Effects.CantAttackOrBlock` (which would quietly free the creature after one turn).

### Tests

16 scenario tests across five files, covering the mana-value branch and the declined "may", the per-player speed check in both directions, the shared duration surviving cleanup and ending when the Vehicle is destroyed, and the conditional discount (castable off one Island only when the target has mana value 1).

`just build` green; `CardDefinitionSnapshotTest` re-blessed — the DFT golden diff is insertions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)