### PR TITLE
Fix auto-tap spending a sacrifice ability's mana for free

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -347,7 +347,7 @@ class ManaSolver(
             .filter { it.entityId !in excludeSources }
             // Auto-pay must not silently sacrifice permanents (e.g. Treasure tokens).
             // The bonus-mana accounting in canPay() still counts these via
-            // calculateSacrificeSelfBonusMana(), but the solver itself never picks them.
+            // sacrificeSelfManaBySource(), but the solver itself never picks them.
             .filter { !it.requiresSacrifice }
             // Same rule for composite Tap+TapPermanents sources (Springleaf Drum) — the
             // resumer must prompt the player to pick which creature gets tapped, so the
@@ -1225,7 +1225,14 @@ class ManaSolver(
                 // so route them through the bonus-mana channel. Only unconditional AddMana/
                 // AddColorlessMana leaves are folded — anything gated/choice-based stays with the
                 // primary path to avoid over-counting.
-                if (ability.effect is CompositeEffect && manaEffect is AddManaEffect) {
+                // …but only from an ability auto-pay is actually allowed to activate. The bonus-mana
+                // channel carries no provenance, so a sacrifice-gated (Ancient Spring's "{T},
+                // Sacrifice this land: Add {W}{B}") or tap-another-permanent ability would donate
+                // free floating mana on top of the source's sacrifice-free tap — letting auto-pay
+                // spend {W}{B} it never paid for. The primary leaf's color is already fenced off by
+                // colorsRequiringSacrifice / tapPermanentsSubCost; the extra leaves are dropped here.
+                val abilityIsAutoPayable = !abilityRequiresSacrifice && abilityTapPermanentsSubCost == null
+                if (abilityIsAutoPayable && ability.effect is CompositeEffect && manaEffect is AddManaEffect) {
                     var seenPrimary = false
                     for (leaf in (ability.effect as CompositeEffect).effects) {
                         when (leaf) {
@@ -1969,8 +1976,9 @@ class ManaSolver(
         //     ability directly. But the spell is still *affordable* — we just need to know it.
         //  3. Cost shapes findAvailableManaSources doesn't model at all (Ashnod's Altar's
         //     "Sacrifice a creature: Add {C}{C}" — no {T} anywhere in the cost).
+        val sacrificeManaBySource = sacrificeSelfManaBySource(state, playerId)
         val bonus = calculateTapPermanentsBonusMana(state, playerId)
-            .plus(calculateSacrificeSelfBonusMana(state, playerId))
+            .plus(sacrificeManaBySource.values.fold(TapPermanentsBonusMana()) { acc, p -> acc + p })
             .plus(calculateCompositeTapPermanentsBonusMana(state, playerId))
             .plus(calculateExplicitActivationBonusMana(state, playerId))
         if (bonus.totalMana == 0) return false
@@ -1994,7 +2002,20 @@ class ManaSolver(
         val augmentedXRemaining = totalXMana - augmentedXPaid
 
         if (augmentedRemaining.isEmpty() && augmentedXRemaining == 0) return true
-        return solve(state, playerId, augmentedRemaining, augmentedXRemaining, excludeSources, spellContext, precomputedSources) != null
+        // Spending a permanent's tap+sacrifice ability uses up its {T}, so it can't also be
+        // auto-tapped for the rest of the cost. Pure sacrifice sources (Treasures) are already
+        // dropped by solve(); this only bites *mixed* sources like Ancient Spring, where counting
+        // both abilities would claim {U} and {W}{B} from one land.
+        val sacrificeConsumedIds = sacrificeManaBySource.keys
+        return solve(
+            state,
+            playerId,
+            augmentedRemaining,
+            augmentedXRemaining,
+            excludeSources + sacrificeConsumedIds,
+            spellContext,
+            precomputedSources
+        ) != null
     }
 
     /**
@@ -2027,17 +2048,33 @@ class ManaSolver(
         // Sacrifice-self sources (treasures) and composite tap+TapPermanents sources
         // (Springleaf Drum) are counted below via their dedicated bonus helpers, so skip
         // them here to avoid double-counting.
-        val sourceMana = (precomputedSources ?: findAvailableManaSources(state, playerId))
+        val sacrificeManaBySource = sacrificeSelfManaBySource(state, playerId)
+        val autoTappableSources = (precomputedSources ?: findAvailableManaSources(state, playerId))
             .filter { !it.requiresSacrifice && it.tapPermanentsSubCost == null }
-            .sumOf { it.manaAmount + it.bonusManaPerTap }
+        val sourceMana = autoTappableSources
+            // A *mixed* source (Ancient Spring — "{T}: Add {U}" plus "{T}, Sacrifice this land:
+            // Add {W}{B}") is auto-tappable and so counted here, but its sacrifice ability is also
+            // counted by the extras helper below. Both abilities spend the same {T}, so the
+            // permanent yields the better of the two — never their sum.
+            .sumOf { source ->
+                maxOf(
+                    source.manaAmount + source.bonusManaPerTap,
+                    sacrificeManaBySource[source.entityId]?.totalMana ?: 0
+                )
+            }
 
         // Add extra mana from "extras" abilities the solver doesn't pick:
         //  - TapPermanents (e.g., Birchlore Rangers)
         //  - Tap+SacrificeSelf mana abilities (e.g., Treasure tokens)
         //  - Composite Tap+TapPermanents mana abilities (e.g., Springleaf Drum)
         //  - Costs with no {T} at all, which the solver doesn't model (e.g., Ashnod's Altar)
+        val autoTappableIds = autoTappableSources.map { it.entityId }.toSet()
+        val sacrificeExtras = sacrificeManaBySource
+            .filterKeys { it !in autoTappableIds }
+            .values
+            .sumOf { it.totalMana }
         val extrasMana = calculateTapPermanentsBonusMana(state, playerId).totalMana +
-            calculateSacrificeSelfBonusMana(state, playerId).totalMana +
+            sacrificeExtras +
             calculateCompositeTapPermanentsBonusMana(state, playerId).totalMana +
             calculateExplicitActivationBonusMana(state, playerId).totalMana
 
@@ -2212,7 +2249,7 @@ class ManaSolver(
      * `canPay` and `getAvailableManaCount`.
      *
      * Mirrors the accept conditions of `abilityCanBeUsed` inside [findAvailableManaSources] and the
-     * cost shapes matched by [calculateTapPermanentsBonusMana], [calculateSacrificeSelfBonusMana]
+     * cost shapes matched by [calculateTapPermanentsBonusMana], [sacrificeSelfManaBySource]
      * and [calculateCompositeTapPermanentsBonusMana]. `ManaSolverExtrasNoDoubleCountTest` pins the
      * two together: it asserts the available-mana count for a Treasure / Birchlore / Springleaf
      * board is unchanged by this helper.
@@ -2330,17 +2367,19 @@ class ManaSolver(
      * be silently paid by the auto-pay flow — the player has to activate the ability directly so
      * the sacrifice is explicit. But the spell is still *affordable* when the player has these
      * permanents available, so `canPay` and `getAvailableManaCount` must count their production.
+     *
+     * Reported per permanent because both callers also count a permanent's *sacrifice-free* mana
+     * ability, and the two share one {T}: a mixed source (Ancient Spring — "{T}: Add {U}" plus
+     * "{T}, Sacrifice this land: Add {W}{B}") produces one or the other, never the sum.
      */
-    internal fun calculateSacrificeSelfBonusMana(
+    internal fun sacrificeSelfManaBySource(
         state: GameState,
         playerId: EntityId
-    ): TapPermanentsBonusMana {
+    ): Map<EntityId, TapPermanentsBonusMana> {
         val projected = state.projectedState
         val battlefieldCards = projected.getBattlefieldControlledBy(playerId)
 
-        var anyColorTotal = 0
-        val specificColorTotal = mutableMapOf<Color, Int>()
-        var colorlessTotal = 0
+        val bySource = mutableMapOf<EntityId, TapPermanentsBonusMana>()
 
         for (entityId in battlefieldCards) {
             val container = state.getEntity(entityId) ?: continue
@@ -2383,21 +2422,17 @@ class ManaSolver(
                 // `Effects.Composite(AddMana(GREEN), AddMana(BLUE))`) are counted in full
                 // rather than dropping to the unhandled `else` branch and contributing zero.
                 val produced = manaProducedByEffect(ability.effect)
-                anyColorTotal += produced.anyColorMana
-                for ((color, amount) in produced.specificMana) {
-                    specificColorTotal[color] = (specificColorTotal[color] ?: 0) + amount
-                }
-                colorlessTotal += produced.colorlessMana
+                bySource[entityId] = (bySource[entityId] ?: TapPermanentsBonusMana()) + produced
             }
         }
 
-        return TapPermanentsBonusMana(anyColorTotal, specificColorTotal, colorlessTotal)
+        return bySource
     }
 
     /**
      * Mana produced by a single mana-ability effect, recursing into [CompositeEffect].
      *
-     * Used by the "bonus mana" affordability helpers (e.g. [calculateSacrificeSelfBonusMana])
+     * Used by the "bonus mana" affordability helpers (e.g. [sacrificeSelfManaBySource])
      * so an ability that adds several mana via `Effects.Composite(AddMana(...), AddMana(...))`
      * is counted in full. Without the recursion such an effect falls into the `else` branch and
      * contributes nothing, so a spell payable only by that ability is wrongly reported
@@ -2493,7 +2528,7 @@ class ManaSolver(
                     .firstNotNullOfOrNull { (it as? AbilityCost.Atom)?.atom as? CostAtom.TapPermanents }
                 if (!hasTap || tapPermanentsCost == null) continue
                 // Skip composites that also bundle SacrificeSelf or a mana sub-cost — those are
-                // handled by other helpers (calculateSacrificeSelfBonusMana) and would
+                // handled by other helpers (sacrificeSelfManaBySource) and would
                 // double-count or complicate color resolution here.
                 if (composite.costs.any { it is AbilityCost.SacrificeSelf || it.manaCostOrNull != null }) continue
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientSpringAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientSpringAutoTapTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.inv.cards.AncientSpring
+import com.wingedsheep.mtg.sets.definitions.inv.cards.MetathranZombie
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ancient Spring has a sacrifice-free mana ability *and* a sacrifice one, and the sacrifice
+ * ability adds two mana on a single tap:
+ *   {T}: Add {U}
+ *   {T}, Sacrifice this land: Add {W}{B}
+ *
+ * Both abilities cost {T}, so the land can only ever be used once: it makes either one {U}, or
+ * {W}{B} while dying. Two things went wrong:
+ *
+ *  1. The extra `{B}` leaf of the sacrifice ability was folded into the source's generic
+ *     "bonus mana per tap" channel (the one auras like Fertile Ground use), which carries no
+ *     sacrifice provenance. Auto-pay therefore saw "tap for {U}, plus a free floating {B}" and
+ *     happily cast Metathran Zombie ({1}{U}) off Ancient Spring alone, without ever sacrificing.
+ *  2. Affordability counted the land twice — once as a regular {U} source and once via the
+ *     sacrifice-ability bonus helper — reporting three available mana from a land that can
+ *     produce at most two.
+ */
+class AncientSpringAutoTapTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AncientSpring, MetathranZombie))
+        return driver
+    }
+
+    test("Ancient Spring alone can't auto-pay Metathran Zombie ({1}{U})") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spring = driver.putPermanentOnBattlefield(activePlayer, "Ancient Spring")
+        val zombie = driver.putCardInHand(activePlayer, "Metathran Zombie")
+
+        // Both of Ancient Spring's abilities tap it, so it makes at most {U} *or* {W}{B} — never
+        // {U} plus something else. {1}{U} is unpayable off this land alone.
+        val result = driver.castSpell(activePlayer, zombie)
+
+        result.isSuccess shouldBe false
+        driver.findPermanent(activePlayer, "Ancient Spring") shouldBe spring
+        driver.isTapped(spring) shouldBe false
+        driver.getGraveyardCardNames(activePlayer).contains("Ancient Spring") shouldBe false
+    }
+
+    test("canPay reports Metathran Zombie ({1}{U}) unaffordable off Ancient Spring alone") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Ancient Spring")
+
+        val solver = ManaSolver(driver.cardRegistry)
+        // {W}{B} is payable — that's exactly what the sacrifice ability makes.
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{W}{B}")) shouldBe true
+        // A lone {U} is payable via the sacrifice-free ability.
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{U}")) shouldBe true
+        // But {1}{U} needs the land to be tapped twice.
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{1}{U}")) shouldBe false
+    }
+
+    test("Ancient Spring counts as two available mana, not three") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(activePlayer, "Ancient Spring")
+
+        val solver = ManaSolver(driver.cardRegistry)
+        // Best case is sacrificing for {W}{B}; the {U} ability shares the same {T} cost.
+        solver.getAvailableManaCount(driver.state, activePlayer) shouldBe 2
+    }
+
+    test("Ancient Spring's sacrifice-free {U} ability still auto-taps alongside another land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spring = driver.putPermanentOnBattlefield(activePlayer, "Ancient Spring")
+        val mountain = driver.putPermanentOnBattlefield(activePlayer, "Mountain")
+        val zombie = driver.putCardInHand(activePlayer, "Metathran Zombie")
+
+        // Mountain pays the generic {1}, Ancient Spring taps for {U} without being sacrificed.
+        val result = driver.castSpell(activePlayer, zombie)
+
+        result.isSuccess shouldBe true
+        driver.isTapped(spring) shouldBe true
+        driver.isTapped(mountain) shouldBe true
+        driver.findPermanent(activePlayer, "Ancient Spring") shouldBe spring
+        driver.getGraveyardCardNames(activePlayer).contains("Ancient Spring") shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardPaidWithTreasureTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardPaidWithTreasureTest.kt
@@ -121,7 +121,7 @@ class WardPaidWithTreasureTest : FunSpec({
     test("auto-pay refuses to silently sacrifice treasures for ward") {
         // If the caster only has treasures available (no other mana), auto-pay should
         // not silently sacrifice them — the player must opt in explicitly. canPay still
-        // reports the cost as affordable (via calculateSacrificeSelfBonusMana), but
+        // reports the cost as affordable (via sacrificeSelfManaBySource), but
         // solve() filters sacrifice sources, so auto-pay produces no solution and the
         // caller falls back to declining.
         val driver = createDriver()


### PR DESCRIPTION
## Bug

With **Ancient Spring** (`{T}: Add {U}` / `{T}, Sacrifice this land: Add {W}{B}`) as the only land,
auto-tap happily cast **Metathran Zombie** (`{1}{U}`) — without sacrificing the land. Affordability
also over-reported the land's output (4 mana, where the true maximum is 2).

Both abilities cost `{T}`, so Ancient Spring makes either one `{U}` *or* `{W}{B}` while dying — never
both.

## Causes

1. **The bonus-mana channel had no provenance.** `findAvailableManaSources` folds the *extra* leaves
   of a multi-mana tap ability (Gruul Turf's `{T}: Add {R}{G}`) into the same "bonus mana per tap"
   channel auras like Fertile Ground use. Ancient Spring's sacrifice ability is
   `Composite(AddMana(W), AddMana(B))`, so its `{B}` leaf landed there — free floating mana on top of
   the sacrifice-free `{U}` tap. The primary leaf's colour was already fenced off by
   `colorsRequiringSacrifice`; the extras were not. The channel is now only fed by abilities auto-pay
   is allowed to activate (no `SacrificeSelf`, no `TapPermanents` sub-cost).

2. **A mixed source was counted twice.** `canPay` / `getAvailableManaCount` counted the permanent as a
   regular auto-tappable source *and* through the tap+sacrifice bonus helper. That helper
   (`sacrificeSelfManaBySource`) now reports per permanent, so `getAvailableManaCount` takes the better
   of the two paths instead of the sum, and `canPay` excludes a permanent from the follow-up `solve()`
   once it has spent its sacrifice ability.

## Tests

New `AncientSpringAutoTapTest`:
- Ancient Spring alone can't auto-pay `{1}{U}` — and is left untapped, not sacrificed.
- `canPay`: `{W}{B}` true, `{U}` true, `{1}{U}` false.
- `getAvailableManaCount` is 2, not 3+.
- Regression: the sacrifice-free `{U}` ability still auto-taps alongside a Mountain (which now
  correctly taps for the generic).

The pre-existing `IrrigationDitchAutoTapTest` (same card shape) still passes, as does the Treasure
affordability path in `WardPaidWithTreasureTest`.

Gates: `just test-rules` (8632 tests, 0 failures), `just test-server`, `just test-ai` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)