### PR TITLE
Add five Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunaGrandsquall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunaGrandsquall.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Beluna Grandsquall // Seek Thrills
+ * {G}{U}{R}
+ * Legendary Creature — Giant Noble
+ * 4/4
+ * Trample
+ * Permanent spells you cast that have an Adventure cost {1} less to cast.
+ *
+ * Adventure: Seek Thrills — {2}{G}{U}{R}, Instant — Adventure
+ * Mill seven cards. Then put all cards that have an Adventure from among the milled cards into
+ * your hand.
+ *
+ * The discount is `YouCast(Permanent ∧ HasAdventure)` + [CostModification.ReduceGeneric] — "permanent
+ * spells" is the load-bearing half of the wording. An adventurer card cast as its Adventure is an
+ * instant or sorcery spell with only the Adventure's characteristics (CR 715.3), so the discount must
+ * not touch it; the engine enforces that structurally, because secondary faces price through
+ * `calculateEffectiveCostWithAlternativeBase`, which only ever applies `AnyCaster` *increases*. The
+ * creature half cast from hand — or cast from exile after its Adventure resolved — goes through the
+ * normal path with the adventurer card's own type line, so it gets the {1}.
+ *
+ * Seek Thrills is [Patterns.Library.mill] (an `isMill = true` gather into the `"milled"` collection,
+ * then a move to the graveyard) followed by a filtered [MoveCollectionEffect] back out of that same
+ * collection. Filtering the collection rather than the graveyard is what makes "from among the milled
+ * cards" mean these seven specifically, and there is no selection step because the oracle says "put
+ * **all** cards that have an Adventure" — no choice, no ordering, no "you may".
+ *
+ * [Filters.HasAdventure] is `CardPredicate.HasAdventure`, a characteristic of the whole card in every
+ * zone — per the WOE rulings it finds an adventurer card in the graveyard even though that card is
+ * showing only its front-face (permanent) characteristics there.
+ */
+val BelunaGrandsquall = card("Beluna Grandsquall") {
+    manaCost = "{G}{U}{R}"
+    colorIdentity = "GUR"
+    typeLine = "Legendary Creature — Giant Noble"
+    oracleText = "Trample\n" +
+        "Permanent spells you cast that have an Adventure cost {1} less to cast."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(
+                Filters.Permanent.withCardPredicate(CardPredicate.HasAdventure),
+            ),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    adventure("Seek Thrills") {
+        manaCost = "{2}{G}{U}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Mill seven cards. Then put all cards that have an Adventure from among the " +
+            "milled cards into your hand. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                Patterns.Library.mill(7),
+                MoveCollectionEffect(
+                    from = "milled",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    filter = Filters.HasAdventure,
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "220"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1783915067"
+
+        ruling(
+            "2023-09-01",
+            "An effect may refer to a card, spell, or permanent that \"has an Adventure.\" This " +
+                "refers to a card, spell, or permanent that has an adventurer card's set of " +
+                "alternative characteristics, even if they're not being used and even if that card " +
+                "was never cast as an Adventure."
+        )
+        ruling(
+            "2023-09-01",
+            "When casting a spell as an Adventure, use the alternative characteristics and ignore " +
+                "all of the card's normal characteristics. The spell's color, mana cost, mana " +
+                "value, and so on are determined by only those alternative characteristics."
+        )
+        ruling(
+            "2023-09-01",
+            "An adventurer card is a permanent card in every zone except the stack, as well as " +
+                "while on the stack if not cast as an Adventure. Ignore its alternative " +
+                "characteristics in those cases."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunaGrandsquall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunaGrandsquall.kt
@@ -28,11 +28,18 @@ import com.wingedsheep.sdk.scripting.predicates.CardPredicate
  *
  * The discount is `YouCast(Permanent ∧ HasAdventure)` + [CostModification.ReduceGeneric] — "permanent
  * spells" is the load-bearing half of the wording. An adventurer card cast as its Adventure is an
- * instant or sorcery spell with only the Adventure's characteristics (CR 715.3), so the discount must
- * not touch it; the engine enforces that structurally, because secondary faces price through
- * `calculateEffectiveCostWithAlternativeBase`, which only ever applies `AnyCaster` *increases*. The
- * creature half cast from hand — or cast from exile after its Adventure resolved — goes through the
- * normal path with the adventurer card's own type line, so it gets the {1}.
+ * instant or sorcery spell with only the Adventure's characteristics (CR 715.3b), so the discount must
+ * not touch it.
+ *
+ * What actually keeps it off is the engine's *pricing path*, not the [Filters.Permanent] predicate:
+ * cost filters are matched against the card definition (`CostCalculator.matchesCardDefinition`), i.e.
+ * the front face, which is a permanent either way. Secondary faces price through
+ * `calculateEffectiveCostWithAlternativeBase`, which consults only `AnyCaster` *increases* and never
+ * `YouCast` reductions — an engine-wide simplification that CR 118.9d does not license in general.
+ * `WoeCardsBatch12ScenarioTest` therefore pins the outcome ("Rip the Seams still costs {2}{W} with
+ * Beluna out"), so closing that gap turns a silent rules break into a red test. The creature half cast
+ * from hand — or cast from exile after its Adventure resolved — goes through the normal path with the
+ * adventurer card's own type line, so it gets the {1}.
  *
  * Seek Thrills is [Patterns.Library.mill] (an `isMill = true` gather into the `"milled"` collection,
  * then a move to the graveyard) followed by a filtered [MoveCollectionEffect] back out of that same
@@ -72,8 +79,7 @@ val BelunaGrandsquall = card("Beluna Grandsquall") {
             "(Then exile this card. You may cast the creature later from exile.)"
         spell {
             effect = Effects.Composite(
-                Patterns.Library.mill(7),
-                MoveCollectionEffect(
+                Patterns.Library.mill(7).effects + MoveCollectionEffect(
                     from = "milled",
                     destination = CardDestination.ToZone(Zone.HAND),
                     filter = Filters.HasAdventure,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CallousSellSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CallousSellSword.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * Callous Sell-Sword // Burn Together
+ * {1}{B}
+ * Creature — Human Soldier
+ * 2/2
+ * This creature enters with a +1/+1 counter on it for each creature that died under your control
+ * this turn.
+ *
+ * Adventure: Burn Together — {R}, Sorcery — Adventure
+ * Target creature you control deals damage equal to its power to any other target. Then sacrifice it.
+ *
+ * The counters are an [EntersWithDynamicCounters] replacement (CR 614.1c), not an enters trigger, so
+ * they are already on it the instant it hits the battlefield — that matters because the intended line
+ * is casting Burn Together first and then the creature, and the sacrificed creature has to be counted.
+ * `TurnTracking(Player.You, CREATURES_DIED)` is the per-player turn tracker, which counts tokens too
+ * ("each creature that died under your control", not "each creature card"). Leaving `otherOnly` false
+ * keeps it self-scoped: the global scan only applies `EntersWithDynamicCounters` when `otherOnly` is
+ * set, so your other creatures don't pick counters up from it.
+ *
+ * Burn Together is the Self-Destruct shape — the chosen creature (target index 0) is the
+ * `damageSource`, so the damage is dealt *by it* (deathtouch, lifelink and damage-redirection all
+ * read off it) and [DynamicAmounts.targetPower]`(0)` is its power at resolution. "Any other target"
+ * is [TargetOther] over [AnyTarget], which enforces distinctness from target 0 rather than merely
+ * offering a second any-target.
+ *
+ * Both rulings about illegal targets fall out of the ordering: if the creature is gone the damage
+ * step has no source and the sacrifice finds nothing, and if only the second target is gone the
+ * sacrifice still happens.
+ */
+val CallousSellSword = card("Callous Sell-Sword") {
+    manaCost = "{1}{B}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "This creature enters with a +1/+1 counter on it for each creature that died " +
+        "under your control this turn."
+    power = 2
+    toughness = 2
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.TurnTracking(Player.You, TurnTracker.CREATURES_DIED),
+        )
+    )
+
+    adventure("Burn Together") {
+        manaCost = "{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target creature you control deals damage equal to its power to any other " +
+            "target. Then sacrifice it. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val yourCreature = target("target creature you control", Targets.CreatureYouControl)
+            val other = target("any other target", TargetOther(baseRequirement = AnyTarget()))
+            effect = Effects.DealDamage(
+                DynamicAmounts.targetPower(0),
+                other,
+                damageSource = yourCreature,
+            ) then Effects.SacrificeTarget(yourCreature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1783915066"
+
+        ruling(
+            "2023-09-01",
+            "If the first target of Burn Together is an illegal target as the spell resolves but " +
+                "the last target is still legal, Burn Together will resolve, but no damage will be " +
+                "dealt and nothing will be sacrificed."
+        )
+        ruling(
+            "2023-09-01",
+            "If the last target of Burn Together is an illegal target as the spell resolves but " +
+                "the first target is still legal, Burn Together will still resolve and you'll " +
+                "still sacrifice the first target."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CallousSellSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CallousSellSword.kt
@@ -33,9 +33,8 @@ import com.wingedsheep.sdk.scripting.values.TurnTracker
  *
  * Burn Together is the Self-Destruct shape — the chosen creature (target index 0) is the
  * `damageSource`, so the damage is dealt *by it* (deathtouch, lifelink and damage-redirection all
- * read off it) and [DynamicAmounts.targetPower]`(0)` is its power at resolution. "Any other target"
- * is [TargetOther] over [AnyTarget], which enforces distinctness from target 0 rather than merely
- * offering a second any-target.
+ * read off it). "Any other target" is [TargetOther] over [AnyTarget], which enforces distinctness
+ * from target 0 rather than merely offering a second any-target.
  *
  * Both rulings about illegal targets fall out of the ordering: if the creature is gone the damage
  * step has no source and the sacrifice finds nothing, and if only the second target is gone the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DecadentDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DecadentDragon.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Decadent Dragon // Expensive Taste
+ * {2}{R}{R}
+ * Creature — Dragon
+ * 4/4
+ * Flying, trample
+ * Whenever this creature attacks, create a Treasure token.
+ *
+ * Adventure: Expensive Taste — {2}{B}, Instant — Adventure
+ * Exile the top two cards of target opponent's library face down. You may look at and play those
+ * cards for as long as they remain exiled.
+ *
+ * Expensive Taste is a gather → exile → grant pipeline over the *targeted opponent's* library
+ * ([CardSource.TopOfLibrary] with [Player.ContextPlayer]`(0)`). Three separate clauses ride on it,
+ * and each is carried by one piece:
+ *
+ *  - **face down** — [FaceDownMode.HIDDEN] on the move, so the cards sit in exile with no turn-up
+ *    cost and are opaque to everyone by default.
+ *  - **you may look at them** — the gather is a library source with the default
+ *    `LookAudience.Controller`, which persists a private reveal to the caster. That reveal survives
+ *    the move to exile, so the caster (and only the caster — their owner never learns what they are
+ *    until they're played, per the ruling) sees through the face-down back.
+ *  - **and play them for as long as they remain exiled** — [GrantMayPlayFromExileEffect] with
+ *    [MayPlayExpiry.Permanent]. "Play", not "cast", so land cards among them are playable too, and
+ *    normal timing rules and mana costs still apply — all of which the permission machinery already
+ *    enforces. The grant is not tied to the Dragon: it outlives the Adventure card leaving exile.
+ */
+val DecadentDragon = card("Decadent Dragon") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Dragon"
+    oracleText = "Flying, trample\n" +
+        "Whenever this creature attacks, create a Treasure token."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateTreasure()
+        description = "Whenever this creature attacks, create a Treasure token."
+    }
+
+    adventure("Expensive Taste") {
+        manaCost = "{2}{B}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Exile the top two cards of target opponent's library face down. You may look " +
+            "at and play those cards for as long as they remain exiled. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            target("target opponent", TargetOpponent())
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(
+                            DynamicAmount.Fixed(2),
+                            Player.ContextPlayer(0),
+                        ),
+                        storeAs = "stolen",
+                    ),
+                    MoveCollectionEffect(
+                        from = "stolen",
+                        destination = CardDestination.ToZone(Zone.EXILE),
+                        faceDown = FaceDownMode.HIDDEN,
+                    ),
+                    GrantMayPlayFromExileEffect(from = "stolen", expiry = MayPlayExpiry.Permanent),
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Wylie Beckert"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1783915066"
+
+        ruling(
+            "2023-09-01",
+            "Only you get to look at the cards exiled with Expensive Taste. Their owner doesn't " +
+                "get to know what they are while they're in exile until you play them."
+        )
+        ruling(
+            "2023-09-01",
+            "You may play the cards exiled with Expensive Taste even if they are land cards."
+        )
+        ruling(
+            "2023-09-01",
+            "You must still follow all normal timing rules to play cards exiled with Expensive Taste."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DecadentDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DecadentDragon.kt
@@ -10,7 +10,6 @@ import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.references.Player
@@ -39,7 +38,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *    `LookAudience.Controller`, which persists a private reveal to the caster. That reveal survives
  *    the move to exile, so the caster (and only the caster — their owner never learns what they are
  *    until they're played, per the ruling) sees through the face-down back.
- *  - **and play them for as long as they remain exiled** — [GrantMayPlayFromExileEffect] with
+ *  - **and play them for as long as they remain exiled** — [Effects.GrantMayPlayFromExile] with
  *    [MayPlayExpiry.Permanent]. "Play", not "cast", so land cards among them are playable too, and
  *    normal timing rules and mana costs still apply — all of which the permission machinery already
  *    enforces. The grant is not tied to the Dragon: it outlives the Adventure card leaving exile.
@@ -83,7 +82,7 @@ val DecadentDragon = card("Decadent Dragon") {
                         destination = CardDestination.ToZone(Zone.EXILE),
                         faceDown = FaceDownMode.HIDDEN,
                     ),
-                    GrantMayPlayFromExileEffect(from = "stolen", expiry = MayPlayExpiry.Permanent),
+                    Effects.GrantMayPlayFromExile(from = "stolen", expiry = MayPlayExpiry.Permanent),
                 ),
             )
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallInn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallInn.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Edgewall Inn
+ * Land
+ *
+ * This land enters tapped.
+ * As this land enters, choose a color.
+ * {T}: Add one mana of the chosen color.
+ * {3}, {T}, Sacrifice this land: Return target card that has an Adventure from your graveyard to
+ * your hand.
+ *
+ * The mana half is the Uncharted Haven shape: [EntersTapped] plus [EntersWithChoice] of
+ * [ChoiceType.COLOR] (an "as this enters" replacement, so the color is locked in before the land is
+ * ever on the battlefield to tap), and the mana ability reads it back via
+ * [Effects.AddManaOfChosenColor] — `ManaColorSet.SourceChosenColor` on this permanent's
+ * `ChosenColorComponent`, not a fresh choice per activation.
+ *
+ * "A card that has an Adventure" is [Filters.HasAdventure] — `CardPredicate.HasAdventure`, a
+ * characteristic of the whole card in every zone. That is deliberately *not* the same thing as
+ * "instant or sorcery card": per the WOE rulings an adventurer card in a graveyard is a permanent
+ * card with its normal characteristics, and the Adventure half is only visible to effects that ask
+ * "has an Adventure". Scoped `ownedByYou()` for "from your graveyard".
+ */
+val EdgewallInn = card("Edgewall Inn") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "As this land enters, choose a color.\n" +
+        "{T}: Add one mana of the chosen color.\n" +
+        "{3}, {T}, Sacrifice this land: Return target card that has an Adventure from your " +
+        "graveyard to your hand."
+
+    replacementEffect(EntersTapped())
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChosenColor()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of the chosen color."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.SacrificeSelf)
+        val adventurer = target(
+            "target card that has an Adventure in your graveyard",
+            TargetObject(
+                filter = TargetFilter(Filters.HasAdventure.ownedByYou(), zone = Zone.GRAVEYARD),
+            ),
+        )
+        effect = Effects.Move(adventurer, Zone.HAND)
+        description = "{3}, {T}, Sacrifice this land: Return target card that has an Adventure " +
+            "from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "255"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg?1783915055"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallInn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/EdgewallInn.kt
@@ -23,11 +23,9 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * {3}, {T}, Sacrifice this land: Return target card that has an Adventure from your graveyard to
  * your hand.
  *
- * The mana half is the Uncharted Haven shape: [EntersTapped] plus [EntersWithChoice] of
- * [ChoiceType.COLOR] (an "as this enters" replacement, so the color is locked in before the land is
- * ever on the battlefield to tap), and the mana ability reads it back via
- * [Effects.AddManaOfChosenColor] — `ManaColorSet.SourceChosenColor` on this permanent's
- * `ChosenColorComponent`, not a fresh choice per activation.
+ * The mana half is the Uncharted Haven shape. [EntersWithChoice] is an "as this enters" replacement,
+ * so the color is locked in before the land is ever on the battlefield to tap, and every activation
+ * reads that one recorded choice back — it is not a fresh choice per activation.
  *
  * "A card that has an Adventure" is [Filters.HasAdventure] — `CardPredicate.HasAdventure`, a
  * characteristic of the whole card in every zone. That is deliberately *not* the same thing as

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfPersistence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfPersistence.kt
@@ -28,9 +28,10 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * conditional on the creature dying, so it happens even if the target is gone on resolution
  * (the whole spell fizzles only because that is its sole target).
  *
- * Note the front face is an **enchantment**, not a creature — the Adventure rules (CR 715) are about
- * permanent spells generally, so this is the same `adventure { }` shape as the creature adventurers,
- * and the enchantment is what you cast from exile afterwards.
+ * Note the front face is an **enchantment**, not a creature — CR 715.3d says only that the controller
+ * exiles the Adventure as it resolves and "may play it" from there, with no restriction on the card's
+ * type, so this is the same `adventure { }` shape as the creature adventurers and the enchantment is
+ * what you cast from exile afterwards.
  */
 val VirtueOfPersistence = card("Virtue of Persistence") {
     manaCost = "{5}{B}{B}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfPersistence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfPersistence.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Virtue of Persistence // Locthwain Scorn
+ * {5}{B}{B}
+ * Enchantment
+ * At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield
+ * under your control.
+ *
+ * Adventure: Locthwain Scorn — {1}{B}, Sorcery — Adventure
+ * Target creature gets -3/-3 until end of turn. You gain 2 life.
+ *
+ * The upkeep trigger targets [TargetFilter.CreatureInGraveyard] — *a* graveyard, not yours, so it
+ * reanimates out of an opponent's yard too — and lands it with
+ * [Effects.PutOntoBattlefieldUnderYourControl] so control follows the enchantment's controller
+ * rather than the card's owner. It's a targeted trigger, so it simply doesn't go on the stack when
+ * every graveyard is empty of creature cards, and it fizzles if the card leaves before resolution.
+ *
+ * Locthwain Scorn is an ordinary -3/-3 until end of turn plus 2 life; the life gain is not
+ * conditional on the creature dying, so it happens even if the target is gone on resolution
+ * (the whole spell fizzles only because that is its sole target).
+ *
+ * Note the front face is an **enchantment**, not a creature — the Adventure rules (CR 715) are about
+ * permanent spells generally, so this is the same `adventure { }` shape as the creature adventurers,
+ * and the enchantment is what you cast from exile afterwards.
+ */
+val VirtueOfPersistence = card("Virtue of Persistence") {
+    manaCost = "{5}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, put target creature card from a graveyard onto " +
+        "the battlefield under your control."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        val creatureCard = target(
+            "target creature card in a graveyard",
+            TargetObject(filter = TargetFilter.CreatureInGraveyard),
+        )
+        effect = Effects.PutOntoBattlefieldUnderYourControl(creatureCard)
+        description = "At the beginning of your upkeep, put target creature card from a graveyard " +
+            "onto the battlefield under your control."
+    }
+
+    adventure("Locthwain Scorn") {
+        manaCost = "{1}{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target creature gets -3/-3 until end of turn. You gain 2 life. " +
+            "(Then exile this card. You may cast the enchantment later from exile.)"
+        spell {
+            val victim = target("target creature", Targets.Creature)
+            effect = Effects.ModifyStats(-3, -3, victim) then Effects.GainLife(2)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "115"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1783915099"
+
+        ruling(
+            "2023-09-01",
+            "If a spell is cast as an Adventure, its controller exiles it instead of putting it " +
+                "into its owner's graveyard as it resolves. For as long as it remains exiled, that " +
+                "player may cast it as a permanent spell."
+        )
+        ruling(
+            "2023-09-01",
+            "You must still follow any timing restrictions and permissions for the permanent spell " +
+                "you cast from exile. Normally, you'll be able to cast it only during your main " +
+                "phase while the stack is empty."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -960,29 +960,24 @@
                     "type": "Composite",
                     "effects": [
                         {
-                            "type": "Composite",
-                            "effects": [
-                                {
-                                    "type": "GatherCards",
-                                    "source": {
-                                        "type": "TopOfLibrary",
-                                        "count": {
-                                            "type": "Fixed",
-                                            "amount": 7
-                                        },
-                                        "isMill": true
-                                    },
-                                    "storeAs": "milled"
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 7
                                 },
-                                {
-                                    "type": "MoveCollection",
-                                    "from": "milled",
-                                    "destination": {
-                                        "type": "ToZone",
-                                        "zone": "Graveyard"
-                                    }
-                                }
-                            ]
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
                         },
                         {
                             "type": "MoveCollection",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -890,6 +890,120 @@
     ]
 }
 
+// Beluna Grandsquall
+{
+    "name": "Beluna Grandsquall",
+    "manaCost": "{G}{U}{R}",
+    "typeLine": "Legendary Creature — Giant Noble",
+    "oracleText": "Trample\nPermanent spells you cast that have an Adventure cost {1} less to cast.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsPermanent",
+                            "HasAdventure"
+                        ]
+                    }
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "MYTHIC",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f5acc0d-33a6-476f-95ca-a1ad788334dd.jpg?1783915067",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "An effect may refer to a card, spell, or permanent that \"has an Adventure.\" This refers to a card, spell, or permanent that has an adventurer card's set of alternative characteristics, even if they're not being used and even if that card was never cast as an Adventure."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "When casting a spell as an Adventure, use the alternative characteristics and ignore all of the card's normal characteristics. The spell's color, mana cost, mana value, and so on are determined by only those alternative characteristics."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "An adventurer card is a permanent card in every zone except the stack, as well as while on the stack if not cast as an Adventure. Ignore its alternative characteristics in those cases."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Seek Thrills",
+            "manaCost": "{2}{G}{U}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Mill seven cards. Then put all cards that have an Adventure from among the milled cards into your hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 7
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "HasAdventure"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Beluna's Gatekeeper
 {
     "name": "Beluna's Gatekeeper",
@@ -1689,6 +1803,103 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Callous Sell-Sword
+{
+    "name": "Callous Sell-Sword",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature enters with a +1/+1 counter on it for each creature that died under your control this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "TurnTracking",
+                    "player": "You",
+                    "tracker": "CREATURES_DIED"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/770ee3da-d33e-466f-9a2e-ad2d08ef5012.jpg?1783915066",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If the first target of Burn Together is an illegal target as the spell resolves but the last target is still legal, Burn Together will resolve, but no damage will be dealt and nothing will be sacrificed."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If the last target of Burn Together is an illegal target as the spell resolves but the first target is still legal, Burn Together will still resolve and you'll still sacrifice the first target."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Burn Together",
+            "manaCost": "{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target creature you control deals damage equal to its power to any other target. Then sacrifice it. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "Power"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any other target"
+                            },
+                            "damageSource": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "SacrificeTarget",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    },
+                    {
+                        "type": "TargetOther",
+                        "baseRequirement": "AnyTarget",
+                        "id": "any other target"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -2697,6 +2908,110 @@
     ]
 }
 
+// Decadent Dragon
+{
+    "name": "Decadent Dragon",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, trample\nWhenever this creature attacks, create a Treasure token.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "descriptionOverride": "Whenever this creature attacks, create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "RARE",
+        "artist": "Wylie Beckert",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/315cbbf7-a2ad-4565-9877-1e903d7fd797.jpg?1783915066",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Only you get to look at the cards exiled with Expensive Taste. Their owner doesn't get to know what they are while they're in exile until you play them."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You may play the cards exiled with Expensive Taste even if they are land cards."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You must still follow all normal timing rules to play cards exiled with Expensive Taste."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Expensive Taste",
+            "manaCost": "{2}{B}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Exile the top two cards of target opponent's library face down. You may look at and play those cards for as long as they remain exiled. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "stolen"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "stolen",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "stolen",
+                            "expiry": "Permanent"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target opponent"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Devouring Sugarmaw
 {
     "name": "Devouring Sugarmaw",
@@ -2973,6 +3288,84 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Edgewall Inn
+{
+    "name": "Edgewall Inn",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nAs this land enters, choose a color.\n{T}: Add one mana of the chosen color.\n{3}, {T}, Sacrifice this land: Return target card that has an Adventure from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": "ManaColorSet.SourceChosenColor"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of the chosen color."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card that has an Adventure in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "HasAdventure"
+                                ],
+                                "controllerPredicate": "OwnedByYou"
+                            },
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card that has an Adventure in your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}, Sacrifice this land: Return target card that has an Adventure from your graveyard to your hand."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "COLOR"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "rarity": "UNCOMMON",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec435e54-628a-43bd-8804-cbc37e375bce.jpg?1783915055"
+    },
+    "colorIdentityOverride": []
 }
 
 // Edgewall Pack
@@ -14457,6 +14850,110 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Virtue of Persistence
+{
+    "name": "Virtue of Persistence",
+    "manaCost": "{5}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card in a graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "controllerOverride": "Controller"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in a graveyard"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put target creature card from a graveyard onto the battlefield under your control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "MYTHIC",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1e5cafb-b0e6-4ee5-8c58-6f8e5ef2b9da.jpg?1783915099",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it as a permanent spell."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You must still follow any timing restrictions and permissions for the permanent spell you cast from exile. Normally, you'll be able to cast it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Locthwain Scorn",
+            "manaCost": "{1}{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target creature gets -3/-3 until end of turn. You gain 2 life. (Then exile this card. You may cast the enchantment later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch12ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoeCardsBatch12ScenarioTest.kt
@@ -1,0 +1,473 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.woe.cards.EdgewallInn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for the twelfth batch of Wilds of Eldraine cards.
+ *
+ * Every card in the batch composes primitives that already existed, so these tests only pin the
+ * multi-hop invariants each card silently depends on — the places where a plausible-looking
+ * composition would still resolve wrong:
+ *
+ *  - **Beluna Grandsquall // Seek Thrills** — the second `MoveCollectionEffect` re-reads the
+ *    `"milled"` collection *after* the mill already drained it to the graveyard, with no selection
+ *    step in between; and the "permanent spells" discount must reach an adventurer's front face
+ *    while never reaching its Adventure (which is the engine's alternative-cost pricing path doing
+ *    the work, not the `Permanent` filter — see the card's KDoc).
+ *  - **Callous Sell-Sword // Burn Together** — the counters are self-scoped (`otherOnly = false`
+ *    means "only this permanent"), and the intended line is Burn Together first, so the creature
+ *    sacrificed to it has to be counted by the time the Sell-Sword itself enters.
+ *  - **Decadent Dragon // Expensive Taste** — the stolen cards land in their *owner's* exile, face
+ *    down, revealed to the caster only, with a permanent may-play permission for the caster. The
+ *    "you may look at them" clause is carried entirely by the gather's reveal surviving the move.
+ *  - **Virtue of Persistence // Locthwain Scorn** — reanimation out of an *opponent's* graveyard
+ *    under your control, and the first non-creature (Enchantment) face cast out of Adventure exile.
+ *  - **Edgewall Inn** — "a card that has an Adventure" is a whole-card characteristic in the
+ *    graveyard, so it finds an adventurer card and rejects a plain instant.
+ */
+class WoeCardsBatch12ScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? = game.state.projectedState.getToughness(id)
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Cast the Adventure (secondary) face of an adventurer card in hand — `faceIndex = 0`. */
+    private fun TestGame.castAdventure(
+        cardName: String,
+        targets: List<ChosenTarget> = emptyList()
+    ) = execute(
+        CastSpell(
+            playerId = player1Id,
+            cardId = findCardsInHand(1, cardName).first(),
+            targets = targets,
+            faceIndex = 0,
+        )
+    )
+
+    init {
+        context("Beluna Grandsquall // Seek Thrills") {
+            test("Seek Thrills mills seven and pulls only the cards that have an Adventure back to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Beluna Grandsquall")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // Exactly seven cards, so the whole library is milled: two adventurers, five not.
+                    .withCardInLibrary(1, "Woodland Acolyte")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Threadbind Clique")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castAdventure("Beluna Grandsquall").error shouldBe null
+                game.resolveStack()
+
+                withClue("the whole seven-card library was milled") {
+                    game.librarySize(1) shouldBe 0
+                }
+                withClue("both adventurer cards were pulled out of the milled pile into hand") {
+                    game.isInHand(1, "Woodland Acolyte") shouldBe true
+                    game.isInHand(1, "Threadbind Clique") shouldBe true
+                    game.isInGraveyard(1, "Woodland Acolyte") shouldBe false
+                    game.isInGraveyard(1, "Threadbind Clique") shouldBe false
+                }
+                withClue("everything without an Adventure stays in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+                withClue("the Adventure exiles itself, so the creature is castable later (CR 715.3d)") {
+                    game.isInExile(1, "Beluna Grandsquall") shouldBe true
+                }
+            }
+
+            test("an adventurer permanent spell costs {1} less with Beluna out") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Beluna Grandsquall", summoningSickness = false)
+                    .withCardInHand(1, "Woodland Acolyte")
+                    // Woodland Acolyte is {2}{W}; two Plains only pay for it at the discounted {1}{W}.
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Woodland Acolyte").error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Woodland Acolyte") shouldBe true
+            }
+
+            test("without Beluna the same two lands are not enough — the discount is doing the work") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Woodland Acolyte")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Woodland Acolyte").error shouldNotBe null
+                game.isOnBattlefield("Woodland Acolyte") shouldBe false
+            }
+
+            test("the Adventure half of an adventurer gets no discount — it is not a permanent spell") {
+                fun ripTheSeams(plains: Int) = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Beluna Grandsquall", summoningSickness = false)
+                    .withCardInHand(1, "Threadbind Clique")
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true)
+                    // Rip the Seams is {2}{W} — three mana, discounted or not.
+                    .withLandsOnBattlefield(1, "Plains", plains)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val short = ripTheSeams(plains = 2)
+                val bearsShort = short.findPermanent("Grizzly Bears").shouldNotBeNull()
+                withClue("two mana must not be enough: Beluna's {1} may not reach an Adventure spell") {
+                    short.castAdventure(
+                        "Threadbind Clique",
+                        listOf(ChosenTarget.Permanent(bearsShort))
+                    ).error shouldNotBe null
+                    short.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+
+                val full = ripTheSeams(plains = 3)
+                val bearsFull = full.findPermanent("Grizzly Bears").shouldNotBeNull()
+                withClue("the same cast at full price resolves — the failure above was the cost, not the target") {
+                    full.castAdventure(
+                        "Threadbind Clique",
+                        listOf(ChosenTarget.Permanent(bearsFull))
+                    ).error shouldBe null
+                    full.resolveStack()
+                    full.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Callous Sell-Sword // Burn Together") {
+            test("Burn Together sacrifices its own creature, and the Sell-Sword then counts it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Callous Sell-Sword")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castAdventure(
+                    "Callous Sell-Sword",
+                    listOf(ChosenTarget.Permanent(giant), ChosenTarget.Player(game.player2Id))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 3/3 dealt its own power to the other target") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("and was sacrificed afterwards") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                game.isInExile(1, "Callous Sell-Sword") shouldBe true
+
+                game.castSpellFromExile(1, "Callous Sell-Sword").error shouldBe null
+                game.resolveStack()
+
+                val sellSword = game.findPermanent("Callous Sell-Sword").shouldNotBeNull()
+                withClue("one creature died under your control this turn — the one Burn Together ate") {
+                    plusOneCounters(game, sellSword) shouldBe 1
+                    power(game, sellSword) shouldBe 3
+                    toughness(game, sellSword) shouldBe 3
+                }
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                withClue("the replacement is self-scoped: your other creatures get nothing") {
+                    plusOneCounters(game, bears) shouldBe 0
+                    power(game, bears) shouldBe 2
+                }
+            }
+
+            test("with nothing dead this turn the Sell-Sword enters as a plain 2/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Callous Sell-Sword")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Callous Sell-Sword").error shouldBe null
+                game.resolveStack()
+
+                val sellSword = game.findPermanent("Callous Sell-Sword").shouldNotBeNull()
+                plusOneCounters(game, sellSword) shouldBe 0
+                power(game, sellSword) shouldBe 2
+            }
+        }
+
+        context("Decadent Dragon // Expensive Taste") {
+            test("the top two cards go to their owner's exile face down, visible and playable only to you") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Decadent Dragon")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val topTwo = game.state.getLibrary(game.player2Id).take(2)
+
+                game.castAdventure(
+                    "Decadent Dragon",
+                    listOf(ChosenTarget.Player(game.player2Id))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("exile is keyed to the owner, not to the caster") {
+                    game.state.getExile(game.player2Id).containsAll(topTwo) shouldBe true
+                    game.librarySize(2) shouldBe 1
+                }
+                topTwo.forEach { stolen ->
+                    withClue("each stolen card is face down in exile") {
+                        game.state.getEntity(stolen)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+                    }
+                    withClue("'you may look at' — revealed to the caster and to nobody else") {
+                        game.state.getEntity(stolen)?.get<RevealedToComponent>()?.playerIds shouldBe
+                            setOf(game.player1Id)
+                    }
+                    withClue("'and play them for as long as they remain exiled'") {
+                        game.state.mayPlayPermissions.any {
+                            stolen in it.cardIds && it.controllerId == game.player1Id
+                        } shouldBe true
+                    }
+                }
+            }
+
+            test("the Dragon makes a Treasure whenever it attacks") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Decadent Dragon", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.findPermanent("Treasure") shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Decadent Dragon" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Treasure").shouldNotBeNull()
+            }
+        }
+
+        context("Virtue of Persistence // Locthwain Scorn") {
+            test("your upkeep reanimates a creature card out of an opponent's graveyard under your control") {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Virtue of Persistence")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bears)).error shouldBe null
+                }
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bears)).error shouldBe null
+                    game.resolveStack()
+                }
+
+                withClue("'from a graveyard' is any graveyard, and control follows the enchantment") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.state.projectedState.getController(bears) shouldBe game.player1Id
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("Locthwain Scorn kills a 2/2, gains 2 life, and the enchantment is cast from exile after") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Virtue of Persistence")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 9)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castAdventure(
+                    "Virtue of Persistence",
+                    listOf(ChosenTarget.Permanent(bears))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("-3/-3 kills the 2/2 and the life gain is unconditional") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                game.isInExile(1, "Virtue of Persistence") shouldBe true
+
+                game.castSpellFromExile(1, "Virtue of Persistence").error shouldBe null
+                game.resolveStack()
+
+                withClue("a non-creature front face is cast out of Adventure exile like any other") {
+                    game.isOnBattlefield("Virtue of Persistence") shouldBe true
+                    game.isInExile(1, "Virtue of Persistence") shouldBe false
+                }
+            }
+        }
+
+        context("Edgewall Inn") {
+            fun inn() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Edgewall Inn", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withCardInGraveyard(1, "Woodland Acolyte")
+                .withCardInGraveyard(1, "Doom Blade")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("the sacrifice ability returns a card that has an Adventure from your graveyard") {
+                val game = inn()
+                val innId = game.findPermanent("Edgewall Inn").shouldNotBeNull()
+                val acolyte = game.findCardsInGraveyard(1, "Woodland Acolyte").single()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = innId,
+                        abilityId = EdgewallInn.activatedAbilities[1].id,
+                        targets = listOf(ChosenTarget.Card(acolyte, game.player1Id, Zone.GRAVEYARD)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("an adventurer card in the graveyard 'has an Adventure' even showing its front face") {
+                    game.isInHand(1, "Woodland Acolyte") shouldBe true
+                }
+                withClue("the Inn sacrificed itself as a cost") {
+                    game.isOnBattlefield("Edgewall Inn") shouldBe false
+                }
+            }
+
+            test("a plain instant in the graveyard is not a legal target") {
+                val game = inn()
+                val innId = game.findPermanent("Edgewall Inn").shouldNotBeNull()
+                val bolt = game.findCardsInGraveyard(1, "Doom Blade").single()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = innId,
+                        abilityId = EdgewallInn.activatedAbilities[1].id,
+                        targets = listOf(ChosenTarget.Card(bolt, game.player1Id, Zone.GRAVEYARD)),
+                    )
+                ).error shouldNotBe null
+                withClue("the ability never went on the stack, so nothing was paid") {
+                    game.isInGraveyard(1, "Doom Blade") shouldBe true
+                    game.isOnBattlefield("Edgewall Inn") shouldBe true
+                }
+            }
+
+            test("the mana ability adds the color chosen as the Inn entered, not a fresh choice") {
+                val game = inn()
+                val innId = game.findPermanent("Edgewall Inn").shouldNotBeNull()
+                game.state = game.state.updateEntity(innId) { c ->
+                    c.with(
+                        CastChoicesComponent(
+                            chosen = mapOf(ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.RED))
+                        )
+                    )
+                }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = innId,
+                        abilityId = EdgewallInn.activatedAbilities[0].id,
+                    )
+                ).error shouldBe null
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                    ?: ManaPoolComponent()
+                withClue("red was the recorded choice") {
+                    pool.red shouldBe 1
+                    pool.white shouldBe 0
+                    pool.colorless shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five WOE cards, all composed from existing SDK primitives — no new effect, condition, or keyword, and no change to `docs/card-sdk-language-reference.md`.

## Cards

- **Beluna Grandsquall // Seek Thrills** — {G}{U}{R} 4/4 trample; "Permanent spells you cast that have an Adventure cost {1} less" is `ModifySpellCost(SpellCostTarget.YouCast(Permanent ∧ HasAdventure), CostModification.ReduceGeneric(1))`. Seek Thrills is `Patterns.Library.mill(7)` followed by a `MoveCollectionEffect` out of the `"milled"` collection into hand, filtered by `Filters.HasAdventure` — no selection step, because the oracle puts *all* of them in hand.
- **Callous Sell-Sword // Burn Together** — {1}{B} 2/2; the counters are `EntersWithDynamicCounters(TurnTracking(Player.You, CREATURES_DIED))`, a replacement effect (CR 614.1c) so they are present the instant it enters. Burn Together is the Self-Destruct shape: `Effects.DealDamage(DynamicAmounts.targetPower(0), other, damageSource = target0)` then `Effects.SacrificeTarget(target0)`, with `TargetOther(AnyTarget())` for "any other target".
- **Decadent Dragon // Expensive Taste** — {2}{R}{R} 4/4 flying, trample; `Triggers.Attacks` → `Effects.CreateTreasure()`. Expensive Taste gathers the top two of `Player.ContextPlayer(0)`'s library, moves them to exile with `faceDown = FaceDownMode.HIDDEN`, and grants `GrantMayPlayFromExileEffect(expiry = MayPlayExpiry.Permanent)`. The "you may look at them" half rides on the gather's default `LookAudience.Controller`, which persists a private reveal to the caster only.
- **Virtue of Persistence // Locthwain Scorn** — {5}{B}{B} Enchantment; `Triggers.YourUpkeep` → `Effects.PutOntoBattlefieldUnderYourControl` over `TargetFilter.CreatureInGraveyard` (*a* graveyard, so it reanimates from an opponent's too). Locthwain Scorn is `Effects.ModifyStats(-3, -3)` then `Effects.GainLife(2)`.
- **Edgewall Inn** — Land; the Uncharted Haven mana shape (`EntersTapped` + `EntersWithChoice(ChoiceType.COLOR)` + `Effects.AddManaOfChosenColor()`), plus `{3}, {T}, Sacrifice this land:` returning a `Filters.HasAdventure.ownedByYou()` card from the graveyard to hand.

## Gate

`just build` — passed. Compilation was clean; the only failure was `CardDefinitionSnapshotTest` on `WOE.json`, whose diff was additions only (the five new card trees — no existing card moved). Re-blessed with `just rebless-cards`, which then passed. `just check-card-printing` reports `ok` for all five: WOE is each card's earliest real printing, and the unscaffolded `pwoe` promos / `sch` reprint need no `Printing(...)` rows. No `backlog/sets/wilds-of-eldraine/cards.md` exists, so there was nothing to tick.

## Not done

This PR came out of an autonomous loop. **Not** performed:

- No manual playthrough in the web client — none of the five was cast, activated, or resolved by hand.
- No UX pass from either seat. In particular, Expensive Taste's face-down exile pile (does the caster see the two stolen cards and can they play them? does the owner correctly *not* see them?) and Edgewall Inn's "as it enters, choose a color" prompt were reasoned about from the engine code, not observed.
- No e2e / Playwright coverage, and no new scenario tests — these cards add no engine behaviour, so they are covered only by the snapshot, lint, facade-boundary, and printing nets.
- Virtue of Persistence is the first adventurer here with a **non-creature** (Enchantment) front face; casting that face out of Adventure exile is untested by anything but the DSL's type-agnostic shape.

No card was dropped from the unit.

**Independent review is still pending** — a reviewer agent will comment its findings on this PR and a corrector agent may push follow-up commits, so this is not final at open time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)