### PR TITLE
Engine AI Phase 2b: 18 tactical puzzles the suite could not express

### DIFF
--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
@@ -15,10 +15,17 @@ import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.model.EntityId
 
 /**
- * The eight things the suite is built to catch. Categories are the localizing signal: an arena run
- * says *that* the AI got worse, a category pass-rate says *what* got worse.
+ * The things the suite is built to catch. Categories are the localizing signal: an arena run says
+ * *that* the AI got worse, a category pass-rate says *what* got worse.
  *
- * See `backlog/engine-ai-improvement.md` § "How we measure" for why these eight.
+ * The first eight are Phase 2's. The last three are Phase 2b's, added because at 44/48 the original
+ * suite had four points of headroom left and two of them were the same Phase 9 constant — so the
+ * plan's most expensive phase had a two-puzzle localizing signal. Each of the three closes a gap
+ * that all 48 shared by construction rather than by choice: nothing was ever on the stack, no
+ * puzzle asserted on an [ActivateAbility] even though [PuzzleMove] already spoke it, and combat
+ * coverage stopped at flying / deathtouch / first strike / vigilance.
+ *
+ * See `backlog/engine-ai-improvement.md` § "How we measure" and § Phase 2b.
  */
 enum class PuzzleCategory(val id: String, val catches: String) {
     LETHAL_DETECTION("lethal", "Missing an alpha strike / burn-to-face kill"),
@@ -29,6 +36,9 @@ enum class PuzzleCategory(val id: String, val catches: String) {
     BOARD_WIPE_TIMING("wipe", "Wrathing while ahead"),
     RACE_MATH("race", "Attack-vs-hold when both players are on a clock"),
     NON_CREATURE_VALUATION("noncreature", "Ignoring an opposing O-Ring / mana rock / anthem"),
+    STACK_RESPONSE("respond", "Never answering a spell that is already on the stack"),
+    ACTIVATED_ABILITIES("activate", "Pingers, tappers and pump abilities left unused"),
+    COMBAT_KEYWORDS("keywords", "Trample / menace / reach / indestructible read as ordinary stats"),
 }
 
 /**
@@ -105,10 +115,16 @@ class PuzzleMove internal constructor(
     val attackerNames: List<String> =
         (action as? DeclareAttackers)?.attackers?.keys?.map(::nameOf).orEmpty()
 
-    /** Declared blocks as `blocker name -> attackers it blocks`. */
-    val blockAssignments: Map<String, List<String>> =
+    /**
+     * Declared blocks as `blocker name -> attackers it blocks`, **one entry per blocker**.
+     *
+     * A list rather than a map on purpose: two creatures with the same name blocking the same
+     * attacker is exactly what a gang block against menace looks like, and keying by name collapses
+     * them into one entry. That silently turned a correct double block into a reported single one.
+     */
+    val blockAssignments: List<Pair<String, List<String>>> =
         (action as? DeclareBlockers)?.blockers.orEmpty()
-            .entries.associate { (blocker, attackers) -> nameOf(blocker) to attackers.map(::nameOf) }
+            .map { (blocker, attackers) -> nameOf(blocker) to attackers.map(::nameOf) }
 
     /** Total projected power of the declared attackers — what a lethal-detection puzzle counts. */
     val attackingPower: Int = (action as? DeclareAttackers)?.attackers?.keys
@@ -122,7 +138,7 @@ class PuzzleMove internal constructor(
             else "DeclareAttackers(${attackerNames.sorted().joinToString(", ")}) — $attackingPower power"
         is DeclareBlockers ->
             if (blockAssignments.isEmpty()) "DeclareBlockers(none)"
-            else "DeclareBlockers(" + blockAssignments.entries.joinToString("; ") { (b, a) ->
+            else "DeclareBlockers(" + blockAssignments.joinToString("; ") { (b, a) ->
                 "$b blocks ${a.joinToString(" & ")}"
             } + ")"
         else -> {
@@ -133,7 +149,7 @@ class PuzzleMove internal constructor(
 
     private fun fail(what: String): Nothing = throw AssertionError("$what, but chose ${describe()}")
 
-    // ── Assertions. Each has many callers across the 48 puzzles; that is what earns them a name. ──
+    // ── Assertions. Each has many callers across the 66 puzzles; that is what earns them a name. ──
 
     fun shouldCast(cardName: String) {
         if (action !is CastSpell || playedCard != cardName) fail("Expected to cast $cardName")
@@ -141,6 +157,17 @@ class PuzzleMove internal constructor(
 
     fun shouldNotCast(cardName: String) {
         if (action is CastSpell && playedCard == cardName) fail("Expected NOT to cast $cardName")
+    }
+
+    /**
+     * Activates [cardName]'s ability. Pair it with [shouldTarget] when the ability is targeted —
+     * `shouldActivate` alone only says the AI reached for the right permanent, not that it pointed
+     * the ability anywhere sensible.
+     */
+    fun shouldActivate(cardName: String) {
+        if (action !is ActivateAbility || playedCard != cardName) {
+            fail("Expected to activate $cardName")
+        }
     }
 
     fun shouldPlayLand(landName: String? = null) {
@@ -188,14 +215,14 @@ class PuzzleMove internal constructor(
     }
 
     fun shouldBlock(blocker: String, attacker: String) {
-        if (blockAssignments[blocker]?.contains(attacker) != true) {
+        if (blockAssignments.none { (b, attackers) -> b == blocker && attacker in attackers }) {
             fail("Expected $blocker to block $attacker")
         }
     }
 
     /** At least [count] creatures must be blocking [attacker] — the double-block assertion. */
     fun shouldBlockWithAtLeast(count: Int, attacker: String) {
-        val blocking = blockAssignments.count { attacker in it.value }
+        val blocking = blockAssignments.count { (_, attackers) -> attacker in attackers }
         if (blocking < count) fail("Expected at least $count blockers on $attacker")
     }
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleCatalog.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleCatalog.kt
@@ -1,16 +1,19 @@
 package com.wingedsheep.ai.puzzles
 
+import com.wingedsheep.ai.puzzles.categories.ActivatedAbilityPuzzles
 import com.wingedsheep.ai.puzzles.categories.BlockingPuzzles
 import com.wingedsheep.ai.puzzles.categories.BoardWipeTimingPuzzles
+import com.wingedsheep.ai.puzzles.categories.CombatKeywordPuzzles
 import com.wingedsheep.ai.puzzles.categories.HoldingInstantsPuzzles
 import com.wingedsheep.ai.puzzles.categories.LethalDetectionPuzzles
 import com.wingedsheep.ai.puzzles.categories.NonCreatureValuationPuzzles
 import com.wingedsheep.ai.puzzles.categories.RaceMathPuzzles
 import com.wingedsheep.ai.puzzles.categories.RemovalTargetingPuzzles
 import com.wingedsheep.ai.puzzles.categories.SequencingPuzzles
+import com.wingedsheep.ai.puzzles.categories.StackResponsePuzzles
 
 /**
- * Every puzzle, in category order. Eight categories × six positions.
+ * Every puzzle, in category order. Eleven categories, six positions each.
  *
  * Adding a puzzle is: write it in its category file, run `just arena-puzzles`, and add its id to
  * [PuzzleSuiteTest.KNOWN_FAILURES] if the AI does not solve it yet.
@@ -26,6 +29,10 @@ object PuzzleCatalog {
         BoardWipeTimingPuzzles.all(),
         RaceMathPuzzles.all(),
         NonCreatureValuationPuzzles.all(),
+        // Phase 2b.
+        StackResponsePuzzles.all(),
+        ActivatedAbilityPuzzles.all(),
+        CombatKeywordPuzzles.all(),
     ).flatten()
 
     fun byCategory(category: PuzzleCategory): List<AiPuzzle> = all.filter { it.category == category }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.engine.support.ScenarioTestBase
 
 /**
- * The same 48 puzzles across several agents, side by side.
+ * The same 66 puzzles across several agents, side by side.
  *
  * ```
  * just arena-puzzles-compare

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzlePositions.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzlePositions.kt
@@ -39,6 +39,25 @@ fun ScenarioTestBase.TestGame.advanceToPriority(seat: Int, step: Step): Scenario
         state.step == step && state.priorityPlayerId == seatId(seat) && !needsDeclaration(seatId(seat))
     }
 
+/**
+ * Advance until [seat] holds priority with something still on the stack — the window a response is
+ * cast in. The position is expected to have put the spell there already, by casting it from the
+ * other seat.
+ *
+ * Separate from [advanceToPriority] because of the failure mode it has to rule out: passing one
+ * time too many resolves the spell, and a puzzle that then asks *"do you counter this?"* about an
+ * empty stack scores the AI on a decision that no longer exists. That check is why this cannot
+ * just be `advanceUntil { priorityPlayerId == … }`.
+ */
+fun ScenarioTestBase.TestGame.advanceToStackResponse(seat: Int): ScenarioTestBase.TestGame =
+    advanceUntil("$seat's response window") {
+        check(state.stack.isNotEmpty()) {
+            "The stack emptied before seat $seat was offered a response window — the position " +
+                "resolved the spell it meant to ask about"
+        }
+        state.priorityPlayerId == seatId(seat)
+    }
+
 /** Whether [playerId] still owes this combat an attacker or blocker declaration. */
 private fun ScenarioTestBase.TestGame.needsDeclaration(playerId: EntityId): Boolean = when {
     state.step == Step.DECLARE_ATTACKERS && playerId == state.activePlayerId ->

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.ai.engine.AiProfile
 import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.engine.support.ScenarioTestBase
 import io.kotest.assertions.withClue
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 
@@ -24,12 +25,14 @@ class PuzzleSuiteTest : ScenarioTestBase() {
     init {
         val runner = PuzzleRunner(cardRegistry) { scenario() }
 
-        test("the suite covers eight categories, six puzzles each, with unique ids") {
+        test("every category carries at least six puzzles, with unique ids") {
             PuzzleCatalog.all.map { it.id }.toSet().size shouldBe PuzzleCatalog.all.size
             PuzzleCategory.entries.forEach { category ->
-                withClue(category) { PuzzleCatalog.byCategory(category).size shouldBe 6 }
+                withClue(category) {
+                    PuzzleCatalog.byCategory(category).size shouldBeGreaterThanOrEqual 6
+                }
             }
-            PuzzleCatalog.all.size shouldBe 48
+            PuzzleCatalog.all.size shouldBe 66
         }
 
         test("every KNOWN_FAILURES id names a real puzzle") {
@@ -63,8 +66,9 @@ class PuzzleSuiteTest : ScenarioTestBase() {
          * of `backlog/engine-ai-improvement.md`; growing it needs a reason in the commit message.
          *
          * Baselined 2026-07-27 against `AiProfile.PRODUCTION` at 39/48; **44/48 since Phase 6**
-         * (`CardIntent`), which closed noncreature-01/03/04 and instants-01/06. Per-category rates
-         * are in `docs/ai/baseline-metrics.md`.
+         * (`CardIntent`), which closed noncreature-01/03/04 and instants-01/06; **60/66 since Phase
+         * 2b** added the respond / activate / keywords categories. Per-category rates are in
+         * `docs/ai/baseline-metrics.md`.
          */
         val KNOWN_FAILURES: Set<String> = setOf(
             // A one-ply evaluator cannot see a prevention effect: the state right after Fog
@@ -85,6 +89,17 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // Phase 9 exists to refit. Raising the anthem prior until this passes would be tuning
             // one guess to cancel another.
             "noncreature-02",
+
+            // ── Phase 2b ──
+            // A regeneration shield is bought *before* the destruction it answers, so at the moment
+            // of the activation the board is unchanged and two mana are gone — the same shape as
+            // instants-05's Fog, and the same fix. Phase 7.
+            "respond-05",
+            // Pumping an unblocked attacker pays now for damage that lands at the combat-damage
+            // step. `evaluate1Ply` simulates to the next quiet state, which is still inside
+            // declare-blockers, so the +1/+0 shows up as `attackPotential` on a creature that is
+            // already attacking and never as life off the opponent. Phase 7.
+            "activate-05",
         )
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/ActivatedAbilityPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/ActivatedAbilityPuzzles.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.ai.puzzles.advanceToPriority
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * The abilities already on the board, which no puzzle has ever asked the AI to use.
+ *
+ * `PuzzleMove.playedCard` has spoken `ActivateAbility` since Phase 2 and not one of the 48
+ * positions asserted on it — so pingers, tappers, firebreathing and removal-on-a-stick are
+ * unmeasured, and so is the *targeting* path they reach: `heuristicTargetRank` is exercised today
+ * only through `CastSpell`.
+ *
+ * Every card here is a plain-text classic, deliberately: `Prodigal Sorcerer` ({T}: 1 damage to any
+ * target), `Icy Manipulator` ({1},{T}: tap an artifact, creature or land), `Royal Assassin` ({T}:
+ * destroy target tapped creature), `Shivan Dragon` ({R}: +1/+0). If the AI cannot use these it
+ * cannot use anything.
+ */
+object ActivatedAbilityPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "activate-01",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Ping the 1/1 the damage actually kills, not the 3/3 it bounces off",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withCardOnBattlefield(2, "Llanowar Elves")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            check = {
+                shouldActivate("Prodigal Sorcerer")
+                shouldTarget("Llanowar Elves")
+            },
+        ),
+
+        AiPuzzle(
+            id = "activate-02",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Ping the opponent's face for the win at 1 life",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withLifeTotal(2, 1)
+                    .build()
+            },
+            // Lethal *through an ability*: `LethalDetectionPuzzles` is attacks and burn spells
+            // only. Also the most direct probe of Phase 3's open finding that `heuristicTargetRank`
+            // ranks an opponent player at -5.0, the same as our own face, because
+            // `ProjectedState.getController` returns null for a player.
+            check = {
+                shouldActivate("Prodigal Sorcerer")
+                shouldTargetOpponentFace()
+            },
+        ),
+
+        AiPuzzle(
+            id = "activate-03",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Tap the Wall with Icy Manipulator so the Wurm can get through",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Icy Manipulator")
+                    .withCardOnBattlefield(2, "Wall of Stone")
+                    .build()
+            },
+            // Spend a resource now to unlock combat later — the one-ply blind spot in miniature.
+            // Tapping the Wall changes nothing the evaluator scores except a 0.9x on one
+            // permanent; the payoff is six damage two steps from here.
+            check = {
+                shouldActivate("Icy Manipulator")
+                shouldTarget("Wall of Stone")
+            },
+        ),
+
+        AiPuzzle(
+            id = "activate-04",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Do not point one damage at a 3/3 — going face or holding both beat it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            // The negative control for activate-01: the same ability, the same board minus the
+            // creature it can kill. Toughness has to be read, not just power.
+            check = { shouldNotTarget("Hill Giant") },
+        ),
+
+        AiPuzzle(
+            id = "activate-05",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Firebreathe the unblocked Dragon toward exactly lethal",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Shivan Dragon")
+                    .withLifeTotal(2, 7)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Shivan Dragon" to 2)) }
+                    .advanceToPriority(1, Step.DECLARE_BLOCKERS)
+            },
+            // Converting floating mana into damage, which nothing else in the suite asks for. A
+            // single-action check can only see the *first* pump; the honest form of this position
+            // is a line puzzle, and it is why Phase 2b wants one.
+            check = { shouldActivate("Shivan Dragon") },
+        ),
+
+        AiPuzzle(
+            id = "activate-06",
+            category = PuzzleCategory.ACTIVATED_ABILITIES,
+            expectation = "Assassinate the attacker rather than chump-block it with the 1/1",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(1, "Royal Assassin")
+                    .build()
+                    .advanceToDeclaration(2, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Craw Wurm" to 1)) }
+                    // Priority in declare-attackers, before blocks: the window where killing the
+                    // attacker is free. Waiting for the blocker declaration throws the Assassin
+                    // under the Wurm instead.
+                    .advanceToPriority(1, Step.DECLARE_ATTACKERS)
+            },
+            check = {
+                shouldActivate("Royal Assassin")
+                shouldTarget("Craw Wurm")
+            },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/CombatKeywordPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/CombatKeywordPuzzles.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToDeclaration
+import com.wingedsheep.sdk.core.Step
+
+/**
+ * Combat past the four keywords [BlockingPuzzles] covers.
+ *
+ * `creatureValue` has a table of twenty-odd keyword bonuses (`BoardFeatures.kt:203-238`) and the
+ * suite exercises four of them. Trample, menace, reach and indestructible each change what a block
+ * or a removal spell is *worth* rather than what it costs, which is the kind of thing a stat-summing
+ * evaluator gets confidently wrong.
+ *
+ * Every position is built so the naive reading picks the wrong side — including the two that pair
+ * off deliberately: `keywords-01` and `-02` are the same 4/4 trampler, and a blanket rule about
+ * either one fails the other.
+ */
+object CombatKeywordPuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "keywords-01",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Do not chump a trampler: the 1/1 buys one point of life and dies",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Fangren Hunter")
+                    .withCardOnBattlefield(2, "Llanowar Elves")
+                    .withLifeTotal(2, 12)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Fangren Hunter" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            // Blocking: the Elves die and three still trample over, 12 -> 9. Not blocking: 12 -> 8.
+            // A whole creature for one point of life.
+            check = { shouldNotBlock() },
+        ),
+
+        AiPuzzle(
+            id = "keywords-02",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Block the trampler with the 0/8 — eight toughness eats all four",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Fangren Hunter")
+                    .withCardOnBattlefield(2, "Wall of Stone")
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Fangren Hunter" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            // The mirror of keywords-01. Trample only spills past *toughness*, so nothing gets
+            // through and the Wall survives — a rule of "don't block tramplers" fails here.
+            check = { shouldBlock("Wall of Stone", "Fangren Hunter") },
+        ),
+
+        AiPuzzle(
+            id = "keywords-03",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Gang-block the menace attacker at 2 life — one blocker is not allowed",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Goblin Trailblazer")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLifeTotal(2, 2)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Goblin Trailblazer" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            // Two power against two life. Menace makes the single block illegal, so the choice is
+            // the double block or death — and both Bears survive it.
+            check = { shouldBlockWithAtLeast(2, "Goblin Trailblazer") },
+        ),
+
+        AiPuzzle(
+            id = "keywords-04",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Reach blocks the flier: the Spider eats the Drake and lives",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardOnBattlefield(1, "Trained Armodon")
+                    .withCardOnBattlefield(2, "Giant Spider")
+                    .withLifeTotal(2, 8)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Wind Drake" to 2, "Trained Armodon" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            // Life is set high enough that survival is not the question — the only question is
+            // whether the AI knows a 2/4 reach creature may block a flier at all. On the Drake it
+            // kills a 2/2 for free; on the Armodon nothing dies either way.
+            check = { shouldBlock("Giant Spider", "Wind Drake") },
+        ),
+
+        AiPuzzle(
+            id = "keywords-05",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Do not block a deathtouch 2/1 with a Serra Angel at 18 life",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Ambush Viper")
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withLifeTotal(2, 18)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Ambush Viper" to 2)) }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            // `blocking-04` asks the AI to *use* deathtouch. This asks it to respect the other
+            // side's: the block trades a 4/4 flier for a 2/1 to save two life.
+            check = { shouldNotBlock() },
+        ),
+
+        AiPuzzle(
+            id = "keywords-06",
+            category = PuzzleCategory.COMBAT_KEYWORDS,
+            expectation = "Murder the Wurm — destroy does nothing to an indestructible creature",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInHand(1, "Murder")
+                    .withCardOnBattlefield(2, "Zetalpa, Primal Dawn")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .build()
+            },
+            // Legal but useless, which is the failure mode `removal-03` (Pacifism) probes from the
+            // other direction. `creatureValue` pays +3.0 for indestructible on top of flying,
+            // double strike, vigilance and trample, so its own keyword table aims the spell at the
+            // one creature the spell cannot kill.
+            check = {
+                shouldCast("Murder")
+                shouldTarget("Craw Wurm")
+                shouldNotTarget("Zetalpa, Primal Dawn")
+            },
+        ),
+    )
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/StackResponsePuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/StackResponsePuzzles.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.ai.puzzles.categories
+
+import com.wingedsheep.ai.puzzles.AiPuzzle
+import com.wingedsheep.ai.puzzles.PuzzleCategory
+import com.wingedsheep.ai.puzzles.advanceToStackResponse
+
+/**
+ * Something is on the stack and the AI holds priority. Does it ever answer?
+ *
+ * Phase 2's 48 positions never put anything on the stack, so the AI was never once asked to
+ * respond — and Phase 4b shipped its budget tiers without the "real counterspell window" CRITICAL
+ * trigger precisely because there was no signal that could have told us whether adding it helped.
+ * This category is that signal.
+ *
+ * Half positive, half negative, for the same reason [HoldingInstantsPuzzles] is: a category made
+ * only of "counter it" scores 100% for an agent that counters everything it sees.
+ */
+object StackResponsePuzzles {
+
+    fun all(): List<AiPuzzle> = listOf(
+
+        AiPuzzle(
+            id = "respond-01",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Counter the Serra Angel",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Plains", 5)
+                    .withCardInHand(2, "Serra Angel")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Counterspell")
+                    .build()
+                    .also { it.castSpell(2, "Serra Angel") }
+                    .advanceToStackResponse(1)
+            },
+            check = {
+                shouldCast("Counterspell")
+                shouldTarget("Serra Angel")
+            },
+        ),
+
+        AiPuzzle(
+            id = "respond-02",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Do not spend the only Counterspell on a 2/2 with seven lands still open",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Forest", 7)
+                    .withCardInHand(2, "Grizzly Bears")
+                    // A grip that plainly still holds something worth the counter.
+                    .withCardsInHand(2, "Craw Wurm", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Counterspell")
+                    .build()
+                    .also { it.castSpell(2, "Grizzly Bears") }
+                    .advanceToStackResponse(1)
+            },
+            check = { shouldNotCast("Counterspell") },
+        ),
+
+        AiPuzzle(
+            id = "respond-03",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Counter the Wrath that would take three creatures with it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withCardInHand(2, "Wrath of God")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Counterspell")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .build()
+                    .also { it.castSpell(2, "Wrath of God") }
+                    .advanceToStackResponse(1)
+            },
+            // The one counter whose value is measured in *board*, not cards — three creatures for
+            // one card is the position a card-advantage-weighted evaluator should find easiest.
+            check = { shouldCast("Counterspell") },
+        ),
+
+        AiPuzzle(
+            id = "respond-04",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Counter the Murder pointed at our Serra Angel",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withCardInHand(2, "Murder")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Counterspell")
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .build()
+                    .also { it.castSpell(2, "Murder", it.findPermanent("Serra Angel")) }
+                    .advanceToStackResponse(1)
+            },
+            // Requires reading what the spell on the stack is *aimed at*. Nothing in `:ai` does
+            // that today: the Murder itself is one card, and only its target says what it costs us.
+            check = {
+                shouldCast("Counterspell")
+                shouldTarget("Murder")
+            },
+        ),
+
+        AiPuzzle(
+            id = "respond-05",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Regenerate the Troll in response to the Wrath",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withCardInHand(2, "Wrath of God")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Troll Ascetic")
+                    .build()
+                    .also { it.castSpell(2, "Wrath of God") }
+                    .advanceToStackResponse(1)
+            },
+            // A regeneration shield is bought *before* the destruction, which is exactly the
+            // ordering a one-ply evaluator has no way to see: at the moment of the activation the
+            // board is unchanged and two mana are gone.
+            check = { shouldActivate("Troll Ascetic") },
+        ),
+
+        AiPuzzle(
+            id = "respond-06",
+            category = PuzzleCategory.STACK_RESPONSE,
+            expectation = "Negate the sorcery — Essence Scatter cannot touch it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withCardInHand(2, "Wrath of God")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Negate")
+                    .withCardInHand(1, "Essence Scatter")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .build()
+                    .also { it.castSpell(2, "Wrath of God") }
+                    .advanceToStackResponse(1)
+            },
+            // Both counters cost {1}{U} and only one is legal here. The enumerator does the
+            // legality half; the puzzle asks whether the AI then casts the survivor or passes.
+            check = { shouldCast("Negate") },
+        ),
+    )
+}

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -166,24 +166,37 @@ must not lose to any gauntlet member worse than 45%.
 ### 2. Tactical puzzle suite — the localizing signal
 
 Win rate says *that* you regressed; a puzzle says *what*. Runs in ~15 s, CI-gated.
