### PR TITLE
Add five Aetherdrift cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7985,11 +7985,19 @@ Card authors rarely reference these directly; they are created/updated by the ma
     `ConditionalStaticAbility`, activated via `ActivationRestriction.OnlyIfCondition`, triggered via
     `triggerCondition` (CR 603.4). No new ability type; activated/triggered labels get the printed
     "Max speed — " prefix. Several abilities may share one block (Tsagan, Raider Warlord).
-    A `staticAbility { ability = ModifySpellCost(…) }` is the one exception to the wrapper: cost
-    calculation scans the raw static list for `is ModifySpellCost` and never unwraps a conditional, so
-    the gate is folded into the modifier's own `CostGating.OnlyIf` slot instead (Racers' Scoreboard,
-    "Max speed — Spells you cast cost {1} less to cast"). Authoring is unchanged — declare it in the
-    block and the builder picks the right seam.
+    Two static kinds are exceptions to the wrapper, both for the same reason — their read site scans
+    the *raw* static list with `filterIsInstance` and never unwraps a conditional, so a
+    `ConditionalStaticAbility` would hide them entirely. Both carry their own condition slot, and the
+    builder folds the gate into it. Authoring is unchanged — declare them in the block and the builder
+    picks the right seam:
+    - `ModifySpellCost` → its `CostGating.OnlyIf` slot (cost calculation; Racers' Scoreboard,
+      "Max speed — Spells you cast cost {1} less to cast").
+    - `MayCastSelfFromZones` → its `condition` slot (`CastFromZoneEnumerator.enumerateIntrinsicZoneCast`
+      / `CastZoneResolver.findMayCastSelfFromZoneAbility`; Lightwheel Enhancements, "Max speed — You
+      may cast this card from your graveyard"). The condition is evaluated in the *casting player's*
+      context at both read sites, which is what lets a max-speed ability function from a zone where
+      the card isn't a permanent at all — per the CR ruling that *"if the granted ability functions in
+      a zone other than the battlefield, the max speed ability does too."*
   - Raising speed is `Effects.IncreaseSpeed(amount, target)`. The inherent CR 702.179d trigger
     ("Whenever one or more opponents lose life during your turn, if your speed is less than 4, your
     speed increases by 1. This ability triggers only once each turn.") is synthesized per player by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.CostGating
 import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
 import com.wingedsheep.sdk.scripting.ModifySpellCost
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -150,6 +151,17 @@ class MaxSpeedBuilder {
                         "Max speed cannot gate a ModifySpellCost that already uses ${existing::class.simpleName} gating"
                     )
                 }
+            )
+            // Same trap as ModifySpellCost, one seam further out: the graveyard/exile cast paths
+            // (`CastFromZoneEnumerator.enumerateIntrinsicZoneCast`, `CastZoneResolver
+            // .findMayCastSelfFromZoneAbility`) scan the raw static list with
+            // `filterIsInstance<MayCastSelfFromZones>`, so a ConditionalStaticAbility wrapper would
+            // hide the permission and the card would simply never be castable. It carries its own
+            // condition slot — evaluated in the *casting player's* context at both read sites, which
+            // is what makes "Max speed — You may cast this card from your graveyard" (Lightwheel
+            // Enhancements) work from a zone where the card is not a permanent at all.
+            is MayCastSelfFromZones -> ability.copy(
+                condition = ability.condition?.let { it and MAX_SPEED_GATE } ?: MAX_SPEED_GATE
             )
             // A `staticAbility { condition = … }` block already wrapped itself; fold the max-speed
             // gate into that wrapper's condition instead of nesting two ConditionalStaticAbility

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/Boommobile.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/Boommobile.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Boommobile — Aetherdrift #113
+ * {2}{R}{R} · Artifact — Vehicle · 5/5
+ *
+ * When this Vehicle enters, add four mana of any one color. Spend this mana only to activate
+ * abilities.
+ * Exhaust — {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this
+ * Vehicle.
+ * Crew 2
+ *
+ * The ramp half is [Effects.AddAnyColorMana] — *one* chosen color, four of it, not four mana in any
+ * combination — tagged [ManaRestriction.AbilityActivationOnly]. Per the Scryfall ruling that mana may
+ * be split across several abilities, which is exactly what a pool-level restriction gives: it
+ * constrains what each pip may be spent on, not how many abilities it feeds. It comfortably covers
+ * the Vehicle's own exhaust ability (and its crew cost is free, so the mana is not stranded).
+ *
+ * The payoff is an ordinary X-cost activated ability with `isExhaust = true`, which the DSL turns
+ * into "Activate only once" by adding [com.wingedsheep.sdk.scripting.ActivationRestriction.Once] —
+ * per-object, so a Boommobile that leaves and returns is a new object and may fire again. X is read
+ * back with [Effects.DealXDamage] (i.e. `DynamicAmount.XValue`). The counter is not conditional on the damage: it lands even if
+ * the target became illegal, so both halves sit in one `Composite`.
+ */
+val Boommobile = card("Boommobile") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "When this Vehicle enters, add four mana of any one color. Spend this mana only to " +
+        "activate abilities.\n" +
+        "Exhaust — {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on " +
+        "this Vehicle. (Activate each exhaust ability only once.)\n" +
+        "Crew 2"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.AddAnyColorMana(4, ManaRestriction.AbilityActivationOnly)
+        description = "When this Vehicle enters, add four mana of any one color. Spend this mana " +
+            "only to activate abilities."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{X}{2}{R}")
+        isExhaust = true
+        val victim = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealXDamage(victim),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Alexandr Leskinen"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg?1783907886"
+        ruling(
+            "2025-02-07",
+            "You may spend the four mana added by the first ability on the same ability or on multiple abilities."
+        )
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LightwheelEnhancements.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LightwheelEnhancements.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Lightwheel Enhancements — Aetherdrift #20
+ * {W} · Enchantment — Aura
+ *
+ * Enchant creature or Vehicle
+ * Start your engines!
+ * Enchanted permanent gets +1/+1 and has vigilance.
+ * Max speed — You may cast this card from your graveyard.
+ *
+ * The buff half is the plain Aura shape (Silken Strength): [ModifyStats] plus a [GrantKeyword] auto-
+ * targeted at the enchanted permanent, over a [GameObjectFilter.CreatureOrVehicle] `auraTarget` so it
+ * can ride a Vehicle that isn't currently a creature.
+ *
+ * The recursion half is the interesting one. Per the Aetherdrift ruling, *"Max speed — [ability]"
+ * means "As long as you have max speed, this object has [ability]" — and if the granted ability
+ * functions in a zone other than the battlefield, the max speed ability does too.* So the permission
+ * has to be live while the card sits in the graveyard, where it is not a permanent and the layer
+ * system never sees it. [MayCastSelfFromZones] is exactly that: an intrinsic self-permission read
+ * straight off the card definition by `CastFromZoneEnumerator` / `CastZoneResolver`, with its own
+ * `condition` slot evaluated in the *casting player's* context — which the [maxSpeed] block folds
+ * `YouHaveMaxSpeed` into rather than wrapping the ability in a `ConditionalStaticAbility` those raw
+ * `filterIsInstance` read sites would never find.
+ *
+ * Nothing gates the cast beyond speed: it is cast for its normal mana cost at normal (sorcery) timing,
+ * and dropping out of max speed revokes the permission mid-window because the condition is re-checked
+ * when the cast is authorized.
+ */
+val LightwheelEnhancements = card("Lightwheel Enhancements") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature or Vehicle\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Enchanted permanent gets +1/+1 and has vigilance.\n" +
+        "Max speed — You may cast this card from your graveyard."
+
+    auraTarget = TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle))
+
+    startYourEngines()
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    maxSpeed {
+        staticAbility {
+            ability = MayCastSelfFromZones(listOf(Zone.GRAVEYARD))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg?1783907917"
+        ruling(
+            "2025-02-07",
+            "\"Max speed — [ability]\" means \"As long as you have max speed, this object has " +
+                "[ability].\" If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+        ruling(
+            "2025-02-07",
+            "A player \"has max speed\" if their speed is 4."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarchOfTheWorldOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MarchOfTheWorldOoze.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * March of the World Ooze — Aetherdrift #169
+ * {3}{G}{G}{G} · Enchantment
+ *
+ * Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other
+ * types.
+ * Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant
+ * creature token.
+ *
+ * The first line is *one* printed static ability spanning two Rule 613 layers — Layer 4 (the Ooze
+ * subtype) and Layer 7b (base 6/6) — so per CR 613.6 both parts must apply to the same locked-in set
+ * of objects. That is what [CompositeStaticAbility] is for (the Bello, Bard of the Brambles shape);
+ * two separate `staticAbility { }` blocks would each re-resolve their own affected set per layer and
+ * could drift apart. Setting *base* P/T (Layer 7b) rather than modifying it means +1/+1 counters and
+ * lords still stack on top of the 6/6, and a later base-setting effect overwrites it.
+ *
+ * The trigger's "if it's not their turn" is an intervening-if (CR 603.4) on the *casting* player, not
+ * on the controller — [Conditions.IsPlayersTurn] over [Player.TriggeringPlayer], the Scytheclaw
+ * Raptor idiom. It is checked both when the ability would trigger and again on resolution, so an
+ * opponent flashing something in during your turn makes a token while their own main-phase sorcery
+ * does not.
+ */
+val MarchOfTheWorldOoze = card("March of the World Ooze") {
+    manaCost = "{3}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control have base power and toughness 6/6 and are Oozes in addition " +
+        "to their other types.\n" +
+        "Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant " +
+        "creature token."
+
+    val yourCreatures = GroupFilter(GameObjectFilter.Creature.youControl())
+
+    // One multi-layer static (CR 613.6): the Layer 4 subtype grant and the Layer 7b base-P/T set
+    // share a single locked-in affected set rather than each resolving their own.
+    staticAbility {
+        ability = CompositeStaticAbility(
+            listOf(
+                SetBasePowerToughnessStatic(6, 6, yourCreatures),
+                GrantSubtype("Ooze", yourCreatures),
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.OpponentCastsSpell
+        triggerCondition = Conditions.Not(Conditions.IsPlayersTurn(Player.TriggeringPlayer))
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elephant")
+        )
+        description = "Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 " +
+            "green Elephant creature token."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "169"
+        artist = "Helge C. Balzer"
+        flavorText = "\"The fauna here functions as a planar antibody.\"\n—Rashmi, aether-seer"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg?1783907868"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiptideGearhulk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiptideGearhulk.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Riptide Gearhulk — Aetherdrift #219
+ * {1}{W}{W}{U}{U} · Artifact Creature — Construct · 2/5
+ *
+ * Double strike
+ * Prowess
+ * When this creature enters, for each opponent, put up to one target nonland permanent that player
+ * controls into its owner's library third from the top.
+ *
+ * "Third from the top" is a positional library move — [Effects.PutIntoLibraryNthFromTop] with
+ * `positionFromTop = 2` (the parameter is 0-indexed: 0 = top, 2 = third). It goes to the *owner's*
+ * library, which the move already does, so a permanent an opponent stole still lands in its owner's
+ * deck. A library with fewer than two cards under the top simply takes it as deep as it goes.
+ *
+ * "For each opponent, … up to one target … that player controls" follows the corpus convention for
+ * this wording (Blatant Thievery, Omega, Heartless Evolution): one *optional* target — exactly right
+ * in 1v1, and the shape the multiplayer per-opponent targeting work generalizes. `optional = true`
+ * carries the "up to one", so declining is legal and the trigger still resolves.
+ */
+val RiptideGearhulk = card("Riptide Gearhulk") {
+    manaCost = "{1}{W}{W}{U}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 5
+    oracleText = "Double strike\n" +
+        "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n" +
+        "When this creature enters, for each opponent, put up to one target nonland permanent that " +
+        "player controls into its owner's library third from the top."
+
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.PROWESS)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "target nonland permanent that player controls",
+            TargetPermanent(optional = true, filter = TargetFilter.NonlandPermanentOpponentControls)
+        )
+        effect = Effects.PutIntoLibraryNthFromTop(victim, positionFromTop = 2)
+        description = "When this creature enters, for each opponent, put up to one target nonland " +
+            "permanent that player controls into its owner's library third from the top."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "219"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg?1783907853"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpikeshellHarrier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpikeshellHarrier.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Spikeshell Harrier — Aetherdrift #65
+ * {4}{U} · Artifact Creature — Robot Turtle · 4/4
+ *
+ * When this creature enters, return target creature or Vehicle an opponent controls to its owner's
+ * hand. If that opponent's speed is greater than each other player's speed, reduce that opponent's
+ * speed by 1. This effect can't reduce their speed below 1.
+ *
+ * "That opponent" is the bounced permanent's *controller*, so both halves hang off the one target:
+ * [Player.ControllerOf] resolves from the captured target id, and its last-known controller survives
+ * the bounce (the resolver falls through the permanent's last-known snapshot before owner), which is
+ * what makes it still name the right player once the card is in hand — the same idiom Unwanted
+ * Remake uses for "its controller" after a destroy.
+ *
+ * **"Greater than each other player's speed"** is a max-over-all-players comparison, which a binary
+ * `Compare` can't express (a `Speed(EachOpponent)` reads only the first opponent). It is instead
+ * counted: *exactly one* player has speed ≥ that opponent's speed iff that opponent is the strict,
+ * unique leader — they always satisfy the inner comparison themselves, so a count of 1 means nobody
+ * else ties or beats them. [DynamicAmount.CountPlayersWith] rebinds the controller per candidate, so
+ * `Speed(Player.You)` inside the loop is each player's own speed while `Speed(thatOpponent)` keeps
+ * reading the bounced permanent's controller.
+ *
+ * The floor is the effect's own, not a rule: [Effects.ReduceSpeed] takes [Speed.STARTING] as its
+ * `minimum`, and `SpeedService` never *grants* speed to a player who has none, so an opponent with no
+ * speed is left alone rather than being pushed up to 1.
+ */
+val SpikeshellHarrier = card("Spikeshell Harrier") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Robot Turtle"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, return target creature or Vehicle an opponent controls " +
+        "to its owner's hand. If that opponent's speed is greater than each other player's speed, " +
+        "reduce that opponent's speed by 1. This effect can't reduce their speed below 1."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val bounced = target(
+            "target creature or Vehicle an opponent controls",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle.opponentControls()))
+        )
+        val thatOpponent = Player.ControllerOf("target creature or Vehicle an opponent controls")
+
+        effect = Effects.Composite(
+            Effects.ReturnToHand(bounced),
+            ConditionalEffect(
+                condition = Compare(
+                    left = DynamicAmount.CountPlayersWith(
+                        scope = Player.Each,
+                        condition = Compare(
+                            left = DynamicAmount.Speed(Player.You),
+                            operator = ComparisonOperator.GTE,
+                            right = DynamicAmount.Speed(thatOpponent)
+                        )
+                    ),
+                    operator = ComparisonOperator.EQ,
+                    right = DynamicAmount.Fixed(1)
+                ),
+                effect = Effects.ReduceSpeed(
+                    amount = DynamicAmount.Fixed(1),
+                    target = EffectTarget.PlayerRef(thatOpponent),
+                    minimum = Speed.STARTING
+                )
+            )
+        )
+        description = "When this creature enters, return target creature or Vehicle an opponent " +
+            "controls to its owner's hand. If that opponent's speed is greater than each other " +
+            "player's speed, reduce that opponent's speed by 1. This effect can't reduce their " +
+            "speed below 1."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Alfonso Santano"
+        flavorText = "\"Target acquired. Resolution: Imminent impact.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg?1783907901"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -1040,6 +1040,109 @@
     ]
 }
 
+// Boommobile
+{
+    "name": "Boommobile",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities.\nExhaust — {X}{2}{R}: This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle. (Activate each exhaust ability only once.)\nCrew 2",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "restriction": "AbilityActivationOnly"
+                },
+                "descriptionOverride": "When this Vehicle enters, add four mana of any one color. Spend this mana only to activate abilities."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{X}{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": "XValue",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "This Vehicle deals X damage to any target. Put a +1/+1 counter on this Vehicle.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "RARE",
+        "artist": "Alexandr Leskinen",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/930c8289-4043-401a-8a7f-22349b7148b4.jpg?1783907886",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "You may spend the four mana added by the first ability on the same ability or on multiple abilities."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Boosted Sloop
 {
     "name": "Boosted Sloop",
@@ -6359,6 +6462,70 @@
     ]
 }
 
+// Lightwheel Enhancements
+{
+    "name": "Lightwheel Enhancements",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature or Vehicle\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nEnchanted permanent gets +1/+1 and has vigilance.\nMax speed — You may cast this card from your graveyard.",
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            },
+            {
+                "type": "MayCastSelfFromZones",
+                "zones": [
+                    "Graveyard"
+                ],
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|Vehicle"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9ab169c1-4e25-4a5d-8961-4f06298c3781.jpg?1783907917",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "\"Max speed — [ability]\" means \"As long as you have max speed, this object has [ability].\" If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Locust Spray
 {
     "name": "Locust Spray",
@@ -6923,6 +7090,77 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// March of the World Ooze
+{
+    "name": "March of the World Ooze",
+    "manaCost": "{3}{G}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.\nWhenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elephant"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "IsPlayersTurn",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CompositeStaticAbility",
+                "abilities": [
+                    {
+                        "type": "SetBasePowerToughnessStatic",
+                        "power": 6,
+                        "toughness": 6,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    {
+                        "type": "GrantSubtype",
+                        "subtype": "Ooze",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "MYTHIC",
+        "artist": "Helge C. Balzer",
+        "flavorText": "\"The fauna here functions as a planar antibody.\"\n—Rashmi, aether-seer",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1964ec5-0dd1-4b54-917c-cbeab05aba79.jpg?1783907868"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -9475,6 +9713,61 @@
     ]
 }
 
+// Riptide Gearhulk
+{
+    "name": "Riptide Gearhulk",
+    "manaCost": "{1}{W}{W}{U}{U}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Double strike\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhen this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonland permanent that player controls"
+                    },
+                    "destination": "Library",
+                    "positionFromTop": 2
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:opponent"
+                    },
+                    "id": "target nonland permanent that player controls"
+                },
+                "descriptionOverride": "When this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "MYTHIC",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44bfb0f7-18ca-4f6e-ba64-92120010456e.jpg?1783907853"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Risen Necroregent
 {
     "name": "Risen Necroregent",
@@ -11029,6 +11322,109 @@
         "artist": "Maxime Minard",
         "flavorText": "The druid's aim was dead on. But their choice of target was dead wrong.",
         "imageUri": "https://cards.scryfall.io/normal/front/8/d/8dd4374f-0301-4b2e-bc99-2cd19568cb3b.jpg?1738359138"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Spikeshell Harrier
+{
+    "name": "Spikeshell Harrier",
+    "manaCost": "{4}{U}",
+    "typeLine": "Artifact Creature — Robot Turtle",
+    "oracleText": "When this creature enters, return target creature or Vehicle an opponent controls to its owner's hand. If that opponent's speed is greater than each other player's speed, reduce that opponent's speed by 1. This effect can't reduce their speed below 1.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature or Vehicle an opponent controls"
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "CountPlayersWith",
+                                        "scope": "Each",
+                                        "condition": {
+                                            "type": "Compare",
+                                            "left": "Speed",
+                                            "operator": "GTE",
+                                            "right": {
+                                                "type": "Speed",
+                                                "player": {
+                                                    "type": "ControllerOf",
+                                                    "targetDescription": "target creature or Vehicle an opponent controls"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "operator": "EQ",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "ChangeSpeed",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "target creature or Vehicle an opponent controls"
+                                    }
+                                },
+                                "amount": {
+                                    "type": "Multiply",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "multiplier": -1
+                                },
+                                "minimum": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|Vehicle ctrl:opponent"
+                    },
+                    "id": "target creature or Vehicle an opponent controls"
+                },
+                "descriptionOverride": "When this creature enters, return target creature or Vehicle an opponent controls to its owner's hand. If that opponent's speed is greater than each other player's speed, reduce that opponent's speed by 1. This effect can't reduce their speed below 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Alfonso Santano",
+        "flavorText": "\"Target acquired. Resolution: Imminent impact.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f1ece22-ca32-45bb-b5f4-480f9b366cb5.jpg?1783907901"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftHeavyHaulersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherdriftHeavyHaulersScenarioTest.kt
@@ -1,0 +1,361 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Aetherdrift batch that leans on the trickier shared vocabulary rather than on new effects:
+ *
+ * | Card | What's actually under test |
+ * |---|---|
+ * | Spikeshell Harrier | "greater than each other player's speed" as a count-of-leaders comparison, and the reduction floor |
+ * | Lightwheel Enhancements | `MayCastSelfFromZones` gated by max speed — a permission that has to be live *in the graveyard* |
+ * | March of the World Ooze | one `CompositeStaticAbility` spanning Layer 4 + Layer 7b, and an intervening-if on the casting player |
+ * | Riptide Gearhulk | the positional library move ("third from the top") |
+ * | Boommobile | a restricted-spend mana ETB, and an exhaust ability with X |
+ */
+class AetherdriftHeavyHaulersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Spikeshell Harrier") {
+
+            test("bounces the target and slows the sole speed leader") {
+                val game = harrierGame()
+                val giant = game.findPermanent("Hill Giant")!!
+                // Opponent alone at speed 3; the Harrier's controller sits at 1.
+                game.state = SpeedService.set(game.state, game.player2Id, 3, "test").first
+
+                game.castHarrierAt(giant)
+
+                withClue("The creature is returned to its owner's hand") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInHand(2, "Hill Giant") shouldBe true
+                }
+                withClue("Nobody else matches their speed, so it drops by 1") {
+                    game.state.speed(game.player2Id) shouldBe 2
+                }
+            }
+
+            test("leaves speed alone when another player is tied for the lead") {
+                val game = harrierGame()
+                val giant = game.findPermanent("Hill Giant")!!
+                game.state = SpeedService.set(game.state, game.player1Id, 3, "test").first
+                game.state = SpeedService.set(game.state, game.player2Id, 3, "test").first
+
+                game.castHarrierAt(giant)
+
+                withClue("The bounce is unconditional") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("\"greater than each other player's speed\" is strict — a tie is not greater") {
+                    game.state.speed(game.player2Id) shouldBe 3
+                }
+            }
+
+            test("can't push the leader below 1") {
+                val game = harrierGame()
+                val giant = game.findPermanent("Hill Giant")!!
+                // Opponent leads at 1 because the controller has no speed at all (reads as 0).
+                game.state = SpeedService.set(game.state, game.player2Id, Speed.STARTING, "test").first
+
+                game.castHarrierAt(giant)
+
+                withClue("The printed floor holds: \"can't reduce their speed below 1\"") {
+                    game.state.speed(game.player2Id) shouldBe Speed.STARTING
+                }
+            }
+        }
+
+        context("Lightwheel Enhancements") {
+
+            test("is castable from the graveyard only at max speed") {
+                val game = lightwheelGame()
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                val blocked = game.castSpellFromGraveyard(1, "Lightwheel Enhancements", bear)
+                withClue("Below max speed the graveyard permission isn't there at all") {
+                    (blocked.error != null).shouldBeTrue()
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val allowed = game.castSpellFromGraveyard(1, "Lightwheel Enhancements", bear)
+                withClue("At max speed it casts from the graveyard: ${allowed.error}") {
+                    allowed.error shouldBe null
+                }
+                game.autoPayIfAsked()
+                game.resolveStack()
+
+                withClue("It attaches and grants +1/+1 and vigilance") {
+                    game.isOnBattlefield("Lightwheel Enhancements") shouldBe true
+                    game.state.projectedState.getPower(bear) shouldBe 3
+                    game.state.projectedState.getToughness(bear) shouldBe 3
+                    game.state.projectedState.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+
+        context("March of the World Ooze") {
+
+            test("makes your creatures base 6/6 Oozes without touching your opponent's") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "March of the World Ooze")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val projected = game.state.projectedState
+
+                withClue("Layer 7b sets base P/T, Layer 4 adds the subtype — both from one ability") {
+                    projected.getPower(bear) shouldBe 6
+                    projected.getToughness(bear) shouldBe 6
+                    projected.hasSubtype(bear, "Ooze") shouldBe true
+                }
+                withClue("\"in addition to their other types\" keeps the printed one") {
+                    projected.hasSubtype(bear, "Bear") shouldBe true
+                }
+                withClue("\"Creatures you control\" excludes the opponent's board") {
+                    projected.getPower(giant) shouldBe 3
+                    projected.hasSubtype(giant, "Ooze") shouldBe false
+                }
+            }
+
+            test("an opponent casting during your turn makes an Elephant, but not on their own turn") {
+                val onYourTurn = marchTriggerGame(activePlayer = 1)
+                onYourTurn.castSpell(2, "Giant Growth", onYourTurn.findPermanent("Hill Giant")!!)
+                onYourTurn.autoPayIfAsked()
+                onYourTurn.resolveStack()
+                withClue("It isn't the caster's turn, so the intervening-if holds") {
+                    onYourTurn.elephantTokens() shouldBe 1
+                }
+
+                val onTheirTurn = marchTriggerGame(activePlayer = 2)
+                onTheirTurn.castSpell(2, "Giant Growth", onTheirTurn.findPermanent("Hill Giant")!!)
+                onTheirTurn.autoPayIfAsked()
+                onTheirTurn.resolveStack()
+                withClue("On the caster's own turn the trigger is suppressed") {
+                    onTheirTurn.elephantTokens() shouldBe 0
+                }
+            }
+        }
+
+        context("Riptide Gearhulk") {
+
+            test("buries a targeted permanent third from the top of its owner's library") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Riptide Gearhulk")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                repeat(6) {
+                    builder.withCardInLibrary(1, "Grizzly Bears")
+                    builder.withCardInLibrary(2, "Grizzly Bears")
+                }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val cast = game.castSpell(1, "Riptide Gearhulk")
+                withClue("Cast failed: ${cast.error}") { cast.error shouldBe null }
+                game.autoPayIfAsked()
+                game.resolveStack()
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(giant))
+                game.resolveStack()
+
+                val library = game.state.getLibrary(game.player2Id)
+                withClue("Index 0 is the top of the library, so third from the top is index 2") {
+                    library.indexOf(giant) shouldBe 2
+                }
+                withClue("It goes to its owner's library, not the caster's") {
+                    game.state.getLibrary(game.player1Id).contains(giant) shouldBe false
+                }
+            }
+        }
+
+        context("Boommobile") {
+
+            test("its enter trigger fills the pool with four mana of one chosen color") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Boommobile")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Boommobile")
+                withClue("Cast failed: ${cast.error}") { cast.error shouldBe null }
+                game.autoPayIfAsked()
+                game.resolveStack()
+                val colorPick = game.getPendingDecision()
+                if (colorPick is ChooseColorDecision) {
+                    game.submitDecision(ColorChosenResponse(colorPick.id, Color.RED))
+                }
+                game.resolveStack()
+
+                withClue("\"Add four mana of any one color\" is four of a single pick, not a mix") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.total shouldBe 4
+                }
+            }
+
+            test("its exhaust ability shoots for X once, then never again") {
+                val builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Boommobile")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Mountain", 10)
+                stockLibraries(builder)
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val boommobile = game.findPermanent("Boommobile")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val abilityId = cardRegistry.getCard("Boommobile")!!.script.activatedAbilities.single().id
+
+                val fire = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = boommobile,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                        xValue = 3
+                    )
+                )
+                withClue("Activation failed: ${fire.error}") { fire.error shouldBe null }
+                game.autoPayIfAsked()
+                game.resolveStack()
+
+                withClue("X damage kills the 3/3, and the Vehicle grows regardless") {
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                    game.state.projectedState.getPower(boommobile) shouldBe 6
+                    game.state.projectedState.getToughness(boommobile) shouldBe 6
+                }
+
+                val again = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = boommobile, abilityId = abilityId, xValue = 1)
+                )
+                withClue("Exhaust means \"Activate only once\" per object") {
+                    (again.error != null).shouldBeTrue()
+                }
+            }
+        }
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────────────────────────────────────
+
+    /** Player 1 holding Spikeshell Harrier with five Islands, facing a Hill Giant. */
+    private fun harrierGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInHand(1, "Spikeshell Harrier")
+            .withCardOnBattlefield(2, "Hill Giant")
+            .withLandsOnBattlefield(1, "Island", 5)
+        stockLibraries(builder)
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    /** Cast the Harrier, point its enter trigger at [victim], and let everything resolve. */
+    private fun TestGame.castHarrierAt(victim: EntityId) {
+        val cast = castSpell(1, "Spikeshell Harrier")
+        withClue("Cast failed: ${cast.error}") { cast.error shouldBe null }
+        autoPayIfAsked()
+        resolveStack()
+        if (getPendingDecision() is ChooseTargetsDecision) selectTargets(listOf(victim))
+        resolveStack()
+    }
+
+    /**
+     * Lightwheel Enhancements already in player 1's graveyard, one Plains to recast it, and a
+     * Grizzly Bears to enchant. Built in the upkeep step so the CR 704.5z start-your-engines
+     * state-based action has a step change to run on.
+     */
+    private fun lightwheelGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardInGraveyard(1, "Lightwheel Enhancements")
+            .withCardOnBattlefield(1, "Grizzly Bears")
+            .withLandsOnBattlefield(1, "Plains", 1)
+        stockLibraries(builder)
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+
+    /**
+     * March of the World Ooze under player 1, with player 2 holding a Giant Growth and the mana for
+     * it. [activePlayer] decides whose turn the opponent casts on — the whole point of the
+     * intervening-if.
+     */
+    private fun marchTriggerGame(activePlayer: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "March of the World Ooze")
+            .withCardOnBattlefield(2, "Hill Giant")
+            .withCardInHand(2, "Giant Growth")
+            .withLandsOnBattlefield(2, "Forest", 1)
+        stockLibraries(builder)
+        return builder
+            .withActivePlayer(activePlayer)
+            .withPriorityPlayer(2)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────────────────────
+
+    private fun stockLibraries(builder: ScenarioBuilder) {
+        repeat(10) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+
+    /** Elephant creature tokens on the battlefield. */
+    private fun TestGame.elephantTokens(): Int =
+        state.getBattlefield().count { id ->
+            val container = state.getEntity(id) ?: return@count false
+            container.has<TokenComponent>() &&
+                container.get<CardComponent>()?.typeLine?.subtypes?.any { it.value == "Elephant" } == true
+        }
+
+    /** Submit auto-pay if the engine paused for a mana-source decision. */
+    private fun TestGame.autoPayIfAsked() {
+        if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+    }
+}


