### PR TITLE
Fix Leyline of Transformation skipping its as-enters choice on an opening-hand start

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LeylineContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LeylineContinuations.kt
@@ -18,7 +18,9 @@ import kotlinx.serialization.Serializable
  *
  * The resumer (see `LeylineContinuationResumer`) handles two outcomes:
  *  - **yes**: route the card through the standard zone-change pipeline (hand → battlefield
- *    under owner's control) so any ETB replacement effects and trackers fire normally.
+ *    under owner's control) so any ETB replacement effects and trackers fire normally, then
+ *    pause for the card's own "as this enters, choose …" replacement if it has one (a Leyline
+ *    of Transformation started from the opening hand still chooses its creature type).
  *  - **no**: leave the card in hand; just drop it from the pending list.
  * After applying the outcome it either pauses with the next leyline prompt or hands the
  * state back to `SubmitDecisionHandler`, which advances the game from UNTAP into the first
@@ -34,4 +36,21 @@ data class LeylineDecisionContinuation(
     val playerId: EntityId,
     val leylineCardId: EntityId,
     val cardName: String
+) : ContinuationFrame
+
+/**
+ * Resume the opening-hand leyline walk after something *else* paused in the middle of it.
+ *
+ * Only one thing does: a leyline that answers "yes" and then has its own "as this enters,
+ * choose …" replacement (Leyline of Transformation's creature type). That choice pauses with an
+ * [EntersWithChoiceOnBattlefieldContinuation] of its own, so the walk over the remaining leylines
+ * has to be parked underneath it. This frame is that park: it carries no decision of its own and
+ * is auto-resumed (see `LeylineContinuationResumer`) once the choice above it finishes, asking the
+ * next player's yes/no or handing the state back for the advance into turn 1.
+ *
+ * @property decisionId Synthetic — this frame is never matched against a player response.
+ */
+@Serializable
+data class LeylinePhaseContinuation(
+    override val decisionId: String
 ) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -333,6 +333,7 @@ val engineSerializersModule = SerializersModule {
         subclass(StaticDrawReplacementContinuation::class)
         subclass(TokenCreationReplacementContinuation::class)
         subclass(LeylineDecisionContinuation::class)
+        subclass(LeylinePhaseContinuation::class)
         subclass(ActivateAbilityChooseXContinuation::class)
         subclass(ActivateAbilityChooseManaXContinuation::class)
         subclass(ActivateAbilityTapXTargetsContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ContinuationHandler.kt
@@ -52,7 +52,9 @@ class ContinuationHandler(
         registerModule(TokenContinuationResumer(services))
         registerModule(RingTemptContinuationResumer(services))
         registerModule(AmassContinuationResumer(services))
-        registerModule(LeylineContinuationResumer(services))
+        val leylineResumer = LeylineContinuationResumer(services)
+        registerModule(leylineResumer)
+        registerAutoResumerModule(leylineResumer)
         registerModule(ActivateAbilityXCostContinuationResumer(services))
         registerModule(com.wingedsheep.engine.handlers.continuations.ActivateAbilityOpponentTargetResumer(services))
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
@@ -4,13 +4,22 @@ import com.wingedsheep.engine.core.DecisionRequestedEvent
 import com.wingedsheep.engine.core.DecisionResponse
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.LeylineDecisionContinuation
+import com.wingedsheep.engine.core.LeylinePhaseContinuation
 import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.MulliganStateComponent
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CardNamePool
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 /**
  * Resumes [LeylineDecisionContinuation] frames: the per-card yes/no walk through every
@@ -21,18 +30,29 @@ import com.wingedsheep.sdk.core.Zone
  *  2. If the player answered yes, routes the card from hand to battlefield through
  *     [ZoneTransitionService] so the standard zone-change pipeline (controller assignment,
  *     [com.wingedsheep.engine.handlers.effects.PermanentEntryTracker], ETB replacements
- *     from other on-battlefield permanents, ZoneChangeEvent emission) fires.
+ *     from other on-battlefield permanents, ZoneChangeEvent emission) fires, then pauses for the
+ *     card's own [EntersWithChoice] replacement if it has one (Leyline of Transformation:
+ *     "As this enchantment enters, choose a creature type").
  *  3. Looks for the next leyline decision via [com.wingedsheep.engine.handlers.MulliganHandler.getNextLeylineChoice].
  *     If one exists, pauses with the next [com.wingedsheep.engine.core.YesNoDecision]; otherwise
  *     returns success, leaving the state at `step = UNTAP` with no pending decision so that
  *     `SubmitDecisionHandler` advances into the first turn via `turnManager.advanceStep`.
+ *
+ * Step 3 also runs from the auto-resumed [LeylinePhaseContinuation], which step 2 parks beneath
+ * the as-enters choice so the walk survives that pause.
  */
 class LeylineContinuationResumer(
     private val services: EngineServices
-) : ContinuationResumerModule {
+) : ContinuationResumerModule, AutoResumerModule {
 
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(LeylineDecisionContinuation::class, ::resumeLeylineDecision)
+    )
+
+    override fun autoResumers(): List<AutoResumer<*>> = listOf(
+        autoResumer(LeylinePhaseContinuation::class) { state, _, events, checkForMore ->
+            continueLeylinePhase(state, events, checkForMore)
+        }
     )
 
     private fun resumeLeylineDecision(
@@ -46,7 +66,7 @@ class LeylineContinuationResumer(
         }
 
         var newState = state
-        val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+        val events = mutableListOf<GameEvent>()
 
         // Drop this card from the deciding player's pending list — whether the player said
         // yes or no, the choice for this specific card is resolved.
@@ -72,16 +92,85 @@ class LeylineContinuationResumer(
             )
             newState = transition.state
             events.addAll(transition.events)
+
+            val entersChoicePause = pauseForEntersWithChoice(
+                newState, continuation.playerId, continuation.leylineCardId, transition.events
+            )
+            if (entersChoicePause != null) return entersChoicePause
         }
 
-        // After applying this choice, look for the next leyline prompt in turn order.
-        val nextLeyline = services.mulliganHandler.getNextLeylineChoice(newState)
+        return continueLeylinePhase(newState, events, checkForMore)
+    }
+
+    /**
+     * A leyline that just entered from the opening hand still makes its own "as this enters,
+     * choose …" choice (CR 614.12) — the card is on the battlefield, but the chosen value has to be
+     * recorded before anything reads it. Reuses the shared on-battlefield entry seam
+     * ([PermanentEntryReplacements.pauseForEntersWithChoice], also used by played lands and
+     * definition-minted tokens), whose resumer stores the value, chains to any further choice, and
+     * fires the entry's ETB triggers off a synthesized [ZoneChangeEvent].
+     *
+     * Because that resumer owns the entry triggers, [transitionEvents] is forwarded *without* the
+     * entry [ZoneChangeEvent] — `SubmitDecisionHandler` runs trigger detection over a paused
+     * resume's events, so carrying it would fire every enters-the-battlefield trigger twice.
+     *
+     * A [LeylinePhaseContinuation] is parked beneath the choice so the walk over the remaining
+     * leylines resumes once the choice (and any chained choice) resolves.
+     *
+     * @return the paused result, or `null` when the card has no as-enters choice (or it can't be
+     *   presented) and the walk should simply continue.
+     */
+    private fun pauseForEntersWithChoice(
+        state: GameState,
+        playerId: EntityId,
+        leylineCardId: EntityId,
+        transitionEvents: List<GameEvent>
+    ): ExecutionResult? {
+        val cardComponent = state.getEntity(leylineCardId)?.get<CardComponent>() ?: return null
+        val cardDef = services.cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return null
+        val firstChoice = cardDef.script.replacementEffects
+            .filterIsInstance<EntersWithChoice>()
+            .sortedBy { it.choiceType.ordinal }
+            .firstOrNull() ?: return null
+
+        val parkedState = state.pushContinuation(
+            LeylinePhaseContinuation(decisionId = "leyline-phase-${leylineCardId.value}")
+        )
+        return PermanentEntryReplacements.pauseForEntersWithChoice(
+            state = parkedState,
+            entityId = leylineCardId,
+            controllerId = playerId,
+            cardComponent = cardComponent,
+            choice = firstChoice,
+            fromZone = Zone.HAND,
+            carryEvents = transitionEvents.filterNot {
+                it is ZoneChangeEvent && it.entityId == leylineCardId
+            },
+            cardNameOptions = if (firstChoice.choiceType == ChoiceType.CARD_NAME) {
+                if (firstChoice.cardNamePool == CardNamePool.ANY) {
+                    services.cardRegistry.allCardNames().toList()
+                } else services.cardRegistry.landCardNames().toList()
+            } else emptyList(),
+        )
+    }
+
+    /**
+     * Ask the next player's leyline yes/no, or finish the phase. Shared by the yes/no resumer and
+     * by the [LeylinePhaseContinuation] auto-resume that picks the walk back up after an as-enters
+     * choice interrupted it.
+     */
+    private fun continueLeylinePhase(
+        state: GameState,
+        events: List<GameEvent>,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        val nextLeyline = services.mulliganHandler.getNextLeylineChoice(state)
         if (nextLeyline != null) {
             val (nextPlayerId, nextCardId) = nextLeyline
-            val nextDecision = services.mulliganHandler.createLeylineDecision(newState, nextPlayerId, nextCardId)
+            val nextDecision = services.mulliganHandler.createLeylineDecision(state, nextPlayerId, nextCardId)
             if (nextDecision != null) {
                 val (decision, nextContinuation) = nextDecision
-                val pausedState = newState.pushContinuation(nextContinuation).withPendingDecision(decision)
+                val pausedState = state.pushContinuation(nextContinuation).withPendingDecision(decision)
                 return ExecutionResult.paused(
                     pausedState,
                     decision,
@@ -97,6 +186,6 @@ class LeylineContinuationResumer(
 
         // No more leyline prompts. Let SubmitDecisionHandler's "step == UNTAP, no pending"
         // branch fire turnManager.advanceStep to start turn 1.
-        return checkForMore(newState, events)
+        return checkForMore(state, events)
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
@@ -1,11 +1,23 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActionProcessor
 import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.KeepHand
 import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.core.SubmitDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.dsk.cards.LeylineOfTransformation
@@ -13,12 +25,18 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.mayBeginGameOnBattlefield
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 private val projector = StateProjector()
@@ -239,6 +257,140 @@ class LeylineOfTransformationScenarioTest : FunSpec({
         predicateEvaluator.matchesCardPredicate(
             state, projected, gyLand, CardPredicate.HasSubtype(Subtype("Goblin"))
         ) shouldBe false
+    }
+
+    // ---- Opening-hand start (CR 103.6a): "you may begin the game with it on the battlefield"
+    //      still has to make the as-enters creature-type choice. ----
+
+    // A second "begin the game on the battlefield" card, with no as-enters choice of its own, so we
+    // can prove the opening-hand walk keeps prompting for the *next* leyline after the creature-type
+    // choice pauses in the middle of it.
+    val plainLeyline = card("Test Plain Leyline") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        mayBeginGameOnBattlefield()
+    }
+
+    /**
+     * Start a real game through [GameInitializer] with all of [p1Deck] in P1's opening hand and both
+     * players keeping, so the CR 103.6 leyline phase is the next thing that happens. Returns the
+     * processor, the state paused on the first leyline yes/no, and the player ids in turn order.
+     */
+    fun startLeylinePhase(p1Deck: Deck): Triple<ActionProcessor, GameState, List<EntityId>> {
+        val registry = CardRegistry().apply {
+            register(TestCards.all)
+            register(listOf(LeylineOfTransformation, bear, goblin, plainLeyline))
+        }
+        val init = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = listOf(
+                    PlayerConfig("P1", p1Deck),
+                    PlayerConfig("P2", Deck.of("Island" to 60))
+                ),
+                startingPlayerIndex = 0,
+                // Draw the whole deck — the leyline scan only inspects the opening hand.
+                startingHandSize = 60
+            )
+        )
+        val processor = ActionProcessor(registry)
+        var state = init.state
+        for (playerId in init.playerIds) {
+            val result = processor.process(state, KeepHand(playerId)).result
+            withClue("KeepHand should succeed: ${result.error}") { result.error shouldBe null }
+            state = result.state
+        }
+        return Triple(processor, state, init.playerIds)
+    }
+
+    fun battlefieldNames(state: GameState, playerId: EntityId): List<String> =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).mapNotNull {
+            state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    test("opening-hand start: saying yes prompts for the creature type") {
+        val (processor, started, players) = startLeylinePhase(
+            Deck.of("Leyline of Transformation" to 1, "Island" to 59)
+        )
+        var state = started
+        val p1 = players[0]
+
+        val leylinePrompt = state.pendingDecision
+        leylinePrompt.shouldBeInstanceOf<YesNoDecision>()
+        leylinePrompt.playerId shouldBe p1
+
+        val afterYes = processor.process(
+            state, SubmitDecision(p1, YesNoResponse(leylinePrompt.id, true))
+        ).result
+        withClue("Answering the leyline prompt should succeed: ${afterYes.error}") {
+            afterYes.error shouldBe null
+        }
+        state = afterYes.state
+
+        // The bug: the card went straight to the battlefield with no chosen creature type, so the
+        // GrantChosenSubtype static ability had nothing to grant for the rest of the game.
+        val choice = state.pendingDecision
+        withClue("Leyline of Transformation must still make its as-enters creature-type choice") {
+            choice shouldNotBe null
+        }
+        choice.shouldBeInstanceOf<ChooseOptionDecision>()
+        choice.playerId shouldBe p1
+        val goblinIndex = choice.options.indexOf("Goblin")
+        withClue("The creature-type options should include Goblin") { goblinIndex shouldNotBe -1 }
+
+        val afterChoice = processor.process(
+            state, SubmitDecision(p1, OptionChosenResponse(choice.id, goblinIndex))
+        ).result
+        withClue("Submitting the creature type should succeed: ${afterChoice.error}") {
+            afterChoice.error shouldBe null
+        }
+        state = afterChoice.state
+
+        val leylineId = state.getZone(ZoneKey(p1, Zone.BATTLEFIELD)).firstOrNull {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Leyline of Transformation"
+        }
+        withClue("Leyline of Transformation should be on the battlefield") { leylineId shouldNotBe null }
+        state.getEntity(leylineId!!)?.get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CREATURE_TYPE) shouldBe
+            ChoiceValue.TextChoice("Goblin")
+
+        withClue("The leyline phase should be over once the choice is made") {
+            state.pendingDecision shouldBe null
+        }
+    }
+
+    test("opening-hand start: the leyline walk continues after the creature-type choice") {
+        val (processor, started, players) = startLeylinePhase(
+            Deck.of("Leyline of Transformation" to 1, "Test Plain Leyline" to 1, "Island" to 58)
+        )
+        var state = started
+        val p1 = players[0]
+
+        var sawCreatureTypeChoice = false
+        var steps = 0
+        while (state.pendingDecision != null && steps++ < 10) {
+            val decision = state.pendingDecision!!
+            val response = when (decision) {
+                is YesNoDecision -> YesNoResponse(decision.id, true)
+                is ChooseOptionDecision -> {
+                    sawCreatureTypeChoice = true
+                    OptionChosenResponse(decision.id, decision.options.indexOf("Goblin"))
+                }
+                else -> error("Unexpected decision during the leyline phase: $decision")
+            }
+            val result = processor.process(state, SubmitDecision(decision.playerId, response)).result
+            withClue("Submitting ${decision.id} should succeed: ${result.error}") {
+                result.error shouldBe null
+            }
+            state = result.state
+        }
+
+        withClue("The creature-type choice should have been asked") { sawCreatureTypeChoice shouldBe true }
+        withClue("The leyline phase should finish, not stall on the paused choice") {
+            state.pendingDecision shouldBe null
+        }
+        withClue("Both opening-hand leylines should have made it to the battlefield") {
+            // Sorted: the order the two leylines are asked about follows the shuffled opening hand.
+            battlefieldNames(state, p1).sorted() shouldBe listOf("Leyline of Transformation", "Test Plain Leyline")
+        }
     }
 
     test("no Leyline on the battlefield means no cross-zone grant (overlay is empty)") {


### PR DESCRIPTION
## Problem

Starting **Leyline of Transformation** from the opening hand (CR 103.6a, "you may begin the game
with it on the battlefield") never asked for a creature type. The enchantment arrived on the
battlefield with an empty `CastChoicesComponent`, so its `GrantChosenSubtype` static ability had
nothing to grant — for the whole game. Casting it normally was fine; only the opening-hand start
was broken.

**Cause:** `LeylineContinuationResumer` moved the card hand → battlefield with
`ZoneTransitionService.moveToZone`, which applies ETB replacements from *other* permanents but
knows nothing about the entering permanent's own `EntersWithChoice`. The three other
direct-to-battlefield entries (played land, definition-minted token, spell resolution) each call
into that seam explicitly; the leyline path never did.

## Fix

The leyline resumer now routes through the shared on-battlefield entry seam
`PermanentEntryReplacements.pauseForEntersWithChoice` after the card enters — the same one
`PlayLandHandler` and `TokenFromDefinition` use, so the chosen value is recorded into
`CastChoicesComponent`, chained choices work, and the entry's ETB triggers fire off the resumer's
synthesized `ZoneChangeEvent`.

That choice pauses *in the middle of* the walk over the remaining opening-hand leylines, so a new
`LeylinePhaseContinuation` is parked beneath it. It carries no decision of its own and is
auto-resumed once the choice above it finishes, asking the next player's yes/no or handing the
state back for the advance into turn 1. The "ask next / finish" logic is now one function shared
by the yes/no resumer and the auto-resume.

Two details worth a reviewer's eye:

- The entry `ZoneChangeEvent` is deliberately dropped from the events carried into the pause.
  `SubmitDecisionHandler` runs trigger detection over a paused resume's events, and the choice
  resumer synthesizes its own entry event — carrying both would fire every
  enters-the-battlefield trigger twice. This is the contract documented on
  `PermanentEntryReplacements`.
- `LeylinePhaseContinuation` is registered in `engineSerializersModule` alongside
  `LeylineDecisionContinuation`, so a game paused mid-leyline-choice still round-trips.

## Tests

Two scenarios added to `LeylineOfTransformationScenarioTest`, both driving a real game through
`GameInitializer` → `KeepHand` → the CR 103.6 leyline phase:

- **saying yes prompts for the creature type** — after the yes, a `ChooseOptionDecision` with the
  creature-type list is pending for the leyline's owner; choosing "Goblin" records
  `ChoiceSlot.CREATURE_TYPE` on the permanent and ends the phase.
- **the leyline walk continues after the creature-type choice** — a second opening-hand leyline
  (a local test card with no as-enters choice) proves the walk resumes: both land on the
  battlefield and the phase finishes instead of stalling on the paused choice.

Both fail on `main` and pass with the fix. `just test-rules` is green.

## Out of scope

`MoveToZoneEffectExecutor` ("put a permanent card from your hand onto the battlefield", e.g.
Elvish Piper) has the same gap — a permanent put onto the battlefield by an effect skips its own
as-enters choice. Not touched here: unlike the leyline phase, that path has to pause in the middle
of a resolving effect, which is a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