-**48 puzzles, 8 categories × 6.** Built in Phase 2; scores are the measured 2026-07-27 baseline for
-`v0`/`production`, with the zero-weight `v0-blind` control in brackets.
+**66 puzzles, 11 categories × 6.** Categories 1–8 built in Phase 2, 9–11 in Phase 2b. The baseline
+column is the measured 2026-07-27 figure for `v0`/`production` (2026-07-29 for the Phase 2b
+categories), with the zero-weight `v0-blind` control in brackets; **"Today"** is `production` now,
+after Phase 6.
 
-| Category | Baseline | What it catches |
-|---|---|---|
-| Lethal detection | 6/6 [6/6] | Missing an alpha strike / burn-to-face kill |
-| Blocking | 6/6 [6/6] | Chump vs trade vs no-block; deathtouch / first strike |
-| Removal targeting | 6/6 [0/6] | Shooting the 1/1 instead of the bomb (`heuristicTargetRank`) |
-| Holding instants | 3/6 [2/6] | Casting a combat trick in your own main phase |
-| Sequencing | 5/6 [0/6] | Land before spell; the land that unlocks the spell |
-| Board-wipe timing | 6/6 [3/6] | Wrathing while ahead |
-| Race math | 5/6 [5/6] | Attack-vs-hold when both players are on a clock |
-| **Non-creature valuation** | **2/6** [0/6] | Ignoring an opposing O-Ring / mana rock / anthem |
+| Category | Baseline | Today | What it catches |
+|---|---|---|---|
+| Lethal detection | 6/6 [6/6] | 6/6 | Missing an alpha strike / burn-to-face kill |
+| Blocking | 6/6 [6/6] | 6/6 | Chump vs trade vs no-block; deathtouch / first strike |
+| Removal targeting | 6/6 [0/6] | 6/6 | Shooting the 1/1 instead of the bomb (`heuristicTargetRank`) |
+| Holding instants | 3/6 [2/6] | 5/6 | Casting a combat trick in your own main phase |
+| Sequencing | 5/6 [0/6] | 5/6 | Land before spell; the land that unlocks the spell |
+| Board-wipe timing | 6/6 [3/6] | 6/6 | Wrathing while ahead |
+| Race math | 5/6 [5/6] | 5/6 | Attack-vs-hold when both players are on a clock |
+| Non-creature valuation | 2/6 [0/6] | 5/6 | Ignoring an opposing O-Ring / mana rock / anthem |
+| Stack response | 5/6 [1/6] | 5/6 | Never answering a spell that is already on the stack |
+| Activated abilities | 5/6 [2/6] | 5/6 | Pingers, tappers and pump abilities left unused |
+| Combat keywords | 6/6 [5/6] | 6/6 | Trample / menace / reach / indestructible read as ordinary stats |
+| **total** | | **60/66** | `v0-blind`: 30/66 |
 
 Two readings the bracketed column forces. Lethal and blocking are carried entirely by
 `CombatAdvisor`'s seed heuristics — the blind agent matches the real one — so they are a regression
 net for *that* code, not for `BoardFeatures.kt`. And the plan's "expect ~0%" on non-creature
 valuation was close but for the wrong reason: see Phase 2's findings.
