### PR TITLE
SPM Batch 2: damage-trigger / replacement / redirect features

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 150 / 190
+**Implemented:** 167 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -17,7 +17,7 @@
 - [x] Biorganic Carapace
 - [ ] Black Cat, Cunning Thief
 - [ ] Carnage, Crimson Chaos
-- [ ] Chameleon, Master of Disguise
+- [x] Chameleon, Master of Disguise
 - [x] Cheering Crowd
 - [x] City Pigeon
 - [x] Common Crook
@@ -32,14 +32,14 @@
 - [x] Doctor Octopus, Master Planner
 - [x] Eddie Brock // Venom, Lethal Protector
 - [x] Eerie Gravestone
-- [ ] Electro's Bolt
+- [x] Electro's Bolt
 - [ ] Electro, Assaulting Battery
 - [x] Ezekiel Sims, Spider-Totem
 - [x] Flash Thompson, Spider-Fan
 - [x] Flying Octobot
 - [x] Friendly Neighborhood
 - [x] Gallant Citizen
-- [ ] Green Goblin, Revenant
+- [x] Green Goblin, Revenant
 - [x] Grow Extra Arms
 - [x] Guy in the Chair
 - [x] Gwen Stacy // Ghost-Spider
@@ -90,27 +90,25 @@
 - [ ] Peter Parker // Amazing Spider-Man
 - [x] Peter Parker's Camera
 - [x] Pictures of Spider-Man
-- [ ] Prison Break
+- [x] Prison Break
 - [x] Professional Wrestler
 - [x] Prowler, Clawed Thief
-- [ ] Pumpkin Bombardment
+- [x] Pumpkin Bombardment
 - [x] Radioactive Spider
-- [ ] Raging Goblinoids
+- [x] Raging Goblinoids
 - [x] Rent Is Due
 - [x] Rhino's Rampage
 - [x] Rhino, Barreling Brute
 - [x] Risky Research
 - [x] Robotics Mastery
-- [x] Risky Research
-- [x] Robotics Mastery
-- [ ] Rocket-Powered Goblin Glider
+- [x] Rocket-Powered Goblin Glider
 - [x] Romantic Rendezvous
 - [x] SP//dr, Piloted by Peni
-- [ ] Sandman's Quicksand
+- [x] Sandman's Quicksand
 - [x] Sandman, Shifting Scoundrel
 - [x] Savage Mansion
-- [ ] Scarlet Spider, Ben Reilly
-- [ ] Scarlet Spider, Kaine
+- [x] Scarlet Spider, Ben Reilly
+- [x] Scarlet Spider, Kaine
 - [x] School Daze
 - [x] Scorpion's Sting
 - [x] Scorpion, Seething Striker
@@ -121,7 +119,7 @@
 - [x] Shock
 - [x] Shocker, Unshakable
 - [x] Shriek, Treblemaker
-- [ ] Silk, Web Weaver
+- [x] Silk, Web Weaver
 - [x] Silver Sable, Mercenary Leader
 - [x] Sinister Hideout
 - [x] Skyward Spider
@@ -133,23 +131,23 @@
 - [x] Spider-Girl, Legacy Hero
 - [x] Spider-Gwen, Free Spirit
 - [x] Spider-Ham, Peter Porker
-- [ ] Spider-Islanders
+- [x] Spider-Islanders
 - [ ] Spider-Man 2099
-- [ ] Spider-Man India
+- [x] Spider-Man India
 - [x] Spider-Man No More
 - [x] Spider-Man Noir
-- [ ] Spider-Man, Brooklyn Visionary
-- [ ] Spider-Man, Web-Slinger
+- [x] Spider-Man, Brooklyn Visionary
+- [x] Spider-Man, Web-Slinger
 - [x] Spider-Mobile
 - [ ] Spider-Punk
 - [x] Spider-Rex, Daring Dino
-- [ ] Spider-Sense
+- [x] Spider-Sense
 - [ ] Spider-Slayer, Hatred Honed
 - [x] Spider-Suit
-- [ ] Spider-UK
+- [x] Spider-UK
 - [ ] Spider-Verse
 - [x] Spider-Woman, Stunning Savior
-- [ ] Spiders-Man, Heroic Horde
+- [x] Spiders-Man, Heroic Horde
 - [x] Spinneret and Spiderling
 - [x] Starling, Aerial Ally
 - [x] Steel Wrecking Ball
@@ -162,7 +160,7 @@
 - [x] Superior Foes of Spider-Man
 - [x] Superior Spider-Man
 - [x] Supportive Parents
-- [ ] Swarm, Being of Bees
+- [x] Swarm, Being of Bees
 - [x] Symbiote Spider-Man
 - [x] Taxi Driver
 - [x] Terrific Team-Up
@@ -173,7 +171,7 @@
 - [x] The Spot, Living Portal
 - [x] Thwip!
 - [x] Tombstone, Career Criminal
-- [ ] Ultimate Green Goblin
+- [x] Ultimate Green Goblin
 - [x] University Campus
 - [x] Unstable Experiment
 - [x] Urban Retreat

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,12 +2,12 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 167 / 188
+**Implemented:** 170 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
-- [ ] Anti-Venom, Horrifying Healer
+- [x] Anti-Venom, Horrifying Healer
 - [ ] Arachne, Psionic Weaver
 - [x] Araña, Heart of the Spider
 - [x] Aunt May
@@ -142,7 +142,7 @@
 - [ ] Spider-Punk
 - [x] Spider-Rex, Daring Dino
 - [x] Spider-Sense
-- [ ] Spider-Slayer, Hatred Honed
+- [x] Spider-Slayer, Hatred Honed
 - [x] Spider-Suit
 - [x] Spider-UK
 - [ ] Spider-Verse
@@ -189,5 +189,5 @@
 - [x] Whoosh!
 - [x] Wild Pack Squad
 - [x] Wisecrack
-- [ ] With Great Power . . .
+- [x] With Great Power . . .
 - [x] Wraith, Vicious Vigilante

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -225,22 +225,22 @@ to a permanent's presence. Fix (add-feature): a color-parameterized `RetainUnspe
 Blocked cards:
 - **Electro, Assaulting Battery** [76] — `{1}{R}{R}` Flying; "You don't lose unspent red mana as steps and phases end." Its other clauses (Flying; cast-instant/sorcery → add {R}; LTB pay-{X} deal X to a player) are all expressible today.
 
-## "Discard a card OR pay {2}" additional cost (DiscardOrPay)
+## "Discard a card OR pay {2}" additional cost (DiscardOrPay) — ✅ IMPLEMENTED
 
 > As an additional cost to cast this spell, **discard a card or pay {2}**.
 
