### PR TITLE
SPM Batch 1: Green Goblin cards + DiscardOrPay additional cost

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 150 / 190
+**Implemented:** 167 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -17,7 +17,7 @@
 - [x] Biorganic Carapace
 - [ ] Black Cat, Cunning Thief
 - [ ] Carnage, Crimson Chaos
-- [ ] Chameleon, Master of Disguise
+- [x] Chameleon, Master of Disguise
 - [x] Cheering Crowd
 - [x] City Pigeon
 - [x] Common Crook
@@ -32,14 +32,14 @@
 - [x] Doctor Octopus, Master Planner
 - [x] Eddie Brock // Venom, Lethal Protector
 - [x] Eerie Gravestone
-- [ ] Electro's Bolt
+- [x] Electro's Bolt
 - [ ] Electro, Assaulting Battery
 - [x] Ezekiel Sims, Spider-Totem
 - [x] Flash Thompson, Spider-Fan
 - [x] Flying Octobot
 - [x] Friendly Neighborhood
 - [x] Gallant Citizen
-- [ ] Green Goblin, Revenant
+- [x] Green Goblin, Revenant
 - [x] Grow Extra Arms
 - [x] Guy in the Chair
 - [x] Gwen Stacy // Ghost-Spider
@@ -90,27 +90,25 @@
 - [ ] Peter Parker // Amazing Spider-Man
 - [x] Peter Parker's Camera
 - [x] Pictures of Spider-Man
-- [ ] Prison Break
+- [x] Prison Break
 - [x] Professional Wrestler
 - [x] Prowler, Clawed Thief
-- [ ] Pumpkin Bombardment
+- [x] Pumpkin Bombardment
 - [x] Radioactive Spider
-- [ ] Raging Goblinoids
+- [x] Raging Goblinoids
 - [x] Rent Is Due
 - [x] Rhino's Rampage
 - [x] Rhino, Barreling Brute
 - [x] Risky Research
 - [x] Robotics Mastery
-- [x] Risky Research
-- [x] Robotics Mastery
-- [ ] Rocket-Powered Goblin Glider
+- [x] Rocket-Powered Goblin Glider
 - [x] Romantic Rendezvous
 - [x] SP//dr, Piloted by Peni
-- [ ] Sandman's Quicksand
+- [x] Sandman's Quicksand
 - [x] Sandman, Shifting Scoundrel
 - [x] Savage Mansion
-- [ ] Scarlet Spider, Ben Reilly
-- [ ] Scarlet Spider, Kaine
+- [x] Scarlet Spider, Ben Reilly
+- [x] Scarlet Spider, Kaine
 - [x] School Daze
 - [x] Scorpion's Sting
 - [x] Scorpion, Seething Striker
@@ -121,7 +119,7 @@
 - [x] Shock
 - [x] Shocker, Unshakable
 - [x] Shriek, Treblemaker
-- [ ] Silk, Web Weaver
+- [x] Silk, Web Weaver
 - [x] Silver Sable, Mercenary Leader
 - [x] Sinister Hideout
 - [x] Skyward Spider
@@ -133,23 +131,23 @@
 - [x] Spider-Girl, Legacy Hero
 - [x] Spider-Gwen, Free Spirit
 - [x] Spider-Ham, Peter Porker
-- [ ] Spider-Islanders
+- [x] Spider-Islanders
 - [ ] Spider-Man 2099
-- [ ] Spider-Man India
+- [x] Spider-Man India
 - [x] Spider-Man No More
 - [x] Spider-Man Noir
-- [ ] Spider-Man, Brooklyn Visionary
-- [ ] Spider-Man, Web-Slinger
+- [x] Spider-Man, Brooklyn Visionary
+- [x] Spider-Man, Web-Slinger
 - [x] Spider-Mobile
 - [ ] Spider-Punk
 - [x] Spider-Rex, Daring Dino
-- [ ] Spider-Sense
+- [x] Spider-Sense
 - [ ] Spider-Slayer, Hatred Honed
 - [x] Spider-Suit
-- [ ] Spider-UK
+- [x] Spider-UK
 - [ ] Spider-Verse
 - [x] Spider-Woman, Stunning Savior
-- [ ] Spiders-Man, Heroic Horde
+- [x] Spiders-Man, Heroic Horde
 - [x] Spinneret and Spiderling
 - [x] Starling, Aerial Ally
 - [x] Steel Wrecking Ball