+
+**At 44/48 this signal was nearly exhausted, which is why Phase 2b exists.** Two of the four
+remaining failures were the same Phase 9 constant, so rollouts had exactly **two** puzzles to move —
+and Phase 7's own exit criterion, phrased over sequencing / race math / board-wipe timing, was
+capped at **one**. Phase 2b's first three categories took that to **four**: `respond-05` and
+`activate-05` both fail for `instants-05`'s reason — paying now for an effect that materializes a
+step later — and two of the four are non-combat, so `CombatAdvisor` cannot carry them.
 
 ### 3. Latency
 
@@ -382,6 +395,238 @@ Files: `ai/src/test/.../puzzles/{AiPuzzle,PuzzleRunner,PuzzleSuiteTest}.kt` + `c
 
 **Exit:** ✅ 48 puzzles committed, ✅ per-category baseline in `docs/ai/baseline-metrics.md`,
 ✅ `just arena-puzzles` runs in ~15 s.
+
+---
+
+### Phase 2b — Puzzle suite, second pass · *4–6 d* — 🟡 **3 of 6 categories shipped 2026-07-29**
+
+> **Shipped: `respond`, `activate`, `keywords` — the three that needed no framework change.**
+> 18 positions in `ai/src/test/.../puzzles/categories/{StackResponse,ActivatedAbility,CombatKeyword}Puzzles.kt`,
+> plus `advanceToStackResponse` in `PuzzlePositions.kt` and `PuzzleMove.shouldActivate`.
+>
+> **Suite 48 → 66. `production` scores 60/66 (91%)**, `v0-blind` 30/66 (45%) — the discrimination
+> control holds at the new size, which was the exit criterion that mattered. The AI solves **16 of
+> the 18** new positions.
+>
+> | Category | `production` | `v0-blind` |
+> |---|---|---|
+> | `respond` | 5/6 | 1/6 |
+> | `activate` | 5/6 | 2/6 |
+> | `keywords` | 6/6 | 5/6 |
+>
+> Three things the build changed about the plan:
+>
+> 1. **A latent harness bug was hiding behind the fact that no old puzzle had twin blockers.**
+>    `PuzzleMove.blockAssignments` was a `Map<String, List<String>>` keyed by **card name**, so two
+>    Grizzly Bears gang-blocking one attacker collapsed into a single entry and
+>    `shouldBlockWithAtLeast` counted **1**. `keywords-03` (menace) reported a failure the AI had
+>    not made — it finds the double block correctly. It is now a `List<Pair<…>>`. The engine's
+>    menace validation (`BlockPhaseManager.validateMenaceRequirements:504`) was never at fault, and
+>    `PuzzleRunner`'s legality gate had already proved as much by not rejecting the move — a report
+>    of an illegal block that the engine accepts is a harness bug, every time.
+> 2. **`keywords` discriminates barely at all — 6/6 against 5/6 blind — and that is the same
+>    finding Phase 2 recorded about `lethal` and `blocking`.** Combat is carried by
+>    `CombatAdvisor`'s seed heuristics, not by `BoardFeatures.kt`, so trample / menace / reach are
+>    a regression net for *that* code. Only `keywords-06` (Murder vs an indestructible creature)
+>    sits with the evaluator, and it passes — `chooseCommittedTargets`' simulation refinement does
+>    overrule `heuristicTargetRank`'s +3.0 indestructible bonus in time.
+> 3. **Both new failures are the same shape, and it is `instants-05`'s shape.** `respond-05`
+>    (regenerate through a Wrath) and `activate-05` (firebreathe an unblocked attacker) both pay
+>    mana *now* for an effect that only materializes at a later step, so the post-simulation state
+>    is strictly worse than passing. **That was the point of building these before Phase 7:** the
+>    rollout evaluator now has a four-puzzle signal on "cannot see past the current step" —
+>    `instants-05`, `race-03`, `respond-05`, `activate-05` — where it had two, and two of the four
+>    are non-combat, so `CombatAdvisor` cannot carry them.
+>
+> **Still to build:** `walker` (needs `ScenarioBuilder.withCountersOn` — a planeswalker placed by
+> `withCardOnBattlefield` enters at **0 loyalty** and dies to state-based actions immediately),
+> `lines` (needs `AiLinePuzzle`), `decisions` (needs `AiDecisionPuzzle`), `pod` (needs an N-seat
+> `withPlayers`). Everything below is the plan as written.
+
+**Do this before Phase 7, not after.** At 44/48 the suite has four points left, and *two* of them
+(`sequencing-02`, `noncreature-02`) are the same Phase 9 constant — `CardAdvantage.cardValue(0) =
+−3.0` — which no amount of rollout will move. So Phase 7's entire puzzle-side signal is
+**`instants-05` and `race-03`: two positions**. Its stated exit criterion, "puzzle gains in
+sequencing / race math / board-wipe timing", is arithmetically capped at **one** puzzle — those
+categories sit at 5/6, 5/6 and 6/6, and the one sequencing miss is the Phase 9 constant. A lever
+this expensive deserves more than a one-bit localizing signal.
+
+The suite also can't see whole regions of the AI. Five structural gaps, each of which the 48
+positions share by construction rather than by choice:
+
+| # | Gap | Consequence |
+|---|---|---|
+| **G1** | Every puzzle probes `chooseAction` at a **clean priority window** | All 18 `PendingDecision` branches in `DecisionResponder.kt` (33 KB) are **completely unmeasured** — discard, tutor, damage assignment, modal choice, distribute, block ordering, mana-source selection |
+| **G2** | Every puzzle scores **one action** | A *line* is inexpressible. "Kill the blocker, then attack" is two actions. This is the shape that would actually measure a rollout evaluator, because seeing past the current action is its whole claim |
+| **G3** | Every puzzle is **1v1** | Phase 3's headline bug was "the AI systematically attacked the wrong player" in a pod, and pod win-share is the only thing that can see it — a signal that says *that*, never *what*. `withPlayers()` is hardcoded to two seats |
+| **G4** | Nothing is ever **on the stack** | The AI is never asked to respond. Phase 4b deliberately shipped without the "real counterspell window" CRITICAL trigger; there is no puzzle that would tell us whether adding it helped |
+| **G5** | No puzzle asserts on an **`ActivateAbility`** | `PuzzleMove.playedCard` already handles it (`AiPuzzle.kt:86`) and zero puzzles use it. Pingers, tappers, firebreathing, regeneration, loyalty abilities — all unmeasured |
+
+Content-wise the 48 are also narrow: five permanents at most, no counters, no damage marked, one
+aura, and combat keywords stop at flying / deathtouch / first strike / vigilance.
+
+**36 new positions across six categories**, taking the suite to **84**. Three land against today's
+framework; three need the extensions in "Framework work" below and are the reason this is 4–6 days
+rather than 2.
+
+#### 9. `STACK_RESPONSE` — "respond" · *no framework change*
+
+The opponent has cast something and the AI holds priority. Closes G4.
+
+| id | Position | Expect | What it catches |
+|---|---|---|---|
+| `respond-01` | P2 casts **Serra Angel**; AI has 2 Islands + **Counterspell** | Counter it | Does the AI respond at all |
+| `respond-02` | P2 (7 lands, full grip) casts **Grizzly Bears**; AI has 2 Islands + **Counterspell** | Pass | Negative control — a category of "counter it" scores 100% for an agent that counters everything |
+| `respond-03` | AI has three creatures; P2 casts **Wrath of God** | Counter it | The counter's value is *board*, not cards — the position where countering is most clearly right |
+| `respond-04` | AI controls **Serra Angel**; P2 casts **Murder** targeting it | Counter it | Reading the **target of a spell on the stack**. Nothing in `:ai` does this today |
+| `respond-05` | AI controls **Troll Ascetic** + 2 Forests; P2 casts **Wrath of God** | Activate `{1}{G}` regenerate | Regeneration as a *response*; also G5 |
+| `respond-06` | P2 casts **Wrath of God**; AI holds **Negate** *and* **Essence Scatter**, 2 lands | Cast Negate | Picks the counter that is legal here rather than passing |
+
+*Position helper:* `advanceToStackResponse(seat)` in `PuzzlePositions.kt` — `withActivePlayer(2)`,
+`castSpell(2, …)`, then pass until the AI seat holds priority with a non-empty stack. Both halves
+exist (`ScenarioTestBase.castSpell:525`, `passPriority:892`); this is ~15 lines alongside
+`advanceToDeclaration` / `advanceToPriority`.
+
+*Prediction:* `respond-01/03/04` plausible, `respond-02` likely passes for the wrong reason (the AI
+rarely casts anything at instant speed on an opponent's turn), `respond-05` fails — nothing models a
+regeneration shield.
+
+#### 10. `ACTIVATED_ABILITIES` — "activate" · *no framework change*
+
+Closes G5. Every card here is already implemented and verified: `Prodigal Sorcerer` (`{T}`: 1 damage
+to any target), `Icy Manipulator` (`{1},{T}`: tap target artifact/creature/land), `Royal Assassin`
+(`{T}`: destroy target tapped creature), `Shivan Dragon` (`{R}`: +1/+0).
+
+| id | Position | Expect | What it catches |
+|---|---|---|---|
+| `activate-01` | AI: **Prodigal Sorcerer**. P2: **Llanowar Elves** + **Hill Giant** | Ping the Elves | Ability targeting through `heuristicTargetRank` — a path only `CastSpell` reaches today |
+| `activate-02` | P2 at **1 life**, empty boards, AI has **Prodigal Sorcerer** | Ping their face | Lethal **through an ability**. The lethal category is attacks and burn spells only. Direct probe of the Phase 3 finding that a player target always ranks −5.0 |
+| `activate-03` | AI: **Craw Wurm** + **Icy Manipulator** + 1 untapped land. P2: **Wall of Stone** (0/8) | Tap the Wall | Spend a resource *now* to unlock combat *later* — the one-ply blind spot in miniature |
+| `activate-04` | AI: **Prodigal Sorcerer**. P2: **Hill Giant** only, both at 20 | Don't point it at the Giant | Negative control on toughness: 1 damage to a 3/3 does nothing |
+| `activate-05` | **Shivan Dragon** unblocked, P2 at 7, two Mountains untapped | Activate firebreathing | Converting floating mana into damage. *Note:* only the first pump is visible to a single-action check — the honest version of this is `line-05` |
+| `activate-06` | P2 attacked with **Craw Wurm** (now tapped) and kept **Hill Giant** home; AI has **Royal Assassin** | Assassinate the Wurm | The ability is only live against a *tapped* creature, and the window is mid-combat |
+
+#### 11. `COMBAT_KEYWORDS` — "keywords" · *no framework change*
+
+Combat past the four keywords the blocking category covers. Each position is built so the naive
+reading picks the wrong side.
+
+| id | Position | Expect | What it catches |
+|---|---|---|---|
+| `keywords-01` | **Fangren Hunter** (4/4 trample) attacks; AI at 12 with **Llanowar Elves** | No block | Chumping a trampler buys one point of life for a whole creature |
+| `keywords-02` | Same attacker; AI has **Wall of Stone** (0/8 defender) | Block | The mirror: 8 toughness eats all 4, *nothing* tramples over. A blanket "don't block tramplers" rule fails this |
+| `keywords-03` | **Goblin Trailblazer** (2/1 menace) attacks; AI at **2 life** with two **Grizzly Bears** | Gang-block with both | Menace makes a single block *illegal* — either find the double block or die |
+| `keywords-04` | **Wind Drake** + **Trained Armodon** attack; AI at 8 with **Giant Spider** (2/4 reach) | Block the Drake | Reach can block a flier at all, and the Drake is the one the Spider eats for free |
+| `keywords-05` | **Ambush Viper** (2/1 deathtouch) attacks; AI at 18 with **Serra Angel** | No block | Deathtouch means blocking trades a bomb for a 2/1 |
+| `keywords-06` | AI holds **Murder**, 3 Swamps. P2: **Zetalpa, Primal Dawn** (indestructible) + **Craw Wurm** | Kill the Wurm | *Legal but useless.* `creatureValue` pays **+3.0 for indestructible** plus flying/double-strike/trample/vigilance, so Zetalpa is by far the highest-ranked target — the evaluator's own keyword table aims the spell at the creature it cannot kill |
+
+*Prediction:* `keywords-06` is the interesting one. `heuristicTargetRank` will point at Zetalpa; the
+question the puzzle answers is whether `chooseCommittedTargets`' simulation refinement is consulted
+in time to overrule it.
+
+#### 12. `PLANESWALKERS` — "walker" · *needs `withCountersOn`*
+
+`permanentValue` prices a walker at `max(4.0, prior + loyalty × 0.8)` (`BoardFeatures.kt:143-146`) —
+Phase 6 built it and **nothing measures it**. 25 planeswalkers are implemented; these use
+`Ajani, Caller of the Pride` (loyalty 4), `Vivien Reid` (5) and `Karn, Scion of Urza` (5).
+
+| id | Position | Expect | What it catches |
+|---|---|---|---|
+| `walker-01` | P2 at 20 with **Ajani** at 4 loyalty, no blockers; AI has **Hill Giant** | Attack Ajani | Is a walker a target at all |
+| `walker-02` | P2 at **3** with **Karn** at 5, no blockers; AI has two **Hill Giants** | All at the face | Lethal beats value — the negative control |
+| `walker-03` | AI controls **Ajani**; P2 attacks it with **Grizzly Bears**; AI has **Hill Giant** untapped | Block | Our own walker is worth defending |
+| `walker-04` | AI controls **Vivien Reid**, precombat main, empty board | Activate a loyalty ability | Does the AI *ever* use a walker |
+| `walker-05` | AI controls **Vivien Reid**; P2 controls **Air Elemental** | Activate the **−3** (destroy target creature with flying), not the +1 | Ability selection *inside* a walker — the closest thing to modal reasoning the action layer has |
+| `walker-06` | P2 has **Karn** at 5 and **Grizzly Bears**; AI has **Serra Angel** (vigilance) | Attack Karn | Vigilance makes the attack free, so the only question left is the valuation |
+
+*Framework:* `withCardOnBattlefield` adds no `CountersComponent`, so a planeswalker placed directly
+enters at **0 loyalty and dies to state-based actions immediately**. Tests that need counters
+hand-roll them today (`MilesMoralesScenarioTest.kt:41`). Add
+`ScenarioBuilder.withCountersOn(name, type, count)` — useful well beyond this suite. `PuzzleMove`
+also needs `attackTargets: Map<String, String>` (attacker → defender name); `DeclareAttackers`
+already carries the defender and `attackerNames` throws it away (`AiPuzzle.kt:105`).
+
+#### 13. `LINES` — multi-action · *needs `AiLinePuzzle`* · **this is the Phase 7 signal**
+
+G2, and the reason to build all of this before Phase 7 rather than after. A line puzzle lets the AI
+act until the turn ends and asserts over the **resulting state**, not the first move.
+
+| id | Position | Assert |
+|---|---|---|
+| `line-01` | AI: **Craw Wurm**, 3 Swamps, **Murder**. P2 at 6 with **Wall of Stone** | P2 is dead. (Murder the Wall → attack for 6. A single-action check can only ask "did you cast Murder") |
+| `line-02` | `sequencing-05`'s board — **Glorious Anthem** + two Bears, P2 at 6 | P2 is dead |
+| `line-03` | `activate-03`'s board, P2 at 6 | P2 is dead — Icy the Wall, then swing |
+| `line-04` | `sequencing-01`'s board — 3 Mountains, a Mountain and a **Hill Giant** in hand | The Giant is on the battlefield *and* the land was played |
+| `line-05` | `activate-05`'s board — **Shivan Dragon**, P2 at 7, two Mountains | P2 is dead — both pumps, not one |
+| `line-06` | AI: **Grizzly Bears**, 1 Forest, **Giant Growth**. P2: **Hill Giant** | Attacked *and* the Growth was spent on the block, not precombat |
+
+`AiLinePuzzle` is a loop: `while (state.priorityPlayerId == aiId && !turnEnded) { process(ai.chooseAction(state)) }`
+with the same 200-iteration guard `advanceUntil` already uses, then a predicate over the final
+`GameState`. ~40 lines in `PuzzleRunner.kt`. **Every line here is currently unreachable by the
+suite, and every one of them is exactly what a rollout evaluator claims to find.**
+
+#### 14. `DECISIONS` — · *needs `AiDecisionPuzzle`* · **the largest unmeasured surface**
+
+G1. Build the position, drive it to a `pendingDecision`, call the AI's `DecisionResponder`, assert
+over the `DecisionResponse`. `PuzzleRunner` currently *rejects* any position with a pending decision
+(`PuzzleRunner.kt:50`) — correctly, for action puzzles; this is the sibling runner.
+
+| id | Decision | Position | Expect |
+|---|---|---|---|
+| `decision-01` | `SelectCardsDecision` | P2 resolves **Mind Rot**; AI hand is **Murder**, **Craw Wurm**, one land, with 2 lands in play | Pitch the uncastable Wurm, keep the removal |
+| `decision-02` | `SearchLibraryDecision` | **Diabolic Tutor** resolving; library has **Wrath of God** and **Serra Angel**; P2 has three creatures | Fetch the Wrath |
+| `decision-03` | `SearchLibraryDecision` | Same, but *we* have the board and P2 is empty | Fetch the Angel — the mirror |
+| `decision-04` | `AssignDamageDecision` | **Fangren Hunter** (4/4 trample) blocked by **Grizzly Bears** | 2 to the blocker, 2 through. `respondDamageAssignment` is *eight lines* that forward `decision.defaultAssignments` unexamined (`DecisionResponder.kt:475`) |
+| `decision-05` | `AssignDamageDecision` | 4/4 double-blocked by a 2/2 and a 3/3 | All 4 into the 3/3 — killing one beats splitting and killing neither |
+| `decision-06` | `SelectManaSourcesDecision` | AI holds **Counterspell**, casts a 2-drop, controls **Island** + 2 **Plains** | Pay with Plains. `respondManaSelection` unconditionally auto-pays whenever the solver has a suggestion (`DecisionResponder.kt:523`) |
+
+*Caveat on `decision-06`:* verify the prompt actually fires — the engine may auto-resolve the
+payment without ever asking. If it does, the defect is `ManaSolver`'s source choice rather than the
+AI's, the puzzle belongs to the engine suite instead, and **that is a finding worth recording**, not
+a reason to drop the position.
+
+#### 15. `POD` — multiplayer tactics · *needs N-seat `withPlayers`* · *optional, ship last*
+
+G3. The pod arena reports win share and nothing else; these localize it. Six positions at `ffa3`
+and `2hg`:
+
+- **`pod-01`** — two opponents, one tapped out and one with blockers: attack the one who can't block.
+- **`pod-02`** — the runaway leader is *across* the table, not next in turn order: removal points at
+  them. This is the exact shape of the pre-Phase-3 bug; it should pass now, which makes it a
+  regression net for `OpponentAggregate.THREAT`.
+- **`pod-03`** — 2HG: block an attacker that is attacking our **teammate** (CR 810 — teammates
+  defend as one side).
+- **`pod-04`** — 2HG: **don't Wrath away our teammate's board.** `BoardPresence` folds teammates into
+  `sides.mine`, so a sweeper killing three of theirs and three of ours must read as neutral.
+- **`pod-05`** — one opponent at 4 and one at 20: swing at the one we can kill.
+- **`pod-06`** — don't spend removal on the player who is already dead to someone else's board.
+
+*Framework:* `withPlayers` builds exactly two seats (`ScenarioTestBase.kt:98`). An N-seat overload
+plus a team assignment is the prerequisite; treat it as the expensive item and ship this category
+after the other five if it is.
+
+#### Framework work, itemized
+
+| Item | Where | Size | Unlocks |
+|---|---|---|---|
+| `advanceToStackResponse(seat)` | `puzzles/PuzzlePositions.kt` | ~15 L | category 9 |
+| `PuzzleMove.attackTargets` | `puzzles/AiPuzzle.kt:105` | ~5 L | `walker-01/02/06` |
+| `ScenarioBuilder.withCountersOn` | `ScenarioTestBase.kt` | ~15 L | category 12; generally useful |
+| `AiLinePuzzle` + runner | `puzzles/PuzzleRunner.kt` | ~40 L | category 13 |
+| `AiDecisionPuzzle` + runner | `puzzles/PuzzleRunner.kt` | ~50 L | category 14 |
+| N-seat `withPlayers` | `ScenarioTestBase.kt:98` | ~60 L | category 15 |
+
+`PuzzleSuiteTest`'s shape invariants change with this: `byCategory(…).size shouldBe 6` becomes
+`shouldBeGreaterThanOrEqual(6)` and `all.size shouldBe 48` is re-pinned. Keep the **`KNOWN_FAILURES`
+set-equality gate exactly as it is** — it is the reason the suite stays green without hiding
+anything, and 36 new positions will arrive with a large known-failure set that is the *point*, not a
+problem.
+
+**Exit:** 84 puzzles committed; a per-category baseline for the six new categories appended to
+`docs/ai/baseline-metrics.md`; `just arena-puzzles` still under ~60 s (the line and decision runners
+each play out more than one action, so this is not free); `v0-blind` still scores strictly lower on
+the expanded suite — the discrimination control has to hold at the new size or the new positions are
+coin flips.
 
 ---
 
@@ -1102,7 +1347,7 @@ but tanks a puzzle category, look hard before shipping.
 ## Recommended order
 
 ```