-A choice between a non-mana cost (discard a card) and a **mana** payment as an additional cost.
-Not supported: `Costs.additional.Choice(...)` handles only non-mana options (`ChoiceCostResolver`
-drops any `CostAtom.Mana` branch → the pay-{2} path silently disappears), and the `*OrPay`
-family (`SacrificeOrPay`, `ExileFromGraveyardOrPay`, `BlightOrPay`, `BeholdOrPay`) has **no
-`DiscardOrPay`**. The `ModalEffect` per-mode-cost workaround (Bitter Triumph "discard or pay 3
-life") doesn't transfer because a mode's `CostAtom.Mana` additional cost is treated as a no-op
-by `CastSpellHandler` (the {2} would be free). Fix (add-feature): a `DiscardOrPay(count, filter,
-alternativeManaCost)` member of the `*OrPay` additional-cost family, wired into
-`CastSpellEnumerator` + `CastSpellHandler`.
+**Implemented** on branch `spm-goblins`. A choice between a non-mana cost (discard a card) and a **mana**
+payment as an additional cost. Added `AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)` +
+`Costs.additional.DiscardOrPay(...)`, mirroring the existing `*OrPay` family (`SacrificeOrPay` /
+`ExileFromGraveyardOrPay` / `BlightOrPay` / `BeholdOrPay`). Wired into `CastSpellEnumerator` (two cast
+paths — discard path with a `costType = "DiscardCard"` hand picker, and pay path folding in the alt mana),
+`CostHandler` (always payable — pay path), and `CastSpellHandler` (validation mana adjustment, payment
+validation, mana application, and the discard-payment application mirroring `CostAtom.Discard`, including
+`ZoneTransitionService.trackDiscard` so it feeds the turn's discard tracking / Mayhem). Path recovered at
+payment time from whether `AdditionalCostPayment.discardedCards` is non-empty.
 
-Blocked cards:
-- **Pumpkin Bombardment** [139] — `{B/R}` Sorcery; "As an additional cost to cast this spell, discard a card or pay {2}. Deals 3 damage to target creature." (the damage half is trivial; the discard-or-pay additional cost is the blocker)
+Implemented cards (1): **Pumpkin Bombardment** [139] — `{B/R}` Sorcery; "discard a card or pay {2}. Deals 3
+damage to target creature."
 
 ## "Play a land from anywhere other than your hand" trigger
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -139,7 +139,17 @@ battlefield-exit (or the predicate evaluated against pre-leave state). `add-feat
 Blocked cards:
 - **Costume Closet** [5] — `{1}{W}` Artifact; enters with two +1/+1 counters + sorcery-speed "{T}: move a counter to target creature you control" (both of those work today) + "Whenever a **modified** creature you control leaves the battlefield, put a +1/+1 counter on this artifact" (the blocked part)
 
-## "Deals damage to a [filtered] creature" trigger (RecipientFilter.Matching on a deals-damage trigger)
+## "Deals damage to a [filtered] creature" trigger (RecipientFilter.Matching on a deals-damage trigger) — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-damage-triggers`. Added the missing `is RecipientFilter.Matching` case to
+`TriggerMatcher.matchesDealsDamageTrigger` (evaluate the filter against the recipient in projected state,
+mirroring `DamageCalculator`). The triggering entity is already the recipient (`TriggerContext.fromEvent`
+sets `triggeringEntityId = event.targetId`), so `Effects.Destroy(EffectTarget.TriggeringEntity)` destroys
+the damaged creature. Also repairs the two already-shipped cards with the identical shape (**East-Mark
+Cavalier** LTR, **Mauhur, Uruk-hai Captain**). Card: **Spider-Slayer, Hatred Honed** [175].
+
+<details><summary>Original analysis</summary>
+
 
 > Whenever <this> deals damage to a **Spider**, destroy that creature.
 
@@ -157,6 +167,7 @@ existing `CreatureYouControl` case) to `matchesDealsDamageTrigger`.
 
 Blocked cards:
 - **Spider-Slayer, Hatred Honed** [175] — `{2}` Legendary Artifact Creature; "Whenever Spider-Slayer deals damage to a Spider, destroy that creature" (blocked). Its other ability — `{6}`, exile-from-graveyard → two tapped 1/1 flying Robot tokens — works fine.
+</details>
 
 ## Chosen card name surviving into a later-firing delayed trigger
 
@@ -289,7 +300,15 @@ sites to consult granted statics (mirroring `MayCastFromGraveyard`).
 Blocked cards:
 - **Gwenom, Remorseless** [56] — `{3}{B}{B}` Deathtouch/lifelink; the attack-granted "play from top, pay life = mana value" is the blocker (deathtouch, lifelink, and the attack trigger itself are fine).
 
-## "Prevent damage to this creature, put that many +1/+1 counters on it" self-replacement
+## "Prevent damage to this creature, put that many +1/+1 counters on it" self-replacement — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-damage-triggers`. Added `is RecipientFilter.Self -> targetId == entityId`
+to `DamageUtils.applyReplaceDamageWithCounters`'s recipient matcher, and invoked it on the creature-damage
+paths — the non-player (`else`) branch of `DamageUtils.dealDamageToTarget` and
+`CombatDamageManager.applyDamageToCreature` (before redirection/final marking). Card: **Anti-Venom,
+Horrifying Healer** [1] (its "if he was cast" ETB reanimation uses the existing `Conditions.WasCast`).
+
+<details><summary>Original analysis</summary>
 
 > If damage would be dealt to Anti-Venom, prevent that damage and put that many +1/+1 counters
 > on him.
@@ -308,6 +327,7 @@ and invoke `applyReplaceDamageWithCounters` on the creature-damage paths
 
 Blocked cards:
 - **Anti-Venom, Horrifying Healer** [1] — `{W}{W}{W}{W}{W}` Symbiote Hero; ETB "if cast, reanimate a creature" is fine, but the damage-prevention-to-counters self-replacement is the blocker.
+</details>
 
 ## Granted activated ability with `UntilYourNextTurn` duration never expires
 
@@ -330,7 +350,15 @@ field, like the player-component grants).
 Blocked cards:
 - **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'" — the type-change + untap work, but the granted mana ability never expires.
 
-## Static damage redirect to the enchanted/equipped creature (Pariah-style)
+## Static damage redirect to the enchanted/equipped creature (Pariah-style) — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-damage-triggers`. Extended `DamageUtils.resolveRedirectTarget` with
+`EffectTarget.EnchantedCreature` / `EquippedCreature` / `EnchantedPermanent` → the Aura/Equipment's
+`AttachedToComponent.targetId`. The "+2/+2 for each attached Aura/Equipment" buff uses the new
+`DynamicAmounts.attachmentsOnEnchantedCreature()` (`EntityProperty(EnchantedCreature, AttachmentCount())`)
+over `GroupFilter.attachedCreature()`. Card: **With Great Power . . .** [24].
+
+<details><summary>Original analysis</summary>
 
 > All damage that would be dealt to you is dealt to **enchanted creature** instead.
 
@@ -347,6 +375,7 @@ expressible (`GrantDynamicStatsEffect` over `attachedCreature()` with
 
 Blocked cards:
 - **With Great Power . . .** [24] — `{3}{W}` Aura; "+2/+2 per attached Aura/Equipment" (fine) + "all damage that would be dealt to you is dealt to enchanted creature instead" (the redirect is the blocker).
+</details>
 
 ## "The legend rule doesn't apply to [filter]" exemption
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6750,6 +6750,11 @@ For "X = the number of [things] attached to this permanent":
 - `DynamicAmounts.equipmentAttachedToSelf()` — only the Equipment attached to the source (Shagrat,
   Loot Bearer: "amass Orcs X, where X is the number of Equipment attached to Shagrat"). Desugars to
   `EntityProperty(Source, AttachmentCount(AttachmentKind.EQUIPMENT))`.
+- `DynamicAmounts.attachmentsOnEnchantedCreature()` — every Aura/Equipment attached to the
+  *enchanted* creature (the creature the source Aura is attached to), for an Aura that buffs its host
+  by its host's own attachment count (With Great Power…: "enchanted creature gets +2/+2 for each Aura
+  and Equipment attached to it"). Desugars to `EntityProperty(EnchantedCreature, AttachmentCount())`.
+  Distinct from `attachmentsOnSelf()`, which counts attachments on the source itself.
 
 `AttachmentCount(kind)` takes an `AttachmentKind` (`ANY` / `EQUIPMENT` / `AURA`); the evaluator
 counts the source's `attachedIds` whose card type matches the kind.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -410,11 +410,24 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   is recovered at payment time from whether the cast action's `additionalCostPayment.sacrificedPermanents`
   is non-empty; the sacrifice path is only offered when you control at least `count` matching
      permanents, so with nothing to sacrifice only the pay path is castable.
+- `Costs.additional.DiscardOrPay(alternativeManaCost, filter = Filters.Any, count = 1)` — "as an
+  additional cost to cast this spell, discard a [filter] or pay {mana}" (Pumpkin Bombardment:
+  "discard a card or pay {2}"). The sibling of `SacrificeOrPay` / `ExileFromGraveyardOrPay` /
+  `BlightOrPay` / `BeholdOrPay` for the "discard a card or pay mana" shape. The enumerator offers up
+  to two cast paths: the **discard path** (base cost + a hand selection of exactly `count` cards
+  matching `filter`, excluding the spell being cast, surfaced as a `costType = "DiscardCard"` cost —
+  the same hand picker used by a plain discard cost like Force of Will) and the **pay path** (base
+  cost + `alternativeManaCost` folded in). The chosen path is recovered at payment time from whether
+  the cast action's `additionalCostPayment.discardedCards` is non-empty; the discard path is only
+  offered when you hold at least `count` other matching cards, so with an empty hand only the pay
+  path is castable. The discard-as-cost still feeds the turn's discard tracking (CR 701.8), so it
+  counts toward `DynamicAmounts.cardsDiscardedThisTurn()` / `Conditions.YouDiscardedThisCardThisTurn`
+  (Mayhem).
 - `Costs.additional.Choice(vararg options)` — **cost-vs-cost**: "as an additional cost to cast this
   spell, pay exactly one of `options`" (Souls of the Lost: *"discard a card **or** sacrifice a
   permanent"*). The general, parameterized form of `Forage` — each option is itself an
   `AdditionalCost` (compose the `Sacrifice` / `Discard` / `ExileFrom` atoms). Distinct from the