@@ -162,7 +160,7 @@
 - [x] Superior Foes of Spider-Man
 - [x] Superior Spider-Man
 - [x] Supportive Parents
-- [ ] Swarm, Being of Bees
+- [x] Swarm, Being of Bees
 - [x] Symbiote Spider-Man
 - [x] Taxi Driver
 - [x] Terrific Team-Up
@@ -173,7 +171,7 @@
 - [x] The Spot, Living Portal
 - [x] Thwip!
 - [x] Tombstone, Career Criminal
-- [ ] Ultimate Green Goblin
+- [x] Ultimate Green Goblin
 - [x] University Campus
 - [x] Unstable Experiment
 - [x] Urban Retreat

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -225,22 +225,22 @@ to a permanent's presence. Fix (add-feature): a color-parameterized `RetainUnspe
 Blocked cards:
 - **Electro, Assaulting Battery** [76] — `{1}{R}{R}` Flying; "You don't lose unspent red mana as steps and phases end." Its other clauses (Flying; cast-instant/sorcery → add {R}; LTB pay-{X} deal X to a player) are all expressible today.
 
-## "Discard a card OR pay {2}" additional cost (DiscardOrPay)
+## "Discard a card OR pay {2}" additional cost (DiscardOrPay) — ✅ IMPLEMENTED
 
 > As an additional cost to cast this spell, **discard a card or pay {2}**.
 