-0̶ → 1̶ → 2̶ → 3̶ → 4̶ → 5̶ → 6̶ → 7 → 8 → 9 → 10
+0̶ → 1̶ → 2̶ → 3̶ → 4̶ → 5̶ → 6̶ → 2b → 7 → 8 → 9 → 10
 ```
 
 Phases 0–6 are done — all four scoreboards exist, the evaluator is no longer one-eyed at a pod
@@ -1119,6 +1364,12 @@ Oblivion Ring and a signet as the same number. Phase 6 also left it two pieces o
 gauntlet, which needs an arena that can separate `{intent-only, advisors-only, both}` before it can
 retire anything.
 
+**Phase 2b is inserted before it, by the same argument that put Phase 2 before everything.** Phase 6
+took the suite to 44/48, which leaves the plan's most expensive phase with a two-puzzle localizing
+signal and no coverage at all of the shapes a rollout is supposed to be good at — multi-action
+lines, mid-combat responses, decisions. Measuring Phase 7 with the suite as it stands means reading
+the arena alone, which is exactly the position Phase 1 was built to get us out of.
+
 Ranked by strength-per-effort, independent of ordering:
 
 | Rank | Phase | Effort | Why |
@@ -1127,6 +1378,7 @@ Ranked by strength-per-effort, independent of ordering:
 | — | **3̶** multiplayer eval | 1–2 d | **Done.** Was ranked 1: the evaluator scored a whole pod as a duel against one arbitrary neighbour, and read a stale life component in 2HG. |
 | 1 | **9** Texel tuning | 4–6 d | Replaces ~25 guessed constants with fitted ones — and Phase 6 raised the stakes: two of the four remaining puzzle failures are *one* constant, `CardAdvantage.cardValue(0) = −3.0`. Cheap once the arena exists. |
 | 2 | **7** rollout evaluator | 6–9 d | Highest *ceiling*; the real lever. Costly, and worthless without the rest. |
+| 3 | **2b** puzzle suite, second pass | 4–6 d | No direct strength — but at 44/48 the suite can move **two** puzzles for Phase 7, and its five structural gaps (decisions, lines, pods, the stack, activated abilities) hide the AI's least-measured code. Same argument as Phase 2, one phase later. |
 | 4 | **1̶ / 2̶** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Both done. |
 | — | **4̶a** auto-pass filter | 3–5 d | **Done.** Demoted by Phase 0 and rescoped to "skip the enumeration": 40% of priority windows now never call the enumerator. Also closed Phase 1's 889-of-945 illegal-action finding, which turned out to be a targeting bug. |
 | — | **4̶b** DecisionBudget | 2–3 d | **Done.** Enabling infrastructure, and it measures like it — neutral in the arena, monotone in the scaling ladder. |

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -834,3 +834,90 @@ A card the analyzer cannot interpret gets `CardIntent.UNKNOWN`, whose `staticPri
 historical flat `0.5`. And the prior is applied as a **floor**, never a ceiling: no permanent is
 ever valued lower than it was before Phase 6. Both choices point the same way — the failure mode is
 "no better than before", never "confidently wrong".