### PR DESCRIPTION
Implements five Aetherdrift (DFT) cards, taking the set from 204/276 to 209/276.

| Card | | What it needed |
|---|---|---|
| **Spikeshell Harrier** | {4}{U} 4/4 | ETB bounce + conditional speed reduction |
| **Lightwheel Enhancements** | {W} Aura | Start your engines!, Max speed graveyard cast |
| **March of the World Ooze** | {3}{G}{G}{G} | One static across layers 4 + 7b, intervening-if trigger |
| **Riptide Gearhulk** | {1}{W}{W}{U}{U} 2/5 | Positional library move ("third from the top") |
| **Boommobile** | {2}{R}{R} 5/5 | Restricted-spend mana ETB, exhaust ability with X |

## Two shapes worth a second look

**Spikeshell Harrier — "greater than each other player's speed."** That is a max-over-all-players comparison, which a binary `Compare` can't express (`Speed(EachOpponent)` reads only the first opponent). It's counted instead: *exactly one* player has speed ≥ that opponent's speed iff that opponent is the strict, unique leader — they always satisfy the inner comparison themselves, so a count of 1 means nobody else ties or beats them. `CountPlayersWith` rebinds the controller per candidate, so `Speed(Player.You)` inside the loop is each player's own speed while `Speed(ControllerOf(target))` keeps naming the bounced permanent's controller.

