### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DevouringSugarmaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DevouringSugarmaw.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Devouring Sugarmaw // Have for Dinner
+ * {2}{B}{B}
+ * Creature — Horror
+ * 6/6
+ * Menace, trample
+ * At the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you
+ * don't, tap this creature.
+ *
+ * Adventure: Have for Dinner — {1}{W}, Instant — Adventure
+ * Create a 1/1 white Human creature token and a Food token.
+ *
+ * The upkeep clause is the literal "you may [action]. If you don't, [consequence]" shape — an
+ * `optional = true` trigger whose body is the sacrifice and whose `elseEffect` taps the Horror
+ * (compare Yawgmoth Demon). The sacrifice filter is [GameObjectFilter.ArtifactEnchantmentOrToken],
+ * the same permanent set bargain feeds on; with none of those on the battlefield the may-action is
+ * infeasible, so the engine skips the prompt and taps the creature directly. Note it *taps* rather
+ * than doesn't-untap: a Sugarmaw already tapped stays tapped, and one tapped this way untaps
+ * normally next turn.
+ *
+ * The token half is fed by the shared WOE token helpers — [woeHumanToken] plus [Effects.CreateFood].
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val DevouringSugarmaw = card("Devouring Sugarmaw") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Horror"
+    oracleText = "Menace, trample\n" +
+        "At the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. " +
+        "If you don't, tap this creature."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.MENACE, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        optional = true
+        effect = SacrificeEffect(GameObjectFilter.ArtifactEnchantmentOrToken)
+        elseEffect = Effects.Tap(EffectTarget.Self)
+    }
+
+    adventure("Have for Dinner") {
+        manaCost = "{1}{W}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a 1/1 white Human creature token and a Food token. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                woeHumanToken(),
+                Effects.CreateFood()
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "224"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1783915066"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GumdropPoisoner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GumdropPoisoner.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gumdrop Poisoner // Tempt with Treats
+ * {2}{B}
+ * Creature — Human Warlock
+ * 3/2
+ * Lifelink
+ * When this creature enters, up to one target creature gets -X/-X until end of turn, where X is
+ * the amount of life you gained this turn.
+ *
+ * Adventure: Tempt with Treats — {B}, Instant — Adventure
+ * Create a Food token.
+ *
+ * X reads the turn tracker ([DynamicAmounts.lifeGainedThisTurn]) on resolution and is negated via
+ * [DynamicAmount.Multiply] by -1, matching the `-X/-X` templating. The Poisoner's own lifelink
+ * damage is dealt long after this ETB resolves, so on a clean board X is normally 0 — the tracker
+ * counts life gained *earlier* this turn, and a 0 result is a legal no-op rather than a fizzle.
+ * The target is `optional = true` ("up to one"), so the ability resolves fine with none chosen.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val GumdropPoisoner = card("Gumdrop Poisoner") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    oracleText = "Lifelink\n" +
+        "When this creature enters, up to one target creature gets -X/-X until end of turn, " +
+        "where X is the amount of life you gained this turn."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(optional = true, filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(
+            DynamicAmount.Multiply(DynamicAmounts.lifeGainedThisTurn(), -1),
+            DynamicAmount.Multiply(DynamicAmounts.lifeGainedThisTurn(), -1),
+            t
+        )
+    }
+
+    adventure("Tempt with Treats") {
+        manaCost = "{B}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a Food token. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.CreateFood()
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "93"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1783915106"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HeartflameDuelist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HeartflameDuelist.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeywordToOwnSpells
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Heartflame Duelist // Heartflame Slash
+ * {1}{W}
+ * Creature — Human Knight
+ * 3/1
+ * Instant and sorcery spells you control have lifelink.
+ *
+ * Adventure: Heartflame Slash — {2}{R}, Instant — Adventure
+ * Heartflame Slash deals 3 damage to any target.
+ *
+ * The lifelink clause is [GrantKeywordToOwnSpells] over [GameObjectFilter.InstantOrSorcery] — the
+ * keyword is projected onto the *spell on the stack*, and the noncombat-damage path consults the
+ * spell source's granted keywords, so a burn spell you control gains you that much life. It grants
+ * to spells you control regardless of who owns them, matching "spells you control".
+ *
+ * Note the two faces are differently coloured ({1}{W} creature, {2}{R} Adventure), so the card's
+ * colour identity is RW even though the front face is mono-white.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val HeartflameDuelist = card("Heartflame Duelist") {
+    manaCost = "{1}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Instant and sorcery spells you control have lifelink."
+    power = 3
+    toughness = 1
+
+    staticAbility {
+        ability = GrantKeywordToOwnSpells(
+            keyword = Keyword.LIFELINK,
+            spellFilter = GameObjectFilter.InstantOrSorcery
+        )
+    }
+
+    adventure("Heartflame Slash") {
+        manaCost = "{2}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Heartflame Slash deals 3 damage to any target. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Any)
+            effect = Effects.DealDamage(3, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Justyna Dura"
+        flavorText = "\"The fire of Embereth will never be doused!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1783915065"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IntrepidTrufflesnout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IntrepidTrufflesnout.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+
+/**
+ * Intrepid Trufflesnout // Go Hog Wild
+ * {1}{G}
+ * Creature — Boar
+ * 3/1
+ * Whenever this creature attacks alone, create a Food token.
+ *
+ * Adventure: Go Hog Wild — {1}{G}, Instant — Adventure
+ * Target creature gets +2/+2 until end of turn.
+ *
+ * "Attacks alone" is [AttackPredicate.Alone] on the SELF-bound attack trigger — it fires only when
+ * the Boar is the *only* creature declared as an attacker (CR 506.5 / the standard "attacks alone"
+ * templating), not merely when it is unblocked.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val IntrepidTrufflesnout = card("Intrepid Trufflesnout") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    oracleText = "Whenever this creature attacks alone, create a Food token. " +
+        "(It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.attacks(requires = setOf(AttackPredicate.Alone))
+        effect = Effects.CreateFood()
+    }
+
+    adventure("Go Hog Wild") {
+        manaCost = "{1}{G}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Target creature gets +2/+2 until end of turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Creature)
+            effect = Effects.ModifyStats(2, 2, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "320"
+        artist = "Kisung Koh"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1783915038"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StorytellerPixie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/StorytellerPixie.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+
+/**
+ * Storyteller Pixie
+ * {3}{U}
+ * Creature — Faerie Wizard
+ * 3/3
+ * Flying
+ * Whenever you cast an Adventure spell, draw a card.
+ *
+ * "An Adventure spell" is the cast-time fact [SpellCastPredicate.CastAsAdventure], not a
+ * characteristic of the card — casting the same adventurer as its creature half doesn't trigger
+ * this (compare Chancellor of Tales, which reads the same predicate). The trigger fires on cast,
+ * so it resolves before the Adventure itself does, and it still draws even if that Adventure is
+ * later countered.
+ */
+val StorytellerPixie = card("Storyteller Pixie") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    oracleText = "Flying\n" +
+        "Whenever you cast an Adventure spell, draw a card."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(requires = setOf(SpellCastPredicate.CastAsAdventure))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "313"
+        artist = "Peter Polach"
+        flavorText = "After the royal nanny had finished his dull, droning recital of the prince " +
+            "and princess's bedtime story, their secret friend emerged and the real story began."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg?1783915040"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -2576,6 +2576,85 @@
     ]
 }
 
+// Devouring Sugarmaw
+{
+    "name": "Devouring Sugarmaw",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Menace, trample\nAt the beginning of your upkeep, you may sacrifice an artifact, enchantment, or token. If you don't, tap this creature.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "MENACE",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "artifact|enchantment|token"
+                },
+                "optional": true,
+                "elseEffect": {
+                    "type": "TapUntap",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "RARE",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58c7f52e-a97d-4475-ae00-3149991e723e.jpg?1783915066"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Have for Dinner",
+            "manaCost": "{1}{W}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a 1/1 white Human creature token and a Food token. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "WHITE"
+                            ],
+                            "creatureTypes": [
+                                "Human"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/5/0/50240867-3a3e-4a8d-9569-816ab4a3671a.jpg?1783914992"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Food"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Diminisher Witch
 {
     "name": "Diminisher Witch",
@@ -4905,6 +4984,89 @@
     ]
 }
 
+// Gumdrop Poisoner
+{
+    "name": "Gumdrop Poisoner",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Lifelink\nWhen this creature enters, up to one target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "LIFE_GAINED"
+                        },
+                        "multiplier": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "LIFE_GAINED"
+                        },
+                        "multiplier": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cb01d4d-91c2-41c6-981e-b4135a1e1e36.jpg?1783915106"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Tempt with Treats",
+            "manaCost": "{B}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a Food token. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        }
+    ]
+}
+
 // Hamlet Glutton
 {
     "name": "Hamlet Glutton",
@@ -5042,6 +5204,76 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Heartflame Duelist
+{
+    "name": "Heartflame Duelist",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Instant and sorcery spells you control have lifelink.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeywordToOwnSpells",
+                "keyword": "LIFELINK",
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "Or",
+                            "predicates": [
+                                "IsInstant",
+                                "IsSorcery"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Justyna Dura",
+        "flavorText": "\"The fire of Embereth will never be doused!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/811b283f-22f3-47b1-a802-11dc8c25d0ee.jpg?1783915065"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Heartflame Slash",
+            "manaCost": "{2}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Heartflame Slash deals 3 damage to any target. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -5796,6 +6028,79 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Intrepid Trufflesnout
+{
+    "name": "Intrepid Trufflesnout",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "Whenever this creature attacks alone, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksAlone"
+                    ]
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "320",
+        "rarity": "UNCOMMON",
+        "artist": "Kisung Koh",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4224747e-1dbc-4a29-b5da-5916d8ca2768.jpg?1783915038"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Go Hog Wild",
+            "manaCost": "{1}{G}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Target creature gets +2/+2 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -11231,6 +11536,52 @@
                 ]
             }
         }
