### PR TITLE
Add four Wilds of Eldraine cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3571,6 +3571,12 @@ matcher branch — `SpellCastEvent` does not grow a new field per axis.
   Conciliator; Gonti's-style borrow effects). Matches when the spell entity's `OwnerComponent`
   (fixed at game start, CR 108.3) differs from the controller; a spell cast from your own zones
   (owner == controller) never satisfies it.
+- `SpellCastPredicate.CastAsAdventure` — the spell was cast **as an Adventure** (CR 715.3), i.e. using
+  the card's alternative characteristics. Used by Chancellor of Tales ("whenever you cast an Adventure
+  spell, you may copy it"). A cast-time fact, not a card characteristic: the same adventurer card cast
+  as its creature half never matches, and neither does an unrelated instant/sorcery. Contrast
+  `CardPredicate.HasAdventure`, which is true of an adventurer *card* in any zone regardless of which
+  half was cast.
 
 Examples:
 
@@ -6593,6 +6599,19 @@ Numbers computed at resolution time.
   `AddDynamicCountersEffect` into a `Fixed` literal at scheduling time (the same treatment `AddManaEffect` gets).
   That is how Nine-Lives Familiar's "with one fewer revival counter" —
   `Subtract(lastKnownSourceCounters(Named(Counters.REVIVAL)), Fixed(1))` — survives to the end step.
+
+### Last-known damage dealt to the source (dies/leaves triggers)
+
+- `LastKnownDamageDealtToSource` — the total damage dealt to the source *this turn*, read as last-known
+  information. Facade: `DynamicAmounts.lastKnownDamageDealtToSource()`. Tangled Colony: "When this
+  creature dies, create X 1/1 black Rat creature tokens …, where X is the amount of damage dealt to it
+  this turn." The engine already tallies damage per source-controller on every permanent it is dealt to
+  and captures that map onto the `ZoneChangeEvent` when the permanent leaves the battlefield, so the
+  value survives into the dies trigger; this node simply sums it across all controllers. The per-player
+  split is what `EachPlayerDrawsForDamageDealtToSource` (Grothama, All-Devouring) reads instead.
+  Evaluates to `0` when no snapshot is present — including for a source still on the battlefield, since
+  the tally is only captured on the way out. Lethal damage is not a cap: excess damage, and non-lethal
+  damage the creature survived earlier in the turn, both count.
 
 - **Last-known source P/T (self-exile / self-sacrifice cost)** — the P/T analogue of
   `LastKnownSourceCounters`, applied automatically to `EntityProperty(EntityReference.Source, Power|Toughness)`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -342,6 +342,13 @@ object DynamicAmounts {
         filter: com.wingedsheep.sdk.scripting.events.CounterTypeFilter
     ): DynamicAmount = DynamicAmount.LastKnownSourceCounters(filter)
 
