### PR TITLE
Add four Wilds of Eldraine Adventure creatures

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BrambleFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BrambleFamiliar.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bramble Familiar // Fetch Quest
+ * {1}{G}
+ * Creature — Elemental Raccoon
+ * 2/2
+ * {T}: Add {G}.
+ * {1}{G}, {T}, Discard a card: Return this creature to its owner's hand.
+ *
+ * Adventure: Fetch Quest — {5}{G}{G}, Sorcery — Adventure
+ * Mill seven cards. Then put a creature, enchantment, or land card from among the milled
+ * cards onto the battlefield.
+ *
+ * The bounce ability returns the *source* to hand, so it takes [EffectTarget.Self] rather than a
+ * target — the creature can rebuy the Adventure by going back to hand and being recast later.
+ * Its cost is the literal three-atom composite (mana + tap + discard); the discard is a cost, not
+ * an effect, so it happens on activation even if the ability is later countered.
+ *
+ * The Adventure is the standard Gather → Move → Select → Move mill-and-retrieve pipeline (see
+ * Picklock Prankster), with `isMill = true` on the gather so mill-watchers see a real mill event,
+ * and a battlefield destination instead of hand. The cards hit the graveyard *first* and the
+ * selection reads the `fetch_milled` collection afterwards — that ordering is what makes "from
+ * among the milled cards" mean those specific seven rather than "anything in your graveyard".
+ *
+ * Oracle says "Then put ... onto the battlefield", not "you may put", so this is
+ * [SelectionMode.ChooseExactly]`(1)`. The executor selects nothing when the eligible pool is empty
+ * (all seven milled cards were instants/sorceries), so the mandatory wording degrades correctly
+ * instead of deadlocking. `showAllCards = true` keeps the ineligible milled cards visible so the
+ * player can see what the mill actually hit.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val BrambleFamiliar = card("Bramble Familiar") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Raccoon"
+    oracleText = "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return this creature to its owner's hand."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+    }
+
+    adventure("Fetch Quest") {
+        manaCost = "{5}{G}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Mill seven cards. Then put a creature, enchantment, or land card from among " +
+            "the milled cards onto the battlefield. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(
+                            count = DynamicAmount.Fixed(7),
+                            player = Player.You,
+                            isMill = true,
+                        ),
+                        storeAs = "fetch_milled",
+                    ),
+                    MoveCollectionEffect(
+                        from = "fetch_milled",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "fetch_milled",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        filter = GameObjectFilter(
+                            cardPredicates = listOf(
+                                CardPredicate.Or(
+                                    listOf(
+                                        CardPredicate.IsCreature,
+                                        CardPredicate.IsEnchantment,
+                                        CardPredicate.IsLand,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        storeSelected = "fetch_selected",
+                        showAllCards = true,
+                        prompt = "Put a creature, enchantment, or land card onto the battlefield",
+                        selectedLabel = "Put onto the battlefield",
+                        remainderLabel = "Leave in graveyard",
+                    ),
+                    MoveCollectionEffect(
+                        from = "fetch_selected",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You),
+                    ),
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1783915084"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HornedLochWhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HornedLochWhale.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Horned Loch-Whale // Lagoon Breach
+ * {4}{U}{U}
+ * Creature — Whale
+ * 6/6
+ * Flash
+ * Ward {2}
+ * This creature enters tapped unless it's your turn.
+ *
+ * Adventure: Lagoon Breach — {1}{U}, Instant — Adventure
+ * The owner of target attacking creature you don't control puts it on their choice of the top
+ * or bottom of their library.
+ *
+ * "Enters tapped unless it's your turn" is [EntersTapped] with the positive
+ * [Conditions.IsYourTurn] as the `unlessCondition` — flashing the Whale in on an opponent's turn
+ * gets a tapped 6/6 that can't block, while hard-casting it on your own main phase gets an
+ * untapped one (see Eddymurk Crab, which prints the same clause inverted).
+ *
+ * The Adventure is [Effects.PutOnTopOrBottomOfLibrary], which already models "their choice" —
+ * the *owner* of the bounced creature picks the destination, not the spell's controller.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val HornedLochWhale = card("Horned Loch-Whale") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Whale"
+    oracleText = "Flash\nWard {2} (Whenever this creature becomes the target of a spell or ability " +
+        "an opponent controls, counter it unless that player pays {2}.)\n" +
+        "This creature enters tapped unless it's your turn."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.FLASH)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    replacementEffect(EntersTapped(unlessCondition = Conditions.IsYourTurn))
+
+    adventure("Lagoon Breach") {
+        manaCost = "{1}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "The owner of target attacking creature you don't control puts it on their " +
+            "choice of the top or bottom of their library. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            val attacker = target(
+                "target attacking creature you don't control",
+                TargetCreature(filter = TargetFilter.AttackingCreature.opponentControls()),
+            )
+            effect = Effects.PutOnTopOrBottomOfLibrary(attacker)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "53"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1783915120"
+
+        ruling(
+            "2023-09-01",
+            "The creature's owner chooses whether to put it on the top or bottom of their library. " +
+                "If multiple cards are put into the library this way (such as when the spell targets " +
+                "a melded permanent), that creature's owner puts all the cards on top or all the " +
+                "cards on the bottom. They put them in whatever order they wish, and do not need to " +
+                "reveal the order."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/QuestingDruid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/QuestingDruid.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Questing Druid // Seek the Beast
+ * {1}{G}
+ * Creature — Human Druid
+ * 1/1
+ * Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on this creature.
+ *
+ * Adventure: Seek the Beast — {1}{R}, Instant — Adventure
+ * Exile the top two cards of your library. Until your next end step, you may play those cards.
+ *
+ * The trigger is a single [CardPredicate.Or] over four [CardPredicate.HasColor]s rather than four
+ * separate triggers: a spell that is more than one of the listed colors still matches the one
+ * predicate once, which is exactly the ruling ("Questing Druid's ability still triggers only
+ * once"). Green-only and colorless spells match nothing, so casting the Druid itself does not
+ * grow it.
+ *
+ * The Adventure is plain impulse draw — [Patterns.Exile.impulse] with a two-card count and a
+ * [MayPlayExpiry.UntilNextEndStep] window ("until your next end step"; on your own turn this
+ * turn's end step counts). The permission grants *playing*, not free casting, so the exiled cards
+ * still cost their mana and a land among them still uses your land drop at sorcery speed.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val QuestingDruid = card("Questing Druid") {
+    manaCost = "{1}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Human Druid"
+    oracleText = "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter " +
+        "on this creature."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            GameObjectFilter.Any.withCardPredicate(
+                CardPredicate.Or(
+                    listOf(
+                        CardPredicate.HasColor(Color.WHITE),
+                        CardPredicate.HasColor(Color.BLUE),
+                        CardPredicate.HasColor(Color.BLACK),
+                        CardPredicate.HasColor(Color.RED),
+                    ),
+                ),
+            ),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    adventure("Seek the Beast") {
+        manaCost = "{1}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Exile the top two cards of your library. Until your next end step, you may " +
+            "play those cards. (Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            effect = Patterns.Exile.impulse(
+                count = 2,
+                expiry = MayPlayExpiry.UntilNextEndStep,
+                storeAs = "seek_the_beast_exiled",
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1783915063"
+
+        ruling(
+            "2023-09-01",
+            "If you cast a spell that's more than one of the listed colors, Questing Druid's " +
+                "ability still triggers only once."
+        )
+        ruling(
+            "2023-09-01",
+            "You pay all costs and follow all normal timing rules for cards played from exile with " +
+                "Seek the Beast. For example, if the exiled card is a land card, you may play it " +
+                "only during your main phase while the stack is empty."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwiningTwins.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TwiningTwins.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Twining Twins // Swift Spiral
+ * {2}{U}{U}
+ * Creature — Faerie Wizard
+ * 4/4
+ * Flying, vigilance, ward {1}
+ *
+ * Adventure: Swift Spiral — {1}{W}, Instant — Adventure
+ * Exile target nontoken creature. Return it to the battlefield under its owner's control at the
+ * beginning of the next end step.
+ *
+ * The Adventure is the plain blink pattern — [Patterns.Exile.exileUntilEndStep] moves the target
+ * to exile and schedules a delayed trigger that returns it at the *next* end step (never the one
+ * currently in progress). The return carries no controller override, so the card comes back under
+ * its owner's control exactly as the oracle text says, and it returns as a new object with no
+ * memory of counters, auras, or damage.
+ *
+ * The "nontoken" restriction is a real targeting restriction, not a resolution check: a token
+ * exiled this way would cease to exist and never come back, so the card refuses to target one at
+ * all (compare Parting Gust).
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val TwiningTwins = card("Twining Twins") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Faerie Wizard"
+    oracleText = "Flying, vigilance, ward {1} (Whenever this creature becomes the target of a spell " +
+        "or ability an opponent controls, counter it unless that player pays {1}.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.ward("{1}"))
+
+    adventure("Swift Spiral") {
+        manaCost = "{1}{W}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Exile target nontoken creature. Return it to the battlefield under its " +
+            "owner's control at the beginning of the next end step. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            val creature = target(
+                "target nontoken creature",
+                TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.nontoken())),
+            )
+            effect = Patterns.Exile.exileUntilEndStep(creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"We spin and spin to keep us busy, but somehow you're the one who's dizzy.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1783915061"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1311,6 +1311,127 @@
     ]
 }
 
+// Bramble Familiar
+{
+    "name": "Bramble Familiar",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elemental Raccoon",
+    "oracleText": "{T}: Add {G}.\n{1}{G}, {T}, Discard a card: Return this creature to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/475d7e9a-759d-4523-a5cd-2a6e0d1b14ea.jpg?1783915084"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Fetch Quest",
+            "manaCost": "{5}{G}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Mill seven cards. Then put a creature, enchantment, or land card from among the milled cards onto the battlefield. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 7
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "fetch_milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "fetch_milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "fetch_milled",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature|enchantment|land",
+                            "storeSelected": "fetch_selected",
+                            "prompt": "Put a creature, enchantment, or land card onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "fetch_selected",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Brave the Wilds
 {
     "name": "Brave the Wilds",
@@ -5733,6 +5854,81 @@
     ]
 }
 
+// Horned Loch-Whale
+{
+    "name": "Horned Loch-Whale",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Whale",
+    "oracleText": "Flash\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nThis creature enters tapped unless it's your turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLASH",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96a05063-0556-42e4-8d4c-8e92be160ef5.jpg?1783915120",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The creature's owner chooses whether to put it on the top or bottom of their library. If multiple cards are put into the library this way (such as when the spell targets a melded permanent), that creature's owner puts all the cards on top or all the cards on the bottom. They put them in whatever order they wish, and do not need to reveal the order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Lagoon Breach",
+            "manaCost": "{1}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "The owner of target attacking creature you don't control puts it on their choice of the top or bottom of their library. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "PutOnLibraryPositionOfChoice",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature you don't control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking ctrl:opponent"
+                        },
+                        "id": "target attacking creature you don't control"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Howling Galefang
 {
     "name": "Howling Galefang",
@@ -8714,6 +8910,123 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Questing Druid
+{
+    "name": "Questing Druid",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasColor",
+                                        "color": "WHITE"
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "BLUE"
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "BLACK"
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "RED"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72c130e2-1e17-4996-a5ae-231155d68261.jpg?1783915063",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you cast a spell that's more than one of the listed colors, Questing Druid's ability still triggers only once."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You pay all costs and follow all normal timing rules for cards played from exile with Seek the Beast. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Seek the Beast",
+            "manaCost": "{1}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Exile the top two cards of your library. Until your next end step, you may play those cards. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "seek_the_beast_exiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "seek_the_beast_exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "seek_the_beast_exiled",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "END"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 
@@ -13546,6 +13859,88 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Twining Twins
+{
+    "name": "Twining Twins",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying, vigilance, ward {1} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{1}"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "\"We spin and spin to keep us busy, but somehow you're the one who's dizzy.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/043718ea-59f6-4d1a-94c5-271704c1a38a.jpg?1783915061"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Swift Spiral",
+            "manaCost": "{1}{W}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Exile target nontoken creature. Return it to the battlefield under its owner's control at the beginning of the next end step. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target nontoken creature"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target nontoken creature"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature nontoken"
+                        },
+                        "id": "target nontoken creature"
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Four Wilds of Eldraine Adventure creatures, all built from existing primitives — no new SDK vocabulary.

## Cards

- **Bramble Familiar // Fetch Quest** ({1}{G} 2/2 Elemental Raccoon) — `{T}: Add {G}` as a
  `manaAbility`, plus `Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap, Costs.DiscardCard)` →
  `Effects.ReturnToHand(Self)` (same cost shape as Fomori Vault). *Fetch Quest* is the
  Gather(`isMill`) → Move-to-graveyard → `SelectFromCollectionEffect(ChooseExactly(1))` →
  Move-to-battlefield pipeline (Picklock Prankster's shape, battlefield destination).
- **Horned Loch-Whale // Lagoon Breach** ({4}{U}{U} 6/6 Whale) — `Keyword.FLASH`,
  `KeywordAbility.ward("{2}")`, `EntersTapped(unlessCondition = Conditions.IsYourTurn)` (Eddymurk Crab
  prints the same clause inverted). *Lagoon Breach* is `Effects.PutOnTopOrBottomOfLibrary` on
  `TargetFilter.AttackingCreature.opponentControls()`; the executor already asks the card's **owner**
  for top-or-bottom, which is what the oracle wants.
- **Questing Druid // Seek the Beast** ({1}{G} 1/1 Human Druid) — `Triggers.youCastSpell` with a single
  `CardPredicate.Or` of four `HasColor`s, so a multicolour spell triggers it exactly once per the
  ruling. *Seek the Beast* is `Patterns.Exile.impulse(2, MayPlayExpiry.UntilNextEndStep)` —
  controller-scoped expiry, correct for "until *your* next end step".
- **Twining Twins // Swift Spiral** ({2}{U}{U} 4/4 Faerie Wizard) — flying, vigilance,
  `KeywordAbility.ward("{1}")`. *Swift Spiral* is `Patterns.Exile.exileUntilEndStep` on
  `TargetFilter(GameObjectFilter.Creature.nontoken())` (Parting Gust's idiom); the return carries no
  controller override, so the card comes back under its owner's control.

Oracle text, costs, type lines, P/T, rarity, artist, collector numbers, colour identity and both
transcribed rulings verified against Scryfall. `just check-card-printing` is `ok` for all four (WOE is
the earliest real printing; only `pwoe`/`slp` promos follow).

## Gate

`just build` — passed (`CardDefinitionSnapshotTest` re-blessed; the WOE.json diff is +395/-0, only the
four new cards). `origin/main` merged into the branch afterwards: clean, and main's concurrent WOE change
(basic lands) does not touch the WOE snapshot, so the gate was not re-run.

## Reviewer notes

**Important (neither is a merge condition; both are follow-ups):**

1. *Questing Druid under-triggers on Adventure spells.* Per CR 715.3b, a spell cast as an Adventure has
   only the face's characteristics — including colour. The engine reads a stack object's colours from the
   card's primary face (`CardDefinition.colors` → `PredicateEvaluator` `HasColor`); `faceIndex` is
   consulted only for type line, script and cost. So with a Questing Druid out, casting a second copy's
   *Seek the Beast* ({1}{R}) should add a counter and won't. Pre-existing engine gap, not introduced
   here; closing it is `add-feature` work.
2. *The mill-and-retrieve pipeline is hand-rolled for the 25th time.* Gather → Move → Select → Move with
   the same four raw constructors now appears in 25 card files. It wants a
   `Patterns.Library.millAndRetrieve(...)` next to `Patterns.Library.mill`. Repo-wide cleanup, not this
   PR's job.

**Minor:** `CardSource.TopOfLibrary.isMill`'s KDoc claims only `Patterns.Library.mill` sets it — Fetch
Quest now sets it directly (the flag is behaviourally right there; the doc needs updating). Picklock
Prankster, same set, omits `isMill` on the same shape, so the two cards disagree under a mill-amount
replacement — Picklock is the one that's wrong. Two redundant `Player.You` defaults. Fetch Quest
auto-resolves without showing the milled cards when exactly one is eligible (correct, but the docstring
overclaims). `backlog/cube-draft-format.md:325` is now 3/4 done — only Elusive Otter // Grove's Bounty
remains on that line, so the box stays unticked.

## Not done

This PR came out of an autonomous loop. No scenario tests were added and none are required (`add-card`
Step 5: tests only when the card adds new SDK vocabulary — these add none), so **behaviour is covered by
the snapshot/facade/lint nets only, not by execution**. There was **no manual playthrough in the web
client, no UX pass from either seat, and no e2e spec**. The full test suite was not re-run after the
`origin/main` merge.

## Dropped from the unit

**Mosswood Dreadknight // Dread Whispers.** Its dies trigger grants "you may cast it from your graveyard
*as an Adventure* until the end of your next turn". `MayPlayPermission` is exile-scoped and carries no
face restriction; `MayCastFromGraveyard` is an unbounded battlefield-source static. A face-restricted,
duration-bounded, graveyard-scoped cast permission is a new engine primitive, so it wants its own unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
