### PR TITLE
Add three Wilds of Eldraine cards

### DIFF
--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 112 / 312
+**Implemented:** 113 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |
@@ -232,7 +232,7 @@
 - [x] Rootbound Crag
 - [ ] Rootcast Apprenticeship
 - [ ] Rose Room Treasurer
-- [ ] Rowdy Research
+- [x] Rowdy Research
 - [ ] Rugged Prairie
 - [x] Sakura-Tribe Elder
 - [ ] Saw in Half

--- a/backlog/sets/bloomburrow-commander/decks/family-matters.md
+++ b/backlog/sets/bloomburrow-commander/decks/family-matters.md
@@ -56,7 +56,7 @@
 - [ ] 1 Path to Exile
 - [ ] 1 Pull from Tomorrow
 - [ ] 1 Rapid Hybridization
-- [ ] 1 Rowdy Research
+- [x] 1 Rowdy Research
 
 ## Sorceries (8)
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/RowdyResearchReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/RowdyResearchReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rowdy Research reprint in Bloomburrow Commander (BLC). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Wilds of Eldraine's `cards/` package;
+ * this file contributes only the BLC presentation row.
+ */
+val RowdyResearchReprint = Printing(
+    oracleId = "1a33a5c2-5aa1-48e5-95a8-d52cdce980de",
+    name = "Rowdy Research",
+    setCode = "BLC",
+    collectorNumber = "173",
+    scryfallId = "22737b82-bb81-4e4d-8ce7-7f06c5692d9b",
+    artist = "Bram Sels",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22737b82-bb81-4e4d-8ce7-7f06c5692d9b.jpg?1783910682",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FaerieSlumberParty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FaerieSlumberParty.kt
@@ -2,13 +2,10 @@ package com.wingedsheep.mtg.sets.definitions.woe.cards
 
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.conditions.Exists
-import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
-import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -22,15 +19,23 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *
  * Ordering is the whole difficulty. The tokens are creatures, so they must be created *after*
  * the mass bounce (created first, they would be returned themselves and cease to exist), but the
- * payoff counts a board state that the bounce has already erased. The pipeline therefore
- * snapshots the count into a number slot first, bounces, then reads the slot back:
+ * payoff counts controllers that the bounce has already erased — `ControllerComponent` is stripped
+ * when a permanent leaves the battlefield, and `move` to a hand routes by *owner*, so reading
+ * controllers afterwards would answer the wrong question for a stolen creature.
  *
- *   storeNumber(CountPlayersWith(EachOpponent, "controls a creature")) → returnAllToHand → tokens
+ * So the pipeline snapshots the controllers while the creatures are still in play (the Builder's
+ * Bane / Break the Spell shape):
  *
- * [DynamicAmount.CountPlayersWith] rebinds the controller per candidate, so `Player.You` inside
- * the [Exists] refers to the opponent being tested — the Bandit's Talent idiom. Because *every*
- * creature is returned, "opponents who controlled a creature returned this way" and "opponents
- * who controlled a creature as this resolved" are the same set.
+ *   1. `gather(Creature)` — every creature, any controller; this is the set that gets returned.
+ *   2. `filterSplit(… opponentControls())` — the opponents' half, evaluated pre-bounce.
+ *   3. `captureControllers(theirs)` — a parallel list of controller ids, snapshotted pre-bounce.
+ *   4. `move(all, ToZone(HAND))` — battlefield → hand always collapses to the owner's hand.
+ *   5. `DistinctEntitiesInCollections(controllers)` de-duplicates that list down to *how many
+ *      distinct opponents*, doubled for the two Faeries each.
+ *
+ * Because the gather is unconditional, "opponents who controlled a creature returned this way" and
+ * "opponents who controlled a creature as this resolved" only diverge if some creature fails to
+ * leave the battlefield at step 4.
  */
 val FaerieSlumberParty = card("Faerie Slumber Party") {
     manaCost = "{4}{U}{U}"
@@ -41,20 +46,37 @@ val FaerieSlumberParty = card("Faerie Slumber Party") {
         "flying and \"This token can block only creatures with flying.\""
 
     spell {
-        effect = Effects.Pipeline {
-            val opponentsHit = storeNumber(
-                DynamicAmount.CountPlayersWith(
-                    scope = Player.EachOpponent,
-                    condition = Exists(
-                        player = Player.You,
-                        zone = Zone.BATTLEFIELD,
-                        filter = GameObjectFilter.Creature,
-                    ),
-                ),
-                name = "faerieSlumberPartyOpponents",
+        effect = Effects.Pipeline(
+            descriptionOverride = "Return all creatures to their owners' hands. For each opponent " +
+                "who controlled a creature returned this way, you create two 1/1 blue Faerie " +
+                "creature tokens with flying and \"This token can block only creatures with " +
+                "flying.\""
+        ) {
+            val creatures = gather(
+                GameObjectFilter.Creature,
+                name = "faerieSlumberPartyCreatures",
             )
-            run(Patterns.Group.returnAllToHand(GroupFilter.AllCreatures))
-            run(woeFaerieToken(count = DynamicAmount.Multiply(opponentsHit.amount, 2)))
+
+            // "each opponent who controlled a creature returned this way" — snapshotted while the
+            // creatures are still on the battlefield, so control-changing effects are honored.
+            val (theirs, _) = filterSplit(
+                creatures,
+                GameObjectFilter.Creature.opponentControls(),
+                name = "faerieSlumberPartyOpponentCreatures",
+                restName = "faerieSlumberPartyOwnCreatures",
+            )
+            val controllers = captureControllers(theirs, name = "faerieSlumberPartyControllers")
+
+            move(creatures, CardDestination.ToZone(Zone.HAND))
+
+            run(
+                woeFaerieToken(
+                    count = DynamicAmount.Multiply(
+                        DynamicAmount.DistinctEntitiesInCollections(listOf(controllers.key)),
+                        2,
+                    )
+                )
+            )
         }
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FaerieSlumberParty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FaerieSlumberParty.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Faerie Slumber Party
+ * {4}{U}{U}
+ * Sorcery
+ *
+ * Return all creatures to their owners' hands. For each opponent who controlled a creature
+ * returned this way, you create two 1/1 blue Faerie creature tokens with flying and
+ * "This token can block only creatures with flying."
+ *
+ * Ordering is the whole difficulty. The tokens are creatures, so they must be created *after*
+ * the mass bounce (created first, they would be returned themselves and cease to exist), but the
+ * payoff counts a board state that the bounce has already erased. The pipeline therefore
+ * snapshots the count into a number slot first, bounces, then reads the slot back:
+ *
+ *   storeNumber(CountPlayersWith(EachOpponent, "controls a creature")) → returnAllToHand → tokens
+ *
+ * [DynamicAmount.CountPlayersWith] rebinds the controller per candidate, so `Player.You` inside
+ * the [Exists] refers to the opponent being tested — the Bandit's Talent idiom. Because *every*
+ * creature is returned, "opponents who controlled a creature returned this way" and "opponents
+ * who controlled a creature as this resolved" are the same set.
+ */
+val FaerieSlumberParty = card("Faerie Slumber Party") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return all creatures to their owners' hands. For each opponent who controlled " +
+        "a creature returned this way, you create two 1/1 blue Faerie creature tokens with " +
+        "flying and \"This token can block only creatures with flying.\""
+
+    spell {
+        effect = Effects.Pipeline {
+            val opponentsHit = storeNumber(
+                DynamicAmount.CountPlayersWith(
+                    scope = Player.EachOpponent,
+                    condition = Exists(
+                        player = Player.You,
+                        zone = Zone.BATTLEFIELD,
+                        filter = GameObjectFilter.Creature,
+                    ),
+                ),
+                name = "faerieSlumberPartyOpponents",
+            )
+            run(Patterns.Group.returnAllToHand(GroupFilter.AllCreatures))
+            run(woeFaerieToken(count = DynamicAmount.Multiply(opponentsHit.amount, 2)))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "311"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg?1783915040"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HyldasCrownOfWinter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HyldasCrownOfWinter.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hylda's Crown of Winter
+ * {3}
+ * Legendary Artifact
+ *
+ * {1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.
+ * {3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents
+ * control.
+ *
+ * The tap ability's discount is a plain `genericCostReduction` gated on
+ * [Conditions.IsYourTurn] (the Starport Security shape with a turn condition instead of a board
+ * condition), so on your own turn it is a free `{T}` tapper and on an opponent's turn it costs
+ * {1}. The reduction rail only eats generic mana, which is all this cost is.
+ *
+ * The sacrifice ability counts *tapped* creatures with
+ * [DynamicAmount.AggregateBattlefield]`(Player.EachOpponent, Creature.tapped())` — the `player`
+ * scope does the "your opponents control" half, and the count is read at resolution, so creatures
+ * this Crown tapped earlier in the turn (and creatures that attacked) are all included.
+ */
+val HyldasCrownOfWinter = card("Hylda's Crown of Winter") {
+    manaCost = "{3}"
+    typeLine = "Legendary Artifact"
+    oracleText = "{1}, {T}: Tap target creature. This ability costs {1} less to activate during " +
+        "your turn.\n" +
+        "{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your " +
+        "opponents control."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val creature = target("target creature", TargetCreature())
+        effect = Effects.Tap(creature)
+        genericCostReduction = DynamicAmount.Conditional(
+            condition = Conditions.IsYourTurn,
+            ifTrue = DynamicAmount.Fixed(1),
+            ifFalse = DynamicAmount.Fixed(0),
+        )
+        description = "{1}, {T}: Tap target creature. This ability costs {1} less to activate " +
+            "during your turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.EachOpponent,
+                filter = GameObjectFilter.Creature.tapped(),
+            )
+        )
+        description = "{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped " +
+            "creature your opponents control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Volkan Baǵa"
+        flavorText = "With each day she wore the crown, her icy kingdom spread, and her heart " +
+            "grew ever colder."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg?1783915057"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RowdyResearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RowdyResearch.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Rowdy Research
+ * {6}{U}
+ * Instant
+ *
+ * This spell costs {1} less to cast for each creature that attacked this turn.
+ * Draw three cards.
+ *
+ * The reduction is [CostReductionSource.CreaturesThatAttackedThisTurn] — the same turn-history
+ * count Witchstalker Frenzy uses, unioned over every player's attackers for every combat phase
+ * this turn rather than scanned off the live battlefield. That matters here for the same reason:
+ * this is an instant you cast late, often after blockers or damage, when the attackers that paid
+ * for it may already be in a graveyard.
+ *
+ * [CostModification.ReduceGenericBy] only eats generic mana, so however many creatures attacked,
+ * the cost bottoms out at {U}, and the reduction never touches the mana value — a Rowdy Research
+ * on the stack is always mana value 7.
+ */
+val RowdyResearch = card("Rowdy Research") {
+    manaCost = "{6}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast for each creature that attacked this turn.\n" +
+        "Draw three cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CreaturesThatAttackedThisTurn()
+            ),
+        )
+    }
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "312"
+        artist = "Bram Sels"
+        flavorText = "\"Stolen treasures can be reclaimed, but stolen knowledge is yours forever.\"\n—Alela"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1783915040"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -4120,6 +4120,102 @@
     ]
 }
 
+// Faerie Slumber Party
+{
+    "name": "Faerie Slumber Party",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This token can block only creatures with flying.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "StoreNumber",
+                    "name": "faerieSlumberPartyOpponents",
+                    "amount": {
+                        "type": "CountPlayersWith",
+                        "scope": "EachOpponent",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "creature"
+                        }
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature"
+                            },
+                            "storeAs": "returnAllToHand_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "returnAllToHand_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "VariableReference",
+                            "variableName": "faerieSlumberPartyOpponents"
+                        },
+                        "multiplier": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Faerie"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f9a993f-1f2b-4b17-b415-e975b7873e18.jpg?1783914992",
+                    "staticAbilities": [
+                        {
+                            "type": "CanOnlyBlockCreaturesWith",
+                            "blockerFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "311",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8e5de58-cc4c-40b2-94c8-4e4d7cebfaf8.jpg?1783915040"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Farsight Ritual
 {
     "name": "Farsight Ritual",
@@ -6371,6 +6467,95 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Hylda's Crown of Winter
+{
+    "name": "Hylda's Crown of Winter",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.",
+                "genericCostReduction": {
+                    "type": "Conditional",
+                    "condition": "IsYourTurn",
+                    "ifTrue": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "ifFalse": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "EachOpponent",
+                        "filter": "creature tapped"
+                    }
+                },
+                "descriptionOverride": "{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "flavorText": "With each day she wore the crown, her icy kingdom spread, and her heart grew ever colder.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0d4a6c0-f00e-45a7-9c88-899460007020.jpg?1783915057"
+    }
 }
 
 // Ice Out
@@ -10557,6 +10742,43 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rowdy Research
+{
+    "name": "Rowdy Research",
+    "manaCost": "{6}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "CreaturesThatAttackedThisTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "312",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "\"Stolen treasures can be reclaimed, but stolen knowledge is yours forever.\"\n—Alela",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1783915040"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -4131,47 +4131,45 @@
             "type": "Composite",
             "effects": [
                 {
-                    "type": "StoreNumber",
-                    "name": "faerieSlumberPartyOpponents",
-                    "amount": {
-                        "type": "CountPlayersWith",
-                        "scope": "EachOpponent",
-                        "condition": {
-                            "type": "Exists",
-                            "player": "You",
-                            "zone": "Battlefield",
-                            "filter": "creature"
-                        }
-                    }
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature"
+                    },
+                    "storeAs": "faerieSlumberPartyCreatures"
                 },
                 {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "BattlefieldMatching",
-                                "filter": "creature"
-                            },
-                            "storeAs": "returnAllToHand_gathered"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "returnAllToHand_gathered",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
-                            }
-                        }
-                    ]
+                    "type": "FilterCollection",
+                    "from": "faerieSlumberPartyCreatures",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "creature ctrl:opponent"
+                    },
+                    "storeMatching": "faerieSlumberPartyOpponentCreatures",
+                    "storeNonMatching": "faerieSlumberPartyOwnCreatures"
+                },
+                {
+                    "type": "CaptureControllers",
+                    "from": "faerieSlumberPartyOpponentCreatures",
+                    "storeAs": "faerieSlumberPartyControllers"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "faerieSlumberPartyCreatures",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
                 },
                 {
                     "type": "CreateToken",
                     "count": {
                         "type": "Multiply",
                         "amount": {
-                            "type": "VariableReference",
-                            "variableName": "faerieSlumberPartyOpponents"
+                            "type": "DistinctEntitiesInCollections",
+                            "collections": [
+                                "faerieSlumberPartyControllers"
+                            ]
                         },
                         "multiplier": 2
                     },
@@ -4202,7 +4200,8 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "descriptionOverride": "Return all creatures to their owners' hands. For each opponent who controlled a creature returned this way, you create two 1/1 blue Faerie creature tokens with flying and \"This token can block only creatures with flying.\""
         }
     },
     "metadata": {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSlumberPartyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSlumberPartyScenarioTest.kt
@@ -14,11 +14,13 @@ import io.kotest.matchers.shouldBe
  *   returned this way, you create two 1/1 blue Faerie creature tokens with flying and
  *   "This token can block only creatures with flying."
  *
- * The ordering is the trap: the count has to be taken *before* the bounce (afterwards there is
- * nothing left to count) while the tokens have to be created *after* it (created first, they are
- * creatures and would be returned themselves, ceasing to exist). Both directions are pinned here —
- * "two tokens survive on the battlefield" fails if the tokens are made too early, and "two tokens"
- * rather than "zero" fails if the count is taken too late.
+ * The ordering is the trap: the controllers have to be snapshotted *before* the bounce (afterwards
+ * `ControllerComponent` is gone and a hand is keyed by owner) while the tokens have to be created
+ * *after* it (created first, they are creatures and would be returned themselves, ceasing to
+ * exist). Both directions are pinned here — "two tokens survive on the battlefield" fails if the
+ * tokens are made too early, and "two tokens" rather than "zero" fails if the count is taken too
+ * late. The first test also separates "per opponent" from "per creature": one opponent with two
+ * creatures is still two Faeries, which is what de-duplicating the captured controller list buys.
  */
 class FaerieSlumberPartyScenarioTest : ScenarioTestBase() {
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSlumberPartyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSlumberPartyScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Faerie Slumber Party (WOE #311).
+ *
+ *   {4}{U}{U} Sorcery
+ *   Return all creatures to their owners' hands. For each opponent who controlled a creature
+ *   returned this way, you create two 1/1 blue Faerie creature tokens with flying and
+ *   "This token can block only creatures with flying."
+ *
+ * The ordering is the trap: the count has to be taken *before* the bounce (afterwards there is
+ * nothing left to count) while the tokens have to be created *after* it (created first, they are
+ * creatures and would be returned themselves, ceasing to exist). Both directions are pinned here —
+ * "two tokens survive on the battlefield" fails if the tokens are made too early, and "two tokens"
+ * rather than "zero" fails if the count is taken too late.
+ */
+class FaerieSlumberPartyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Faerie Slumber Party") {
+
+            test("bounces every creature and pays off two Faeries for the one opponent hit") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Faerie Slumber Party")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Savannah Lions", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Faerie Slumber Party").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("your own creature goes back to your hand too") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("both of the opponent's creatures go back to their hand") {
+                    game.isInHand(2, "Hill Giant") shouldBe true
+                    game.isInHand(2, "Savannah Lions") shouldBe true
+                }
+                withClue(
+                    "one opponent controlled a returned creature → two Faerie tokens, and they are " +
+                        "still on the battlefield because they were made after the bounce"
+                ) {
+                    game.findAllPermanents("Faerie Token").size shouldBe 2
+                }
+            }
+
+            test("an opponent with no creatures pays off nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Faerie Slumber Party")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Faerie Slumber Party").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("your creature still bounces") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("no opponent controlled a returned creature → no tokens") {
+                    game.findAllPermanents("Faerie Token").size shouldBe 0
+                }
+            }
+
+            test("an empty board resolves cleanly with no tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Faerie Slumber Party")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Faerie Slumber Party").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("nothing to return and nothing to pay off") {
+                    game.findAllPermanents("Faerie Token").size shouldBe 0
+                }
+                withClue("the sorcery itself is in the graveyard") {
+                    game.isInGraveyard(1, "Faerie Slumber Party") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldasCrownOfWinterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldasCrownOfWinterScenarioTest.kt
@@ -1,0 +1,217 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Hylda's Crown of Winter (WOE #247) — Legendary Artifact.
+ *
+ *   {1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.
+ *   {3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents
+ *   control.
+ *
+ * The discount is proved by mana starvation rather than by reading a number: with **no lands at
+ * all**, the tap ability is payable on your own turn (cost {0} + {T}) and not on an opponent's
+ * (cost {1} + {T}), and one Island makes the off-turn activation work again.
+ *
+ * The draw counts only *tapped* creatures *opponents* control, so the third test deliberately
+ * seeds an untapped opposing creature and a tapped creature of your own — neither may count.
+ */
+class HyldasCrownOfWinterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hylda's Crown of Winter") {
+
+            test("during your turn the tap ability costs nothing but the {T}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val tapAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id
+
+                // No lands anywhere: only the {1}-less discount makes this payable.
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = tapAbility,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("with no mana available the discounted ability should still activate: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("the targeted creature is tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("on an opponent's turn the discount is gone, so {1} must be paid") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val tapAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = tapAbility,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+
+                withClue("off-turn with no mana the {1} cannot be paid, so nothing is tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+                    game.state.getEntity(crown)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("one Island covers the undiscounted {1} on an opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val tapAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = tapAbility,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activating off-turn with one land should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("the targeted creature is tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("the sacrifice ability draws one card per tapped creature opponents control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    // Two tapped creatures for the opponent → two cards.
+                    .withCardOnBattlefield(2, "Grizzly Bears", tapped = true, summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true, summoningSickness = false)
+                    // An untapped opposing creature and a tapped creature of *yours* must not count.
+                    .withCardOnBattlefield(2, "Savannah Lions", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Air Elemental", tapped = true, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(1, "Bog Imp")
+                    .withCardInLibrary(1, "Wind Drake")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val sacrificeAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[1].id
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = sacrificeAbility,
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("two tapped opposing creatures → two cards; your own tapped Air Elemental is ignored") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+                withClue("the Crown was sacrificed as part of the cost") {
+                    game.findPermanent("Hylda's Crown of Winter") shouldBe null
+                }
+            }
+
+            test("no tapped creatures opponents control → no cards drawn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val sacrificeAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[1].id
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = sacrificeAbility,
+                    )
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("an empty count draws nothing rather than failing") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldasCrownOfWinterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldasCrownOfWinterScenarioTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario tests for Hylda's Crown of Winter (WOE #247) — Legendary Artifact.
@@ -80,7 +81,7 @@ class HyldasCrownOfWinterScenarioTest : ScenarioTestBase() {
                 val tapAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
                     .activatedAbilities[0].id
 
-                game.execute(
+                val result = game.execute(
                     ActivateAbility(
                         playerId = game.player1Id,
                         sourceId = crown,
@@ -89,6 +90,9 @@ class HyldasCrownOfWinterScenarioTest : ScenarioTestBase() {
                     )
                 )
 
+                withClue("the activation is rejected outright, not merely left unpaid") {
+                    result.error shouldNotBe null
+                }
                 withClue("off-turn with no mana the {1} cannot be paid, so nothing is tapped") {
                     game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
                     game.state.getEntity(crown)?.has<TappedComponent>() shouldBe false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RowdyResearchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RowdyResearchScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Phase
@@ -109,6 +110,37 @@ class RowdyResearchScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("an opponent's attackers discount it too — the count is unioned over every player") {
+                // The card's whole use case: an instant you hold up while the opponent swings.
+                // CostCalculator sums PlayerAttackersThisTurnComponent across state.turnOrder, so
+                // attackers you do not control still pay for it.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 1, "Hill Giant" to 1)
+                ).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Rowdy Research"),
+                    game.player1Id,
+                )
+
+                withClue("player 2's two attackers reduce player 1's spell from 6 to 4 generic") {
+                    cost.genericAmount shouldBe 4
+                }
+            }
+
             test("the reduction never eats the {U}") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
@@ -173,6 +205,47 @@ class RowdyResearchScenarioTest : ScenarioTestBase() {
                 }
                 withClue("all three library cards were drawn") {
                     game.librarySize(1) shouldBe 0
+                }
+            }
+
+            test("a real cast pays the reduced cost — two attackers make five Islands enough") {
+                // Tests 1-4 read the calculator directly; this one proves the reduction survives
+                // the enumerator + payment path. Five Islands cannot pay {6}{U}, so the cast only
+                // succeeds if the two attackers actually took it down to {4}{U}.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Air Elemental")
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 2, "Hill Giant" to 2)
+                ).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Rowdy Research").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+
+                withClue("the reduction only eats generic mana, never the printed mana value") {
+                    val spellId = game.state.stack.last()
+                    game.state.getEntity(spellId)?.get<CardComponent>()?.manaValue shouldBe 7
+                }
+
+                game.resolveStack()
+
+                withClue("the spell leaves hand (-1) and draws three (+3)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 3
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RowdyResearchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RowdyResearchScenarioTest.kt
@@ -1,0 +1,180 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rowdy Research (WOE #312).
+ *
+ *   {6}{U} Instant
+ *   This spell costs {1} less to cast for each creature that attacked this turn.
+ *   Draw three cards.
+ *
+ * The interesting half is the discount, and specifically that it is *turn history* rather than a
+ * battlefield scan: this is an instant you cast after combat, when the attackers that paid for it
+ * are frequently dead. The other guard is the colored pip — no number of attackers may reduce the
+ * cost below {U}.
+ */
+class RowdyResearchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rowdy Research") {
+
+            test("no creature attacked → the full 6 generic") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Rowdy Research"),
+                    game.player1Id,
+                )
+
+                withClue("nothing attacked, so the generic component stays at 6") {
+                    cost.genericAmount shouldBe 6
+                }
+            }
+
+            test("two creatures attacked → 4 generic") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 2, "Hill Giant" to 2)
+                ).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Rowdy Research"),
+                    game.player1Id,
+                )
+
+                withClue("two attackers reduce the generic from 6 to 4") {
+                    cost.genericAmount shouldBe 4
+                }
+            }
+
+            test("an attacker that died in combat still discounts the spell") {
+                // The card is an after-combat instant, so this is the case the turn-history
+                // source exists for: a battlefield scan would un-discount the dead attacker.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears"))).error shouldBe null
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("the attacker traded and is no longer on the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Rowdy Research"),
+                    game.player1Id,
+                )
+
+                withClue("the dead attacker still counts, so 6 becomes 5") {
+                    cost.genericAmount shouldBe 5
+                }
+            }
+
+            test("the reduction never eats the {U}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Savannah Lions", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Air Elemental", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Craw Wurm", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Bog Imp", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf(
+                        "Grizzly Bears" to 2,
+                        "Hill Giant" to 2,
+                        "Savannah Lions" to 2,
+                        "Air Elemental" to 2,
+                        "Craw Wurm" to 2,
+                        "Bog Imp" to 2,
+                    )
+                ).error shouldBe null
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Rowdy Research"),
+                    game.player1Id,
+                )
+
+                withClue("six attackers clear all 6 generic but cannot reduce below {U}") {
+                    cost.genericAmount shouldBe 0
+                    cost.colorCount[Color.BLUE] shouldBe 1
+                }
+            }
+
+            test("resolving Rowdy Research draws three cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rowdy Research")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Rowdy Research").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the spell leaves hand (-1) and draws three (+3)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 3
+                }
+                withClue("all three library cards were drawn") {
+                    game.librarySize(1) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three Wilds of Eldraine cards, all built from primitives that already exist — no new effect, executor, condition, or keyword.

## Cards

- **Rowdy Research** (#312) — `{6}{U}` instant: draw three cards, costs `{1}` less for each creature that attacked this turn. Composes `ModifySpellCost(SelfCast, ReduceGenericBy(CostReductionSource.CreaturesThatAttackedThisTurn()))` with `Effects.DrawCards(3)` — the same turn-history count Witchstalker Frenzy uses, so a copy cast after combat still sees the attackers that already died.
- **Hylda's Crown of Winter** (#247) — legendary artifact. `{1}, {T}: Tap target creature` with `genericCostReduction = DynamicAmount.Conditional(Conditions.IsYourTurn, 1, 0)` (Starport Security's shape with a turn condition instead of a board one); `{3}, Sacrifice: Draw a card for each tapped creature your opponents control` via `Effects.DrawCards(DynamicAmount.AggregateBattlefield(Player.EachOpponent, Creature.tapped()))`.
- **Faerie Slumber Party** (#311) — `{4}{U}{U}` mass bounce with a per-opponent Faerie payoff. The count has to be taken *before* the bounce (afterwards there's nothing left to count) and the tokens created *after* it (created first they'd be returned themselves and cease to exist), so it's an inline `Effects.Pipeline`: `gather(Creature)` → `filterSplit(opponentControls())` → `captureControllers(theirs)` → `move(all, ToZone(HAND))` → `woeFaerieToken(2 × DistinctEntitiesInCollections(controllers))`. Reuses the existing WOE Faerie token helper.

Also adds `blc/cards/RowdyResearchReprint.kt` — Bloomburrow Commander is scaffolded and reprints Rowdy Research in 2024, so it gets a presentation-only `Printing(...)` row while WOE stays canonical — and ticks the card off both BLC backlogs.

## Dropped from the unit (2 of 5)

Both needed new engine vocabulary, which `CONTRIBUTING.md` keeps to one new-primitive card per PR:

- **Eerie Interference** — "Prevent all damage that would be dealt to you and creatures you control this turn by creatures." No existing shield combines a recipient scope (a player *plus* a group) with a source filter; the only source-filtered modification (`PreventCombatDamageFromGroup`) is combat-only, and `PreventDamageExecutor` short-circuits on `recipientGroup != null` before reading `sourceFilter` at all.
- **Troyan, Gutsy Explorer** — "Spend this mana only to cast spells with mana value 5 or greater or spells with `{X}` in their mana costs." Needs a new `ManaRestriction` variant (`SpellsMV4OrGreater` has no `{X}` branch; `CreatureMV4OrXCost` is creature-only) plus a branch in `ManaPool.isSatisfiedBy`.

## What was checked

`just build` — passed. `just rebless-cards` re-blessed `snapshots/cards/WOE.json`; only the three new cards were added, nothing pre-existing moved. `just check-card-printing` is clean for all three. 15 new scenario tests (7 + 5 + 3), one file per card, all green.

## What was **not** checked

This PR came out of an autonomous loop. None of the following happened:

- **No manual playthrough in the web client.** Nobody clicked Hylda's Crown's tapper, watched the Faerie tokens land, or confirmed the ability button text reads sensibly.
- **No UX pass from both seats** — in particular Hylda's Crown's targeting flow and whether the turn-conditional discount is legible in the action menu.
- **No e2e / Playwright run.** No `e2e-scenarios` spec was added or executed.
- No multiplayer (>2 player) verification of Faerie Slumber Party's per-opponent count; the tests are two-player.

One modelling note: Faerie Slumber Party snapshots the *controllers* of the opponents' creatures before the bounce and counts the distinct ones, rather than counting opponents who control a creature at resolution. (An earlier revision of this PR claimed no primitive existed for "distinct opponents among a gathered collection" — that was wrong; `captureControllers` + `DynamicAmount.DistinctEntitiesInCollections` compose into exactly that, and the card now uses them.) The one remaining divergence from "controlled a creature returned this way" is a creature that fails to leave the battlefield at the move step.

## Not final

Independent review is still pending: a reviewer agent will comment its findings on this PR and a corrector agent may push follow-up commits. Please don't treat the diff as settled at open time.