+    /**
+     * The total damage dealt to the source this turn, captured as last-known information when it
+     * left the battlefield — "where X is the amount of damage dealt to it this turn" (Tangled
+     * Colony). See [DynamicAmount.LastKnownDamageDealtToSource].
+     */
+    fun lastKnownDamageDealtToSource(): DynamicAmount = DynamicAmount.LastKnownDamageDealtToSource
+
     // =========================================================================
     // Spell-cast trigger values
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -523,6 +523,23 @@ sealed interface SpellCastPredicate {
     data object NotOwnedByController : SpellCastPredicate {
         override val description = "you don't own"
     }
+
+    /**
+     * The spell was cast **as an Adventure** (CR 715.3) — "Whenever you cast an Adventure spell"
+     * (Chancellor of Tales). This is about how the card was cast, not what the card is: the same
+     * adventurer card cast as its creature half does *not* satisfy it, and per the 2023-09-01
+     * rulings an "Adventure spell" is never found among instants/sorceries that merely have an
+     * Adventure printed on them.
+     *
+     * Contrast [com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAdventure], which is a
+     * zone-independent characteristic of the *card* (Frantic Firebolt tallying adventurer cards in
+     * a graveyard) and is true regardless of which half was cast.
+     */
+    @SerialName("SpellCastAsAdventure")
+    @Serializable
+    data object CastAsAdventure : SpellCastPredicate {
+        override val description = "as an Adventure"
+    }
 }
 
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -505,6 +505,27 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The total damage dealt to the ability's source this turn, read as last-known information —
+     * "where X is the amount of damage dealt to it this turn" (Tangled Colony).
+     *
+     * Backed by the same per-turn tally the engine already keeps on every permanent that is dealt
+     * damage (summed per source-controller and captured onto the `ZoneChangeEvent` when the
+     * permanent leaves the battlefield), so it reads correctly from a dies/leaves trigger where
+     * the entity itself is already gone. Summing that map gives the total from *all* sources; the
+     * per-player split is what
+     * [com.wingedsheep.sdk.scripting.effects.EachPlayerDrawsForDamageDealtToSourceEffect]
+     * (Grothama, All-Devouring) uses instead.
+     *
+     * Evaluates to `0` when no snapshot is present — including for a source still on the
+     * battlefield, since the tally is only captured on the way out.
+     */
+    @SerialName("LastKnownDamageDealtToSource")
+    @Serializable
+    data object LastKnownDamageDealtToSource : DynamicAmount {
+        override val description: String = "the amount of damage dealt to it this turn"
+    }
+
+    /**
      * The value of `{X}` this object was cast with, read off the *current object* regardless of
      * what zone it is in.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ChancellorOfTales.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ChancellorOfTales.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Chancellor of Tales
+ * {3}{U}
+ * Creature — Faerie Advisor
+ * 2/3
+ *
+ * Flying
+ * Whenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.
+ *
+ * "An Adventure spell" is a cast-time fact, not a characteristic of the card — the same adventurer
+ * cast as its creature half doesn't trigger this. That's [SpellCastPredicate.CastAsAdventure]; the
+ * copy itself is the standard [Effects.CopyTargetSpell] on the triggering spell, which already
+ * offers the "you may choose new targets" step (CR 707.10).
+ *
+ * The copy is created on the stack rather than cast, so it never re-triggers this ability, and it
+ * is exiled as it resolves without granting permission to cast the creature (2023-09-01 ruling).
+ */
+val ChancellorOfTales = card("Chancellor of Tales") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Advisor"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Whenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(requires = setOf(SpellCastPredicate.CastAsAdventure))
+        effect = MayEffect(Effects.CopyTargetSpell(EffectTarget.TriggeringEntity))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Joshua Raphael"
+        flavorText = "\"...so the knight stabbed the troll, the troll threw the knight off the " +
+            "bridge, and they both forgot about the sword.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg?1783915122"
+        ruling(
+            "2023-09-01",
+            "If an effect copies an Adventure spell, that copy is exiled as it resolves. It ceases " +
+                "to exist as a state-based action; it's not possible to cast the copy as a permanent."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CruelSomnophage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CruelSomnophage.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cruel Somnophage // Can't Wake Up
+ * {1}{B}
+ * Creature — Nightmare
+ * * / *
+ *
+ * Cruel Somnophage's power and toughness are each equal to the number of creature cards in all
+ * graveyards.
+ *
+ * Adventure: Can't Wake Up — {1}{U}, Sorcery — Adventure
+ * Target player mills four cards.
+ *
+ * The star-over-star body is a characteristic-defining ability (CR 604.3): `dynamicStats` wires the
+ * same [com.wingedsheep.sdk.scripting.values.DynamicAmount] into base power and base toughness, so
+ * it applies in Layer 7a and — per the card's ruling — functions in every zone, not just the
+ * battlefield. [Player.Each] makes the count span *all* graveyards rather than only the
+ * controller's.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val CruelSomnophage = card("Cruel Somnophage") {
+    manaCost = "{1}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Nightmare"
+    dynamicStats(
+        DynamicAmounts.zone(Player.Each, Zone.GRAVEYARD, GameObjectFilter.Creature).count()
+    )
+    oracleText = "Cruel Somnophage's power and toughness are each equal to the number of creature " +
+        "cards in all graveyards."
+
+    adventure("Can't Wake Up") {
+        manaCost = "{1}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target player mills four cards. (Then exile this card. You may cast the " +
+            "creature later from exile.)"
+        spell {
+            target("target player", Targets.Player)
+            effect = Patterns.Library.mill(4, EffectTarget.ContextTarget(0))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1783915066"
+        ruling(
+            "2023-09-01",
+            "The ability that defines Cruel Somnophage's power and toughness functions in all " +
+                "zones, not just the battlefield."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GalvanicGiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GalvanicGiant.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Galvanic Giant // Storm Reading
+ * {3}{U}
+ * Creature — Giant Wizard
+ * 3/3
+ *
+ * Whenever you cast a spell with mana value 5 or greater, tap target creature an opponent
+ * controls and put a stun counter on it.
+ *
+ * Adventure: Storm Reading — {5}{U}{U}, Instant — Adventure
+ * Draw four cards, then discard two cards.
+ *
+ * The trigger is an ordinary `youCastSpell` with a mana-value floor on the spell filter; the
+ * payoff mirrors the WOE tap-and-stun shape (Snaremaster Sprite, Freeze in Place). An
+ * already-tapped creature is a legal target and still gets the stun counter.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val GalvanicGiant = card("Galvanic Giant") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Giant Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you cast a spell with mana value 5 or greater, tap target creature an " +
+        "opponent controls and put a stun counter on it. (If a permanent with a stun counter would " +
+        "become untapped, remove one from it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.manaValueAtLeast(5))
+        val t = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.Tap(t) then Effects.AddCounters(Counters.STUN, 1, t)
+    }
+
+    adventure("Storm Reading") {
+        manaCost = "{5}{U}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Draw four cards, then discard two cards. (Then exile this card. You may cast " +
+            "the creature later from exile.)"
+        spell {
+            effect = Effects.DrawCards(4) then Effects.Discard(2)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "52"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1783915121"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TangledColony.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TangledColony.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tangled Colony
+ * {1}{B}
+ * Creature — Rat
+ * 3/2
+ *
+ * This creature can't block.
+ * When this creature dies, create X 1/1 black Rat creature tokens with "This token can't block,"
+ * where X is the amount of damage dealt to it this turn.
+ *
+ * X is last-known information (CR 608.2h): the entity is already in the graveyard when the dies
+ * trigger resolves, so the count reads the per-turn damage tally captured onto the
+ * `ZoneChangeEvent` — [DynamicAmounts.lastKnownDamageDealtToSource]. Lethal damage isn't a cap:
+ * damage in excess of toughness, and non-lethal damage dealt earlier in the turn that this
+ * creature survived, both count.
+ */
+val TangledColony = card("Tangled Colony") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    power = 3
+    toughness = 2
+    oracleText = "This creature can't block.\n" +
+        "When this creature dies, create X 1/1 black Rat creature tokens with \"This token can't " +
+        "block,\" where X is the amount of damage dealt to it this turn."
+
+    staticAbility {
+        ability = CantBlock(GroupFilter.source())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.lastKnownDamageDealtToSource(),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Rat"),
+            staticAbilities = listOf(CantBlock(GroupFilter.source())),
+            imageUri = "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Filip Burburan"
+        flavorText = "Clawing for scraps and driven mad by hunger, the individual rats became a " +
+            "writhing mass."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg?1783915099"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1730,6 +1730,59 @@
     "colorIdentityOverride": []
 }
 
+// Chancellor of Tales
+{
+    "name": "Chancellor of Tales",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Advisor",
+    "oracleText": "Flying\nWhenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellCastAsAdventure"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"...so the knight stabbed the troll, the troll threw the knight off the bridge, and they both forgot about the sword.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f67bd5ef-305b-4bf7-990b-3014778b14a0.jpg?1783915122",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If an effect copies an Adventure spell, that copy is exiled as it resolves. It ceases to exist as a state-based action; it's not possible to cast the copy as a permanent."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Charging Hooligan
 {
     "name": "Charging Hooligan",
@@ -2241,6 +2294,100 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Cruel Somnophage
+{
+    "name": "Cruel Somnophage",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Nightmare",
+    "oracleText": "Cruel Somnophage's power and toughness are each equal to the number of creature cards in all graveyards.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateZone",
+                "player": "Each",
+                "zone": "Graveyard",
+                "filter": "creature"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateZone",
+                "player": "Each",
+                "zone": "Graveyard",
+                "filter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39b11ff0-9946-4337-86fb-42e967f3d2e4.jpg?1783915066",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The ability that defines Cruel Somnophage's power and toughness functions in all zones, not just the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Can't Wake Up",
+            "manaCost": "{1}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target player mills four cards. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -4203,6 +4350,132 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Galvanic Giant
+{
+    "name": "Galvanic Giant",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Giant Wizard",
+    "oracleText": "Whenever you cast a spell with mana value 5 or greater, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "ManaValueAtLeast",
+                                "min": 5
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "UNCOMMON",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60976109-30ad-4f12-99eb-c5ef560fcf1b.jpg?1783915121"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Storm Reading",
+            "manaCost": "{5}{U}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Draw four cards, then discard two cards. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 2 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 
@@ -11599,6 +11872,59 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Tangled Colony
+{
+    "name": "Tangled Colony",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "This creature can't block.\nWhen this creature dies, create X 1/1 black Rat creature tokens with \"This token can't block,\" where X is the amount of damage dealt to it this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": "LastKnownDamageDealtToSource",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Rat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e0205f2-25c1-403b-b408-56e3f2d63b4d.jpg?1783915000",
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "RARE",
+        "artist": "Filip Burburan",
+        "flavorText": "Clawing for scraps and driven mad by hunger, the individual rats became a writhing mass.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/77111ce8-6469-4bf7-882a-4ded1e5d7cad.jpg?1783915099"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1596,6 +1596,16 @@ class TriggerMatcher(
                 )
             }
         }
+        // Cast as an Adventure (CR 715.3): an ADVENTURE-layout card declares exactly one face —
+        // the Adventure — so a recorded faceIndex on an adventurer card means the alternative
+        // characteristics were used. Casting the same card as its creature half leaves faceIndex
+        // null and does not match.
+        SpellCastPredicate.CastAsAdventure -> {
+            val spellComponent = state.getEntity(event.spellEntityId)?.get<SpellOnStackComponent>()
+            val hasAdventure = state.getEntity(event.spellEntityId)
+                ?.get<CardComponent>()?.hasAdventure == true
+            hasAdventure && spellComponent?.faceIndex != null
+        }
         SpellCastPredicate.NotOwnedByController -> {
             val ownerId = state.getEntity(event.spellEntityId)
                 ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -133,6 +133,12 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            // Total damage dealt to the source this turn, summed across every source-controller.
+            // The per-player tally is captured onto the ZoneChangeEvent when the permanent leaves
+            // the battlefield, so a dies trigger still reads it after the entity is gone.
+            is DynamicAmount.LastKnownDamageDealtToSource ->
+                context.triggerLastKnownDamageDealtByPlayers?.values?.sum() ?: 0
+
             // The {X} this object was cast with, read off the current object regardless of zone.
             // Reads, in order: the durable CastChoicesComponent on the battlefield permanent (and
             // for a later activated ability); the SpellOnStackComponent while the object is still

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChancellorOfTalesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChancellorOfTalesScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.ChancellorOfTales
+import com.wingedsheep.mtg.sets.definitions.woe.cards.CruelSomnophage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chancellor of Tales (WOE #45): {3}{U} 2/3 Faerie Advisor with flying
+ *
+ * "Whenever you cast an Adventure spell, you may copy it. You may choose new targets for the copy."
+ *
+ * Covers the new `SpellCastPredicate.CastAsAdventure`: the trigger keys off *how* the card was
+ * cast, so casting the same adventurer card as its creature half must not fire it.
+ *
+ * The Adventure used here is Cruel Somnophage's "Can't Wake Up" ({1}{U} Sorcery — Adventure,
+ * "Target player mills four cards"), whose effect is directly observable in the graveyard count.
+ */
+class ChancellorOfTalesScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ChancellorOfTales, CruelSomnophage))
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /** Cast Cruel Somnophage's Adventure face ("Can't Wake Up") at [target]. */
+    fun GameTestDriver.castCantWakeUp(player: EntityId, card: EntityId, target: EntityId) {
+        submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                faceIndex = 0,
+                targets = listOf(ChosenTarget.Player(target)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+    }
+
+    /** Drain the stack, answering the copy's optional "choose new targets" prompt if it appears. */
+    fun GameTestDriver.finishResolving(player: EntityId, retarget: EntityId) {
+        repeat(8) {
+            if (pendingDecision is ChooseTargetsDecision) {
+                submitTargetSelection(player, listOf(retarget))
+            } else if (!isPaused && stackSize > 0) {
+                bothPass()
+            }
+        }
+    }
+
+    test("casting an Adventure spell offers a copy, and accepting mills twice") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Chancellor of Tales")
+        val somnophage = driver.putCardInHand(player, "Cruel Somnophage")
+        driver.giveMana(player, Color.BLUE, 2) // {1}{U}
+
+        val graveyardBefore = driver.getGraveyard(opponent).size
+
+        driver.castCantWakeUp(player, somnophage, opponent)
+
+        // The cast trigger sits above the spell; resolving it asks "you may copy it".
+        driver.bothPass()
+        driver.isPaused shouldBe true
+        driver.submitYesNo(player, true)
+
+        driver.finishResolving(player, opponent)
+
+        // Original + copy = eight cards milled.
+        driver.getGraveyard(opponent).size shouldBe graveyardBefore + 8
+    }
+
+    test("declining the copy mills only once") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Chancellor of Tales")
+        val somnophage = driver.putCardInHand(player, "Cruel Somnophage")
+        driver.giveMana(player, Color.BLUE, 2)
+
+        val graveyardBefore = driver.getGraveyard(opponent).size
+
+        driver.castCantWakeUp(player, somnophage, opponent)
+        driver.bothPass()
+        driver.isPaused shouldBe true
+        driver.submitYesNo(player, false)
+
+        driver.finishResolving(player, opponent)
+
+        driver.getGraveyard(opponent).size shouldBe graveyardBefore + 4
+    }
+
+    test("casting the creature half is not an Adventure spell and does not trigger") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Chancellor of Tales")
+        // One creature card in a graveyard, so the */* Somnophage resolves as a 1/1 rather than
+        // dying to state-based actions as a 0/0 before we can look at it.
+        driver.putCardInGraveyard(player, "Grizzly Bears")
+        val somnophage = driver.putCardInHand(player, "Cruel Somnophage")
+        driver.giveMana(player, Color.BLACK, 2) // {1}{B} creature half
+
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = somnophage,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+
+        // Only the creature spell is on the stack — no copy trigger was added above it.
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        val resolved = driver.getCreatures(player).single { driver.getCardName(it) == "Cruel Somnophage" }
+        driver.state.projectedState.getPower(resolved) shouldBe 1
+        driver.state.projectedState.getToughness(resolved) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TangledColonyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TangledColonyScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.TangledColony
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tangled Colony (WOE #113): {1}{B} 3/2 Rat
+ *
+ * "This creature can't block.
+ *  When this creature dies, create X 1/1 black Rat creature tokens with 'This token can't block,'
+ *  where X is the amount of damage dealt to it this turn."
+ *
+ * Covers the new `DynamicAmount.LastKnownDamageDealtToSource` node: the per-turn damage tally is
+ * captured onto the `ZoneChangeEvent` when the creature leaves the battlefield, so the dies trigger
+ * can still read it after the entity is gone.
+ *
+ * Tests:
+ * 1. Lethal damage in excess of toughness is not capped — a Lightning Bolt on a 3/2 makes 3 Rats.
+ * 2. Non-lethal damage the creature survived earlier in the turn still counts toward X.
+ * 3. Dying without having been dealt damage makes no tokens at all (X = 0).
+ * 4. Tangled Colony itself can't block.
+ */
+class TangledColonyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TangledColony))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.ratTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Rat Token" }
+
+    test("excess damage counts — 3 damage to a 3/2 makes three Rat tokens") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colony = driver.putCreatureOnBattlefield(player, "Tangled Colony")
+
+        driver.giveMana(player, Color.RED, 1)
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.castSpellWithTargets(player, bolt, listOf(ChosenTarget.Permanent(colony)))
+        driver.bothPass() // bolt resolves -> 3 damage -> Colony dies, queuing the dies trigger
+        driver.bothPass() // dies trigger resolves
+
+        val tokens = driver.ratTokens(player)
+        tokens.size shouldBe 3
+        tokens.forEach { token ->
+            driver.state.projectedState.getPower(token) shouldBe 1
+            driver.state.projectedState.getToughness(token) shouldBe 1
+            driver.state.projectedState.cantBlock(token) shouldBe true
+        }
+    }
+
+    test("non-lethal damage dealt earlier in the turn accumulates into X") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colony = driver.putCreatureOnBattlefield(player, "Tangled Colony")
+
+        // Pump to 6/5 so the first Bolt is survivable and its damage stays marked.
+        driver.giveMana(player, Color.GREEN, 1)
+        val growth = driver.putCardInHand(player, "Giant Growth")
+        driver.castSpellWithTargets(player, growth, listOf(ChosenTarget.Permanent(colony)))
+        driver.bothPass()
+
+        driver.giveMana(player, Color.RED, 1)
+        val bolt1 = driver.putCardInHand(player, "Lightning Bolt")
+        driver.castSpellWithTargets(player, bolt1, listOf(ChosenTarget.Permanent(colony)))
+        driver.bothPass() // 3 damage marked; the 6/5 survives
+        driver.getCreatures(player).contains(colony) shouldBe true
+
+        driver.giveMana(player, Color.RED, 1)
+        val bolt2 = driver.putCardInHand(player, "Lightning Bolt")
+        driver.castSpellWithTargets(player, bolt2, listOf(ChosenTarget.Permanent(colony)))
+        driver.bothPass() // 6 total >= toughness 5 -> dies
+        driver.bothPass() // dies trigger resolves
+
+        driver.ratTokens(player).size shouldBe 6
+    }
+
+    test("dying without being dealt damage creates no tokens") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colony = driver.putCreatureOnBattlefield(player, "Tangled Colony")
+
+        driver.giveMana(player, Color.BLACK, 2)
+        val doomBlade = driver.putCardInHand(player, "Doom Blade")
+        driver.castSpellWithTargets(player, doomBlade, listOf(ChosenTarget.Permanent(colony)))
+        driver.bothPass() // Doom Blade resolves -> Colony is destroyed, no damage dealt
+        driver.bothPass() // dies trigger resolves with X = 0
+
+        driver.ratTokens(player).size shouldBe 0
+    }
+
+    test("Tangled Colony can't block") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val colony = driver.putCreatureOnBattlefield(player, "Tangled Colony")
+        driver.state.projectedState.cantBlock(colony) shouldBe true
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -654,6 +654,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -698,6 +703,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -740,6 +750,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         val container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -776,6 +791,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -819,6 +839,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -878,6 +903,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
@@ -989,6 +1019,11 @@ class GameTestDriver {
             spellEffect = cardDef.spellEffect,
             hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
             hasActivatedAbility = cardDef.hasActivatedAbility,
+            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
+            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
+            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
+            hasAdventure = cardDef.isAdventure,
+            originalSetCode = cardDef.setCode,
         )
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(


### PR DESCRIPTION
Four more Wilds of Eldraine cards, picked to lean on composition where possible and to add only small, reusable vocabulary where the SDK genuinely lacked it.

## Cards

| Card | Shape |
|---|---|
| **Cruel Somnophage // Can't Wake Up** | `*`/`*` CDA equal to creature cards in *all* graveyards; Adventure mills four. Pure composition — `dynamicStats` over `AggregateZone(Player.Each, GRAVEYARD, Creature)`. |
| **Galvanic Giant // Storm Reading** | "Whenever you cast a spell with mana value 5 or greater, tap target creature an opponent controls and put a stun counter on it"; Adventure draws four, discards two. Pure composition. |
| **Chancellor of Tales** | "Whenever you cast an Adventure spell, you may copy it." |
| **Tangled Colony** | Can't block; dies into X 1/1 can't-block Rats, where X is the damage dealt to it this turn. |

## SDK additions

Both are one sealed case plus one engine branch, sitting on plumbing that already existed.

**`SpellCastPredicate.CastAsAdventure`** — the spell was cast using the card's alternative characteristics (CR 715.3). It reads the `faceIndex` already recorded on the stack spell; an `ADVENTURE`-layout card declares exactly one face, so a recorded index means the Adventure half. Casting the same card as its creature half leaves it null and doesn't match. Deliberately distinct from `CardPredicate.HasAdventure`, which is a zone-independent property of the *card* (Frantic Firebolt tallying adventurer cards in a graveyard) and stays true regardless of which half was cast.

**`DynamicAmount.LastKnownDamageDealtToSource`** — the total damage dealt to the source this turn, as last-known information (CR 608.2h). The engine already tallies damage per source-controller on every permanent and captures that map onto the `ZoneChangeEvent` when the permanent leaves the battlefield; until now only Grothama, All-Devouring's per-player split consumed it. This node sums it, so a dies trigger reads the total after the entity is gone. Lethal damage is not a cap — excess damage and earlier non-lethal damage both count.

## Test-harness fix

`GameTestDriver` mints card entities directly rather than through `CardEntityFactory`, and was omitting `hasAdventure` and `originalSetCode`. Any predicate reading those precomputed characteristics silently never matched under test — which is exactly how the Chancellor trigger first failed. All seven mint sites now populate them, matching the factory.

## Verification

- `just build`, `just test`, `just check` — all green (2661 rules-engine test classes, no failures).
- `just rebless-cards`; the WOE golden gained only the four new cards (326 insertions, 0 deletions).
- `just check-card-printing` clean for all four — WOE is the earliest real printing in every case.
- Every mechanical field re-verified against Scryfall field by field (mana cost, type line, P/T, rarity, collector number, artist, image URI, and both Adventure faces).
- New scenario tests: `TangledColonyScenarioTest` (4 cases — excess damage, damage accumulating across a survived hit, dying undamaged for X=0, can't-block) and `ChancellorOfTalesScenarioTest` (3 cases — copy accepted, copy declined, creature half doesn't trigger).

No new decision types or UI: the copy prompt reuses the yes/no + retarget flow, and the stun/tap and Adventure casting flows already exist in the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