**Lightwheel Enhancements — one SDK change.** "Max speed — You may cast this card from your graveyard" needs the permission live in a zone where the card isn't a permanent, so it's a `MayCastSelfFromZones`. Both read sites for that static (`CastFromZoneEnumerator.enumerateIntrinsicZoneCast`, `CastZoneResolver.findMayCastSelfFromZoneAbility`) scan the raw static list with `filterIsInstance`, so the `maxSpeed { }` block's `ConditionalStaticAbility` wrapper would have hidden it entirely and the card would simply never be castable. `MaxSpeedBuilder` now folds the gate into the ability's own `condition` slot — exactly the treatment `ModifySpellCost` already gets, and for the same reason. `docs/card-sdk-language-reference.md` updated in the same change.

## Tests

`AetherdriftHeavyHaulersScenarioTest` — 9 scenarios covering the speed comparison (sole leader, tie, and the printed floor), the gated graveyard cast in both states, the `CompositeStaticAbility` spanning layers 4 and 7b, the intervening-if on the *casting* player, the positional library move, and the exhaust ability firing once and never again.

`just test` is green; the `DFT.json` snapshot diff is additions only, all five of them mine.

## Left out

**Lifecraft Engine.** Its "Vehicle creatures you control are the chosen type" only reaches a Vehicle once crew has animated it — and crew's animation is itself a Layer 4 effect with a later timestamp. That's a CR 613.8 dependency the projector doesn't detect: `EffectSorter.dependsOn` tests affected-set overlap, and the dependent effect's set is empty *precisely because* the dependency hasn't applied yet. Fixing it means trial application in the dependency sorter — an `add-feature`-sized change, not a card. Swapped Boommobile in rather than ship a card that resolves wrong when crewed.

## Note, unrelated to this branch

`just check-backlog` reports pre-existing drift in `innistrad-crimson-vow` and `marvels-spider-man`. Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)