### PR TITLE
Add the basic lands to Mirage

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/MirageSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/MirageSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.mir
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.CardDefinition
@@ -25,11 +24,14 @@ object MirageSet : MtgSet {
     override val displayName = "Mirage"
     override val releaseDate = "1996-10-08"
     override val block = "Mirage"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/MirageBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/MirageBasicLands.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.mtg.sets.definitions.mir.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Mirage Basic Lands
+ *
+ * Mirage printed four art variants of each basic land type (cards 331-350): Plains 331-334,
+ * Island 335-338, Swamp 339-342, Mountain 343-346, Forest 347-350.
+ */
+
+// =============================================================================
+// Plains (Cards 331-334)
+// =============================================================================
+
+val MirPlains331 = basicLand("Plains") {
+    collectorNumber = "331"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/888f32ad-3bdd-4c46-b3f0-522ac9763591.jpg?1783947035"
+}
+
+val MirPlains332 = basicLand("Plains") {
+    collectorNumber = "332"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b078ef66-a83b-4e12-bcba-838bc3809322.jpg?1783947033"
+}
+
+val MirPlains333 = basicLand("Plains") {
+    collectorNumber = "333"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac15978d-41e6-4eaa-9456-0de3b912d437.jpg?1783947035"
+}
+
+val MirPlains334 = basicLand("Plains") {
+    collectorNumber = "334"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81bbbf38-5d1a-4013-aff9-6167709897f0.jpg?1783947034"
+}
+
+// =============================================================================
+// Island (Cards 335-338)
+// =============================================================================
+
+val MirIsland335 = basicLand("Island") {
+    collectorNumber = "335"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df84bf1b-8698-4c3e-baa9-926f0efc6a12.jpg?1783947033"
+}
+
+val MirIsland336 = basicLand("Island") {
+    collectorNumber = "336"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/776912e7-fa16-4d71-b830-0a5d35f38297.jpg?1783947033"
+}
+
+val MirIsland337 = basicLand("Island") {
+    collectorNumber = "337"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e571f07-167f-4a7d-8f98-0c98d7d15e81.jpg?1783947032"
+}
+
+val MirIsland338 = basicLand("Island") {
+    collectorNumber = "338"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a39fc1e0-caf0-4cfa-bbf2-fea7ca32c00d.jpg?1783947034"
+}
+
+// =============================================================================
+// Swamp (Cards 339-342)
+// =============================================================================
+
+val MirSwamp339 = basicLand("Swamp") {
+    collectorNumber = "339"
+    artist = "Bob Eggleton"
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2d28477-8be1-4caf-8185-64f47905ccb1.jpg?1783947032"
+}
+
+val MirSwamp340 = basicLand("Swamp") {
+    collectorNumber = "340"
+    artist = "Bob Eggleton"
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2c4be2d6-d168-4e67-8d75-a04f637b56dd.jpg?1783947031"
+}
+
+val MirSwamp341 = basicLand("Swamp") {
+    collectorNumber = "341"
+    artist = "Bob Eggleton"
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65181db5-3fc5-497b-ba61-385efdf740ed.jpg?1783947031"
+}
+
+val MirSwamp342 = basicLand("Swamp") {
+    collectorNumber = "342"
+    artist = "Bob Eggleton"
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/5083de34-d127-45df-9252-ff09b5cf8b47.jpg?1783947031"
+}
+
+// =============================================================================
+// Mountain (Cards 343-346)
+// =============================================================================
+
+val MirMountain343 = basicLand("Mountain") {
+    collectorNumber = "343"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97004cdc-0baf-415d-8e87-7f36667c4628.jpg?1783947032"
+}
+
+val MirMountain344 = basicLand("Mountain") {
+    collectorNumber = "344"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/207a468f-79c3-486e-ac5a-4516361b7b4d.jpg?1783947031"
+}
+
+val MirMountain345 = basicLand("Mountain") {
+    collectorNumber = "345"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/681b9c8a-6140-4086-bc72-37f0058a8e9f.jpg?1783947032"
+}
+
+val MirMountain346 = basicLand("Mountain") {
+    collectorNumber = "346"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1cef9230-34fa-496f-8835-5dfaac627f70.jpg?1783947031"
+}
+
+// =============================================================================
+// Forest (Cards 347-350)
+// =============================================================================
+
+val MirForest347 = basicLand("Forest") {
+    collectorNumber = "347"
+    artist = "Tony Roberts"
+    imageUri = "https://cards.scryfall.io/normal/front/a/0/a0ae7a81-9a61-4112-af22-369c525b2eb1.jpg?1783947031"
+}
+
+val MirForest348 = basicLand("Forest") {
+    collectorNumber = "348"
+    artist = "Tony Roberts"
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb6b3f80-20bf-4693-b106-cfb31a3d7f83.jpg?1783947030"
+}
+
+val MirForest349 = basicLand("Forest") {
+    collectorNumber = "349"
+    artist = "Tony Roberts"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d8a67bf6-818b-4afe-af15-3d955dc5e884.jpg?1783947029"
+}
+
+val MirForest350 = basicLand("Forest") {
+    collectorNumber = "350"
+    artist = "Tony Roberts"
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95dfef30-acca-4b15-a05e-d33289055218.jpg?1783947029"
+}
+
+val MirageBasicLands = listOf(
+    MirPlains331,
+    MirPlains332,
+    MirPlains333,
+    MirPlains334,
+    MirIsland335,
+    MirIsland336,
+    MirIsland337,
+    MirIsland338,
+    MirSwamp339,
+    MirSwamp340,
+    MirSwamp341,
+    MirSwamp342,
+    MirMountain343,
+    MirMountain344,
+    MirMountain345,
+    MirMountain346,
+    MirForest347,
+    MirForest348,
+    MirForest349,
+    MirForest350,
+)


### PR DESCRIPTION
Mirage printed four art variants of each basic land type (cards 331-350): Plains 331-334, Island 335-338, Swamp 339-342, Mountain 343-346, Forest 347-350. Registered via the same per-set basicLand() convention as Limited Edition Beta.

Removed basicLandsFallback = PortalSet from MirageSet now that all five colors have their own Mirage art — the booster generator and every other consumer use Mirage's own basics directly.