### PR TITLE
Make Ascend a real static ability, and close out PR #1510's review

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -916,7 +916,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     before resolution the whole spell fizzles per the normal CR 608.2b check, so no energy is gained either.
   - `PayFixedCounters(counterType, amount, player = Player.You)` — the all-or-nothing counterpart to
     `PayCounters`: pays an exact `amount`, not a chosen one. No decision of its own — designed as the `action`
-    half of a `ReflexiveTriggerEffect` ("you may pay {E}{E}{E}. **When** you do, ...", CR 603.2 — a fresh
+    half of a `ReflexiveTriggerEffect` ("you may pay {E}{E}{E}. **When** you do, ...", CR 603.12 — a fresh
     triggered ability with its own targets, distinct from a same-ability "**If** you do" continuation), where
     the reflexive's own yes/no *is* the payment decision. Fails outright (no partial removal) if the payer has
     fewer than `amount` — per the 2024-06-07 {E} ruling, "you can't pay that amount multiple times to multiply
@@ -8021,8 +8021,20 @@ Card authors rarely reference these directly; they are created/updated by the ma
   Rendezvous (end-step trigger gated on `Conditions.OpponentHasMoreCardsInHand`).
 - **Hideaway N** — `KeywordAbility.hideaway(n)` (display, "Hideaway N") + `MoveCollectionEffect(faceDown = FaceDownMode.HIDDEN,
   linkToSource = true)` + `CardSource.FromLinkedExile()`; no special engine plumbing needed.
-- **Ascend / City's Blessing** — `Keyword.ASCEND` + `Effects.GainCitysBlessing()` + `Conditions.YouHaveCitysBlessing` /
-  `SourceProjectionCondition.ControllerHasCitysBlessing` + `PlayerCitysBlessingComponent`.
+- **Ascend / City's Blessing** (CR 702.131) — on a **permanent**, `keywords(Keyword.ASCEND)` is the whole
+  implementation: ascend there is a *static* ability (702.131b, "**any time** you control ten or more
+  permanents…"), and the engine's `AscendCitysBlessingCheck` state-based action grants the designation to
+  any player controlling an ascend permanent once they control ten permanents. Do **not** write it as an
+  enters-the-battlefield trigger — that samples the count once, on the turn a cheap creature is least
+  likely to meet it, and never looks again. On an **instant or sorcery** ascend is a spell ability
+  (702.131a), so those cards spell it out with `Effects.GainCitysBlessing()` in the spell's effect, as does
+  any card that just says "you get the city's blessing".
+  Read it back with `Conditions.YouHaveCitysBlessing` / `SourceProjectionCondition.ControllerHasCitysBlessing`;
+  the marker is `PlayerCitysBlessingComponent` and is never removed (702.131b/c, "for the rest of the game").
+  Both the read and the two writers go through `CitysBlessingService`, which also evaluates the ascend
+  condition *live* — that is what makes "create a token, then if you have the city's blessing…" come out
+  right when the token itself is your tenth permanent (Ocelot Pride), since state-based actions aren't
+  polled mid-resolution.
 - **Speed / Start your engines! / Max speed** (Aetherdrift, CR 702.178–702.179) — a player's speed is
   an `Int` 0–4 (`Speed.NONE` / `Speed.STARTING` / `Speed.MAX` in `core/Speed.kt`) held by
   `PlayerSpeedComponent`. It only ever rises, is clamped at 4, and is never removed — like the city's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -204,7 +204,7 @@ data class PayCountersEffect(
  * whether to pay the named total, and per the 2024-06-07 ruling you can't pay a partial amount
  * to get a partial effect.
  *
- * Designed as the `action` half of a [ReflexiveTriggerEffect] ("When you do" — CR 603.2 — a
+ * Designed as the `action` half of a [ReflexiveTriggerEffect] ("When you do" — CR 603.12 — a
  * fresh triggered ability with its own targets, distinct from a same-ability "If you do"
  * continuation): the outer yes/no is the payment decision itself, so this effect performs no
  * decision of its own — it deducts [amount] atomically and fails outright (no partial removal)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TendershootDryad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TendershootDryad.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.ModifyStats
-import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 val TendershootDryad = card("Tendershoot Dryad") {
@@ -22,17 +21,11 @@ val TendershootDryad = card("Tendershoot Dryad") {
         "At the beginning of each upkeep, create a 1/1 green Saproling creature token.\n" +
         "Saprolings you control get +2/+2 as long as you have the city's blessing."
 
+    // Ascend on a permanent is a static ability that checks continuously (CR 702.131b), so the
+    // keyword is the whole implementation — the engine's 702.131b state-based action
+    // (AscendCitysBlessingCheck) grants the city's blessing the moment you control ten permanents,
+    // not only on the turn this entered.
     keywords(Keyword.ASCEND)
-
-    // Ascend: when this enters, if you control 10+ permanents, gain the city's blessing.
-    // Wired explicitly per CR 702.131a (Ascend on a permanent spell == ETB intervening-if).
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        effect = ConditionalEffect(
-            condition = Conditions.ControlPermanentsAtLeast(10),
-            effect = Effects.GainCitysBlessing()
-        )
-    }
 
     // At the beginning of each upkeep, create a 1/1 green Saproling token.
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/GuideOfSouls.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/GuideOfSouls.kt
@@ -19,7 +19,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Whenever you attack, you may pay {E}{E}{E}. When you do, put two +1/+1 counters and a flying
  * counter on target attacking creature. It becomes an Angel in addition to its other types.
  *
- * The second ability is a genuine reflexive trigger (CR 603.2, per the 2024-06-07 ruling): the
+ * The second ability is a genuine reflexive trigger (CR 603.12, per the 2024-06-07 ruling): the
  * "may pay {E}{E}{E}" isn't targeted itself — a *second* triggered ability fires when the payment
  * is made, and *that* ability chooses the attacking creature, so opponents get a response window
  * between the payment and the target lock. Modeled with [ReflexiveTriggerEffect] rather than a

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/OcelotPride.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/OcelotPride.kt
@@ -25,6 +25,13 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * creature token. Then if you have the city's blessing, for each token you control that entered
  * this turn, create a token that's a copy of it.
  *
+ * Ascend is [Keyword.ASCEND] and nothing else. On a permanent it's a *static* ability (CR
+ * 702.131b, "**any time** you control ten or more permanents…"), which the engine handles for
+ * every ascend permanent at once — see
+ * [com.wingedsheep.engine.mechanics.sba.player.AscendCitysBlessingCheck]. Writing it as an
+ * enters-the-battlefield trigger instead would sample the count once, on the turn a one-mana 1/1 is
+ * least likely to see ten permanents, and never look again.
+ *
  * The end-step ability is a genuine intervening-if (CR 603.4, [triggerCondition]): it doesn't
  * trigger at all unless you gained life *before* the end step began, and it re-checks the same
  * condition at resolution — modeled the same way as Resplendent Angel's near-identical ability.
@@ -50,16 +57,10 @@ val OcelotPride = card("Ocelot Pride") {
         "Cat creature token. Then if you have the city's blessing, for each token you control " +
         "that entered this turn, create a token that's a copy of it."
 
+    // Ascend needs no ability here: CR 702.131b makes it a static ability, and the engine's
+    // 702.131b state-based action grants the city's blessing to anyone controlling a permanent
+    // with Keyword.ASCEND once they control ten permanents.
     keywords(Keyword.FIRST_STRIKE, Keyword.LIFELINK, Keyword.ASCEND)
-
-    // Ascend: when this enters, if you control 10+ permanents, gain the city's blessing.
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        effect = ConditionalEffect(
-            condition = Conditions.ControlPermanentsAtLeast(10),
-            effect = Effects.GainCitysBlessing()
-        )
-    }
 
     triggeredAbility {
         trigger = Triggers.YourEndStep

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -2218,32 +2218,6 @@
             {
                 "id": "ability_1",
                 "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Gated",
-                    "gate": {
-                        "type": "Gate.WhenCondition",
-                        "condition": {
-                            "type": "Compare",
-                            "left": {
-                                "type": "AggregateBattlefield",
-                                "player": "You"
-                            },
-                            "operator": "GTE",
-                            "right": {
-                                "type": "Fixed",
-                                "amount": 10
-                            }
-                        }
-                    },
-                    "then": "GainCitysBlessing"
-                }
-            },
-            {
-                "id": "ability_2",
-                "trigger": {
                     "type": "StepEvent",
                     "step": "UPKEEP",
                     "player": "Each"

--- a/mtg-sets/src/test/resources/snapshots/cards/MH3.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH3.json
@@ -301,32 +301,6 @@
             {
                 "id": "ability_1",
                 "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Gated",
-                    "gate": {
-                        "type": "Gate.WhenCondition",
-                        "condition": {
-                            "type": "Compare",
-                            "left": {
-                                "type": "AggregateBattlefield",
-                                "player": "You"
-                            },
-                            "operator": "GTE",
-                            "right": {
-                                "type": "Fixed",
-                                "amount": 10
-                            }
-                        }
-                    },
-                    "then": "GainCitysBlessing"
-                }
-            },
-            {
-                "id": "ability_2",
-                "trigger": {
                     "type": "StepEvent",
                     "step": "END"
                 },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Energy.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Energy.kt
@@ -46,7 +46,7 @@ fun BridgeBuilder.energy() {
     // `_Cost: PayEnergy` — a *fixed* amount, nested inside a `MayCost` envelope: "you may pay
     // {E}{E}{E}. When you do, ..." (Guide of Souls, MH3). Distinct from PayAnyAmountOfEnergy (a
     // chosen amount 0..current, no separate reflexive trigger) — here the amount is fixed and the
-    // payoff is a genuine CR 603.2 reflexive trigger with its own targets, not a same-ability "if
+    // payoff is a genuine CR 603.12 reflexive trigger with its own targets, not a same-ability "if
     // you do" continuation. A new leaf effect (PayFixedCountersEffect, @SerialName
     // "PayFixedCounters"): fails outright rather than clamping when the payer has fewer than the
     // named amount, so `ReflexiveTriggerEffectExecutor.isActionFeasible` can gate the "may pay"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -149,7 +149,7 @@ import com.wingedsheep.engine.state.components.identity.PlottedComponent
 import com.wingedsheep.engine.state.components.identity.ForetoldComponent
 import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
 import com.wingedsheep.sdk.scripting.conditions.VoidCondition
-import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingComponent
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
 import com.wingedsheep.engine.state.components.player.TheRingComponent
 
 /**
@@ -1032,7 +1032,12 @@ class ConditionEvaluator(
         ctx: ConditionEvaluationContext
     ): Boolean {
         val playerId = resolvePlayer(state, condition.player, ctx) ?: return false
-        return state.getEntity(playerId)?.has<PlayerCitysBlessingComponent>() == true
+        // Not a bare component read: CR 702.131b's ascend is continuous, so a player who has just
+        // crossed ten permanents mid-resolution already has the blessing, before the state-based
+        // action writes the marker. The ctx projection (not state.projectedState) is what keeps the
+        // projection-mode caller — Tendershoot Dryad's city's-blessing static gate — from
+        // re-entering the lazy projection initializer. See CitysBlessingService.
+        return CitysBlessingService.has(state, playerId, ctx.projectedStateFor(state))
     }
 
     private fun evaluatePermanentTypeEnteredBattlefieldThisTurnCtx(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GainCitysBlessingExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/GainCitysBlessingExecutor.kt
@@ -1,22 +1,22 @@
 package com.wingedsheep.engine.handlers.effects.player
 
-import com.wingedsheep.engine.core.CitysBlessingGainedEvent
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.PlayerComponent
-import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingComponent
 import com.wingedsheep.sdk.scripting.effects.GainCitysBlessingEffect
 import kotlin.reflect.KClass
 
 /**
- * Resolves [GainCitysBlessingEffect].
+ * Resolves [GainCitysBlessingEffect] — "you get the city's blessing", including ascend's
+ * spell-ability form on an instant or sorcery (CR 702.131a).
  *
- * Adds [PlayerCitysBlessingComponent] to the target player. Idempotent: if the
- * player already has the blessing, nothing changes and no event fires (per
- * CR 702.131c the blessing is permanent — granting it twice is a no-op).
+ * Ascend on a *permanent* does not come through here: CR 702.131b makes it a static ability, which
+ * lives in [com.wingedsheep.engine.mechanics.sba.player.AscendCitysBlessingCheck]. Both paths write
+ * through [CitysBlessingService.grant], which is idempotent — per CR 702.131c the blessing is
+ * permanent, so granting it twice changes nothing and fires no second event.
  */
 class GainCitysBlessingExecutor : EffectExecutor<GainCitysBlessingEffect> {
 
@@ -34,25 +34,15 @@ class GainCitysBlessingExecutor : EffectExecutor<GainCitysBlessingEffect> {
             return EffectResult.error(state, "City's blessing target must be a player")
         }
 
-        val playerContainer = state.getEntity(targetId)
-            ?: return EffectResult.error(state, "Target player no longer exists")
-
-        if (playerContainer.has<PlayerCitysBlessingComponent>()) {
-            return EffectResult.success(state)
+        if (state.getEntity(targetId) == null) {
+            return EffectResult.error(state, "Target player no longer exists")
         }
 
-        val newState = state.updateEntity(targetId) { container ->
-            container.with(PlayerCitysBlessingComponent)
-        }
-
-        val playerName = playerContainer.get<PlayerComponent>()?.name ?: "Player"
         val sourceName = context.sourceId?.let {
             state.getEntity(it)?.get<CardComponent>()?.name
         } ?: "Unknown"
 
-        return EffectResult.success(
-            newState,
-            listOf(CitysBlessingGainedEvent(targetId, playerName, sourceName))
-        )
+        val (newState, events) = CitysBlessingService.grant(state, targetId, sourceName)
+        return EffectResult.success(newState, events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/citysblessing/CitysBlessingService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/citysblessing/CitysBlessingService.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.mechanics.citysblessing
+
+import com.wingedsheep.engine.core.CitysBlessingGainedEvent
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingComponent
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The one place the **city's blessing** designation (CR 702.131c) is read and granted.
+ *
+ * Two callers exist and they must not drift apart:
+ *
+ * - [com.wingedsheep.engine.mechanics.sba.player.AscendCitysBlessingCheck] persists the designation
+ *   for a player whose ascend permanent currently sees ten permanents.
+ * - [com.wingedsheep.engine.handlers.effects.player.GainCitysBlessingExecutor] persists it for the
+ *   spell-ability form (CR 702.131a — ascend on an instant or sorcery) and for any card that simply
+ *   says "you get the city's blessing".
+ *
+ * **Why [has] is more than a component read.** CR 702.131b makes ascend on a permanent a *static*
+ * ability — "**any time** you control ten or more permanents … you get the city's blessing" — so the
+ * designation is yours the instant the tenth permanent is there, with nothing on the stack and no
+ * priority in between. The engine polls state-based actions only between resolutions, which is one
+ * poll too late for the case the card's own rulings call out: Ocelot Pride's last ability creates a
+ * Cat, and if that Cat is your tenth permanent you have the blessing *by the time the same
+ * resolution reaches* "Then if you have the city's blessing…". Reading the ascend condition live
+ * here, rather than waiting for the marker to be written, is what makes that mid-resolution read
+ * come out right. [AscendCitysBlessingCheck] then writes the marker at the next poll, which is what
+ * makes the designation survive dropping back below ten permanents (CR 702.131b, "for the rest of
+ * the game") and what the client badge renders.
+ */
+object CitysBlessingService {
+
+    /** CR 702.131a/b — the permanent count ascend looks for. */
+    const val ASCEND_THRESHOLD = 10
+
+    /**
+     * Does [playerId] have the city's blessing right now?
+     *
+     * True once it has been granted (the marker is never removed — CR 702.131b/c), and true *live*
+     * while an ascend permanent they control sees ten or more permanents, before the state-based
+     * action has had a chance to write the marker.
+     */
+    fun has(
+        state: GameState,
+        playerId: EntityId,
+        projected: ProjectedState = state.projectedState
+    ): Boolean =
+        state.getEntity(playerId)?.has<PlayerCitysBlessingComponent>() == true ||
+            qualifiesViaAscend(state, playerId, projected)
+
+    /**
+     * CR 702.131b — does [playerId] control a permanent with ascend *and* ten or more permanents?
+     *
+     * Both halves read [projected], not the printed card: a *granted* ascend counts, and a permanent
+     * stolen with a Layer 2 control change counts for its new controller.
+     *
+     * [projected] is a parameter rather than a `state.projectedState` read because this is reachable
+     * *from inside* projection — Tendershoot Dryad's "Saprolings you control get +2/+2 as long as you
+     * have the city's blessing" is a `ConditionalStaticAbility` whose gate the layer system evaluates
+     * while the projection is still being computed. Touching the lazy `GameState.projectedState`
+     * there re-enters its initializer and recurses until the stack overflows, so mid-projection
+     * callers pass the in-flight snapshot instead (`ConditionEvaluationContext.projectedStateFor`).
+     */
+    fun qualifiesViaAscend(
+        state: GameState,
+        playerId: EntityId,
+        projected: ProjectedState = state.projectedState
+    ): Boolean {
+        val controlled = projected.getBattlefieldControlledBy(playerId)
+        if (controlled.size < ASCEND_THRESHOLD) return false
+        return controlled.any { projected.hasKeyword(it, Keyword.ASCEND) }
+    }
+
+    /**
+     * Persist the designation for [playerId], attributing the grant to [sourceName].
+     *
+     * Idempotent: a player who already has the marker is left alone and no event fires, which is
+     * what lets the state-based action run every poll for the rest of the game without spamming
+     * [CitysBlessingGainedEvent].
+     */
+    fun grant(
+        state: GameState,
+        playerId: EntityId,
+        sourceName: String
+    ): Pair<GameState, List<GameEvent>> {
+        val container = state.getEntity(playerId) ?: return state to emptyList()
+        if (container.has<PlayerCitysBlessingComponent>()) return state to emptyList()
+
+        val playerName = container.get<PlayerComponent>()?.name ?: "Player"
+        val newState = state.updateEntity(playerId) { it.with(PlayerCitysBlessingComponent) }
+        return newState to listOf(CitysBlessingGainedEvent(playerId, playerName, sourceName))
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaOrder.kt
@@ -6,6 +6,7 @@ package com.wingedsheep.engine.mechanics.sba
  */
 object SbaOrder {
     const val START_YOUR_ENGINES = 50       // 704.5z (Aetherdrift speed)
+    const val ASCEND_CITYS_BLESSING = 60    // 702.131b (ascend on a permanent is a static ability)
     const val PLAYER_LIFE_LOSS = 100        // 704.5a
     const val COMMANDER_DAMAGE_LOSS = 150   // 704.5c (Commander format)
     const val POISON_LOSS = 200             // 704.5b

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/AscendCitysBlessingCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/AscendCitysBlessingCheck.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.mechanics.sba.player
+
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
+import com.wingedsheep.engine.mechanics.sba.SbaOrder
+import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingComponent
+import com.wingedsheep.sdk.core.Keyword
+
+/**
+ * CR 702.131b — **ascend** on a permanent is a static ability: "any time you control ten or more
+ * permanents and you don't have the city's blessing, you get the city's blessing for the rest of
+ * the game."
+ *
+ * Modeled the same way as [StartYourEnginesCheck], and for the same reason: the trigger-shaped
+ * alternative is wrong. An enters-the-battlefield trigger samples the permanent count exactly once,
+ * at the moment the ascend permanent lands, and never looks again — which for a one-mana 1/1 like
+ * Ocelot Pride means the threshold is checked on the turn you are least likely to meet it and the
+ * card's city's-blessing half never comes online. Running here instead means the count is re-read
+ * every time state-based actions are polled, so the blessing arrives the moment the tenth permanent
+ * does, whichever permanent that is; a *granted* ascend counts, because the keyword is read from
+ * projected state (Layer 6); and gaining control of an opponent's ascend permanent gives *you* the
+ * blessing, with no change-of-control trigger to write.
+ *
+ * Writing the marker is what makes the designation permanent — [CitysBlessingService.grant] is
+ * idempotent and the component is never removed, so dropping back below ten permanents (or losing
+ * the ascend permanent entirely) keeps the blessing, per CR 702.131b/c.
+ *
+ * **Reads don't wait for this check.** CR 704.3 has state-based actions checked whenever a player
+ * would receive priority; this engine polls them more narrowly — after a spell or ability resolves,
+ * after the draw step, after combat damage, on the end-the-turn path, and after a decision resolves.
+ * Never inside a resolution, and not after a land drop. Either gap would be visible here: Ocelot
+ * Pride's "create a Cat, *then* if you have the city's blessing…" needs the count re-read
+ * mid-resolution when that Cat is the tenth permanent, and playing your tenth land should hand you
+ * the blessing before anything else happens. So every *read* goes through
+ * [CitysBlessingService.has], which evaluates the ascend condition live. This check is the
+ * persistence half — it writes the marker at the next poll so the designation outlives dropping
+ * back below ten permanents — not the whole rule.
+ *
+ * Ordering: next to the other player-designation check, before the loss checks, so a player ends an
+ * SBA pass with a consistent designation. The position is otherwise immaterial — gaining the city's
+ * blessing can't cause or prevent any other state-based action.
+ */
+class AscendCitysBlessingCheck : StateBasedActionCheck {
+    override val name = "702.131b Ascend / City's Blessing"
+    override val order = SbaOrder.ASCEND_CITYS_BLESSING
+
+    override fun check(state: GameState): ExecutionResult {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+
+        for (playerId in state.turnOrder) {
+            // Already marked: skip before the battlefield scan. The blessing is never removed, so
+            // for most of a game this is the branch every poll takes.
+            if (newState.getEntity(playerId)?.has<PlayerCitysBlessingComponent>() == true) continue
+            if (!CitysBlessingService.qualifiesViaAscend(newState, playerId)) continue
+            val (updated, grantEvents) = CitysBlessingService.grant(
+                state = newState,
+                playerId = playerId,
+                sourceName = Keyword.ASCEND.displayName
+            )
+            newState = updated
+            events.addAll(grantEvents)
+        }
+
+        return ExecutionResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerSbaModule.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.mechanics.sba.StateBasedActionModule
 class PlayerSbaModule : StateBasedActionModule {
     override fun checks(): List<StateBasedActionCheck> = listOf(
         StartYourEnginesCheck(),
+        AscendCitysBlessingCheck(),
         PlayerLifeLossCheck(),
         CommanderDamageLossCheck(),
         PoisonLossCheck(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.view
 import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
 import com.wingedsheep.engine.mechanics.combat.rules.DefenderBypass
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
@@ -2148,10 +2149,13 @@ class ClientStateTransformer(
             )
         }
 
-        // Check for PlayerCitysBlessingComponent (Ascend / city's blessing, CR 702.131).
-        // Surface the actual Scryfall "City's Blessing" marker card (tblc #40) as the badge
-        // image so it matches the physical-game marker players know.
-        if (container.has<PlayerCitysBlessingComponent>()) {
+        // Ascend / city's blessing (CR 702.131). Read through CitysBlessingService rather than the
+        // component so the badge tracks the rule: ascend on a permanent is continuous, and a player
+        // who has just crossed ten permanents already has the blessing even though the state-based
+        // action that writes the marker hasn't been polled yet. Surface the actual Scryfall "City's
+        // Blessing" marker card (tblc #40) as the badge image so it matches the physical-game
+        // marker players know.
+        if (CitysBlessingService.has(state, playerId)) {
             effects.add(
                 ClientPlayerEffect(
                     effectId = "citys_blessing",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArenaOfGloryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArenaOfGloryScenarioTest.kt
@@ -6,9 +6,11 @@ import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.mh3.cards.ArenaOfGlory
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -29,6 +31,27 @@ class ArenaOfGloryScenarioTest : FunSpec({
         val d = GameTestDriver()
         d.registerCards(TestCards.all)
         return d
+    }
+
+    /** Walk the turn cycle until [player] is active again and has passed their untap step. */
+    fun advanceToOwnNextTurn(d: GameTestDriver, player: EntityId) {
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        while (d.activePlayer != player) {
+            d.passPriorityUntil(Step.END)
+            d.bothPass()
+        }
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /**
+     * Untap [permanent] behind the engine's back, standing in for any untapper. Needed because
+     * Arena of Glory's exert ability also costs {T}, so the only way to reach the CR 701.43b corners
+     * ("a permanent can be exerted even if it's not tapped or has already been exerted") is to get
+     * the land untapped again without waiting for an untap step.
+     */
+    fun forceUntap(d: GameTestDriver, permanent: EntityId) {
+        d.replaceState(d.state.updateEntity(permanent) { it.without<TappedComponent>() })
     }
 
     test("enters tapped without a Mountain, untapped with one") {
@@ -60,11 +83,10 @@ class ArenaOfGloryScenarioTest : FunSpec({
         val d = driver()
         d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
         val active = d.activePlayer!!
-        val opp = d.getOpponent(active)
         d.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val arena = d.putLandOnBattlefield(active, "Arena of Glory")
-        d.giveMana(active, com.wingedsheep.sdk.core.Color.RED, 1)
+        d.giveMana(active, Color.RED, 1)
 
         d.submitSuccess(
             ActivateAbility(playerId = active, sourceId = arena, abilityId = exertAbilityId)
@@ -72,32 +94,63 @@ class ArenaOfGloryScenarioTest : FunSpec({
         d.state.getEntity(arena)?.has<TappedComponent>() shouldBe true
         d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe true
 
-        // Advance through the rest of this turn, all of the opponent's turn, and into the
-        // exerting player's own next untap step.
-        d.passPriorityUntil(Step.END)
-        d.bothPass()
-        while (d.activePlayer != active) {
-            d.passPriorityUntil(Step.END)
-            d.bothPass()
-        }
-        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
-
+        // Through the rest of this turn, all of the opponent's turn, and into the exerting
+        // player's own next untap step: the exert skips it, and the marker expires there.
+        advanceToOwnNextTurn(d, active)
         d.state.getEntity(arena)?.has<TappedComponent>() shouldBe true
         d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe false
 
         // A later turn (no re-exert) untaps it normally.
-        d.putCardInHand(active, "Plains") // keep the library non-empty-adjacent; unused otherwise
-        while (d.activePlayer != active) {
-            d.passPriorityUntil(Step.END)
-            d.bothPass()
-        }
-        d.passPriorityUntil(Step.END)
-        d.bothPass()
-        while (d.activePlayer != active) {
-            d.passPriorityUntil(Step.END)
-            d.bothPass()
-        }
+        advanceToOwnNextTurn(d, active)
+        d.state.getEntity(arena)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("exerting an untapped, already-exerted permanent is legal and doesn't stack (CR 701.43b)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
         d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val arena = d.putLandOnBattlefield(active, "Arena of Glory")
+        d.giveMana(active, Color.RED, 1)
+        d.submitSuccess(ActivateAbility(playerId = active, sourceId = arena, abilityId = exertAbilityId))
+        d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe true
+
+        // Untapped and already exerted — CR 701.43b says both are fine, so the cost is payable and
+        // the activation succeeds a second time this turn.
+        forceUntap(d, arena)
+        d.giveMana(active, Color.RED, 1)
+        d.submitSuccess(ActivateAbility(playerId = active, sourceId = arena, abilityId = exertAbilityId))
+        d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe true
+
+        // "If you exert a permanent more than once before your next untap step, each effect causing
+        // it not to untap expires during the same untap step" — two exerts cost exactly one untap
+        // step, not two. After the first one it's still tapped, with the marker gone…
+        advanceToOwnNextTurn(d, active)
+        d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe false
+        d.state.getEntity(arena)?.has<TappedComponent>() shouldBe true
+
+        // …and the next untap step untaps it normally.
+        advanceToOwnNextTurn(d, active)
+        d.state.getEntity(arena)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("an exerted permanent that is already untapped still loses the marker at the untap step") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val arena = d.putLandOnBattlefield(active, "Arena of Glory")
+        d.giveMana(active, Color.RED, 1)
+        d.submitSuccess(ActivateAbility(playerId = active, sourceId = arena, abilityId = exertAbilityId))
+        forceUntap(d, arena)
+
+        // 2024-06-07 ruling: "If an exerted permanent is already untapped during your next untap
+        // step … exert's effect … expires without having done anything." The marker is not a stun
+        // counter — it doesn't wait around for an untap to eat.
+        advanceToOwnNextTurn(d, active)
+        d.state.getEntity(arena)?.has<ExertedComponent>() shouldBe false
         d.state.getEntity(arena)?.has<TappedComponent>() shouldBe false
     }
 
@@ -110,9 +163,14 @@ class ArenaOfGloryScenarioTest : FunSpec({
         val arena = d.putLandOnBattlefield(active, "Arena of Glory")
 
         // Plain {T}: Add {R} — spent on Grizzly Bears — should NOT grant haste.
+        //
+        // The pool is exactly {R}{G} and Grizzly Bears costs {1}{G}: the green pays the {G} pip and
+        // the plain ability's red is the *only* mana left to pay the {1}, so it is necessarily
+        // spent on the spell. Handing over a colourless as well would let it pay the generic half
+        // and leave the red sitting untouched in the pool, at which point this assertion would
+        // still pass even if the plain ability did carry a haste rider.
         d.submitSuccess(ActivateAbility(playerId = active, sourceId = arena, abilityId = plainAbilityId))
-        d.giveColorlessMana(active, 1) // Grizzly Bears costs {1}{G}; supply the generic half
-        d.giveMana(active, com.wingedsheep.sdk.core.Color.GREEN, 1)
+        d.giveMana(active, Color.GREEN, 1)
         val bearsId = d.putCardInHand(active, "Grizzly Bears")
         d.castSpell(active, bearsId)
         d.bothPass()
@@ -127,12 +185,12 @@ class ArenaOfGloryScenarioTest : FunSpec({
         d.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val arena = d.putLandOnBattlefield(active, "Arena of Glory")
-        d.giveMana(active, com.wingedsheep.sdk.core.Color.RED, 1) // pays the {R} part of the exert cost
+        d.giveMana(active, Color.RED, 1) // pays the {R} part of the exert cost
 
         d.submitSuccess(ActivateAbility(playerId = active, sourceId = arena, abilityId = exertAbilityId))
         // The activation produces {R}{R} into the pool; give the extra generic mana Grizzly
         // Bears needs beyond the {G} pip, which the exert-tagged red also covers as generic.
-        d.giveMana(active, com.wingedsheep.sdk.core.Color.GREEN, 1)
+        d.giveMana(active, Color.GREEN, 1)
         val bearsId = d.putCardInHand(active, "Grizzly Bears")
         d.castSpell(active, bearsId)
         d.bothPass()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OcelotPrideScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OcelotPrideScenarioTest.kt
@@ -1,0 +1,248 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
+import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PlayerCitysBlessingComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ocelot Pride (MH3) — three chained pieces, tested apart from each other.
+ *
+ * 1. **Ascend is continuous** (CR 702.131b). It is the keyword and nothing else; the engine's
+ *    702.131b state-based action grants the city's blessing whenever the tenth permanent shows up,
+ *    not only on the turn Ocelot Pride entered. For a one-mana 1/1 that distinction is the whole
+ *    card: you essentially never control ten permanents on turn one, so an ETB-trigger reading of
+ *    ascend would leave the second half of the last ability permanently dead.
+ * 2. **The end-step ability is a genuine intervening-if** (CR 603.4) — it doesn't trigger unless you
+ *    gained life before the end step began.
+ * 3. **"Then if you have the city's blessing…" is resolution-time only**, and per the 2024-06-07
+ *    ruling the Cat created earlier in the *same* resolution counts, both toward the ten-permanent
+ *    ascend threshold and as a token that entered this turn.
+ */
+class OcelotPrideScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        return d
+    }
+
+    /**
+     * Does [playerId] have the city's blessing, as every consumer of it sees the question — the
+     * `YouHaveCitysBlessing` condition, the static-ability projection and the client badge all read
+     * through [CitysBlessingService]. Not a bare component read: the marker is written by a
+     * state-based action, and CR 702.131b's ascend is continuous, so the designation is yours
+     * before the next poll.
+     */
+    fun hasCitysBlessing(d: GameTestDriver, playerId: EntityId): Boolean =
+        CitysBlessingService.has(d.state, playerId)
+
+    /** The persisted marker specifically — what survives dropping back below ten permanents. */
+    fun blessingMarkerWritten(d: GameTestDriver, playerId: EntityId): Boolean =
+        d.state.getEntity(playerId)?.has<PlayerCitysBlessingComponent>() == true
+
+    fun catTokens(d: GameTestDriver, playerId: EntityId): Int =
+        d.getCreatures(playerId).count { d.getCardName(it) == "Cat Token" }
+
+    /** "if you gained life this turn" reads LifeGainedAmountThisTurnComponent — seed it directly. */
+    fun seedLifeGained(d: GameTestDriver, playerId: EntityId, amount: Int) {
+        d.replaceState(
+            d.state.updateEntity(playerId) { it.with(LifeGainedAmountThisTurnComponent(amount)) }
+        )
+    }
+
+    fun grantCitysBlessing(d: GameTestDriver, playerId: EntityId) {
+        d.replaceState(d.state.updateEntity(playerId) { it.with(PlayerCitysBlessingComponent) })
+    }
+
+    /**
+     * Drain the stack and any pending decisions, then stop. Deliberately does *not* pass on an
+     * empty stack — an unconditional `bothPass()` loop walks the turn forward and skips the very
+     * end step these tests are trying to observe.
+     */
+    fun settle(d: GameTestDriver, maxSteps: Int = 20) {
+        repeat(maxSteps) {
+            when {
+                d.pendingDecision != null -> d.autoResolveDecision()
+                d.getTopOfStack() != null -> d.bothPass()
+                else -> return
+            }
+        }
+    }
+
+    /**
+     * Advance to the next turn's draw step, which is one of the points the engine polls state-based
+     * actions (the others being after a resolution, after combat damage and on the end-the-turn
+     * path — notably *not* a bare priority pass).
+     *
+     * Only the tests that assert on the persisted marker need this. The battlefield helpers write
+     * straight into the state instead of going through the play-land and cast pipelines, so nothing
+     * has polled since the board was assembled; every *rules* read of the blessing goes through
+     * [CitysBlessingService] and doesn't wait for a poll.
+     */
+    fun pollStateBasedActions(d: GameTestDriver) {
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.passPriorityUntil(Step.DRAW)
+        settle(d)
+    }
+
+    test("crossing ten permanents after Ocelot Pride entered still grants the city's blessing (CR 702.131b)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast it for real so that, on a board of two permanents, ascend genuinely finds fewer than
+        // ten — exactly as a turn-one Ocelot Pride would.
+        d.giveMana(active, Color.WHITE, 1)
+        val prideCard = d.putCardInHand(active, "Ocelot Pride")
+        d.castSpell(active, prideCard)
+        settle(d)
+
+        d.findPermanent(active, "Ocelot Pride") shouldNotBe null
+        hasCitysBlessing(d, active) shouldBe false
+
+        // Now climb well past ten permanents, as any real game does a few turns later.
+        repeat(12) { d.putLandOnBattlefield(active, "Plains") }
+        d.getPermanents(active).size shouldBeGreaterThanOrEqual 10
+
+        // Ascend is static and continuous: once the tenth permanent is there the blessing is yours,
+        // with no second enters-the-battlefield event to wait for.
+        hasCitysBlessing(d, active) shouldBe true
+    }
+
+    test("the city's blessing survives dropping back below ten permanents (CR 702.131b/c)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pride = d.putCreatureOnBattlefield(active, "Ocelot Pride")
+        val lands = (1..12).map { d.putLandOnBattlefield(active, "Plains") }
+        pollStateBasedActions(d)
+        blessingMarkerWritten(d, active) shouldBe true
+
+        // Wrath the board back down under the threshold — including the ascend permanent itself.
+        d.moveToGraveyard(pride)
+        lands.forEach { d.moveToGraveyard(it) }
+        pollStateBasedActions(d)
+        d.getPermanents(active).size shouldBe 0
+
+        // "For the rest of the game": the designation is a one-way marker, not a continuous effect
+        // that switches off with the board that produced it.
+        blessingMarkerWritten(d, active) shouldBe true
+        hasCitysBlessing(d, active) shouldBe true
+    }
+
+    test("with ten-plus permanents reached later, the end-step ability still doubles the Cat") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.giveMana(active, Color.WHITE, 1)
+        val prideCard = d.putCardInHand(active, "Ocelot Pride")
+        d.castSpell(active, prideCard)
+        settle(d)
+
+        repeat(12) { d.putLandOnBattlefield(active, "Plains") }
+        seedLifeGained(d, active, 1)
+        catTokens(d, active) shouldBe 0
+
+        d.passPriorityUntil(Step.END)
+        settle(d)
+
+        // One Cat from the first clause, plus one copy of it from the city's-blessing clause
+        // (per the 2024-06-07 ruling, the Cat made earlier in this same resolution has already
+        // "entered this turn" by the time the second clause is reached).
+        catTokens(d, active) shouldBe 2
+    }
+
+    test("the Cat that is your tenth permanent grants the blessing before the same resolution checks for it") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Nine permanents: Ocelot Pride plus eight lands. The Cat the trigger is about to make is
+        // the tenth.
+        d.putCreatureOnBattlefield(active, "Ocelot Pride")
+        repeat(8) { d.putLandOnBattlefield(active, "Plains") }
+        settle(d)
+        d.getPermanents(active).size shouldBe 9
+        hasCitysBlessing(d, active) shouldBe false
+
+        seedLifeGained(d, active, 1)
+        d.passPriorityUntil(Step.END)
+        settle(d)
+
+        // 2024-06-07 ruling: "If the creature token created by Ocelot Pride's last ability is your
+        // tenth permanent, you'll get the city's blessing before the ability would check to see if
+        // you have the city's blessing." State-based actions aren't polled mid-resolution, so this
+        // only comes out right because ascend is read live rather than waiting for the marker.
+        hasCitysBlessing(d, active) shouldBe true
+        catTokens(d, active) shouldBe 2
+    }
+
+    test("one permanent short, the Cat is not doubled") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Eight permanents; the Cat makes nine, one short of ascend's threshold.
+        d.putCreatureOnBattlefield(active, "Ocelot Pride")
+        repeat(7) { d.putLandOnBattlefield(active, "Plains") }
+        settle(d)
+
+        seedLifeGained(d, active, 1)
+        d.passPriorityUntil(Step.END)
+        settle(d)
+
+        hasCitysBlessing(d, active) shouldBe false
+        catTokens(d, active) shouldBe 1
+    }
+
+    test("without life gained this turn the ability doesn't trigger at all (CR 603.4)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Ocelot Pride")
+        repeat(12) { d.putLandOnBattlefield(active, "Plains") }
+        hasCitysBlessing(d, active) shouldBe true
+
+        d.passPriorityUntil(Step.END)
+        settle(d)
+
+        catTokens(d, active) shouldBe 0
+    }
+
+    test("control: granted the city's blessing directly, the doubling works without ascend") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Ocelot Pride")
+        grantCitysBlessing(d, active)
+        seedLifeGained(d, active, 1)
+        catTokens(d, active) shouldBe 0
+
+        d.passPriorityUntil(Step.END)
+        settle(d)
+
+        catTokens(d, active) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendershootDryadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendershootDryadScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.citysblessing.CitysBlessingService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tendershoot Dryad (RIX, printed here from BLC) — the other ascend card, and the one that pins the
+ * *projection-mode* half of the city's blessing.
+ *
+ * Its "Saprolings you control get +2/+2 as long as you have the city's blessing" is a
+ * `ConditionalStaticAbility`, so the layer system evaluates the `YouHaveCitysBlessing` gate **while
+ * the projection is still being computed**. Ascend's ten-permanent count is itself a projected read
+ * (granted keywords, Layer 2 control changes), so the gate has to be handed the in-flight projection
+ * rather than reaching for `GameState.projectedState` — the lazy initializer would re-enter itself
+ * and recurse until the stack overflows. A five-drop reaches ten permanents often enough that this
+ * is the normal path through the card, not a corner.
+ */
+class TendershootDryadScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        return d
+    }
+
+    fun saprolings(d: GameTestDriver, playerId: EntityId): List<EntityId> =
+        d.getCreatures(playerId).filter { d.getCardName(it) == "Saproling Token" }
+
+    test("ascend switches on the Saproling lord as soon as the tenth permanent arrives") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Nine permanents — one short. The Saproling the upkeep trigger is about to make is the tenth.
+        d.putCreatureOnBattlefield(active, "Tendershoot Dryad")
+        repeat(8) { d.putLandOnBattlefield(active, "Forest") }
+        d.getPermanents(active).size shouldBe 9
+        CitysBlessingService.has(d.state, active) shouldBe false
+
+        // Walk into the next upkeep so "at the beginning of each upkeep" fires.
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.passPriorityUntil(Step.UPKEEP)
+        repeat(10) {
+            if (d.pendingDecision != null) d.autoResolveDecision()
+            else if (d.getTopOfStack() != null) d.bothPass()
+        }
+
+        val saproling = saprolings(d, active).single()
+        CitysBlessingService.has(d.state, active) shouldBe true
+
+        // 1/1 base, +2/+2 from the now-live conditional static ability. Reading this at all is the
+        // test: the gate is evaluated inside projection, on a board whose ascend count is projected.
+        d.state.projectedState.getPower(saproling) shouldBe 3
+        d.state.projectedState.getToughness(saproling) shouldBe 3
+    }
+
+    test("below ten permanents the Saprolings are plain 1/1s") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Tendershoot Dryad")
+        repeat(3) { d.putLandOnBattlefield(active, "Forest") }
+
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.passPriorityUntil(Step.UPKEEP)
+        repeat(10) {
+            if (d.pendingDecision != null) d.autoResolveDecision()
+            else if (d.getTopOfStack() != null) d.bothPass()
+        }
+
+        val saproling = saprolings(d, active).single()
+        CitysBlessingService.has(d.state, active) shouldBe false
+        d.state.projectedState.getPower(saproling) shouldBe 1
+        d.state.projectedState.getToughness(saproling) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrabenCharmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrabenCharmScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thraben Charm (MH3) — a `modal(chooseCount = 1)` charm whose third mode is the first use of
+ * `TargetPlayer(unlimited = true)` *inside a modal mode*. Every prior user of an unlimited player
+ * target (Riverchurn Monument, The Death of Gwen Stacy, Kaboom!) is a top-level ability or a saga
+ * chapter, where the target list is the spell's whole target list; here it has to survive being
+ * bound to one mode's scope and read back as `Player.ContextPlayer(0)` inside a
+ * [com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect]. Both ends of "any number" are
+ * covered: two players and none.
+ *
+ * Mode 1's amount is doubled, not fixed, so it is checked at two different creature counts — a
+ * hard-coded 4 would pass the first case alone.
+ */
+class ThrabenCharmScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        return d
+    }
+
+    /**
+     * Cast Thraben Charm choosing [modeIndex], binding [modeTargets] to that mode. Modal targets go
+     * in `modeTargetsOrdered` (aligned 1:1 with `chosenModes`) as well as the flat `targets` list —
+     * resolution reads `ContextTarget`/`ContextPlayer` out of the per-mode bindings.
+     */
+    fun castCharm(
+        d: GameTestDriver,
+        playerId: EntityId,
+        cardId: EntityId,
+        modeIndex: Int,
+        modeTargets: List<ChosenTarget> = emptyList()
+    ) = d.submit(
+        CastSpell(
+            playerId = playerId,
+            cardId = cardId,
+            targets = modeTargets,
+            chosenModes = listOf(modeIndex),
+            modeTargetsOrdered = listOf(modeTargets),
+            paymentStrategy = PaymentStrategy.FromPool
+        )
+    )
+
+    fun damageOn(d: GameTestDriver, entityId: EntityId): Int =
+        d.state.getEntity(entityId)?.get<DamageComponent>()?.amount ?: 0
+
+    fun payFor(d: GameTestDriver, playerId: EntityId) {
+        d.giveMana(playerId, Color.WHITE, 1)
+        d.giveColorlessMana(playerId, 1)
+    }
+
+    test("mode 1 deals twice your creature count — two creatures kill a 3/3") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Grizzly Bears")
+        d.putCreatureOnBattlefield(active, "Grizzly Bears")
+        val courser = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        payFor(d, active)
+        val charm = d.putCardInHand(active, "Thraben Charm")
+        castCharm(d, active, charm, 0, listOf(ChosenTarget.Permanent(courser))).isSuccess shouldBe true
+        d.bothPass()
+
+        // 2 creatures × 2 = 4 damage, lethal to a 3/3.
+        d.findPermanent(opp, "Centaur Courser") shouldBe null
+        d.getGraveyardCardNames(opp) shouldContain "Centaur Courser"
+    }
+
+    test("mode 1 with one creature deals only 2 — the amount tracks the creature count") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(active, "Grizzly Bears")
+        val courser = d.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        payFor(d, active)
+        val charm = d.putCardInHand(active, "Thraben Charm")
+        castCharm(d, active, charm, 0, listOf(ChosenTarget.Permanent(courser))).isSuccess shouldBe true
+        d.bothPass()
+
+        damageOn(d, courser) shouldBe 2
+        d.findPermanent(opp, "Centaur Courser") shouldBe courser
+    }
+
+    test("mode 2 destroys target enchantment") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val glade = d.putPermanentOnBattlefield(opp, "Centaur Glade")
+
+        payFor(d, active)
+        val charm = d.putCardInHand(active, "Thraben Charm")
+        castCharm(d, active, charm, 1, listOf(ChosenTarget.Permanent(glade))).isSuccess shouldBe true
+        d.bothPass()
+
+        d.findPermanent(opp, "Centaur Glade") shouldBe null
+        d.getGraveyardCardNames(opp) shouldContain "Centaur Glade"
+    }
+
+    test("mode 3 exiles the graveyards of every targeted player") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardInGraveyard(active, "Grizzly Bears")
+        d.putCardInGraveyard(opp, "Centaur Courser")
+        d.putCardInGraveyard(opp, "Hill Giant")
+
+        payFor(d, active)
+        val charm = d.putCardInHand(active, "Thraben Charm")
+        castCharm(
+            d, active, charm, 2,
+            listOf(ChosenTarget.Player(active), ChosenTarget.Player(opp))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.getExileCardNames(active) shouldContain "Grizzly Bears"
+        d.getExileCardNames(opp) shouldContain "Centaur Courser"
+        d.getExileCardNames(opp) shouldContain "Hill Giant"
+
+        // Both graveyards are emptied, including the caster's own. What's left in the caster's is
+        // Thraben Charm itself, put there as the last step of its own resolution (CR 608.2m) —
+        // after the exile, so it isn't caught by it.
+        d.getGraveyardCardNames(active) shouldBe listOf("Thraben Charm")
+        d.getGraveyard(opp) shouldBe emptyList()
+    }
+
+    test("mode 3 with zero targets resolves and exiles nothing") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCardInGraveyard(active, "Grizzly Bears")
+        d.putCardInGraveyard(opp, "Centaur Courser")
+
+        payFor(d, active)
+        val charm = d.putCardInHand(active, "Thraben Charm")
+        castCharm(d, active, charm, 2).isSuccess shouldBe true
+        d.bothPass()
+
+        // "Any number" includes none: the spell resolves, nothing is exiled, and — the point of the
+        // case — it doesn't fizzle for lack of a legal target or fall through to some default
+        // "every player" reading.
+        d.getGraveyardCardNames(active) shouldContain "Grizzly Bears"
+        d.getGraveyardCardNames(opp) shouldContain "Centaur Courser"
+        d.getExile(active) shouldBe emptyList()
+        d.getExile(opp) shouldBe emptyList()
+    }
+})

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1324,7 +1324,7 @@ function GameCardImpl({
         </div>
       )}
 
-      {/* Exerted indicator (CR 701.39a) — won't untap during its controller's next untap step. */}
+      {/* Exerted indicator (CR 701.43a) — won't untap during its controller's next untap step. */}
       {battlefield && card.isExerted && (
         <div
           aria-label="Exerted — won't untap next turn"

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -202,7 +202,7 @@ export interface ClientCard {
 
   /** State flags */
   readonly isTapped: boolean
-  /** Exerted (CR 701.39a) — won't untap during its controller's next untap step. */
+  /** Exerted (CR 701.43a) — won't untap during its controller's next untap step. */
   readonly isExerted?: boolean
   readonly hasSummoningSickness: boolean
   readonly isTransformed: boolean


### PR DESCRIPTION
Follow-up to the review on #1510 (now merged). Addresses all six findings; the blocking one needed real engine work.

## 1. Ascend never fires — fixed in the engine (blocking)

CR 702.131b: ascend on a permanent is a **static** ability — "*any time* you control ten or more permanents and you don't have the city's blessing, you get the city's blessing." Both ascend cards modeled it as an ETB trigger gated on `ControlPermanentsAtLeast(10)`, which samples the count once — on the turn a one-mana 1/1 is least likely to meet it — and never looks again. Ocelot Pride's entire city's-blessing clause was dead in real games.

Ascend is engine behavior now. `keywords(Keyword.ASCEND)` is the whole card-side implementation; the ETB triggers are gone from both Ocelot Pride and Tendershoot Dryad.

- **`CitysBlessingService`** — the one place the designation is read or granted. `has()` is the persisted marker **or** a live ascend qualification.
- **`AscendCitysBlessingCheck`** — a new SBA, ordered beside `StartYourEnginesCheck` (which is the same shape of rule, and modeled the same way for the same reasons). It persists the marker.
- **`ConditionEvaluator`** and the **client badge** both read through the service.

The live arm of `has()` is load-bearing, not belt-and-braces. State-based actions are never polled mid-resolution, so ruling #3 — "if the creature token created by Ocelot Pride's last ability is your tenth permanent, you'll get the city's blessing before the ability would check" — only comes out right because the Cat flips the read immediately. That case is now a test rather than something to defer.

Tendershoot Dryad (BLC), which had the same gap, is fixed by the same change.

### One subtlety worth a look in review

`qualifiesViaAscend` takes the projection as a **parameter** instead of reading `state.projectedState`. Tendershoot Dryad's "Saprolings you control get +2/+2 as long as you have the city's blessing" is a `ConditionalStaticAbility`, so the layer system evaluates that gate *while the projection is still being computed*; reaching for the lazy `projectedState` there re-enters its own initializer and recurses until the stack overflows. `ConditionEvaluator` passes `ctx.projectedStateFor(state)`. Same hazard the `defaultProjection` plumbing on `DynamicAmountEvaluator` already guards against. `TendershootDryadScenarioTest` pins it.

## 2. Ocelot Pride and Thraben Charm had no tests

- **`OcelotPrideScenarioTest`** (7) — the three cases from the review, plus: the Cat that is your tenth permanent (ruling #3), one permanent short so the Cat isn't doubled, the intervening-if not triggering without life gained, and the blessing surviving a wrath that takes you below ten.
- **`ThrabenCharmScenarioTest`** (5) — each mode; mode 1 at two different creature counts, since a hard-coded 4 would pass a single case; mode 3 with two target players **and** with none.
- **`TendershootDryadScenarioTest`** (2) — the projection-mode path above.

## 3 & 4. Rule numbers

Exert is CR **701.43**, not 701.39 (701.39 is Bolster). The Kotlin sites were already corrected; this fixes the last two, in `gameState.ts` and `GameCard.tsx`.

Reflexive triggered abilities are CR **603.12**, not 603.2 (603.2 is "an ability triggers when its event happens", and has no sub-rules). Four sites — `GuideOfSouls.kt`, `CounterEffects.kt`, `Energy.kt`, `card-sdk-language-reference.md` — now matching the convention the rest of the repo already uses.

Both verified against the 2025-06-06 CR, as was 702.131b.

## 5. The haste test didn't test haste

`ArenaOfGloryScenarioTest` handed over a colourless *and* a green before casting Grizzly Bears `{1}{G}`, so the green paid the `{G}`, the colourless paid the `{1}`, and the rider-tagged red sat untouched — the assertion passed for a reason unrelated to the rider. Dropping the colourless leaves a pool of exactly `{R}{G}`, so the red must pay the `{1}`.

## 6. Exert corners

Two cases for the CR 701.43b prose that five files dwell on:

- **Exerting an untapped, already-exerted permanent** — legal, and "each effect causing it not to untap expires during the same untap step": two exerts cost exactly one untap step, not two.
- **A marker on an already-untapped permanent** expires having done nothing (2024-06-07 ruling) — which is what distinguishes it from a stun counter.

## Verification

`just test` green. Card snapshots reblessed — the diff is the removed ascend trigger in `MH3.json` and `BLC.json`, and nothing else.

## Not fixed here

`just check-card-printing "Tendershoot Dryad"` reports drift: the canonical `CardDefinition` lives in `blc` but the earliest real printing is `rix`. That's true on `main` today and predates this branch — I only touched the card's ascend wiring, so I left the relocation alone.

The web-client edits are comment-only and the worktree has no `node_modules`, so I skipped `npm run typecheck` rather than doing an install for two comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