-  `*OrPay` family (`SacrificeOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
+  `*OrPay` family (`SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
   fold a **mana** alternative into the spell's cost, whereas `Choice` is for options that are each
   independently payable **non-mana** costs (no mana-cost change). The enumerator emits **one cast
   action per payable option** (`CastSpellEnumerator.expandChoiceAdditionalCosts` +

--- a/manual-scenarios/sets/spm/damage-triggers.json
+++ b/manual-scenarios/sets/spm/damage-triggers.json
@@ -1,0 +1,49 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Lightning Bolt",
+      "Anti-Venom, Horrifying Healer",
+      "Spider-Slayer, Hatred Honed",
+      "Ghalta, Stampede Tyrant",
+      "With Great Power . . ."
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": ["Radioactive Spider"],
+    "library": ["Plains", "Plains", "Plains", "Plains", "Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [{"name": "Broodspinner"}],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/sets/spm/goblins-batch.json
+++ b/manual-scenarios/sets/spm/goblins-batch.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Gallant Citizen"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Ultimate Green Goblin",
+      "Green Goblin, Revenant",
+      "Pumpkin Bombardment",
+      "City Pigeon",
+      "Common Crook"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Mountain", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -527,6 +527,17 @@ object Costs {
         ): AdditionalCost =
             AdditionalCost.SacrificeOrPay(filter, alternativeManaCost, count)
 
+        /**
+         * Discard [count] card(s) matching [filter] from your hand, or pay
+         * [alternativeManaCost] instead (Pumpkin Bombardment — "discard a card or pay {2}").
+         */
+        fun DiscardOrPay(
+            alternativeManaCost: String,
+            filter: GameObjectFilter = GameObjectFilter.Any,
+            count: Int = 1,
+        ): AdditionalCost =
+            AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)
+
         /** "Behold a [filter] and exile it" — [Behold] + [ExileFromStorage] composed. */
         fun BeholdAndExile(
             filter: GameObjectFilter,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -598,6 +598,15 @@ object DynamicAmounts {
     fun attachmentsOnSelf(): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.AttachmentCount())
 
+    /**
+     * Number of Auras and Equipment attached to the enchanted creature — the creature the source
+     * Aura is attached to (With Great Power…: "enchanted creature gets +2/+2 for each Aura and
+     * Equipment attached to it"). Distinct from [attachmentsOnSelf], which counts attachments on
+     * the source itself.
+     */
+    fun attachmentsOnEnchantedCreature(): DynamicAmount =
+        DynamicAmount.EntityProperty(EntityReference.EnchantedCreature, EntityNumericProperty.AttachmentCount())
+
     /** Number of Equipment attached to the source (Shagrat, Loot Bearer's amass amount). */
     fun equipmentAttachedToSelf(): DynamicAmount =
         DynamicAmount.EntityProperty(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -409,6 +409,54 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
+     * Discard [count] card(s) matching [filter] from your hand, or pay additional mana: the caster
+     * must either discard that many matching cards, or pay extra mana on top of the spell's base
+     * mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] / [ExileFromGraveyardOrPay] /
+     * [SacrificeOrPay] for the "discard a card or pay" shape (e.g. Pumpkin Bombardment —
+     * "discard a card or pay {2}").
+     *
+     * The enumerator produces up to two legal actions: one for the discard path (base cost + card
+     * selection from hand, surfaced with `costType = "DiscardCard"` like Force of Will's plain
+     * discard cost) and one for the pay path (base cost + [alternativeManaCost]). The discard path
+     * is only offered when the caster holds at least [count] cards matching [filter] (excluding the
+     * spell being cast). The chosen path is recovered at payment time from whether
+     * [AdditionalCostPayment.discardedCards] is non-empty. The discard-as-cost still counts toward
+     * the turn's discard tracking (CR 701.8), like every other discard site.
+     *
+     * @property alternativeManaCost Extra mana to pay instead of discarding (e.g. "{2}")
+     * @property filter Which hand cards qualify (default any card)
+     * @property count How many matching cards to discard on the discard path
+     */
+    @SerialName("DiscardOrPay")
+    @Serializable
+    data class DiscardOrPay(
+        val alternativeManaCost: String,
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val count: Int = 1,
+    ) : AdditionalCost {
+        override val description: String = buildString {
+            append("Discard ")
+            if (count == 1) {
+                val filterDesc = filter.description
+                val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
+                append("$article ")
+                append(filterDesc)
+            } else {
+                append("$count ")
+                append(filter.description)
+                append("s")
+            }
+            append(" or pay ")
+            append(alternativeManaCost)
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
      * Exile cards from a named pipeline collection and optionally link them to the
      * source spell/permanent via LinkedExileComponent.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AntiVenomHorrifyingHealer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/AntiVenomHorrifyingHealer.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Anti-Venom, Horrifying Healer — Marvel's Spider-Man #1
+ * {W}{W}{W}{W}{W} · Legendary Creature — Symbiote Hero · 5/5
+ *
+ * When Anti-Venom enters, if he was cast, return target creature card from your graveyard to
+ * the battlefield.
+ * If damage would be dealt to Anti-Venom, prevent that damage and put that many +1/+1 counters
+ * on him.
+ *
+ * The damage-to-counters clause is a `RecipientFilter.Self` `ReplaceDamageWithCounters`, now wired
+ * on the creature-damage paths (`CombatDamageManager.applyDamageToCreature` +
+ * `DamageUtils.applyDamage`).
+ */
+val AntiVenomHorrifyingHealer = card("Anti-Venom, Horrifying Healer") {
+    manaCost = "{W}{W}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Symbiote Hero"
+    power = 5
+    toughness = 5
+    oracleText = "When Anti-Venom enters, if he was cast, return target creature card from your " +
+        "graveyard to the battlefield.\n" +
+        "If damage would be dealt to Anti-Venom, prevent that damage and put that many +1/+1 " +
+        "counters on him."
+
+    // When Anti-Venom enters, if he was cast, reanimate a creature from your graveyard.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        val creature = target("target creature card", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(creature)
+    }
+
+    // If damage would be dealt to Anti-Venom, prevent it and put that many +1/+1 counters on him.
+    replacementEffect(
+        ReplaceDamageWithCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.Self)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "1"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "\"You are a sickness on this city. I am the cure!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/560384fe-7be0-4b93-a515-2fe687ab2492.jpg?1783905365"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GreenGoblinRevenant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GreenGoblinRevenant.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Green Goblin, Revenant — Marvel's Spider-Man #130
+ * {3}{B}{R} · Legendary Creature — Goblin Human Villain · 3/3
+ *
+ * Flying, deathtouch
+ * Whenever Green Goblin attacks, discard a card. Then draw a card for each card you've
+ * discarded this turn.
+ *
+ * The discard resolves before the draw, so the just-discarded card is counted — the count is
+ * read at the time the draw resolves via [DynamicAmounts.cardsDiscardedThisTurn].
+ */
+val GreenGoblinRevenant = card("Green Goblin, Revenant") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Human Villain"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, deathtouch\n" +
+        "Whenever Green Goblin attacks, discard a card. Then draw a card for each card you've " +
+        "discarded this turn."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            Effects.Discard(1),
+            Effects.DrawCards(DynamicAmounts.cardsDiscardedThisTurn()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Chris Rahn"
+        flavorText = "\"The Green Goblin lives again!\"\n—Green Goblin, Harry Osborn"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/218ef931-46f5-4a4d-9f26-898a1ff8f70f.jpg?1783905318"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PumpkinBombardment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PumpkinBombardment.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pumpkin Bombardment — Marvel's Spider-Man #139
+ * {B/R} · Sorcery
+ *
+ * As an additional cost to cast this spell, discard a card or pay {2}.
+ * Pumpkin Bombardment deals 3 damage to target creature.
+ *
+ * The additional cost is the "discard a card or pay {N}" shape
+ * ([Costs.additional.DiscardOrPay]); with an empty hand only the pay path is offered.
+ */
+val PumpkinBombardment = card("Pumpkin Bombardment") {
+    manaCost = "{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, discard a card or pay {2}.\n" +
+        "Pumpkin Bombardment deals 3 damage to target creature."
+
+    additionalCost(
+        Costs.additional.DiscardOrPay(alternativeManaCost = "{2}")
+    )
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Leon Tukker"
+        flavorText = "\"Happy Halloween, Spider-Man!\"\n—Green Goblin, Norman Osborn"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a268ad73-9a1f-47d9-9a85-a4669a769c3d.jpg?1783905315"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderSlayerHatredHoned.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderSlayerHatredHoned.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spider-Slayer, Hatred Honed — Marvel's Spider-Man #175
+ * {2} · Legendary Artifact Creature — Human Villain · 2/1
+ *
+ * Whenever Spider-Slayer deals damage to a Spider, destroy that creature.
+ * {6}, Exile this card from your graveyard: Create two tapped 1/1 colorless Robot
+ * artifact creature tokens with flying.
+ *
+ * The first ability uses `RecipientFilter.Matching` on a self deals-damage trigger — the same
+ * shape as East-Mark Cavalier / Mauhur (now wired in `TriggerMatcher.matchesDealsDamageTrigger`).
+ */
+val SpiderSlayerHatredHoned = card("Spider-Slayer, Hatred Honed") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact Creature — Human Villain"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever Spider-Slayer deals damage to a Spider, destroy that creature.\n" +
+        "{6}, Exile this card from your graveyard: Create two tapped 1/1 colorless Robot " +
+        "artifact creature tokens with flying."
+
+    // Whenever Spider-Slayer deals damage to a Spider, destroy that creature.
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            recipient = RecipientFilter.Matching(
+                GameObjectFilter.Creature.withAnySubtype("Spider")
+            )
+        )
+        effect = Effects.Destroy(EffectTarget.TriggeringEntity)
+    }
+
+    // {6}, Exile this card from your graveyard: Create two tapped 1/1 flying Robot tokens.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.ExileSelf)
+        activateFromZone = Zone.GRAVEYARD
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Robot"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2,
+            tapped = true,
+            artifactToken = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "David Álvarez"
+        flavorText = "\"With each attempt on Spider-Man's life, my father came closer to ending " +
+            "the menace. It is my pleasure to finish the job.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac37ca6f-a6ee-4dfb-949f-2562f98d09d0.jpg?1783905300"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UltimateGreenGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UltimateGreenGoblin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.mayhem
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ultimate Green Goblin — Marvel's Spider-Man #157
+ * {1}{B/R}{B/R} · Legendary Creature — Goblin Villain · 5/4
+ *
+ * At the beginning of your upkeep, discard a card, then create a Treasure token.
+ * Mayhem {2}{B/R}
+ */
+val UltimateGreenGoblin = card("Ultimate Green Goblin") {
+    manaCost = "{1}{B/R}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Villain"
+    power = 5
+    toughness = 4
+    oracleText = "At the beginning of your upkeep, discard a card, then create a Treasure token.\n" +
+        "Mayhem {2}{B/R} (You may cast this card from your graveyard for {2}{B/R} if you discarded it " +
+        "this turn. Timing rules still apply.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.Discard(1),
+            Effects.CreateTreasure(1),
+        )
+    }
+    mayhem("{2}{B/R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "157"
+        artist = "Jesper Ejsing"
+        flavorText = "Osborn's lust for power was nothing short of monstrous."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e82d3f71-8404-40e7-b7fa-35713d1b384e.jpg?1783905308"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/WithGreatPower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/WithGreatPower.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.RedirectDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * With Great Power . . . — Marvel's Spider-Man #24
+ * {3}{W} · Enchantment — Aura
+ *
+ * Enchant creature you control
+ * Enchanted creature gets +2/+2 for each Aura and Equipment attached to it.
+ * All damage that would be dealt to you is dealt to enchanted creature instead.
+ *
+ * The redirect is a Pariah-style static [RedirectDamage] to `EffectTarget.EnchantedCreature`
+ * (now resolved by `DamageUtils.resolveRedirectTarget`).
+ */
+val WithGreatPower = card("With Great Power . . .") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\n" +
+        "Enchanted creature gets +2/+2 for each Aura and Equipment attached to it.\n" +
+        "All damage that would be dealt to you is dealt to enchanted creature instead."
+
+    auraTarget = Targets.CreatureYouControl
+
+    // Enchanted creature gets +2/+2 for each Aura and Equipment attached to it.
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmount.Multiply(DynamicAmounts.attachmentsOnEnchantedCreature(), 2),
+            toughnessBonus = DynamicAmount.Multiply(DynamicAmounts.attachmentsOnEnchantedCreature(), 2)
+        )
+    }
+
+    // All damage that would be dealt to you is dealt to enchanted creature instead.
+    replacementEffect(
+        RedirectDamage(
+            redirectTo = EffectTarget.EnchantedCreature,
+            appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.You)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "E. M. Gist"
+        flavorText = ". . . there must also come great responsibility!"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f717c096-e161-426e-a8d7-c93b117e16b9.jpg?1783905357"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -2200,6 +2200,89 @@
     ]
 }
 
+// Green Goblin, Revenant
+{
+    "name": "Green Goblin, Revenant",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Legendary Creature — Goblin Human Villain",
+    "oracleText": "Flying, deathtouch\nWhenever Green Goblin attacks, discard a card. Then draw a card for each card you've discarded this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "CARDS_DISCARDED"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "\"The Green Goblin lives again!\"\n—Green Goblin, Harry Osborn",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/218ef931-46f5-4a4d-9f26-898a1ff8f70f.jpg?1783905318"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Grow Extra Arms
 {
     "name": "Grow Extra Arms",
@@ -5768,6 +5851,51 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Pumpkin Bombardment
+{
+    "name": "Pumpkin Bombardment",
+    "manaCost": "{B/R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, discard a card or pay {2}.\nPumpkin Bombardment deals 3 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "DiscardOrPay",
+                "alternativeManaCost": "{2}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Leon Tukker",
+        "flavorText": "\"Happy Halloween, Spider-Man!\"\n—Green Goblin, Norman Osborn",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a268ad73-9a1f-47d9-9a85-a4669a769c3d.jpg?1783905315"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -10861,6 +10989,94 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ultimate Green Goblin
+{
+    "name": "Ultimate Green Goblin",
+    "manaCost": "{1}{B/R}{B/R}",
+    "typeLine": "Legendary Creature — Goblin Villain",
+    "oracleText": "At the beginning of your upkeep, discard a card, then create a Treasure token.\nMayhem {2}{B/R} (You may cast this card from your graveyard for {2}{B/R} if you discarded it this turn. Timing rules still apply.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MAYHEM"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Mayhem",
+            "cost": "{2}{B/R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "RARE",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Osborn's lust for power was nothing short of monstrous.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e82d3f71-8404-40e7-b7fa-35713d1b384e.jpg?1783905308"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -255,6 +255,66 @@
     ]
 }
 
+// Anti-Venom, Horrifying Healer
+{
+    "name": "Anti-Venom, Horrifying Healer",
+    "manaCost": "{W}{W}{W}{W}{W}",
+    "typeLine": "Legendary Creature — Symbiote Hero",
+    "oracleText": "When Anti-Venom enters, if he was cast, return target creature card from your graveyard to the battlefield.\nIf damage would be dealt to Anti-Venom, prevent that damage and put that many +1/+1 counters on him.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card"
+                },
+                "triggerCondition": "WasCast"
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ReplaceDamageWithCounters",
+                "counterType": "+1/+1",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "MYTHIC",
+        "artist": "Néstor Ossandón Leal",
+        "flavorText": "\"You are a sickness on this city. I am the cure!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/560384fe-7be0-4b93-a515-2fe687ab2492.jpg?1783905365"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Araña, Heart of the Spider
 {
     "name": "Araña, Heart of the Spider",
@@ -9058,6 +9118,83 @@
     ]
 }
 
+// Spider-Slayer, Hatred Honed
+{
+    "name": "Spider-Slayer, Hatred Honed",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact Creature — Human Villain",
+    "oracleText": "Whenever Spider-Slayer deals damage to a Spider, destroy that creature.\n{6}, Exile this card from your graveyard: Create two tapped 1/1 colorless Robot artifact creature tokens with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": "creature Spider"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "TriggeringEntity",
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Robot"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "tapped": true,
+                    "artifactToken": true
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "David Álvarez",
+        "flavorText": "\"With each attempt on Spider-Man's life, my father came closer to ending the menace. It is my pleasure to finish the job.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac37ca6f-a6ee-4dfb-949f-2562f98d09d0.jpg?1783905300"
+    },
+    "colorIdentityOverride": []
+}
+
 // Spider-Suit
 {
     "name": "Spider-Suit",
@@ -12275,6 +12412,69 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// With Great Power . . .
+{
+    "name": "With Great Power . . .",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nEnchanted creature gets +2/+2 for each Aura and Equipment attached to it.\nAll damage that would be dealt to you is dealt to enchanted creature instead.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "EnchantedCreature",
+                        "numericProperty": "AttachmentCount"
+                    },
+                    "multiplier": 2
+                },
+                "toughnessBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "EnchantedCreature",
+                        "numericProperty": "AttachmentCount"
+                    },
+                    "multiplier": 2
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectDamage",
+                "redirectTo": "EnchantedCreature",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "You"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "E. M. Gist",
+        "flavorText": ". . . there must also come great responsibility!",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f717c096-e161-426e-a8d7-c93b117e16b9.jpg?1783905357"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -112,7 +112,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             is EventPattern.DealsDamageEvent -> {
                 event is DamageDealtEvent &&
                     event.sourceId == attachedEntityId &&