+
+---
+
+# Phase 2b — Puzzle suite, second pass
+
+Measured 2026-07-29. Three of the six planned categories shipped — the three that needed no
+framework change. `just arena-puzzles`.
+
+## Why the suite needed a second pass
+
+Phase 6 took it to 44/48, and **two of the four remaining failures were the same constant**
+(`CardAdvantage.cardValue(0) = −3.0`, which Phase 9 exists to refit). So the plan's most expensive
+phase, the rollout evaluator, had a **two-puzzle** localizing signal — and its written exit
+criterion, phrased over sequencing / race math / board-wipe timing, could move exactly **one**,
+because those categories stood at 5/6, 5/6 and 6/6 and the one sequencing miss is the Phase 9
+constant.
+
+The 48 also shared five properties by construction rather than by choice: every position probed
+`chooseAction` at a clean priority window (so all 18 `PendingDecision` branches in
+`DecisionResponder.kt` were unmeasured), scored **one** action (so a *line* was inexpressible), was
+1v1, never had anything on the stack, and never asserted on an `ActivateAbility` — even though
+`PuzzleMove` had spoken one since Phase 2.
+
+## Per-category baseline — 48 → 66 puzzles
+
+`AiProfile.PRODUCTION`, with the zero-weight `v0-blind` control.
+
+| Category | `production` | `v0-blind` |
+|---|---|---|
+| lethal | 6/6 | 6/6 |
+| blocking | 6/6 | 6/6 |
+| removal | 6/6 | 0/6 |
+| instants | 5/6 | 2/6 |
+| sequencing | 5/6 | 0/6 |
+| wipe | 6/6 | 3/6 |
+| race | 5/6 | 5/6 |
+| noncreature | 5/6 | 0/6 |
+| **respond** *(new)* | **5/6** | **1/6** |
+| **activate** *(new)* | **5/6** | **2/6** |
+| **keywords** *(new)* | **6/6** | **5/6** |
+| **total** | **60/66 (91%)** | **30/66 (45%)** |
+
+The AI solves **16 of the 18** new positions. The discrimination control holds at the new size,
+which was the criterion that mattered: a set of 18 positions that a blind agent solves as often as
+the real one would be 18 coin flips.
+
+## What Phase 2b found
+
+**1. A latent harness bug, hiding behind the fact that no earlier puzzle had twin blockers.**
+`PuzzleMove.blockAssignments` was a `Map<String, List<String>>` keyed by **card name**, so two
+Grizzly Bears gang-blocking one attacker collapsed into a single map entry and
+`shouldBlockWithAtLeast` counted 1. `keywords-03` (menace) therefore reported a failure the AI had
+not made — it finds the double block correctly. It is a `List<Pair<…>>` now.
+
+The engine was never at fault, and `PuzzleRunner` had already said so: it processes every chosen
+move and fails the puzzle when the engine rejects it, and it did not reject this one.
+`BlockPhaseManager.validateMenaceRequirements:504` is correct. **A puzzle reporting an illegal move
+that the engine accepts is a harness bug, every time** — the legality gate is the tell.
+
+**2. `keywords` barely discriminates — 6/6 against 5/6 blind — which is Phase 2's finding again.**
+Combat is carried by `CombatAdvisor`'s seed heuristics, not by `BoardFeatures.kt`, exactly as
+`lethal` and `blocking` already showed. Trample, menace and reach are a regression net for *that*
+code and a `BoardFeatures` change will not move them. The one position in the category that the
+evaluator owns is `keywords-06` — Murder with an indestructible creature and a Craw Wurm to choose
+between — and it passes: `chooseCommittedTargets`' simulation refinement does overrule
+`heuristicTargetRank`'s +3.0 indestructible bonus in time. That was a predicted failure and the
+prediction was wrong, which is worth more than the pass.
+
+**3. Both new failures are `instants-05`'s shape, and that is the deliverable.**
+
+| Puzzle | Why it fails |
+|---|---|
+| `respond-05` | A regeneration shield is bought *before* the destruction it answers. At the moment of the activation the board is unchanged and two mana are gone |
+| `activate-05` | Firebreathing an unblocked attacker pays now for damage that lands at the combat-damage step. `evaluate1Ply` simulates to the next quiet state, which is still inside declare-blockers |
+
+Both are "pay now for an effect that materializes a step later", which is precisely what
+`instants-05` (Fog at 2 life) has failed on since Phase 2. **Phase 7's signal is now four puzzles
+rather than two** — `instants-05`, `race-03`, `respond-05`, `activate-05` — and two of the four are
+non-combat, so `CombatAdvisor` cannot carry them the way it carries `lethal` and `blocking`.
+
+## Not built
+
+`walker`, `lines`, `decisions` and `pod` need framework work first, itemized in
+`backlog/engine-ai-improvement.md` § Phase 2b. One concrete finding from scoping them:
+`withCardOnBattlefield` attaches no `CountersComponent`, so a **planeswalker placed directly on the
+battlefield enters at 0 loyalty and dies to state-based actions immediately** — the walker category
+cannot be written until `ScenarioBuilder` can seed counters.