+    ]
+}
+
+// Storyteller Pixie
+{
+    "name": "Storyteller Pixie",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\nWhenever you cast an Adventure spell, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellCastAsAdventure"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "313",
+        "rarity": "UNCOMMON",
+        "artist": "Peter Polach",
+        "flavorText": "After the royal nanny had finished his dull, droning recital of the prince and princess's bedtime story, their secret friend emerged and the real story began.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9f4cf85-2120-4897-aecd-4ee4b02d6f9b.jpg?1783915040"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Five WOE cards, all composed from existing SDK primitives — no new engine vocabulary, no SDK surface change (so no `card-sdk-language-reference.md` update).

| Card | Shape |
|---|---|
| **Intrepid Trufflesnout // Go Hog Wild** (320) | Attacks-alone Food trigger via `AttackPredicate.Alone`; Adventure instant pumps +2/+2. |
| **Gumdrop Poisoner // Tempt with Treats** (93) | Lifelink. ETB gives *up to one* target creature -X/-X, X = `LIFE_GAINED` turn tracker negated through `DynamicAmount.Multiply(_, -1)`. Adventure creates a Food. |
| **Heartflame Duelist // Heartflame Slash** (228) | `GrantKeywordToOwnSpells(LIFELINK, InstantOrSorcery)` — the noncombat-damage path already consults a spell source's granted keywords. Adventure deals 3 to any target. Colour identity RW across the faces. |
| **Devouring Sugarmaw // Have for Dinner** (224) | Menace, trample, and the literal "you may sacrifice an artifact, enchantment, or token. If you don't, tap this creature" — `optional = true` trigger + `elseEffect`, same shape as Yawgmoth Demon. With no eligible permanent the may-action is infeasible, so the prompt is skipped and the tap applies. Adventure creates a Human + a Food from the shared `WoeTokens` helpers. |
| **Storyteller Pixie** (313) | Flying; draws on `SpellCastPredicate.CastAsAdventure` — the cast-time fact, so casting the adventurer as its creature half doesn't trigger it (same predicate Chancellor of Tales reads). |

### Scoped out

Two cards I started on turned out to need engine work rather than card authoring, so they're not here:

- **Elusive Otter // Grove's Bounty** — "Distribute X +1/+1 counters" needs `DistributeCountersAmongTargetsEffect.totalCounters` to accept a `DynamicAmount`; it's an `Int` today.
- **Back for Seconds** — the bargained branch ("you may put one of *those* cards with mana value 4 or less onto the battlefield instead") needs plumbing to turn the spell's declared targets into a selectable collection.

Both are `add-feature` territory.

### Verification

- `just build` green (compile + `mtg-sets` suite incl. `CardLintTest` and `FacadeBoundaryTest`).
- `just rebless-cards`; the WOE golden diff is **351 lines, all additions** — only these five card trees.
- `just check-card-printing` clean for all five (each is WOE-original, canonical in the earliest real printing).
- Every mechanical field re-verified field-by-field against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, image URI, oracle text, flavor, and both Adventure faces) — all match. Image URIs return HTTP 200.
- WOE booster coverage 193 → 198 of 266.

No new decision types or visual mechanics, so no new decision component or e2e spec — every prompt these raise (optional target, yes/no upkeep sacrifice, sacrifice selection, any-target) routes through existing UI.

Note: `just check-backlog` reports pre-existing drift in `innistrad-crimson-vow` and `marvels-spider-man`. Untouched by this branch and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)