### PR TITLE
Improve deckbuilder mana recommendations

### DIFF
--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -10744,40 +10744,6 @@
     ]
 }
 
-// Rowdy Research
-{
-    "name": "Rowdy Research",
-    "manaCost": "{6}{U}",
-    "typeLine": "Instant",
-    "oracleText": "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",
-    "script": {
-        "spellEffect": {
-            "type": "DrawCards",
-            "count": {
-                "type": "Fixed",
-                "amount": 3
-            }
-        },
-        "staticAbilities": [
-            {
-                "type": "ModifySpellCost",
-                "target": "SelfCast",
-                "modification": {
-                    "type": "ReduceGenericBy",
-                    "source": "CreaturesThatAttackedThisTurn"
-                }
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "312",
-        "rarity": "UNCOMMON",
-        "artist": "Bram Sels",
-        "flavorText": "\"Stolen treasures can be reclaimed, but stolen knowledge is yours forever.\"\n—Alela",
-        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1783915040"
-    },
-    "colorIdentityOverride": [
-        "BLUE"
 // Rowan's Grim Search
 {
     "name": "Rowan's Grim Search",
@@ -10905,6 +10871,43 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Rowdy Research
+{
+    "name": "Rowdy Research",
+    "manaCost": "{6}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "CreaturesThatAttackedThisTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "312",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "\"Stolen treasures can be reclaimed, but stolen knowledge is yours forever.\"\n—Alela",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b7e901-5ba4-4374-9eeb-96354279a123.jpg?1783915040"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/web-client/src/utils/landSuggestion.test.ts
+++ b/web-client/src/utils/landSuggestion.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  suggestBasicLands,
+  type BasicLand,
+  type DeckEntry,
+} from './landSuggestion'
+
+const basics: BasicLand[] = [
+  { name: 'Plains', color: 'W' },
+  { name: 'Island', color: 'U' },
+  { name: 'Swamp', color: 'B' },
+  { name: 'Mountain', color: 'R' },
+  { name: 'Forest', color: 'G' },
+]
+
+function spell(name: string, manaCost: string, cmc: number, count: number): DeckEntry {
+  return {
+    name,
+    manaCost,
+    cmc,
+    count,
+    isLand: false,
+    isBasicLand: false,
+    producedColors: [],
+  }
+}
+
+describe('suggestBasicLands', () => {
+  it('keeps the Limited default at 17 lands', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White spell', '{1}{W}', 2, 12),
+        spell('Blue spell', '{2}{U}', 3, 11),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(17)
+  })
+
+  it('reserves enough sources for an early double-pipped color', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('Red two-drop', '{1}{R}', 2, 12),
+        spell('Blue double-pip', '{1}{U}{U}', 3, 2),
+        spell('Colorless filler', '{3}', 3, 9),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(result.Island ?? 0).toBeGreaterThanOrEqual(7)
+    expect((result.Mountain ?? 0) + (result.Island ?? 0)).toBe(17)
+  })
+
+  it('credits dual lands before allocating basics', () => {
+    const dual: DeckEntry = {
+      name: 'Azorius dual',
+      manaCost: '',
+      cmc: 0,
+      count: 4,
+      isLand: true,
+      isBasicLand: false,
+      producedColors: ['W', 'U'],
+    }
+    const result = suggestBasicLands({
+      entries: [
+        spell('White spell', '{1}{W}', 2, 10),
+        spell('Blue spell', '{1}{U}', 2, 9),
+        dual,
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect((result.Plains ?? 0) + (result.Island ?? 0)).toBe(17)
+    expect(result.Plains ?? 0).toBeGreaterThan(0)
+    expect(result.Island ?? 0).toBeGreaterThan(0)
+  })
+
+  it('splits hybrid requirements between either payable color', () => {
+    const result = suggestBasicLands({
+      entries: [spell('Hybrid spell', '{1}{W/U}', 2, 23)],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(Math.abs((result.Plains ?? 0) - (result.Island ?? 0))).toBeLessThanOrEqual(1)
+    expect((result.Plains ?? 0) + (result.Island ?? 0)).toBe(17)
+  })
+})

--- a/web-client/src/utils/landSuggestion.test.ts
+++ b/web-client/src/utils/landSuggestion.test.ts
@@ -120,7 +120,7 @@ describe('suggestBasicLands', () => {
     expect((result.Mountain ?? 0) + (result.Swamp ?? 0)).toBe(17)
   })
 
-  it('scales the land total for a normal 60-card constructed curve', () => {
+  it('fills a normal constructed deck to exactly 60 cards', () => {
     const result = suggestBasicLands({
       entries: [
         spell('White two-drop', '{1}{W}', 2, 18),
@@ -130,7 +130,7 @@ describe('suggestBasicLands', () => {
       minDeckSize: 60,
     })
 
-    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(27)
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(24)
     expect(Math.abs((result.Plains ?? 0) - (result.Island ?? 0))).toBeLessThanOrEqual(1)
   })
 
@@ -171,5 +171,98 @@ describe('suggestBasicLands', () => {
     const result = suggestBasicLands({ entries: [], availableBasics: basics, minDeckSize: 40 })
 
     expect(result).toEqual({ Plains: 0, Island: 0, Swamp: 0, Mountain: 0, Forest: 0 })
+  })
+
+  it('treats two hybrid symbols as needing two combined white-or-blue sources', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('Red two-drop', '{1}{R}', 2, 12),
+        spell('Double hybrid spell', '{W/U}{W/U}', 2, 2),
+        spell('Colorless filler', '{3}', 3, 9),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect((result.Plains ?? 0) + (result.Island ?? 0)).toBeGreaterThanOrEqual(7)
+    expect((result.Plains ?? 0) + (result.Island ?? 0) + (result.Mountain ?? 0)).toBe(17)
+  })
+
+  it('does not require a colored source for a purely Phyrexian pip', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('Red spell', '{1}{R}', 2, 22),
+        spell('Phyrexian spell', '{W/P}', 1, 1),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(result.Plains).toBe(0)
+    expect(result.Mountain).toBe(17)
+  })
+
+  it('does not merge the colored requirements of mutually exclusive card faces', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White spell', '{1}{W}', 2, 22),
+        spell('Two-faced spell', '{1}{W} // {3}{U}{U}', 2, 1),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(result.Island).toBe(0)
+    expect(result.Plains).toBe(17)
+  })
+
+  it('keeps every represented color alive in a five-color Limited deck', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White spell', '{2}{W}', 3, 5),
+        spell('Blue spell', '{2}{U}', 3, 5),
+        spell('Black spell', '{2}{B}', 3, 5),
+        spell('Red spell', '{2}{R}', 3, 4),
+        spell('Green spell', '{2}{G}', 3, 4),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    for (const land of basics) expect(result[land.name] ?? 0).toBeGreaterThanOrEqual(3)
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(17)
+  })
+
+  it('adds no basics when existing lands already meet the target', () => {
+    const fiveColorLand: DeckEntry = {
+      name: 'Five-color land',
+      manaCost: '',
+      cmc: 0,
+      count: 20,
+      isLand: true,
+      isBasicLand: false,
+      producedColors: ['W', 'U', 'B', 'R', 'G'],
+    }
+    const result = suggestBasicLands({
+      entries: [spell('Gold spell', '{W}{U}{B}{R}{G}', 5, 23), fiveColorLand],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(0)
+  })
+
+  it('uses only the first available printing for a basic-land color', () => {
+    const result = suggestBasicLands({
+      entries: [spell('White spell', '{1}{W}', 2, 23)],
+      availableBasics: [
+        { name: 'Plains A', color: 'W' },
+        { name: 'Plains B', color: 'W' },
+      ],
+      minDeckSize: 40,
+    })
+
+    expect(result['Plains A']).toBe(17)
+    expect(result['Plains B']).toBe(0)
   })
 })

--- a/web-client/src/utils/landSuggestion.test.ts
+++ b/web-client/src/utils/landSuggestion.test.ts
@@ -89,4 +89,87 @@ describe('suggestBasicLands', () => {
     expect(Math.abs((result.Plains ?? 0) - (result.Island ?? 0))).toBeLessThanOrEqual(1)
     expect((result.Plains ?? 0) + (result.Island ?? 0)).toBe(17)
   })
+
+  it('puts every basic into the sole color of a mono-color Limited deck', () => {
+    const result = suggestBasicLands({
+      entries: [spell('Green spell', '{2}{G}', 3, 23)],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(result.Forest).toBe(17)
+    expect(result.Plains).toBe(0)
+    expect(result.Island).toBe(0)
+    expect(result.Swamp).toBe(0)
+    expect(result.Mountain).toBe(0)
+  })
+
+  it('keeps a late single-card splash smaller than the early main color', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('Red two-drop', '{1}{R}', 2, 18),
+        spell('Black finisher', '{5}{B}', 6, 1),
+        spell('Colorless filler', '{3}', 3, 4),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(result.Swamp).toBeGreaterThanOrEqual(3)
+    expect(result.Mountain ?? 0).toBeGreaterThan(result.Swamp ?? 0)
+    expect((result.Mountain ?? 0) + (result.Swamp ?? 0)).toBe(17)
+  })
+
+  it('scales the land total for a normal 60-card constructed curve', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White two-drop', '{1}{W}', 2, 18),
+        spell('Blue three-drop', '{2}{U}', 3, 18),
+      ],
+      availableBasics: basics,
+      minDeckSize: 60,
+    })
+
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(27)
+    expect(Math.abs((result.Plains ?? 0) - (result.Island ?? 0))).toBeLessThanOrEqual(1)
+  })
+
+  it('lets two mana-producing nonlands replace one land when the deck has enough spells', () => {
+    const manaRock: DeckEntry = {
+      name: 'Mana rock',
+      manaCost: '{2}',
+      cmc: 2,
+      count: 2,
+      isLand: false,
+      isBasicLand: false,
+      producedColors: ['W', 'U'],
+    }
+    const result = suggestBasicLands({
+      entries: [
+        spell('White spell', '{1}{W}', 2, 11),
+        spell('Blue spell', '{1}{U}', 2, 11),
+        manaRock,
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(16)
+  })
+
+  it('uses an available fallback basic when the matching basic is unavailable', () => {
+    const result = suggestBasicLands({
+      entries: [spell('Blue spell', '{1}{U}', 2, 23)],
+      availableBasics: [{ name: 'Wastes-like fallback', color: 'W' }],
+      minDeckSize: 40,
+    })
+
+    expect(result['Wastes-like fallback']).toBe(17)
+  })
+
+  it('returns zeroes for an empty deck instead of inventing a mana base', () => {
+    const result = suggestBasicLands({ entries: [], availableBasics: basics, minDeckSize: 40 })
+
+    expect(result).toEqual({ Plains: 0, Island: 0, Swamp: 0, Mountain: 0, Forest: 0 })
+  })
 })

--- a/web-client/src/utils/landSuggestion.ts
+++ b/web-client/src/utils/landSuggestion.ts
@@ -99,7 +99,11 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
   const curveTotal = curveBasedLandCount(spells)
   const ratioBasedBasics = curveTotal - nonBasicLandCount - manaRockReduction
   const minBasedBasics = Math.max(minDeckSize - spellCount - nonBasicLandCount, 0)
-  const targetBasics = Math.max(ratioBasedBasics, minBasedBasics, 0)
+  // When the caller names a deck size and the deck is still short, fill
+  // exactly that many slots. The curve estimate is useful when no target is
+  // known, but must not turn a 36-spell constructed deck into 63 cards.
+  const targetBasics =
+    minDeckSize > 0 && minBasedBasics > 0 ? minBasedBasics : Math.max(ratioBasedBasics, 0)
   if (targetBasics === 0) return result
 
   const requirements = spells.flatMap(colorRequirements)
@@ -217,16 +221,27 @@ interface ColorRequirement {
 
 function colorRequirements(card: DeckEntry): ColorRequirement[] {
   const plain: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
+  const hybridPips: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
   const hybridWeights: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
-  for (const match of card.manaCost.matchAll(/\{([^}]+)\}/g)) {
+  // Faces are alternative costs, never one combined cost. Card summaries use
+  // the front/primary face first, matching what the deckbuilder displays.
+  const primaryCost = card.manaCost.split('//', 1)[0] ?? card.manaCost
+  for (const match of primaryCost.matchAll(/\{([^}]+)\}/g)) {
     const symbol = match[1]!.toUpperCase()
     if (COLORS.includes(symbol as LandColor)) {
       plain[symbol as LandColor]++
       continue
     }
-    const sides = symbol.split('/').filter((s): s is LandColor => COLORS.includes(s as LandColor))
+    const rawSides = symbol.split('/')
+    // A Phyrexian symbol can always be paid with life, so it does not impose
+    // a mandatory colored-source requirement.
+    if (rawSides.includes('P')) continue
+    const sides = rawSides.filter((s): s is LandColor => COLORS.includes(s as LandColor))
     if (sides.length > 0) {
-      for (const side of sides) hybridWeights[side] += 1 / sides.length
+      for (const side of sides) {
+        hybridPips[side]++
+        hybridWeights[side] += 1 / sides.length
+      }
     }
   }
 
@@ -240,7 +255,14 @@ function colorRequirements(card: DeckEntry): ColorRequirement[] {
     if (plain[color] > 0) {
       out.push({ color, pips: plain[color], turn, weight: pipSeverity(plain[color]) })
     }
-    if (hybridWeights[color] > 0) out.push({ color, pips: 1, turn, weight: hybridWeights[color] })
+    if (hybridPips[color] > 0) {
+      out.push({
+        color,
+        pips: hybridPips[color],
+        turn,
+        weight: pipSeverity(hybridPips[color]) * hybridWeights[color],
+      })
+    }
   }
   return out
 }

--- a/web-client/src/utils/landSuggestion.ts
+++ b/web-client/src/utils/landSuggestion.ts
@@ -92,6 +92,7 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
       for (let i = 0; i < entry.count; i++) spells.push(entry)
     }
   }
+  if (spellCount === 0 && nonBasicLandCount === 0) return result
 
   // Curve-based total land target.
   const manaRockReduction = Math.floor(nonLandManaSourceCount / 2)
@@ -148,6 +149,14 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
     }
     basicsByColor[bestColor]++
     remaining--
+  }
+
+  // A partial/custom card catalog may not expose the basic type a deck asks
+  // for. Preserve the promised land total with the first available basic
+  // rather than silently returning an undersized deck.
+  if (remaining > 0) {
+    const fallback = availableBasics[0]
+    if (fallback) basicsByColor[fallback.color] += remaining
   }
 
   for (const color of COLORS) {

--- a/web-client/src/utils/landSuggestion.ts
+++ b/web-client/src/utils/landSuggestion.ts
@@ -11,11 +11,10 @@
  *      control. We pick a land ratio off the average non-land CMC.
  *   2. Discount the target by non-basic lands (full credit) and by
  *      mana-producing non-lands like rocks/dorks (half credit).
- *   3. Compute per-color demand using each spell's pip count (multi-pip is
- *      non-linear) weighted by CMC (cheap spells need more reliable colors).
- *   4. Distribute the basic count across colors proportional to demand,
- *      after subtracting the colored sources existing non-basics already
- *      provide. Splash colors get a 3-source floor.
+ *   3. Turn every colored cost into an on-curve castability requirement.
+ *   4. Allocate basics one at a time to the color with the largest increase
+ *      in hypergeometric castability. This naturally values early and
+ *      double-pipped spells more than late single-pipped spells.
  *
  * Callers map their own card shapes (`SealedCardInfo`, `CardSummary`, …)
  * into `DeckEntry` and apply the returned counts to their own store.
@@ -102,78 +101,58 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
   const targetBasics = Math.max(ratioBasedBasics, minBasedBasics, 0)
   if (targetBasics === 0) return result
 
-  // Curve-weighted color demand from each spell's pips.
-  const demand: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
-  for (const card of spells) {
-    const cWeight = cmcWeight(card.cmc)
-    const pipsPerColor: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
-    const matches = card.manaCost.match(/\{([^}]+)\}/g) ?? []
-    for (const m of matches) {
-      const inner = m.slice(1, -1) as LandColor
-      if (inner in pipsPerColor) pipsPerColor[inner]++
-    }
-    for (const c of COLORS) {
-      const pips = pipsPerColor[c]
-      if (pips > 0) demand[c] += pipWeight(pips) * cWeight
-    }
-  }
-
-  const totalDemand = sumColors(demand)
+  const requirements = spells.flatMap(colorRequirements)
+  const usedColors = new Set(requirements.map((r) => r.color))
 
   // Colorless deck: dump everything into the first available basic.
-  if (totalDemand === 0) {
+  if (requirements.length === 0) {
     const first = availableBasics[0]
     if (first) result[first.name] = targetBasics
     return result
   }
 
-  // Discount existing colored sources from demand.
-  const targetTotalLands = targetBasics + nonBasicLandCount
-  const sourceScale = targetTotalLands > 0 ? totalDemand / targetTotalLands : 0
-  const adjusted: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
-  for (const c of COLORS) {
-    adjusted[c] = Math.max(0, demand[c] - existingSources[c] * sourceScale)
-  }
-  const adjTotal = sumColors(adjusted)
-  const distDemand = adjTotal > 0 ? adjusted : demand
-  const distTotal = adjTotal > 0 ? adjTotal : totalDemand
-
-  // Distribute basics proportional to demand, ordered by demand for stable rounding.
-  const ordered: LandColor[] = COLORS
-    .filter((c) => distDemand[c] > 0)
-    .sort((a, b) => distDemand[b] - distDemand[a])
-
   const colorToLand = mapColorsToLands(availableBasics)
-  let assigned = 0
-  for (const color of ordered) {
-    const land = colorToLand[color]
-    if (!land) continue
-    const share = Math.round((distDemand[color] / distTotal) * targetBasics)
-    result[land] = share
-    assigned += share
-  }
-  // Fix rounding drift on the largest pile.
-  if (assigned !== targetBasics && ordered.length > 0) {
-    const top = colorToLand[ordered[0]!]
-    if (top) result[top] = (result[top] ?? 0) + (targetBasics - assigned)
+  const allocatable = COLORS.filter((c) => usedColors.has(c) && colorToLand[c])
+  const basicsByColor: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
+  const deckSize = Math.max(spellCount + nonBasicLandCount + targetBasics, minDeckSize)
+
+  // A color represented in the spell suite should not be stranded at zero.
+  // Seed up to three total sources, then let probability gains decide every
+  // remaining slot. Existing duals/fixing count toward this floor.
+  let remaining = targetBasics
+  for (const color of allocatable) {
+    const seed = Math.min(remaining, Math.max(0, Math.ceil(3 - existingSources[color])))
+    basicsByColor[color] += seed
+    remaining -= seed
   }
 
-  // Splash floor: ensure every used color has ≥ 3 total sources, stealing
-  // from the most over-represented color when needed.
-  for (const color of ordered) {
-    const land = colorToLand[color]
-    if (!land) continue
-    const total = (result[land] ?? 0) + existingSources[color]
-    if (total < 3) {
-      const needed = Math.ceil(3 - total)
-      result[land] = (result[land] ?? 0) + needed
-      const donor = ordered
-        .filter((c) => c !== color)
-        .map((c) => colorToLand[c])
-        .filter((l): l is string => Boolean(l))
-        .sort((a, b) => (result[b] ?? 0) - (result[a] ?? 0))[0]
-      if (donor && (result[donor] ?? 0) > needed) result[donor] = (result[donor] ?? 0) - needed
+  while (remaining > 0 && allocatable.length > 0) {
+    let bestColor = allocatable[0]!
+    let bestGain = Number.NEGATIVE_INFINITY
+    for (const color of allocatable) {
+      const sources = existingSources[color] + basicsByColor[color]
+      const gain = requirements
+        .filter((r) => r.color === color)
+        .reduce(
+          (sum, r) =>
+            sum +
+            r.weight *
+              (castability(deckSize, sources + 1, r.pips, r.turn) -
+                castability(deckSize, sources, r.pips, r.turn)),
+          0,
+        )
+      if (gain > bestGain) {
+        bestGain = gain
+        bestColor = color
+      }
     }
+    basicsByColor[bestColor]++
+    remaining--
+  }
+
+  for (const color of COLORS) {
+    const land = colorToLand[color]
+    if (land) result[land] = basicsByColor[color]
   }
 
   return result
@@ -220,22 +199,87 @@ export function detectProducedColors(opts: {
 // Internals
 // ---------------------------------------------------------------------------
 
-/** Karsten-flavoured weight: cheap spells need more reliable color access. */
-function cmcWeight(cmc: number): number {
-  if (cmc <= 1) return 1.6
-  if (cmc === 2) return 1.35
-  if (cmc === 3) return 1.1
-  if (cmc === 4) return 0.95
-  return 0.8
+interface ColorRequirement {
+  readonly color: LandColor
+  readonly pips: number
+  readonly turn: number
+  readonly weight: number
 }
 
-/** Multi-pip cost is non-linear: WW costs disproportionately more sources than W. */
-function pipWeight(pips: number): number {
-  if (pips <= 0) return 0
-  if (pips === 1) return 1.0
-  if (pips === 2) return 2.9
-  if (pips === 3) return 5.3
-  return 5.3 + (pips - 3) * 2.0
+function colorRequirements(card: DeckEntry): ColorRequirement[] {
+  const plain: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
+  const hybridWeights: Record<LandColor, number> = { W: 0, U: 0, B: 0, R: 0, G: 0 }
+  for (const match of card.manaCost.matchAll(/\{([^}]+)\}/g)) {
+    const symbol = match[1]!.toUpperCase()
+    if (COLORS.includes(symbol as LandColor)) {
+      plain[symbol as LandColor]++
+      continue
+    }
+    const sides = symbol.split('/').filter((s): s is LandColor => COLORS.includes(s as LandColor))
+    if (sides.length > 0) {
+      for (const side of sides) hybridWeights[side] += 1 / sides.length
+    }
+  }
+
+  const turn = Math.max(1, Math.ceil(card.cmc))
+  const out: ColorRequirement[] = []
+  for (const color of COLORS) {
+    // Missing the second/third source for a pip-dense spell is more damaging
+    // than missing one source for a splash card. This severity multiplier
+    // keeps a pile of single-pip cards from drowning out an early {C}{C}
+    // requirement merely because the pile contains more copies.
+    if (plain[color] > 0) {
+      out.push({ color, pips: plain[color], turn, weight: pipSeverity(plain[color]) })
+    }
+    if (hybridWeights[color] > 0) out.push({ color, pips: 1, turn, weight: hybridWeights[color] })
+  }
+  return out
+}
+
+function pipSeverity(pips: number): number {
+  if (pips <= 1) return 1
+  if (pips === 2) return 3
+  return 3 + (pips - 2) * 3
+}
+
+/**
+ * Probability of seeing at least [pips] sources by the spell's on-curve turn.
+ * Fractional sources (mana dorks/rocks) are linearly interpolated.
+ */
+function castability(deckSize: number, sources: number, pips: number, turn: number): number {
+  const lower = Math.floor(sources)
+  const fraction = sources - lower
+  const cardsSeen = Math.min(deckSize, 7 + Math.max(0, turn - 1))
+  const low = hypergeometricAtLeast(deckSize, lower, cardsSeen, pips)
+  if (fraction === 0) return low
+  const high = hypergeometricAtLeast(deckSize, lower + 1, cardsSeen, pips)
+  return low + (high - low) * fraction
+}
+
+function hypergeometricAtLeast(
+  population: number,
+  successes: number,
+  draws: number,
+  needed: number,
+): number {
+  if (needed <= 0) return 1
+  if (successes < needed || draws < needed) return 0
+  const max = Math.min(successes, draws)
+  let probability = 0
+  for (let hits = needed; hits <= max; hits++) {
+    probability +=
+      (combination(successes, hits) * combination(population - successes, draws - hits)) /
+      combination(population, draws)
+  }
+  return Math.min(1, probability)
+}
+
+function combination(n: number, k: number): number {
+  if (k < 0 || k > n) return 0
+  const small = Math.min(k, n - k)
+  let value = 1
+  for (let i = 1; i <= small; i++) value = (value * (n - small + i)) / i
+  return value
 }
 
 /** Total land target driven by avg non-land CMC. Aggro 16, midrange 17, control 18. */
@@ -246,10 +290,6 @@ function curveBasedLandCount(spells: readonly DeckEntry[]): number {
   const ratio = avg < 2.3 ? 0.4 : avg < 3.2 ? 0.425 : 0.45
   const total = Math.max(Math.round(spells.length / (1 - ratio)), 40)
   return Math.round(total * ratio)
-}
-
-function sumColors(r: Record<LandColor, number>): number {
-  return r.W + r.U + r.B + r.R + r.G
 }
 
 function mapColorsToLands(basics: readonly BasicLand[]): Partial<Record<LandColor, string>> {


### PR DESCRIPTION
## Summary
- replace proportional basic-land splitting with deterministic hypergeometric castability optimization
- account for casting turn, colored-pip density, hybrid costs, dual lands, and fractional nonland mana sources
- share the improved result across sealed/draft and standalone deckbuilders
- add focused regression coverage for Limited land totals, double-pip requirements, dual lands, and hybrid mana

## Research basis
- Wizards Limited guidance: 17 lands as the normal 40-card baseline
- Reid Duke mana-base guidance: curve, colored sources, fixing, and fractional mana producers
- Frank Karsten colored-source analysis: evaluate sources by the turn and pip density needed to cast spells

## Verification
- `npm run typecheck`
- `npm test` — 24 files, 265 tests passed
- `git diff --check`