--- a/docs/ai/measurement.md
+++ b/docs/ai/measurement.md
@@ -249,17 +249,17 @@ The arena tells you *that* something regressed. A puzzle tells you *what*.
 
 ```bash
 just arena-puzzles              # the gate — always-on, seconds
-just arena-puzzles-compare      # the same 48 across v0 / production / v0-blind
+just arena-puzzles-compare      # the same 66 across v0 / production / v0-blind
 ```
 
-48 hand-authored positions in `ai/src/test/kotlin/com/wingedsheep/ai/puzzles/`, 8 categories × 6.
+66 hand-authored positions in `ai/src/test/kotlin/com/wingedsheep/ai/puzzles/`, 11 categories × 6.
 Each builds a board with `ScenarioTestBase`, asks the AI for **one** move, and asserts a predicate
-over it. Current per-category numbers: [`baseline-metrics.md`](baseline-metrics.md#phase-2--puzzle-baselines).
+over it. Current per-category numbers: [`baseline-metrics.md`](baseline-metrics.md#phase-2b--puzzle-suite-second-pass).
 
-### The gate is `KNOWN_FAILURES`, not 48/48
+### The gate is `KNOWN_FAILURES`, not 66/66
 
-`PuzzleSuiteTest` asserts the failing-id set **equals** a committed set. Today's AI solves 39 of 48,
-and a suite pinned to 48/48 would be red forever and therefore ignored.
+`PuzzleSuiteTest` asserts the failing-id set **equals** a committed set. Today's AI solves 60 of 66,
+and a suite pinned to 66/66 would be red forever and therefore ignored.
 
 Equality — not "is a subset of" — is the point. It flags a regression *and* an unexpected fix:
 
@@ -290,7 +290,16 @@ Three things the runner enforces so a mis-built position cannot score as a pass:
 `advanceToDeclaration(seat, step)` stops where a seat is asked to declare attackers or blockers;
 `advanceToPriority(seat, step)` stops at the ordinary priority window *after* declarations, which
 is where a combat trick is cast. They differ by one window and using the wrong one is the easiest
-way to write a puzzle that measures the wrong decision.
+way to write a puzzle that measures the wrong decision. `advanceToStackResponse(seat)` stops with
+something still **on the stack** — cast the spell from the other seat first — and fails loudly if
+one pass too many resolved it, because a puzzle asking "do you counter this?" about an empty stack
+scores a decision that no longer exists.
+
+**If a puzzle reports an illegal-looking move that the engine accepted, suspect the harness first.**
+`PuzzleRunner` processes every chosen move and fails the puzzle when the engine rejects it, so a
+"the AI single-blocked a menace creature" report means `PuzzleMove` mis-read the action, not that
+the rules are wrong. That is exactly what happened to `keywords-03`: blocks were keyed by card
+name, and two creatures with the same name collapsed into one entry.
 
 ### Include positive controls
 

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ arena A B GAMES="300" SET="BLB" SEED="20260727":
 arena-puzzles:
     scripts/gradle-locked :ai:test --tests "*.PuzzleSuiteTest"
 
-# Same 48 puzzles across AI profiles (v0, production) with a side-by-side per-category table.
+# Same 66 puzzles across AI profiles (v0, production) with a side-by-side per-category table.
 [group: 'ai']
 arena-puzzles-compare:
     scripts/gradle-locked :ai:test --tests "*.PuzzleComparisonBenchmark" -Dbenchmark=true


### PR DESCRIPTION
## Why

At **44/48** the puzzle suite had run out of headroom. Two of the four remaining failures are the same Phase 9 constant (`CardAdvantage.cardValue(0) = −3.0`), so **Phase 7 — the rollout evaluator, the plan's most expensive phase — had a two-puzzle localizing signal**. Its written exit criterion, phrased over sequencing / race math / board-wipe timing, could move exactly *one*, because those categories stand at 5/6, 5/6 and 6/6 and the one sequencing miss is that same constant.

The 48 also shared five properties by construction rather than by choice: every position probed `chooseAction` at a clean priority window (so all 18 `PendingDecision` branches in `DecisionResponder.kt` are unmeasured), scored **one** action, was 1v1, never had anything on the stack, and never asserted on an `ActivateAbility` — even though `PuzzleMove` had spoken one since Phase 2.

## What

The three categories that need no framework change. **48 → 66 puzzles.**

| Category | What it catches | `production` | `v0-blind` |
|---|---|---|---|
| `respond` | Never answering a spell already on the stack | 5/6 | 1/6 |
| `activate` | Pingers, tappers and pump abilities left unused | 5/6 | 2/6 |
| `keywords` | Trample / menace / reach / indestructible read as ordinary stats | 6/6 | 5/6 |

**`production` 60/66 (91%) against `v0-blind`'s 30/66 (45%)** — the discrimination control holds at the new size, which was the criterion that mattered. The AI solves 16 of the 18 new positions.

Supporting bits: `advanceToStackResponse(seat)` in `PuzzlePositions.kt`, `PuzzleMove.shouldActivate`, and `PuzzleSuiteTest`'s shape invariant relaxed from "exactly 6" to "at least 6". The `KNOWN_FAILURES` set-equality gate is untouched — it is why the suite stays green without hiding anything.

## Three findings

**1. A latent harness bug, hiding behind the fact that no earlier puzzle had twin blockers.** `PuzzleMove.blockAssignments` was a `Map<String, List<String>>` keyed by **card name**, so two Grizzly Bears gang-blocking one attacker collapsed into a single entry and `shouldBlockWithAtLeast` counted 1. `keywords-03` reported a failure the AI had not made — it finds the double block correctly. Now a `List<Pair<…>>`.

The engine was never at fault, and `PuzzleRunner` had already said so: it processes every chosen move and fails the puzzle when the engine rejects it, and it did not reject this one. `BlockPhaseManager.validateMenaceRequirements:504` is correct. **A puzzle reporting an illegal move the engine accepts is a harness bug, every time** — that reasoning is now written into `measurement.md`.

**2. `keywords` barely discriminates — 6/6 against 5/6 blind — which is Phase 2's finding again.** Combat is carried by `CombatAdvisor`'s seed heuristics, not `BoardFeatures.kt`, exactly as `lethal` and `blocking` already showed. The one position the evaluator owns is `keywords-06` (Murder, choosing between an indestructible Zetalpa and a Craw Wurm), and it **passes** — I predicted it would fail on the `+3.0` indestructible bonus, but `chooseCommittedTargets`' simulation refinement overrules `heuristicTargetRank` in time. The wrong prediction is worth more than the pass.

**3. Both new failures are `instants-05`'s shape, and that is the deliverable.**

| Puzzle | Why it fails |
|---|---|
| `respond-05` | A regeneration shield is bought *before* the destruction it answers — at the moment of the activation the board is unchanged and two mana are gone |
| `activate-05` | Firebreathing an unblocked attacker pays now for damage that lands at the combat-damage step; `evaluate1Ply` stops at the next quiet state, still inside declare-blockers |

**Phase 7's signal goes from two puzzles to four** — `instants-05`, `race-03`, `respond-05`, `activate-05` — and two of the four are non-combat, so `CombatAdvisor` cannot carry them the way it carries `lethal` and `blocking`.

## Also planned, not built

`backlog/engine-ai-improvement.md` gains a full Phase 2b section covering the three remaining categories and their framework prerequisites, itemized with file paths and sizes: `walker` (`ScenarioBuilder.withCountersOn`), `lines` (`AiLinePuzzle`), `decisions` (`AiDecisionPuzzle`), `pod` (N-seat `withPlayers`).

One concrete finding from scoping them: **`withCardOnBattlefield` attaches no `CountersComponent`, so a planeswalker placed directly on the battlefield enters at 0 loyalty and dies to state-based actions immediately.** The walker category cannot be written until the builder can seed counters.

`lines` is the one worth doing next — it is ~40 lines of runner and it is the category that measures a rollout evaluator most directly, since a *line* is exactly what a single-action puzzle cannot express.

## Verification

- `just arena-puzzles` — green, 60/66, ~16 s
- `just test-ai` — green

Test-only Kotlin plus docs; no engine, SDK or card-SDK surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