-                    matcher.matchesDealsDamageTrigger(trigger, event, state)
+                    matcher.matchesDealsDamageTrigger(trigger, event, state, auraControllerId)
             }
             is EventPattern.AttackEvent -> {
                 event is AttackersDeclaredEvent && attachedEntityId in event.attackers &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DamageTriggerDetector.kt
@@ -97,7 +97,9 @@ class DamageTriggerDetector(
         for (ability in abilities) {
             val trigger = ability.trigger
             if (trigger is EventPattern.DealsDamageEvent && ability.binding == TriggerBinding.SELF) {
-                if (matcher.matchesDealsDamageTrigger(trigger, event, state)) {
+                // Pass the ability's controller so RecipientFilter.Matching can evaluate
+                // controller-relative recipient filters (e.g. "a creature an opponent controls").
+                if (matcher.matchesDealsDamageTrigger(trigger, event, state, controllerId)) {
                     triggers.add(
                         PendingTrigger(
                             ability = ability,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1342,6 +1342,22 @@ class TriggerMatcher(
                 recipientControllerLki(event, state) == controllerId
             }
             RecipientFilter.AnyPermanent -> event.targetId !in state.turnOrder
+            is RecipientFilter.Matching -> {
+                // "deals damage to a [filtered] creature/permanent" (East-Mark Cavalier,
+                // Mauhur, Spider-Slayer). Evaluate the filter against the recipient in projected
+                // state — mirrors DamageCalculator's Matching handling. A recipient that left the
+                // battlefield to the same damage is no longer projectable, but there is nothing
+                // left to act on ("destroy that creature"), so a live match is sufficient.
+                val filter = (trigger.recipient as RecipientFilter.Matching).filter
+                event.targetId !in state.turnOrder &&
+                    state.getEntity(event.targetId) != null &&
+                    predicateEvaluator.matches(
+                        state, state.projectedState, event.targetId, filter,
+                        com.wingedsheep.engine.handlers.PredicateContext(
+                            controllerId = controllerId ?: EntityId("")
+                        )
+                    )
+            }
             RecipientFilter.Self -> false // handled elsewhere
             else -> false
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1347,15 +1347,16 @@ class TriggerMatcher(
                 // Mauhur, Spider-Slayer). Evaluate the filter against the recipient in projected
                 // state — mirrors DamageCalculator's Matching handling. A recipient that left the
                 // battlefield to the same damage is no longer projectable, but there is nothing
-                // left to act on ("destroy that creature"), so a live match is sufficient.
+                // left to act on ("destroy that creature"), so a live match is sufficient. A null
+                // controller can't evaluate controller-relative filters (e.g. "a creature an
+                // opponent controls"), so require it rather than passing an empty sentinel id.
                 val filter = (trigger.recipient as RecipientFilter.Matching).filter
-                event.targetId !in state.turnOrder &&
+                controllerId != null &&
+                    event.targetId !in state.turnOrder &&
                     state.getEntity(event.targetId) != null &&
                     predicateEvaluator.matches(
                         state, state.projectedState, event.targetId, filter,
-                        com.wingedsheep.engine.handlers.PredicateContext(
-                            controllerId = controllerId ?: EntityId("")
-                        )
+                        PredicateContext(controllerId = controllerId)
                     )
             }
             RecipientFilter.Self -> false // handled elsewhere

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1142,6 +1142,10 @@ class CostHandler {
                 // Always payable: player can always choose the "pay mana" path
                 true
             }
+            is AdditionalCost.DiscardOrPay -> {
+                // Always payable: player can always choose the "pay mana" path
+                true
+            }
             is AdditionalCost.Composite -> {
                 // All steps must be payable
                 cost.steps.all { canPayAdditionalCost(state, it, controllerId) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -958,6 +958,19 @@ class CastSpellHandler(
             }
         }
 
+        // Apply DiscardOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val discardOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.DiscardOrPay>()
+                .firstOrNull()
+            if (discardOrPay != null) {
+                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
+                if (!choseDiscard) {
+                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
+                }
+            }
+        }
+
         // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
         // waterbend amount {N} (or {X}) as generic mana; the tapped artifacts/creatures in
         // alternativePayment reduce that generic below, capped at N.
@@ -1882,6 +1895,31 @@ class CastSpellHandler(
                     }
                     // If sacrificedPermanents is empty, the player is paying extra mana instead
                 }
+                is AdditionalCost.DiscardOrPay -> {
+                    // DiscardOrPay: player chose the discard path if discardedCards is non-empty,
+                    // otherwise they pay extra mana (validated via mana payment).
+                    val discarded = action.additionalCostPayment?.discardedCards ?: emptyList()
+                    if (discarded.isNotEmpty()) {
+                        if (discarded.size != additionalCost.count) {
+                            return "You must discard exactly ${additionalCost.count} card(s) from your hand"
+                        }
+                        val handCards = state.getZone(ZoneKey(action.playerId, Zone.HAND))
+                        val context = PredicateContext(controllerId = action.playerId)
+                        for (cardId in discarded) {
+                            if (cardId !in handCards) {
+                                return "Card to discard is not in your hand"
+                            }
+                            if (cardId == action.cardId) {
+                                return "Cannot discard the spell being cast"
+                            }
+                            if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
+                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
+                                return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
+                            }
+                        }
+                    }
+                    // If discardedCards is empty, the player is paying extra mana instead
+                }
                 is AdditionalCost.PayLifePerTarget -> {
                     val required = additionalCost.amountPerTarget * action.targets.size
                     val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
@@ -2169,6 +2207,20 @@ class CastSpellHandler(
                 val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
                 if (!choseSacrifice) {
                     effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply DiscardOrPay: if player chose the "pay mana" path (no discarded cards), add the
+        // extra mana on top of the base cost.
+        if (cardDef != null && !playForFreeInExecute) {
+            val discardOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.DiscardOrPay>()
+                .firstOrNull()
+            if (discardOrPay != null) {
+                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
+                if (!choseDiscard) {
+                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
                 }
             }
         }
@@ -2641,6 +2693,37 @@ class CastSpellHandler(
                                 if (currentState.getEntity(permId) == null) continue
                                 currentState = sacrificePermanentAsCost(currentState, permId, action.playerId, events)
                             }
+                        }
+                    }
+                    is AdditionalCost.DiscardOrPay -> {
+                        // Discard the chosen cards if the player chose the discard path.
+                        // If discardedCards is empty, "pay mana" path — extra mana already added
+                        // above. Mirrors the CostAtom.Discard payment, including the discard
+                        // tracking (CR 701.8) that feeds Mayhem / "discarded this turn" reads.
+                        val discardedCards = action.additionalCostPayment.discardedCards
+                        if (discardedCards.isNotEmpty()) {
+                            discardedAsCostCards.addAll(discardedCards)
+                            for (cardId in discardedCards) {
+                                val cardContainer = currentState.getEntity(cardId) ?: continue
+                                val card = cardContainer.get<CardComponent>() ?: continue
+                                val handZone = ZoneKey(action.playerId, Zone.HAND)
+                                val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
+
+                                currentState = currentState.removeFromZone(handZone, cardId)
+                                currentState = currentState.addToZone(graveyardZone, cardId)
+
+                                events.add(ZoneChangeEvent(
+                                    entityId = cardId,
+                                    entityName = card.name,
+                                    fromZone = Zone.HAND,
+                                    toZone = Zone.GRAVEYARD,
+                                    ownerId = action.playerId
+                                ))
+                            }
+                            val discardNames = discardedCards.map { currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
+                            events.add(CardsDiscardedEvent(action.playerId, discardedCards, discardNames))
+                            currentState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                                .trackDiscard(currentState, action.playerId, discardedCards)
                         }
                     }
                     is AdditionalCost.PayLifePerTarget -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -224,6 +224,12 @@ object DamageUtils {
             // Damage-to-an-opponent → prevent + each opponent mills that many (The Mindskinner).
             val millResult = applyReplaceDamageWithMill(newState, targetId, effectiveAmount, sourceId)
             if (millResult != null) return millResult
+        } else {
+            // Damage-to-a-creature self-replacement (Anti-Venom): "if damage would be dealt to
+            // <this creature>, prevent it and put that many +1/+1 counters on him." Matches only a
+            // Self-recipient replacement whose host is the damaged creature.
+            val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
+            if (counterResult != null) return counterResult
         }
 
         // Events from a reflect shield (Eye for an Eye) that fired but let the damage proceed.
@@ -1116,6 +1122,13 @@ object DamageUtils {
                     ?.get<com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent>()
                     ?.snapshot?.controllerId
         is EffectTarget.Self -> replacementOwnerId
+        // Pariah-style redirect (With Great Power…): "all damage dealt to you is dealt to
+        // enchanted creature instead." The replacement lives on the Aura/Equipment; the
+        // recipient is whatever it's attached to.
+        is EffectTarget.EnchantedCreature,
+        is EffectTarget.EquippedCreature,
+        is EffectTarget.EnchantedPermanent ->
+            state.getEntity(replacementOwnerId)?.get<AttachedToComponent>()?.targetId
         else -> null
     }
 
@@ -1862,6 +1875,9 @@ object DamageUtils {
                 // Check recipient filter
                 val recipientMatches = when (val recipient = damageEvent.recipient) {
                     is RecipientFilter.You -> targetId == sourceControllerId
+                    // "If damage would be dealt to <this creature>…" (Anti-Venom) — the damaged
+                    // permanent is the replacement's own host; counters go on it (entityId).
+                    is RecipientFilter.Self -> targetId == entityId
                     is RecipientFilter.Any -> true
                     else -> false
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -202,6 +202,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var exileOrPayTargets = emptyList<EntityId>()
             var sacOrPayCost: AdditionalCost.SacrificeOrPay? = null
             var sacOrPayTargets = emptyList<EntityId>()
+            var discardOrPayCost: AdditionalCost.DiscardOrPay? = null
+            var discardOrPayTargets = emptyList<EntityId>()
             var canPayAdditionalCosts = true
             val flattenedCosts = additionalCosts.flatMap {
                 if (it is AdditionalCost.Composite) it.steps else listOf(it)
@@ -370,6 +372,22 @@ class CastSpellEnumerator : ActionEnumerator {
                             state, playerId, CostAtom.Sacrifice(cost.filter, cost.count)
                         )
                     }
+                    is AdditionalCost.DiscardOrPay -> {
+                        // Always payable: player can always choose the "pay mana" path.
+                        // Surface the hand cards eligible for the discard path (excluding the
+                        // spell being cast).
+                        discardOrPayCost = cost
+                        val handZone = ZoneKey(playerId, Zone.HAND)
+                        val handCards = state.getZone(handZone).filter { it != cardId }
+                        val predicateContext = PredicateContext(controllerId = playerId)
+                        discardOrPayTargets = if (cost.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
+                            handCards
+                        } else {
+                            handCards.filter {
+                                context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext)
+                            }
+                        }
+                    }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
                         // uses projected state (continuous effects matter); hidden / card
@@ -445,6 +463,12 @@ class CastSpellEnumerator : ActionEnumerator {
             val sacOrPayBaseCost = effectiveCost
             if (sacOrPayCost != null) {
                 effectiveCost = effectiveCost + ManaCost.parse(sacOrPayCost.alternativeManaCost)
+            }
+
+            // Save base cost for discard path, then add extra mana for the "pay" path
+            val discardOrPayBaseCost = effectiveCost
+            if (discardOrPayCost != null) {
+                effectiveCost = effectiveCost + ManaCost.parse(discardOrPayCost.alternativeManaCost)
             }
 
             // Spell-level waterbend additional cost (Avatar: The Last Airbender). A *mandatory*
@@ -602,11 +626,17 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, sacOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
+            // Check discard path affordability (base cost without the extra mana, but needs
+            // enough matching cards in hand to discard).
+            val canAffordDiscardOrPayPath = if (discardOrPayCost != null && discardOrPayTargets.size >= discardOrPayCost.count) {
+                context.manaSolver.canPay(state, playerId, discardOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
+            } else false
+
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
             val canAffordFreeCast = context.freeCastPermissionFor(cardId)
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordFreeCast) {
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordDiscardOrPayPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -706,6 +736,24 @@ class CastSpellEnumerator : ActionEnumerator {
                     sacrificeCount = sacOrPayCost.count,
                 )
                 Triple(sacManaCostString, sacAutoTapPreview, sacCostInfo)
+            } else null
+
+            // Compute discard path info (separate legal action with lower mana cost + hand card
+            // selection). Reuses the "DiscardCard" cost type so the client drives the same hand
+            // discard selection used by Force of Will's plain discard cost.
+            val discardOrPayPathInfo = if (canAffordDiscardOrPayPath && discardOrPayCost != null) {
+                val discardManaCostString = discardOrPayBaseCost.toString()
+                val discardAutoTapPreview = if (context.skipAutoTapPreview) null else {
+                    context.manaSolver.solve(state, playerId, discardOrPayBaseCost, precomputedSources = cachedSources)
+                        ?.sources?.map { it.entityId }
+                }
+                val discardCostInfo = AdditionalCostData(
+                    description = discardOrPayCost.description,
+                    costType = "DiscardCard",
+                    validDiscardTargets = discardOrPayTargets,
+                    discardCount = discardOrPayCost.count,
+                )
+                Triple(discardManaCostString, discardAutoTapPreview, discardCostInfo)
             } else null
 
             // Calculate X cost info if the spell has X in its cost (printed, or the waterbend {X}
@@ -1222,6 +1270,19 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = sacOrPayPathInfo.second
                             ))
                         }
+                        if (discardOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Discard)",
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
+                                additionalCostInfo = discardOrPayPathInfo.third,
+                                manaCostString = discardOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = discardOrPayPathInfo.second
+                            ))
+                        }
                     } else {
                         if (canAfford) {
                             result.add(LegalAction(
@@ -1447,6 +1508,27 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = sacOrPayPathInfo.second
                             ))
                         }
+                        if (discardOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Discard)",
+                                action = CastSpell(playerId, cardId),
+                                validTargets = firstReqInfo.validTargets,
+                                requiresTargets = true,
+                                targetCount = firstReqInfo.maxTargets,
+                                minTargets = firstReq.effectiveMinCount,
+                                targetDescription = firstReq.description,
+                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
+                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
+                                additionalCostInfo = discardOrPayPathInfo.third,
+                                manaCostString = discardOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = discardOrPayPathInfo.second
+                            ))
+                        }
                     }
                 }
             } else {
@@ -1561,6 +1643,16 @@ class CastSpellEnumerator : ActionEnumerator {
                         additionalCostInfo = sacOrPayPathInfo.third,
                         manaCostString = sacOrPayPathInfo.first,
                         autoTapPreview = sacOrPayPathInfo.second
+                    ))
+                }
+                if (discardOrPayPathInfo != null) {
+                    result.add(LegalAction(
+                        actionType = "CastSpell",
+                        description = "Cast ${cardComponent.name} (Discard)",
+                        action = CastSpell(playerId, cardId),
+                        additionalCostInfo = discardOrPayPathInfo.third,
+                        manaCostString = discardOrPayPathInfo.first,
+                        autoTapPreview = discardOrPayPathInfo.second
                     ))
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -1017,6 +1017,16 @@ internal class CombatDamageManager(
         newState = shieldState
         if (effectiveAmount <= 0) return newState
 
+        // Damage-to-counters self-replacement (Anti-Venom): "if damage would be dealt to <this
+        // creature>, prevent it and put that many +1/+1 counters on him." Replaces the damage
+        // entirely (CR 615) — checked before redirection and final marking.
+        val counterResult = DamageUtils.applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
+        if (counterResult != null) {
+            newState = counterResult.state
+            events.addAll(counterResult.events)
+            return newState
+        }
+
         // Damage redirection (Glarecaster, Zealous Inquisitor). See applyDamageToPlayer for why
         // inBatch=true — a Glarecaster shield protects its controller's creatures too, so a blocked
         // attacker's damage to a protected blocker is redirected as part of the same batch.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiVenomHorrifyingHealerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiVenomHorrifyingHealerScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Anti-Venom, Horrifying Healer (SPM) — "If damage would be dealt to Anti-Venom, prevent that
+ * damage and put that many +1/+1 counters on him." Pins the `RecipientFilter.Self`
+ * `ReplaceDamageWithCounters` now wired on the creature-damage paths (`DamageUtils.applyDamage`
+ * non-player branch + `CombatDamageManager.applyDamageToCreature`).
+ */
+class AntiVenomHorrifyingHealerScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun GameTestDriver.bolt(player: EntityId, target: ChosenTarget) {
+        giveMana(player, Color.RED, 1)
+        val b = putCardInHand(player, "Lightning Bolt")
+        castSpellWithTargets(player, b, listOf(target))
+        bothPass()
+        resolveStack(this)
+    }
+
+    test("noncombat damage to Anti-Venom is prevented and put on him as +1/+1 counters") {
+        val (driver, you, opponent) = newGame()
+        val av = driver.putCreatureOnBattlefield(you, "Anti-Venom, Horrifying Healer") // 5/5
+
+        // You have priority in your main phase; bolt your own Anti-Venom (damage to him is replaced
+        // regardless of the source).
+        driver.bolt(you, ChosenTarget.Permanent(av)) // 3 damage
+
+        // Damage replaced entirely — none marked, three +1/+1 counters, still on the battlefield.
+        (driver.state.getEntity(av)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+        (driver.state.getEntity(av)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 3
+        driver.state.getBattlefield().contains(av) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiVenomHorrifyingHealerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AntiVenomHorrifyingHealerScenarioTest.kt
@@ -1,7 +1,10 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -11,13 +14,18 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 /**
- * Anti-Venom, Horrifying Healer (SPM) — "If damage would be dealt to Anti-Venom, prevent that
- * damage and put that many +1/+1 counters on him." Pins the `RecipientFilter.Self`
- * `ReplaceDamageWithCounters` now wired on the creature-damage paths (`DamageUtils.applyDamage`
- * non-player branch + `CombatDamageManager.applyDamageToCreature`).
+ * Anti-Venom, Horrifying Healer (SPM) — a 5/5 with two abilities:
+ *  - "When Anti-Venom enters, if he was cast, return target creature card from your graveyard to
+ *    the battlefield." (an intervening-"if" `Conditions.WasCast` ETB reanimation), and
+ *  - "If damage would be dealt to Anti-Venom, prevent that damage and put that many +1/+1 counters
+ *    on him." — the `RecipientFilter.Self` `ReplaceDamageWithCounters` wired on both creature-damage
+ *    paths: `DamageUtils.applyDamage` (noncombat) and `CombatDamageManager.applyDamageToCreature`
+ *    (combat).
  */
 class AntiVenomHorrifyingHealerScenarioTest : FunSpec({
 
@@ -56,5 +64,60 @@ class AntiVenomHorrifyingHealerScenarioTest : FunSpec({
         (driver.state.getEntity(av)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
         (driver.state.getEntity(av)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 3
         driver.state.getBattlefield().contains(av) shouldBe true
+    }
+
+    test("combat damage to Anti-Venom is prevented and put on him as +1/+1 counters") {
+        val (driver, you, opponent) = newGame()
+        val av = driver.putCreatureOnBattlefield(you, "Anti-Venom, Horrifying Healer") // 5/5
+        driver.removeSummoningSickness(av)
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3 blocker
+
+        // Anti-Venom attacks; the 3/3 blocks. The blocker's 3 combat damage hits Anti-Venom via
+        // CombatDamageManager.applyDamageToCreature — the distinct path from the Lightning Bolt case.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(av), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(courser to listOf(av)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The 3 combat damage is replaced entirely — none marked, three +1/+1 counters on him.
+        (driver.state.getEntity(av)?.get<DamageComponent>()?.amount ?: 0) shouldBe 0
+        (driver.state.getEntity(av)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 3
+        driver.state.getBattlefield().contains(av) shouldBe true
+        // Anti-Venom still dealt its own 5 — the 3/3 blocker is destroyed.
+        driver.state.getBattlefield().contains(courser) shouldBe false
+    }
+
+    test("cast: the intervening-if ETB returns a creature card from your graveyard to the battlefield") {
+        val (driver, you, _) = newGame()
+        driver.putCardInGraveyard(you, "Centaur Courser")
+        val av = driver.putCardInHand(you, "Anti-Venom, Horrifying Healer")
+        repeat(5) { driver.putLandOnBattlefield(you, "Plains") } // {W}{W}{W}{W}{W}
+
+        driver.submit(
+            CastSpell(playerId = you, cardId = av, paymentStrategy = PaymentStrategy.AutoPay),
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve Anti-Venom; the was-cast ETB trigger goes on the stack, wants a target
+
+        val courser = driver.getGraveyard(you).first {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Centaur Courser"
+        }
+        driver.pendingDecision.shouldNotBeNull()
+        driver.submitTargetSelection(you, listOf(courser))
+        resolveStack(driver)
+
+        driver.findPermanent(you, "Centaur Courser").shouldNotBeNull()
+    }
+
+    test("not cast: an Anti-Venom put onto the battlefield does not trigger the reanimation") {
+        val (driver, you, _) = newGame()
+        driver.putCardInGraveyard(you, "Centaur Courser")
+
+        // Enters without being cast → Conditions.WasCast is false → no ETB trigger, no target request.
+        driver.putCreatureOnBattlefield(you, "Anti-Venom, Horrifying Healer")
+
+        driver.pendingDecision.shouldBeNull()
+        driver.findPermanent(you, "Centaur Courser").shouldBeNull()
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EastMarkCavalierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EastMarkCavalierScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ltr.cards.EastMarkCavalier
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * East-Mark Cavalier (LTR #9) — "Whenever this creature deals damage to a Goblin or Orc, destroy
+ * that creature." Regression coverage for the shipped card that shares Spider-Slayer's shape: the
+ * `RecipientFilter.Matching` deals-damage trigger repaired in `TriggerMatcher.matchesDealsDamageTrigger`.
+ * Before that fix this ability silently never fired.
+ *
+ * The Goblin blocker is a 0/4 so the Cavalier survives and the Goblin survives the raw 2 combat
+ * damage — proving it is the *trigger* (not lethal combat damage) that destroys it, and that a
+ * non-Goblin/Orc is left alone.
+ */
+class EastMarkCavalierScenarioTest : FunSpec({
+
+    val testGoblin = card("Test Goblin Blocker") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Goblin"
+        power = 0
+        toughness = 4
+    }
+    val testBear = card("Test Bear Blocker") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 0
+        toughness = 4
+    }
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EastMarkCavalier, testGoblin, testBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("destroys a Goblin it deals combat damage to (even though the Goblin survives the damage)") {
+        val (driver, you, opponent) = newGame()
+        val cavalier = driver.putCreatureOnBattlefield(you, "East-Mark Cavalier") // 2/2
+        driver.removeSummoningSickness(cavalier)
+        val goblin = driver.putCreatureOnBattlefield(opponent, "Test Goblin Blocker") // 0/4
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(cavalier), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(goblin to listOf(cavalier)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The Goblin took only 2 (survives a 4-toughness body on its own), but the trigger destroys it.
+        driver.state.getBattlefield().contains(goblin) shouldBe false
+        // The Cavalier took 0 and survives.
+        driver.state.getBattlefield().contains(cavalier) shouldBe true
+    }
+
+    test("does not destroy a non-Goblin/Orc it deals combat damage to") {
+        val (driver, you, opponent) = newGame()
+        val cavalier = driver.putCreatureOnBattlefield(you, "East-Mark Cavalier") // 2/2
+        driver.removeSummoningSickness(cavalier)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Test Bear Blocker") // 0/4, not a Goblin/Orc
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(cavalier), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(bear to listOf(cavalier)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // Non-Goblin/Orc: no destroy trigger; the 0/4 survives the 2 combat damage.
+        driver.state.getBattlefield().contains(bear) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pumpkin Bombardment (SPM).
+ *
+ * {B/R} Sorcery
+ * As an additional cost to cast this spell, discard a card or pay {2}.
+ * Pumpkin Bombardment deals 3 damage to target creature.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.DiscardOrPay] additional cost
+ * (discard path vs pay path), including the case where an empty hand leaves only the pay path.
+ */
+class PumpkinBombardmentScenarioTest : ScenarioTestBase() {
+
+    // A 3/3 target that dies to Pumpkin Bombardment's 3 damage, and a spare card to discard.
+    private val testBear = card("Pumpkin Test Bear") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Bear"
+        power = 3
+        toughness = 3
+    }
+    private val spareCard = card("Pumpkin Test Spare") {
+        manaCost = "{1}"
+        typeLine = "Creature — Goblin"
+        power = 1
+        toughness = 1
+    }
+
+    init {
+        cardRegistry.register(listOf(testBear, spareCard))
+
+        context("DiscardOrPay additional cost") {
+            test("discard path: discards a card and deals 3 damage to the target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withCardInHand(2, "Pumpkin Test Spare")
+                    .withLandsOnBattlefield(2, "Mountain", 1) // {R} pays {B/R}
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.state.getBattlefield().first {
+                    val c = game.state.getEntity(it)
+                    c?.get<CardComponent>()?.name == "Pumpkin Test Bear" &&
+                        c.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val pumpkinId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Bombardment"
+                }
+                val spareId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Test Spare"
+                }
+
+                val result = game.execute(
+                    CastSpell(
+                        game.player2Id,
+                        pumpkinId,
+                        listOf(ChosenTarget.Permanent(bearId)),
+                        additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(spareId)),
+                    )
+                )
+                withClue("Pumpkin Bombardment should cast via the discard path: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The spare card should be discarded") {
+                    game.isInGraveyard(2, "Pumpkin Test Spare") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("The target creature should be destroyed by 3 damage") {
+                    game.isInGraveyard(1, "Pumpkin Test Bear") shouldBe true
+                }
+            }
+
+            test("pay path: no discard, engine adds {2}, and deals 3 damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withCardInHand(2, "Pumpkin Test Spare")
+                    .withLandsOnBattlefield(2, "Mountain", 3) // enough for {B/R} + {2}
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bearId = game.state.getBattlefield().first {
+                    val c = game.state.getEntity(it)
+                    c?.get<CardComponent>()?.name == "Pumpkin Test Bear" &&
+                        c.get<ControllerComponent>()?.playerId == game.player1Id
+                }
+                val pumpkinId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Pumpkin Bombardment"
+                }
+
+                // Pay path: no discard payment — the engine adds {2} to the cost.
+                val result = game.execute(
+                    CastSpell(game.player2Id, pumpkinId, listOf(ChosenTarget.Permanent(bearId)))
+                )
+                withClue("Pumpkin Bombardment should cast via the pay path: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The spare card should still be in hand (no discard on the pay path)") {
+                    game.isInHand(2, "Pumpkin Test Spare") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("The target creature should be destroyed by 3 damage") {
+                    game.isInGraveyard(1, "Pumpkin Test Bear") shouldBe true
+                }
+            }
+
+            test("with an empty hand, only the pay path is castable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Pumpkin Test Bear")
+                    .withCardInHand(2, "Pumpkin Bombardment")
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pumpkinActions = game.getLegalActions(2)
+                    .filter { it.description.startsWith("Cast Pumpkin Bombardment") }
+                withClue("Pumpkin Bombardment should be castable (pay path)") {
+                    pumpkinActions.isNotEmpty() shouldBe true
+                }
+                withClue("No discard path should be offered with no other card in hand") {
+                    pumpkinActions.none { it.description.endsWith("(Discard)") } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderSlayerHatredHonedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderSlayerHatredHonedScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spider-Slayer, Hatred Honed (SPM) — "Whenever Spider-Slayer deals damage to a Spider, destroy
+ * that creature." Pins the `RecipientFilter.Matching` deals-damage trigger now wired in
+ * `TriggerMatcher.matchesDealsDamageTrigger` (the same shape as East-Mark Cavalier / Mauhur).
+ *
+ * The blocker is a 1/3 so it survives the 2 combat damage on its own — proving it is the *trigger*
+ * (not lethal combat damage) that destroys a Spider, and that a non-Spider is left alone.
+ */
+class SpiderSlayerHatredHonedScenarioTest : FunSpec({
+
+    // 0 power so Spider-Slayer (a 2/1) survives the block — isolating the destroy *trigger* from
+    // lethal combat damage in either direction.
+    val testSpider = card("Test Spider Blocker") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Spider"
+        power = 0
+        toughness = 3
+    }
+    val testBear = card("Test Bear Blocker") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 1
+        toughness = 3
+    }
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testSpider, testBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("destroys a Spider it deals combat damage to (even though the Spider survives the damage)") {
+        val (driver, you, opponent) = newGame()
+        val slayer = driver.putCreatureOnBattlefield(you, "Spider-Slayer, Hatred Honed")
+        driver.removeSummoningSickness(slayer)
+        val spider = driver.putCreatureOnBattlefield(opponent, "Test Spider Blocker") // 1/3
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(slayer), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(spider to listOf(slayer)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The Spider took only 2 (survives a 3-toughness body on its own), but the trigger destroys it.
+        driver.state.getBattlefield().contains(spider) shouldBe false
+        // Spider-Slayer took 1 and survives.
+        driver.state.getBattlefield().contains(slayer) shouldBe true
+    }
+
+    test("does not destroy a non-Spider it deals combat damage to") {
+        val (driver, you, opponent) = newGame()
+        val slayer = driver.putCreatureOnBattlefield(you, "Spider-Slayer, Hatred Honed")
+        driver.removeSummoningSickness(slayer)
+        val bear = driver.putCreatureOnBattlefield(opponent, "Test Bear Blocker") // 1/3, not a Spider
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(slayer), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(bear to listOf(slayer)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // Non-Spider: no destroy trigger; the 1/3 survives the 2 combat damage.
+        driver.state.getBattlefield().contains(bear) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderSlayerHatredHonedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderSlayerHatredHonedScenarioTest.kt
@@ -1,7 +1,12 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.SpiderSlayerHatredHoned
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
@@ -18,6 +23,8 @@ import io.kotest.matchers.shouldBe
  * (not lethal combat damage) that destroys a Spider, and that a non-Spider is left alone.
  */
 class SpiderSlayerHatredHonedScenarioTest : FunSpec({
+
+    val slayerActivatedAbilityId = SpiderSlayerHatredHoned.activatedAbilities.single().id
 
     // 0 power so Spider-Slayer (a 2/1) survives the block — isolating the destroy *trigger* from
     // lethal combat damage in either direction.
@@ -83,5 +90,33 @@ class SpiderSlayerHatredHonedScenarioTest : FunSpec({
 
         // Non-Spider: no destroy trigger; the 1/3 survives the 2 combat damage.
         driver.state.getBattlefield().contains(bear) shouldBe true
+    }
+
+    test("{6}, exile from graveyard: creates two tapped 1/1 flying Robot artifact tokens") {
+        val (driver, you, _) = newGame()
+        val slayer = driver.putCardInGraveyard(you, "Spider-Slayer, Hatred Honed")
+        driver.giveColorlessMana(you, 6)
+
+        driver.submit(
+            ActivateAbility(playerId = you, sourceId = slayer, abilityId = slayerActivatedAbilityId),
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        resolveStack(driver)
+
+        // Exile is part of the cost — the card leaves the graveyard for exile.
+        driver.getExile(you).contains(slayer) shouldBe true
+        driver.state.getBattlefield().contains(slayer) shouldBe false
+
+        val robots = driver.state.getBattlefield().filter { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == "Robot Token" &&
+                driver.getController(id) == you
+        }
+        robots.size shouldBe 2
+        robots.forEach { r ->
+            driver.state.getEntity(r)?.has<TappedComponent>() shouldBe true
+            driver.state.projectedState.getPower(r) shouldBe 1
+            driver.state.projectedState.getToughness(r) shouldBe 1
+            driver.state.projectedState.hasKeyword(r, Keyword.FLYING) shouldBe true
+        }
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WithGreatPowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WithGreatPowerScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * With Great Power . . . (SPM) — Aura: enchanted creature gets +2/+2 per Aura/Equipment attached to
+ * it, and all damage that would be dealt to you is dealt to the enchanted creature instead.
+ *
+ * Pins the Pariah-style static `RedirectDamage` to `EffectTarget.EnchantedCreature` (now resolved
+ * by `DamageUtils.resolveRedirectTarget`) and the `attachmentsOnEnchantedCreature()` dynamic buff.
+ */
+class WithGreatPowerScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("buffs the enchanted creature (+2/+2 per attachment) and redirects damage from you to it") {
+        val (driver, you, opponent) = newGame()
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+
+        // Cast With Great Power . . . on Centaur Courser.
+        driver.giveMana(you, Color.WHITE, 4)
+        val wgp = driver.putCardInHand(you, "With Great Power . . .")
+        driver.castSpellWithTargets(you, wgp, listOf(ChosenTarget.Permanent(courser)))
+        driver.bothPass()
+        resolveStack(driver)
+
+        // One attachment (the Aura itself) → +2/+2 → 5/5.
+        driver.state.projectedState.getPower(courser) shouldBe 5
+        driver.state.projectedState.getToughness(courser) shouldBe 5
+
+        // Damage that would be dealt to you is dealt to the enchanted creature instead. You have
+        // priority in your main phase; bolt yourself — the redirect applies to any damage to you.
+        val before = driver.getLifeTotal(you)
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(you)))
+        driver.bothPass()
+        resolveStack(driver)
+
+        driver.getLifeTotal(you) shouldBe before // unchanged — redirected
+        (driver.state.getEntity(courser)?.get<DamageComponent>()?.amount ?: 0) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WithGreatPowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WithGreatPowerScenarioTest.kt
@@ -62,4 +62,25 @@ class WithGreatPowerScenarioTest : FunSpec({
         driver.getLifeTotal(you) shouldBe before // unchanged — redirected
         (driver.state.getEntity(courser)?.get<DamageComponent>()?.amount ?: 0) shouldBe 3
     }
+
+    test("the +2/+2 scales per attachment: two attachments on the creature grant +4/+4 each") {
+        val (driver, you, _) = newGame()
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+
+        // Enchant Centaur Courser with two copies of With Great Power . . . ({3}{W} each). Nothing
+        // stops two of the same Aura on one creature, and it gives a clean two-attachment board
+        // without dragging in Equipment stat bonuses.
+        driver.giveMana(you, Color.WHITE, 8)
+        repeat(2) {
+            val wgp = driver.putCardInHand(you, "With Great Power . . .")
+            driver.castSpellWithTargets(you, wgp, listOf(ChosenTarget.Permanent(courser)))
+            driver.bothPass()
+            resolveStack(driver)
+        }
+
+        // Two Auras attached → each grants +2/+2 *per attachment* = +4/+4 → +8/+8 total → 11/11.
+        // A flat "+2/+2" (ignoring the count) would give only 7/7, so this pins the scaling.
+        driver.state.projectedState.getPower(courser) shouldBe 11
+        driver.state.projectedState.getToughness(courser) shouldBe 11
+    }
 })


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1513

## SPM Batch 2 — damage-trigger / replacement / redirect features

**Stacked on `spm-goblins`** — this PR is only the diff against that branch.

Three SPM cards, each unlocked by a small, composable damage-system capability. Two of the
capabilities also repair already-shipped cards with the identical shape.

### Cards
- **Anti-Venom, Horrifying Healer** [1] — `{W}{W}{W}{W}{W}` 5/5. "If he was cast" ETB reanimation
  (existing `Conditions.WasCast`) + "prevent damage to him, put that many +1/+1 counters on him"
  self-replacement.
- **Spider-Slayer, Hatred Honed** [175] — `{2}` 2/1. "Deals damage to a Spider → destroy it" +
  `{6}`, exile-from-graveyard → two tapped 1/1 flying Robot artifact tokens.
- **With Great Power . . .** [24] — `{3}{W}` Aura. "+2/+2 for each Aura/Equipment attached" +
  Pariah-style "all damage to you is dealt to enchanted creature instead."

### Engine capabilities (composition-first — no new Effect/executor types)
1. **Deals-damage-to-a-filtered-creature trigger** — added the missing `RecipientFilter.Matching`
   case to `TriggerMatcher.matchesDealsDamageTrigger`, evaluated against the recipient in projected
   state with the ability's real controller (threaded through `DamageTriggerDetector` /
   `AttachmentTriggerDetector`). Also repairs the identically-shaped, silently-broken **East-Mark
   Cavalier** and **Mauhur, Uruk-hai Captain** (LTR).
2. **Prevent-damage-to-counters on creatures** — added `RecipientFilter.Self` to
   `DamageUtils.applyReplaceDamageWithCounters` and invoked it on both creature-damage paths
   (`DamageUtils` noncombat + `CombatDamageManager.applyDamageToCreature`).
3. **Pariah-style static redirect** — `resolveRedirectTarget` now handles
   `EnchantedCreature`/`EquippedCreature`/`EnchantedPermanent`; the buff uses the new
   `DynamicAmounts.attachmentsOnEnchantedCreature()` over the existing `GrantDynamicStatsEffect`.

### Tests
Scenario tests for all three cards plus a regression test for East-Mark Cavalier, covering both
abilities per card: cast→reanimate and the `WasCast` gate; noncombat *and* combat damage→counters;
per-attachment stat scaling (two Auras → +8/+8); the graveyard token ability; and
destroy-vs-leave-alone by subtype. Full `rules-engine` suite green (2675 classes, 0 failures). SPM
snapshot reblessed (only these three cards move); docs, `mechanics.md`, and `cards.md` (170/188)
updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