-A choice between a non-mana cost (discard a card) and a **mana** payment as an additional cost.
-Not supported: `Costs.additional.Choice(...)` handles only non-mana options (`ChoiceCostResolver`
-drops any `CostAtom.Mana` branch → the pay-{2} path silently disappears), and the `*OrPay`
-family (`SacrificeOrPay`, `ExileFromGraveyardOrPay`, `BlightOrPay`, `BeholdOrPay`) has **no
-`DiscardOrPay`**. The `ModalEffect` per-mode-cost workaround (Bitter Triumph "discard or pay 3
-life") doesn't transfer because a mode's `CostAtom.Mana` additional cost is treated as a no-op
-by `CastSpellHandler` (the {2} would be free). Fix (add-feature): a `DiscardOrPay(count, filter,
-alternativeManaCost)` member of the `*OrPay` additional-cost family, wired into
-`CastSpellEnumerator` + `CastSpellHandler`.
+**Implemented** on branch `spm-goblins`. A choice between a non-mana cost (discard a card) and a **mana**
+payment as an additional cost. Added `AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)` +
+`Costs.additional.DiscardOrPay(...)`, mirroring the existing `*OrPay` family (`SacrificeOrPay` /
+`ExileFromGraveyardOrPay` / `BlightOrPay` / `BeholdOrPay`). Wired into `CastSpellEnumerator` (two cast
+paths — discard path with a `costType = "DiscardCard"` hand picker, and pay path folding in the alt mana),
+`CostHandler` (always payable — pay path), and `CastSpellHandler` (validation mana adjustment, payment
+validation, mana application, and the discard-payment application mirroring `CostAtom.Discard`, including
+`ZoneTransitionService.trackDiscard` so it feeds the turn's discard tracking / Mayhem). Path recovered at
+payment time from whether `AdditionalCostPayment.discardedCards` is non-empty.
 
-Blocked cards:
-- **Pumpkin Bombardment** [139] — `{B/R}` Sorcery; "As an additional cost to cast this spell, discard a card or pay {2}. Deals 3 damage to target creature." (the damage half is trivial; the discard-or-pay additional cost is the blocker)
+Implemented cards (1): **Pumpkin Bombardment** [139] — `{B/R}` Sorcery; "discard a card or pay {2}. Deals 3
+damage to target creature."
 
 ## "Play a land from anywhere other than your hand" trigger
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -410,11 +410,24 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   is recovered at payment time from whether the cast action's `additionalCostPayment.sacrificedPermanents`
   is non-empty; the sacrifice path is only offered when you control at least `count` matching
      permanents, so with nothing to sacrifice only the pay path is castable.
+- `Costs.additional.DiscardOrPay(alternativeManaCost, filter = Filters.Any, count = 1)` — "as an
+  additional cost to cast this spell, discard a [filter] or pay {mana}" (Pumpkin Bombardment:
+  "discard a card or pay {2}"). The sibling of `SacrificeOrPay` / `ExileFromGraveyardOrPay` /
+  `BlightOrPay` / `BeholdOrPay` for the "discard a card or pay mana" shape. The enumerator offers up
+  to two cast paths: the **discard path** (base cost + a hand selection of exactly `count` cards
+  matching `filter`, excluding the spell being cast, surfaced as a `costType = "DiscardCard"` cost —
+  the same hand picker used by a plain discard cost like Force of Will) and the **pay path** (base
+  cost + `alternativeManaCost` folded in). The chosen path is recovered at payment time from whether
+  the cast action's `additionalCostPayment.discardedCards` is non-empty; the discard path is only
+  offered when you hold at least `count` other matching cards, so with an empty hand only the pay
+  path is castable. The discard-as-cost still feeds the turn's discard tracking (CR 701.8), so it
+  counts toward `DynamicAmounts.cardsDiscardedThisTurn()` / `Conditions.YouDiscardedThisCardThisTurn`
+  (Mayhem).
 - `Costs.additional.Choice(vararg options)` — **cost-vs-cost**: "as an additional cost to cast this
   spell, pay exactly one of `options`" (Souls of the Lost: *"discard a card **or** sacrifice a
   permanent"*). The general, parameterized form of `Forage` — each option is itself an
   `AdditionalCost` (compose the `Sacrifice` / `Discard` / `ExileFrom` atoms). Distinct from the
-  `*OrPay` family (`SacrificeOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
+  `*OrPay` family (`SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
   fold a **mana** alternative into the spell's cost, whereas `Choice` is for options that are each
   independently payable **non-mana** costs (no mana-cost change). The enumerator emits **one cast
   action per payable option** (`CastSpellEnumerator.expandChoiceAdditionalCosts` +

--- a/manual-scenarios/sets/spm/goblins-batch.json
+++ b/manual-scenarios/sets/spm/goblins-batch.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Gallant Citizen"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Ultimate Green Goblin",
+      "Green Goblin, Revenant",
+      "Pumpkin Bombardment",
+      "City Pigeon",
+      "Common Crook"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Mountain", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -527,6 +527,17 @@ object Costs {
         ): AdditionalCost =
             AdditionalCost.SacrificeOrPay(filter, alternativeManaCost, count)
 
+        /**
+         * Discard [count] card(s) matching [filter] from your hand, or pay
+         * [alternativeManaCost] instead (Pumpkin Bombardment — "discard a card or pay {2}").
+         */
+        fun DiscardOrPay(
+            alternativeManaCost: String,
+            filter: GameObjectFilter = GameObjectFilter.Any,
+            count: Int = 1,
+        ): AdditionalCost =
+            AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)
+
         /** "Behold a [filter] and exile it" — [Behold] + [ExileFromStorage] composed. */
         fun BeholdAndExile(
             filter: GameObjectFilter,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -409,6 +409,54 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
+     * Discard [count] card(s) matching [filter] from your hand, or pay additional mana: the caster
+     * must either discard that many matching cards, or pay extra mana on top of the spell's base
+     * mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] / [ExileFromGraveyardOrPay] /
+     * [SacrificeOrPay] for the "discard a card or pay" shape (e.g. Pumpkin Bombardment —
+     * "discard a card or pay {2}").
+     *
+     * The enumerator produces up to two legal actions: one for the discard path (base cost + card
+     * selection from hand, surfaced with `costType = "DiscardCard"` like Force of Will's plain
+     * discard cost) and one for the pay path (base cost + [alternativeManaCost]). The discard path
+     * is only offered when the caster holds at least [count] cards matching [filter] (excluding the
+     * spell being cast). The chosen path is recovered at payment time from whether
+     * [AdditionalCostPayment.discardedCards] is non-empty. The discard-as-cost still counts toward
+     * the turn's discard tracking (CR 701.8), like every other discard site.
+     *
+     * @property alternativeManaCost Extra mana to pay instead of discarding (e.g. "{2}")
+     * @property filter Which hand cards qualify (default any card)
+     * @property count How many matching cards to discard on the discard path
+     */
+    @SerialName("DiscardOrPay")
+    @Serializable
+    data class DiscardOrPay(
+        val alternativeManaCost: String,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1,
+    ) : AdditionalCost {
+        override val description: String = buildString {
+            append("Discard ")
+            if (count == 1) {
+                val filterDesc = filter.description
+                val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
+                append("$article ")
+                append(filterDesc)
+            } else {
+                append("$count ")
+                append(filter.description)
+                append("s")
+            }
+            append(" or pay ")
+            append(alternativeManaCost)
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
      * Exile cards from a named pipeline collection and optionally link them to the
      * source spell/permanent via LinkedExileComponent.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GreenGoblinRevenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GreenGoblinRevenant.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Green Goblin, Revenant — Marvel's Spider-Man #130
+ * {3}{B}{R} · Legendary Creature — Goblin Human Villain · 3/3
+ *
+ * Flying, deathtouch
+ * Whenever Green Goblin attacks, discard a card. Then draw a card for each card you've
+ * discarded this turn.
+ *
+ * The discard resolves before the draw, so the just-discarded card is counted — the count is
+ * read at the time the draw resolves via [DynamicAmounts.cardsDiscardedThisTurn].
+ */
+val GreenGoblinRevenant = card("Green Goblin, Revenant") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Human Villain"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, deathtouch\n" +
+        "Whenever Green Goblin attacks, discard a card. Then draw a card for each card you've " +
+        "discarded this turn."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            Effects.Discard(1),
+            Effects.DrawCards(DynamicAmounts.cardsDiscardedThisTurn()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Chris Rahn"
+        flavorText = "\"The Green Goblin lives again!\"\n—Green Goblin, Harry Osborn"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/218ef931-46f5-4a4d-9f26-898a1ff8f70f.jpg?1783905318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PumpkinBombardment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PumpkinBombardment.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pumpkin Bombardment — Marvel's Spider-Man #139
+ * {B/R} · Sorcery
+ *
+ * As an additional cost to cast this spell, discard a card or pay {2}.
+ * Pumpkin Bombardment deals 3 damage to target creature.
+ *
+ * The additional cost is the "discard a card or pay {N}" shape
+ * ([Costs.additional.DiscardOrPay]); with an empty hand only the pay path is offered.
+ */
+val PumpkinBombardment = card("Pumpkin Bombardment") {
+    manaCost = "{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, discard a card or pay {2}.\n" +
+        "Pumpkin Bombardment deals 3 damage to target creature."
+
+    additionalCost(
+        Costs.additional.DiscardOrPay(alternativeManaCost = "{2}")
+    )
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Leon Tukker"
+        flavorText = "\"Happy Halloween, Spider-Man!\"\n—Green Goblin, Norman Osborn"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a268ad73-9a1f-47d9-9a85-a4669a769c3d.jpg?1783905315"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UltimateGreenGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UltimateGreenGoblin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.mayhem
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ultimate Green Goblin — Marvel's Spider-Man #157
+ * {1}{B/R}{B/R} · Legendary Creature — Goblin Villain · 5/4
+ *
+ * At the beginning of your upkeep, discard a card, then create a Treasure token.
+ * Mayhem {2}{B/R}
+ */
+val UltimateGreenGoblin = card("Ultimate Green Goblin") {
+    manaCost = "{1}{B/R}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Villain"
+    power = 5
+    toughness = 4
+    oracleText = "At the beginning of your upkeep, discard a card, then create a Treasure token.\n" +
+        "Mayhem {2}{B/R} (You may cast this card from your graveyard for {2}{B/R} if you discarded it " +
+        "this turn. Timing rules still apply.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.Discard(1),
+            Effects.CreateTreasure(1),
+        )
+    }
+    mayhem("{2}{B/R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "157"
+        artist = "Jesper Ejsing"
+        flavorText = "Osborn's lust for power was nothing short of monstrous."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e82d3f71-8404-40e7-b7fa-35713d1b384e.jpg?1783905308"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -2200,6 +2200,89 @@
     ]
 }
 
+// Green Goblin, Revenant
+{
+    "name": "Green Goblin, Revenant",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Legendary Creature — Goblin Human Villain",
+    "oracleText": "Flying, deathtouch\nWhenever Green Goblin attacks, discard a card. Then draw a card for each card you've discarded this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "CARDS_DISCARDED"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "\"The Green Goblin lives again!\"\n—Green Goblin, Harry Osborn",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/218ef931-46f5-4a4d-9f26-898a1ff8f70f.jpg?1783905318"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Grow Extra Arms
 {
     "name": "Grow Extra Arms",
@@ -5768,6 +5851,51 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Pumpkin Bombardment
+{
+    "name": "Pumpkin Bombardment",
+    "manaCost": "{B/R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, discard a card or pay {2}.\nPumpkin Bombardment deals 3 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "DiscardOrPay",
+                "alternativeManaCost": "{2}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Leon Tukker",
+        "flavorText": "\"Happy Halloween, Spider-Man!\"\n—Green Goblin, Norman Osborn",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a268ad73-9a1f-47d9-9a85-a4669a769c3d.jpg?1783905315"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -10861,6 +10989,94 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ultimate Green Goblin
+{
+    "name": "Ultimate Green Goblin",
+    "manaCost": "{1}{B/R}{B/R}",
+    "typeLine": "Legendary Creature — Goblin Villain",
+    "oracleText": "At the beginning of your upkeep, discard a card, then create a Treasure token.\nMayhem {2}{B/R} (You may cast this card from your graveyard for {2}{B/R} if you discarded it this turn. Timing rules still apply.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MAYHEM"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Mayhem",
+            "cost": "{2}{B/R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "RARE",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Osborn's lust for power was nothing short of monstrous.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e82d3f71-8404-40e7-b7fa-35713d1b384e.jpg?1783905308"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1142,6 +1142,10 @@ class CostHandler {
                 // Always payable: player can always choose the "pay mana" path
                 true
             }
+            is AdditionalCost.DiscardOrPay -> {
+                // Always payable: player can always choose the "pay mana" path
+                true
+            }
             is AdditionalCost.Composite -> {
                 // All steps must be payable
                 cost.steps.all { canPayAdditionalCost(state, it, controllerId) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -958,6 +958,19 @@ class CastSpellHandler(
             }
         }
 
+        // Apply DiscardOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val discardOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.DiscardOrPay>()
+                .firstOrNull()
+            if (discardOrPay != null) {
+                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
+                if (!choseDiscard) {
+                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
+                }
+            }
+        }
+
         // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
         // waterbend amount {N} (or {X}) as generic mana; the tapped artifacts/creatures in
         // alternativePayment reduce that generic below, capped at N.
@@ -1882,6 +1895,31 @@ class CastSpellHandler(
                     }
                     // If sacrificedPermanents is empty, the player is paying extra mana instead
                 }
+                is AdditionalCost.DiscardOrPay -> {
+                    // DiscardOrPay: player chose the discard path if discardedCards is non-empty,
+                    // otherwise they pay extra mana (validated via mana payment).
+                    val discarded = action.additionalCostPayment?.discardedCards ?: emptyList()
+                    if (discarded.isNotEmpty()) {
+                        if (discarded.size != additionalCost.count) {
+                            return "You must discard exactly ${additionalCost.count} card(s) from your hand"
+                        }
+                        val handCards = state.getZone(ZoneKey(action.playerId, Zone.HAND))
+                        val context = PredicateContext(controllerId = action.playerId)
+                        for (cardId in discarded) {
+                            if (cardId !in handCards) {
+                                return "Card to discard is not in your hand"
+                            }
+                            if (cardId == action.cardId) {
+                                return "Cannot discard the spell being cast"
+                            }
+                            if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
+                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
+                                return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
+                            }
+                        }
+                    }
+                    // If discardedCards is empty, the player is paying extra mana instead
+                }
                 is AdditionalCost.PayLifePerTarget -> {
                     val required = additionalCost.amountPerTarget * action.targets.size
                     val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
@@ -2169,6 +2207,20 @@ class CastSpellHandler(
                 val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
                 if (!choseSacrifice) {
                     effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply DiscardOrPay: if player chose the "pay mana" path (no discarded cards), add the
+        // extra mana on top of the base cost.
+        if (cardDef != null && !playForFreeInExecute) {
+            val discardOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.DiscardOrPay>()
+                .firstOrNull()
+            if (discardOrPay != null) {
+                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
+                if (!choseDiscard) {
+                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
                 }
             }
         }
@@ -2641,6 +2693,37 @@ class CastSpellHandler(
                                 if (currentState.getEntity(permId) == null) continue
                                 currentState = sacrificePermanentAsCost(currentState, permId, action.playerId, events)
                             }
+                        }
+                    }
+                    is AdditionalCost.DiscardOrPay -> {
+                        // Discard the chosen cards if the player chose the discard path.
+                        // If discardedCards is empty, "pay mana" path — extra mana already added
+                        // above. Mirrors the CostAtom.Discard payment, including the discard
+                        // tracking (CR 701.8) that feeds Mayhem / "discarded this turn" reads.
+                        val discardedCards = action.additionalCostPayment.discardedCards
+                        if (discardedCards.isNotEmpty()) {
+                            discardedAsCostCards.addAll(discardedCards)
+                            for (cardId in discardedCards) {
+                                val cardContainer = currentState.getEntity(cardId) ?: continue
+                                val card = cardContainer.get<CardComponent>() ?: continue
+                                val handZone = ZoneKey(action.playerId, Zone.HAND)
+                                val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
+
+                                currentState = currentState.removeFromZone(handZone, cardId)
+                                currentState = currentState.addToZone(graveyardZone, cardId)
+
+                                events.add(ZoneChangeEvent(
+                                    entityId = cardId,
+                                    entityName = card.name,
+                                    fromZone = Zone.HAND,
+                                    toZone = Zone.GRAVEYARD,
+                                    ownerId = action.playerId
+                                ))
+                            }
+                            val discardNames = discardedCards.map { currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
+                            events.add(CardsDiscardedEvent(action.playerId, discardedCards, discardNames))
+                            currentState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                                .trackDiscard(currentState, action.playerId, discardedCards)
                         }
                     }
                     is AdditionalCost.PayLifePerTarget -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -202,6 +202,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var exileOrPayTargets = emptyList<EntityId>()
             var sacOrPayCost: AdditionalCost.SacrificeOrPay? = null
             var sacOrPayTargets = emptyList<EntityId>()
+            var discardOrPayCost: AdditionalCost.DiscardOrPay? = null
+            var discardOrPayTargets = emptyList<EntityId>()
             var canPayAdditionalCosts = true
             val flattenedCosts = additionalCosts.flatMap {
                 if (it is AdditionalCost.Composite) it.steps else listOf(it)
@@ -370,6 +372,22 @@ class CastSpellEnumerator : ActionEnumerator {
                             state, playerId, CostAtom.Sacrifice(cost.filter, cost.count)
                         )
                     }
+                    is AdditionalCost.DiscardOrPay -> {
+                        // Always payable: player can always choose the "pay mana" path.
+                        // Surface the hand cards eligible for the discard path (excluding the
+                        // spell being cast).
+                        discardOrPayCost = cost
+                        val handZone = ZoneKey(playerId, Zone.HAND)
+                        val handCards = state.getZone(handZone).filter { it != cardId }
+                        val predicateContext = PredicateContext(controllerId = playerId)
+                        discardOrPayTargets = if (cost.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
+                            handCards
+                        } else {
+                            handCards.filter {
+                                context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext)
+                            }
+                        }
+                    }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
                         // uses projected state (continuous effects matter); hidden / card
@@ -445,6 +463,12 @@ class CastSpellEnumerator : ActionEnumerator {
             val sacOrPayBaseCost = effectiveCost
             if (sacOrPayCost != null) {
                 effectiveCost = effectiveCost + ManaCost.parse(sacOrPayCost.alternativeManaCost)
+            }
+
+            // Save base cost for discard path, then add extra mana for the "pay" path
+            val discardOrPayBaseCost = effectiveCost
+            if (discardOrPayCost != null) {
+                effectiveCost = effectiveCost + ManaCost.parse(discardOrPayCost.alternativeManaCost)
             }
 
             // Spell-level waterbend additional cost (Avatar: The Last Airbender). A *mandatory*
@@ -602,11 +626,17 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, sacOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
+            // Check discard path affordability (base cost without the extra mana, but needs
+            // enough matching cards in hand to discard).
+            val canAffordDiscardOrPayPath = if (discardOrPayCost != null && discardOrPayTargets.size >= discardOrPayCost.count) {
+                context.manaSolver.canPay(state, playerId, discardOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
+            } else false
+
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
             val canAffordFreeCast = context.freeCastPermissionFor(cardId)
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordFreeCast) {
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordDiscardOrPayPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -706,6 +736,24 @@ class CastSpellEnumerator : ActionEnumerator {
                     sacrificeCount = sacOrPayCost.count,
                 )
                 Triple(sacManaCostString, sacAutoTapPreview, sacCostInfo)
+            } else null
+
+            // Compute discard path info (separate legal action with lower mana cost + hand card
+            // selection). Reuses the "DiscardCard" cost type so the client drives the same hand
+            // discard selection used by Force of Will's plain discard cost.
+            val discardOrPayPathInfo = if (canAffordDiscardOrPayPath && discardOrPayCost != null) {
+                val discardManaCostString = discardOrPayBaseCost.toString()
+                val discardAutoTapPreview = if (context.skipAutoTapPreview) null else {
+                    context.manaSolver.solve(state, playerId, discardOrPayBaseCost, precomputedSources = cachedSources)
+                        ?.sources?.map { it.entityId }
+                }
+                val discardCostInfo = AdditionalCostData(
+                    description = discardOrPayCost.description,
+                    costType = "DiscardCard",
+                    validDiscardTargets = discardOrPayTargets,
+                    discardCount = discardOrPayCost.count,
+                )
+                Triple(discardManaCostString, discardAutoTapPreview, discardCostInfo)
             } else null
 
             // Calculate X cost info if the spell has X in its cost (printed, or the waterbend {X}
@@ -1222,6 +1270,19 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = sacOrPayPathInfo.second
                             ))
                         }
+                        if (discardOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Discard)",
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
+                                additionalCostInfo = discardOrPayPathInfo.third,
+                                manaCostString = discardOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = discardOrPayPathInfo.second
+                            ))
+                        }
                     } else {
                         if (canAfford) {
                             result.add(LegalAction(
@@ -1447,6 +1508,27 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = sacOrPayPathInfo.second
                             ))
                         }
+                        if (discardOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Discard)",
+                                action = CastSpell(playerId, cardId),
+                                validTargets = firstReqInfo.validTargets,
+                                requiresTargets = true,
+                                targetCount = firstReqInfo.maxTargets,
+                                minTargets = firstReq.effectiveMinCount,
+                                targetDescription = firstReq.description,
+                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
+                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
+                                additionalCostInfo = discardOrPayPathInfo.third,
+                                manaCostString = discardOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = discardOrPayPathInfo.second
+                            ))
+                        }
                     }
                 }
             } else {
@@ -1561,6 +1643,16 @@ class CastSpellEnumerator : ActionEnumerator {
                         additionalCostInfo = sacOrPayPathInfo.third,
                         manaCostString = sacOrPayPathInfo.first,
                         autoTapPreview = sacOrPayPathInfo.second
+                    ))
+                }
+                if (discardOrPayPathInfo != null) {
+                    result.add(LegalAction(
+                        actionType = "CastSpell",
+                        description = "Cast ${cardComponent.name} (Discard)",
+                        action = CastSpell(playerId, cardId),
+                        additionalCostInfo = discardOrPayPathInfo.third,
+                        manaCostString = discardOrPayPathInfo.first,
+                        autoTapPreview = discardOrPayPathInfo.second
                     ))
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pumpkin Bombardment (SPM).
+ *
+ * {B/R} Sorcery
+ * As an additional cost to cast this spell, discard a card or pay {2}.
+ * Pumpkin Bombardment deals 3 damage to target creature.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.DiscardOrPay] additional cost
+ * (discard path vs pay path), including the case where an empty hand leaves only the pay path.
+ */
+class PumpkinBombardmentScenarioTest : ScenarioTestBase() {
+
+    // A 3/3 target that dies to Pumpkin Bombardment's 3 damage, and a spare card to discard.
+    private val testBear = card("Pumpkin Test Bear") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Bear"
+        power = 3
+        toughness = 3
+    }
+    private val spareCard = card("Pumpkin Test Spare") {
+        manaCost = "{1}"
+        typeLine = "Creature — Goblin"
+        power = 1
+        toughness = 1
+    }
+
+    init {
+        cardRegistry.register(listOf(testBear, spareCard))
+
+        context("DiscardOrPay additional cost") {
+            test("discard path: discards a card and deals 3 damage to the target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withCardInHand(2, "Pumpkin Test Spare")
+                    .withLandsOnBattlefield(2, "Mountain", 1) // {R} pays {B/R}
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.state.getBattlefield().first {
+                    val c = game.state.getEntity(it)
+                    c?.get<CardComponent>()?.name == "Pumpkin Test Bear" &&
+                        c.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val pumpkinId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Bombardment"
+                }
+                val spareId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Test Spare"
+                }
+
+                val result = game.execute(
+                    CastSpell(
+                        game.player2Id,
+                        pumpkinId,
+                        listOf(ChosenTarget.Permanent(bearId)),
+                        additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(spareId)),
+                    )
+                )
+                withClue("Pumpkin Bombardment should cast via the discard path: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The spare card should be discarded") {
+                    game.isInGraveyard(2, "Pumpkin Test Spare") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("The target creature should be destroyed by 3 damage") {
+                    game.isInGraveyard(1, "Pumpkin Test Bear") shouldBe true
+                }
+            }
+
+            test("pay path: no discard, engine adds {2}, and deals 3 damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withCardInHand(2, "Pumpkin Test Spare")
+                    .withLandsOnBattlefield(2, "Mountain", 3) // enough for {B/R} + {2}
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.state.getBattlefield().first {
+                    val c = game.state.getEntity(it)
+                    c?.get<CardComponent>()?.name == "Pumpkin Test Bear" &&
+                        c.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val pumpkinId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Bombardment"
+                }
+
+                // Pay path: no discard payment — the engine adds {2} to the cost.
+                val result = game.execute(
+                    CastSpell(game.player2Id, pumpkinId, listOf(ChosenTarget.Permanent(bearId)))
+                )
+                withClue("Pumpkin Bombardment should cast via the pay path: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The spare card should still be in hand (no discard on the pay path)") {
+                    game.isInHand(2, "Pumpkin Test Spare") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("The target creature should be destroyed by 3 damage") {
+                    game.isInGraveyard(1, "Pumpkin Test Bear") shouldBe true
+                }
+            }
+
+            test("with an empty hand, only the pay path is castable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pumpkinActions = game.getLegalActions(2)
+                    .filter { it.description.startsWith("Cast Pumpkin Bombardment") }
+                withClue("Pumpkin Bombardment should be castable (pay path)") {
+                    pumpkinActions.isNotEmpty() shouldBe true
+                }
+                withClue("No discard path should be offered with no other card in hand") {
+                    pumpkinActions.none { it.description.endsWith("(Discard)") } shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## SPM Batch 1 — Green Goblin cards + `DiscardOrPay` additional cost

First of a series of stacked PRs completing Marvel's Spider-Man (SPM). Stacks on the Mayhem branch (`spm-mayhem`). This batch adds three cards and one new SDK additional-cost primitive, plus reconciles the SPM checklist.

### New engine capability — `DiscardOrPay` additional cost
`AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)` + `Costs.additional.DiscardOrPay(...)` — "as an additional cost to cast this spell, **discard a card or pay {N}**". Mirrors the existing `*OrPay` family (`SacrificeOrPay` / `ExileFromGraveyardOrPay` / `BlightOrPay` / `BeholdOrPay`):

- **Enumerator** offers up to two cast paths — a **discard path** (base cost + a `costType = "DiscardCard"` hand picker, the same one plain discard costs like Force of Will use) and a **pay path** (base cost + the alternative mana folded in).
- **`CostHandler`** treats it as always payable (the pay path is always available).
- **`CastSpellHandler`** handles the validation mana adjustment, payment validation, mana application, and the discard-payment application — mirroring `CostAtom.Discard`, including `ZoneTransitionService.trackDiscard` so the discard-as-cost feeds the turn's discard tracking (CR 701.8) and thus Mayhem / `cardsDiscardedThisTurn`.
- Chosen path is recovered at payment time from whether `AdditionalCostPayment.discardedCards` is non-empty; the discard path is only offered when you hold ≥ `count` other matching cards, so with an empty hand only the pay path is castable.

### Cards
- **Ultimate Green Goblin** [157] — `{1}{B/R}{B/R}` 5/4; upkeep "discard a card, then create a Treasure" + Mayhem `{2}{B/R}` (pure composition on the just-landed Mayhem feature).
- **Green Goblin, Revenant** [130] — `{3}{B}{R}` 3/3 Flying/deathtouch; "attacks → discard a card, then draw a card for each card you've discarded this turn" (via `DynamicAmounts.cardsDiscardedThisTurn()`).
- **Pumpkin Bombardment** [139] — `{B/R}` Sorcery; the new `DiscardOrPay {2}` cost + 3 damage to target creature.

### Tests
- `PumpkinBombardmentScenarioTest` — discard path, pay path, and empty-hand-only-pay (all green).
- Manual DevScenario `manual-scenarios/sets/spm/goblins-batch.json` — the active player holds all three cards with enough mana to cast them all, a target creature, and spare cards to discard.
- Card snapshot golden reblessed: the SPM diff adds only these three cards.

### Bookkeeping
- Reconciled `backlog/sets/marvels-spider-man/cards.md` — the previously-shipped web-slinging (8) and Mayhem (9) cards were implemented but never ticked; header now reads **167/188** and two duplicate entries were removed.
- Updated `docs/card-sdk-language-reference.md` and the SPM `mechanics.md` for the new cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
