### PR TITLE
Fix Commander decks in team games

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -14,6 +14,22 @@ section; do not let SDK additions land without a corresponding doc update.
 
 ---
 
+## 0. Game formats
+
+`Format` is the runtime rules configuration, separate from deck-construction `DeckFormat`.
+
+- `Format.Commander` — enables per-player commanders, command zones, commander damage, command-zone
+  casting tax, and the command-zone replacement choice. Its configuration includes
+  `commanderDamageThreshold`, `deckSize`, `startingLife`, `startingHandSize`, and
+  `alwaysDivertToCommand`.
+- `Format.TeamVsTeam` — team membership with individual turns and life totals. By default it is a
+  normal 20-life format with no commanders. Supplying `commanderDamageThreshold` and `deckSize`
+  opts it into the same Commander rules while retaining Team-vs-Team seating and win conditions.
+- `Format.TwoHeadedGiant` — shared life, turns, combat, and team loss. It deliberately does not expose
+  Commander configuration because Two-Headed Giant and Commander have conflicting starting-life rules.
+- `Format.usesCommanders` — capability flag derived from a non-null `commanderDamageThreshold`; engine
+  systems use this instead of checking for one concrete format subtype.
+
 ## 1. Top-level card DSL
 
 **Entry points**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -63,6 +63,12 @@ class FreeForAllHandler(
         // excludes it. Mirrors TournamentMatchHandler.startSingleMatch.
         val isCommanderShape = (lobby.format == com.wingedsheep.gameserver.lobby.TournamentFormat.PREMADE_DECKS &&
             lobby.deckFormat?.isCommanderShape == true) || lobby.format.isCommanderFormat
+        if (isCommanderShape && lobby.isTwoHeadedGiant) {
+            logger.warn(
+                "FFA lobby ${lobby.lobbyId}: cannot start Two-Headed Giant with a Commander-shaped deck format"
+            )
+            return false
+        }
         if (isCommanderShape) {
             val missing = playerStates.filter { it.commander == null }
             if (missing.isNotEmpty()) {
@@ -82,12 +88,11 @@ class FreeForAllHandler(
             tokenArtRegistry = tokenArtRegistry,
             maxPlayers = playerStates.size,
         )
-        if (isCommanderShape) {
-            gameSession.engineFormat = if (lobby.format.isCommanderFormat) {
+        val commanderFormat = when {
+            !isCommanderShape -> null
+            lobby.format.isCommanderFormat ->
                 lobby.commanderPreset.toFormat().copy(deckSize = lobby.deckSizeMin)
-            } else {
-                com.wingedsheep.sdk.core.Format.Commander()
-            }
+            else -> com.wingedsheep.sdk.core.Format.Commander()
         }
         // CR 802 / 803 — the lobby's chosen attack rule applies to this multiplayer game.
         gameSession.attackMode = lobby.attackMode
@@ -102,6 +107,14 @@ class FreeForAllHandler(
         if (lobby.isTeamGame) {
             gameSession.engineFormat = if (lobby.isTwoHeadedGiant) {
                 com.wingedsheep.sdk.core.Format.TwoHeadedGiant()
+            } else if (commanderFormat != null) {
+                com.wingedsheep.sdk.core.Format.TeamVsTeam(
+                    startingLife = commanderFormat.startingLife,
+                    startingHandSize = commanderFormat.startingHandSize,
+                    commanderDamageThreshold = commanderFormat.commanderDamageThreshold,
+                    deckSize = commanderFormat.deckSize,
+                    alwaysDivertToCommand = commanderFormat.alwaysDivertToCommand,
+                )
             } else {
                 com.wingedsheep.sdk.core.Format.TeamVsTeam()
             }
@@ -110,6 +123,8 @@ class FreeForAllHandler(
                 randomTeams = lobby.randomTeams,
                 manualAssignment = lobby.teamAssignments,
             )
+        } else if (commanderFormat != null) {
+            gameSession.engineFormat = commanderFormat
         }
 
         for (playerState in playerStates) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -1183,6 +1183,18 @@ class LobbyHandler(
             return
         }
 
+        if (lobby.isTwoHeadedGiant &&
+            ((lobby.format == TournamentFormat.PREMADE_DECKS && lobby.deckFormat?.isCommanderShape == true) ||
+                lobby.format.isCommanderFormat)
+        ) {
+            sender.sendError(
+                session,
+                ErrorCode.INVALID_ACTION,
+                "Two-Headed Giant cannot be combined with Commander, Brawl, or Standard Brawl"
+            )
+            return
+        }
+
         // Reveal any deferred "Random Set" placeholders now that the game is starting — the concrete
         // sets stay hidden in the lobby until this moment (mirrors the Quick Game deferred roll). Done
         // before the extension gate and pool generation so both see concrete, validated set codes.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -480,6 +480,13 @@ class QuickGameLobbyHandler(
     }
 
     private fun startGame(lobby: QuickGameLobby) {
+        if (lobby.twoHeadedGiant && lobby.format?.isCommanderShape == true) {
+            logger.warn("Lobby ${lobby.lobbyId}: Two-Headed Giant cannot use a Commander-shaped deck format")
+            broadcastClosed(lobby, "Two-Headed Giant cannot be combined with Commander, Brawl, or Standard Brawl")
+            lobbyRepository.remove(lobby.lobbyId)
+            return
+        }
+
         // Commander-shape lobby with a human player who never designated a commander would crash
         // mid-init when GameInitializer requires `commanderCardName`. Surface the error early so
         // the player can pick a different deck before everyone gets disconnected.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/SpectatorStateBuilder.kt
@@ -213,11 +213,11 @@ class SpectatorStateBuilder(
     }
 
     /**
-     * Per-commander damage tallies against [defenderId]. Empty outside `Format.Commander`. Mirrors
+     * Per-commander damage tallies against [defenderId]. Empty when the format has no commanders. Mirrors
      * the player-facing transformer so the spectator badge renders identically.
      */
     private fun buildCommanderDamage(state: GameState, defenderId: EntityId): List<ClientCommanderDamage> {
-        val format = state.format as? Format.Commander ?: return emptyList()
+        val threshold = state.format.commanderDamageThreshold ?: return emptyList()
         if (state.commanderDamage.isEmpty()) return emptyList()
         return state.commanderDamage
             .asSequence()
@@ -233,7 +233,7 @@ class SpectatorStateBuilder(
                     commanderName = card.name,
                     controllerId = controllerId,
                     amount = entry.amount,
-                    threshold = format.commanderDamageThreshold,
+                    threshold = threshold,
                     imageUri = card.imageUri,
                 )
             }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
@@ -215,6 +215,44 @@ class FreeForAllLobbyTest : FunSpec() {
                     .any { it.message.contains("Free-for-All") } shouldBe true
             }
         }
+
+        test("Two-Headed Giant refuses a Commander deck format before touching submitted decks") {
+            val host = createClient()
+            host.connectAs("Host")
+            host.send(ClientMessage.CreateTournamentLobby(
+                setCodes = listOf("POR"),
+                format = "PREMADE_DECKS",
+                maxPlayers = 4,
+                gameMode = "TWO_HEADED_GIANT",
+            ))
+            eventually(5.seconds) {
+                host.messages.any { it is ServerMessage.LobbyCreated } shouldBe true
+            }
+            val lobbyId = host.messages.filterIsInstance<ServerMessage.LobbyCreated>().first().lobbyId
+
+            for (name in listOf("Teammate", "Opponent A", "Opponent B")) {
+                createClient().also { client ->
+                    client.connectAs(name)
+                    client.send(ClientMessage.JoinLobby(lobbyId))
+                }
+            }
+            eventually(5.seconds) {
+                host.latestLobbyUpdate()?.players?.size shouldBe 4
+            }
+
+            host.send(ClientMessage.UpdateLobbySettings(deckFormat = "COMMANDER"))
+            eventually(5.seconds) {
+                host.latestLobbyUpdate()?.settings?.deckFormat shouldBe "COMMANDER"
+            }
+            host.send(ClientMessage.StartTournamentLobby)
+
+            eventually(5.seconds) {
+                host.messages.filterIsInstance<ServerMessage.Error>().any {
+                    it.message.contains("Two-Headed Giant") && it.message.contains("Commander")
+                } shouldBe true
+            }
+            host.messages.none { it is ServerMessage.FreeForAllGameStarting } shouldBe true
+        }
     }
 
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Format.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Format.kt
@@ -15,6 +15,18 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 sealed interface Format {
+    /**
+     * Commander rules enabled by this game format. A non-null threshold means each player must
+     * designate a commander, receives a command zone, and can lose to commander damage.
+     *
+     * Team vs. Team may opt into these rules while retaining its team membership and individual
+     * life/turn model. Two-Headed Giant deliberately cannot: its shared-life rules conflict with
+     * Commander's per-player starting life.
+     */
+    val commanderDamageThreshold: Int? get() = null
+    val deckSize: Int? get() = null
+    val alwaysDivertToCommand: Boolean get() = false
+    val usesCommanders: Boolean get() = commanderDamageThreshold != null
 
     /**
      * CR 810.4 / 810.9 — the players on a team share **one life total** (and one pooled poison
@@ -65,11 +77,11 @@ sealed interface Format {
      */
     @Serializable
     data class Commander(
-        val commanderDamageThreshold: Int = 21,
-        val deckSize: Int = 100,
+        override val commanderDamageThreshold: Int = 21,
+        override val deckSize: Int = 100,
         val startingLife: Int = 40,
         val startingHandSize: Int = 7,
-        val alwaysDivertToCommand: Boolean = false,
+        override val alwaysDivertToCommand: Boolean = false,
     ) : Format
 
     /**
@@ -147,11 +159,17 @@ sealed interface Format {
      *
      * @property startingLife Each player's own starting life total (standard 20).
      * @property startingHandSize Cards drawn for each player's opening hand.
+     * @property commanderDamageThreshold Non-null when this game also uses Commander rules.
+     * @property deckSize Total deck size including the commander for Commander-shaped games.
+     * @property alwaysDivertToCommand See [Commander.alwaysDivertToCommand].
      */
     @Serializable
     data class TeamVsTeam(
         val startingLife: Int = 20,
         val startingHandSize: Int = 7,
+        override val commanderDamageThreshold: Int? = null,
+        override val deckSize: Int? = null,
+        override val alwaysDivertToCommand: Boolean = false,
     ) : Format
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -166,7 +166,7 @@ class GameInitializer(
         // commander card name. The commander is NOT counted in [Deck.cards] (matches the deck
         // validator's convention and CR 903.6a) — it's instantiated separately in step 3 below
         // and routed to Zone.COMMAND.
-        if (config.format is Format.Commander) {
+        if (config.format.usesCommanders) {
             for (playerConfig in config.players) {
                 val name = playerConfig.commanderCardName
                 require(!name.isNullOrBlank()) {
@@ -296,7 +296,7 @@ class GameInitializer(
             val playerId = playerIds[index]
 
             val commanderName: String? = when {
-                config.format is Format.Commander -> playerConfig.commanderCardName
+                config.format.usesCommanders -> playerConfig.commanderCardName
                 else -> null
             }
             val commanderEntityIds = mutableListOf<EntityId>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -538,7 +538,7 @@ object ZoneMovementUtils {
         }
 
         // Commander zone-change shortcut (CR 903.9). When `alwaysDivertToCommand` is enabled
-        // on Format.Commander, a card with CommanderComponent that would move to
+        // on a Commander-enabled format, a card with CommanderComponent that would move to
         // graveyard / exile / hand / library from any other zone is silently diverted to the
         // command zone. Token copies of a commander aren't the commander itself (CR 903.10a)
         // and never carry CommanderComponent, so the TokenComponent guard is implicit.
@@ -551,7 +551,7 @@ object ZoneMovementUtils {
             fromZone != Zone.COMMAND
         ) {
             val format = state.format
-            if (format is com.wingedsheep.sdk.core.Format.Commander && format.alwaysDivertToCommand) {
+            if (format.usesCommanders && format.alwaysDivertToCommand) {
                 return ZoneChangeRedirectResult(Zone.COMMAND)
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/CommanderZoneChoiceCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/CommanderZoneChoiceCheck.kt
@@ -19,8 +19,8 @@ import com.wingedsheep.sdk.core.Zone
  * that zone since the last time state-based actions were checked, its owner may put it
  * into the command zone.
  *
- * Implementation: when the format is [Format.Commander] *without* the
- * [Format.Commander.alwaysDivertToCommand] shortcut, pause the SBA loop with a yes/no
+ * Implementation: when the format enables commanders *without* the
+ * [Format.alwaysDivertToCommand] shortcut, pause the SBA loop with a yes/no
  * decision the first time the SBA sees a given commander outside the command zone. After
  * the prompt (yes or no) we attach [CommanderZoneChoiceAskedComponent] so the SBA does
  * not re-ask on the next iteration; [ZoneTransitionService.moveToZone] strips that marker
@@ -37,7 +37,8 @@ class CommanderZoneChoiceCheck(
     override val order = SbaOrder.COMMANDER_ZONE_CHOICE
 
     override fun check(state: GameState): ExecutionResult {
-        val format = state.format as? Format.Commander ?: return ExecutionResult.success(state)
+        val format = state.format
+        if (!format.usesCommanders) return ExecutionResult.success(state)
         // alwaysDivertToCommand sends the commander to the command zone synchronously via the
         // zone-change replacement, so it never sits in a non-command zone for this SBA to see.
         if (format.alwaysDivertToCommand) return ExecutionResult.success(state)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/CommanderDamageLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/CommanderDamageLossCheck.kt
@@ -24,10 +24,9 @@ class CommanderDamageLossCheck : StateBasedActionCheck {
 
     override fun check(state: GameState): ExecutionResult {
         if (state.gameOver) return ExecutionResult.success(state)
-        val format = state.format as? Format.Commander ?: return ExecutionResult.success(state)
+        val threshold = state.format.commanderDamageThreshold ?: return ExecutionResult.success(state)
         if (state.commanderDamage.isEmpty()) return ExecutionResult.success(state)
 
-        val threshold = format.commanderDamageThreshold
         var newState = state
         val events = mutableListOf<GameEvent>()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -247,7 +247,7 @@ data class GameState(
      * Cumulative combat damage dealt by each commander to each player, keyed by
      * `(commanderEntityId, defendingPlayerId)`. Populated by `CombatDamageManager` at the
      * `DamageDealtEvent` emission sites for combat damage to a player. Read by the
-     * `CommanderDamageLossCheck` SBA against [Format.Commander.commanderDamageThreshold].
+     * `CommanderDamageLossCheck` SBA against [Format.commanderDamageThreshold].
      */
     val commanderDamage: List<CommanderDamageEntry> = emptyList(),
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CommanderComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CommanderComponent.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.Serializable
  *   the higher tax next time
  * - CR 903.9a state-based action: when the card sits in graveyard / exile / hand / library,
  *   the owner is prompted to put it into the command zone (see
- *   `CommanderZoneChoiceCheck`). The legacy `Format.Commander.alwaysDivertToCommand` flag
+ *   `CommanderZoneChoiceCheck`). The `Format.alwaysDivertToCommand` flag
  *   short-circuits the prompt with a synchronous replacement-time divert.
  * - commander-damage tracking — combat damage dealt by this entity contributes to the
  *   `commanderDamage` map, gated by absence of `TokenComponent` (CR 903.10a — token copies are

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -649,7 +649,7 @@ data class ClientPlayer(
 
     /**
      * Per-commander cumulative combat damage dealt to this player (CR 903.10a). One entry per
-     * commander that has dealt at least 1 damage. Empty outside `Format.Commander`. The client
+     * commander that has dealt at least 1 damage. Empty when the format has no commanders. The client
      * renders these as progress badges (e.g., `⚔ Atraxa 14/21`) under the life orb.
      */
     val commanderDamage: List<ClientCommanderDamage> = emptyList(),
@@ -675,7 +675,7 @@ data class ClientPlayer(
  * Per-commander commander-damage tally against a single defending player. Carried inside
  * [ClientPlayer.commanderDamage].
  *
- * @property threshold Single-source loss threshold from `Format.Commander.commanderDamageThreshold`
+ * @property threshold Single-source loss threshold from `Format.commanderDamageThreshold`
  *   (21 in classic Commander, 16 in the BRAWL preset). Included per-entry so the client doesn't
  *   need to know format internals to render `amount/threshold`.
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1908,15 +1908,14 @@ class ClientStateTransformer(
     }
 
     /**
-     * Build per-commander damage tallies against [playerId]. Empty outside `Format.Commander`
+     * Build per-commander damage tallies against [playerId]. Empty when the format has no commanders
      * and for defenders no commander has connected with yet.
      */
     private fun buildCommanderDamage(
         state: GameState,
         playerId: EntityId
     ): List<ClientCommanderDamage> {
-        val format = state.format as? com.wingedsheep.sdk.core.Format.Commander
-            ?: return emptyList()
+        val threshold = state.format.commanderDamageThreshold ?: return emptyList()
         if (state.commanderDamage.isEmpty()) return emptyList()
 
         return state.commanderDamage
@@ -1933,7 +1932,7 @@ class ClientStateTransformer(
                     commanderName = card.name,
                     controllerId = controllerId,
                     amount = entry.amount,
-                    threshold = format.commanderDamageThreshold,
+                    threshold = threshold,
                     imageUri = card.imageUri,
                 )
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/CommanderSetupTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/CommanderSetupTest.kt
@@ -92,6 +92,34 @@ class CommanderSetupTest : FunSpec({
         }
     }
 
+    test("Team vs Team can enable Commander rules for every player") {
+        val initializer = GameInitializer(registry())
+        val deck = Deck.of("Forest" to 99)
+        val format = Format.TeamVsTeam(
+            startingLife = 40,
+            commanderDamageThreshold = 21,
+            deckSize = 100,
+        )
+        val result = initializer.initializeGame(
+            GameConfig(
+                format = format,
+                players = (1..4).map { seat ->
+                    PlayerConfig("P$seat", deck, commanderCardName = "Ragavan, Nimble Pilferer")
+                },
+                teams = listOf(listOf(0, 1), listOf(2, 3)),
+                skipMulligans = true,
+            )
+        )
+
+        result.state.format shouldBe format
+        for (pid in result.playerIds) {
+            result.state.getEntity(pid)!!.get<LifeTotalComponent>()!!.life shouldBe 40
+            val commanderId = result.state.getZone(ZoneKey(pid, Zone.COMMAND)).single()
+            result.state.getEntity(commanderId)!!.get<CommanderComponent>()!!.ownerId shouldBe pid
+            (commanderId in result.state.getZone(ZoneKey(pid, Zone.LIBRARY))) shouldBe false
+        }
+    }
+
     test("Commander format rejects players without a designated commander") {
         val initializer = GameInitializer(registry())
         // Deck.cards does NOT include the commander (CR 903.6a / DeckValidator convention) —

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/CommanderDamageLossCheckTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/CommanderDamageLossCheckTest.kt
@@ -71,4 +71,16 @@ class CommanderDamageLossCheckTest : FunSpec({
         CommanderDamageLossCheck().check(state2).newState
             .getEntity(p2)!!.get<PlayerLostComponent>() shouldNotBe null
     }
+
+    test("Team vs Team applies commander damage when Commander rules are enabled") {
+        val format = Format.TeamVsTeam(
+            startingLife = 40,
+            commanderDamageThreshold = 21,
+            deckSize = 100,
+        )
+        val state = baseState(format).recordCommanderDamage(cmdrA, p2, 21)
+
+        CommanderDamageLossCheck().check(state).newState
+            .getEntity(p2)!!.get<PlayerLostComponent>() shouldNotBe null
+    }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/CommanderZoneChoiceCheckTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/sba/CommanderZoneChoiceCheckTest.kt
@@ -127,6 +127,18 @@ class CommanderZoneChoiceCheckTest : FunSpec({
         result.isPaused shouldBe false
     }
 
+    test("Team vs Team prompts when Commander rules are enabled") {
+        val format = Format.TeamVsTeam(
+            startingLife = 40,
+            commanderDamageThreshold = 21,
+            deckSize = 100,
+        )
+        val result = check.check(stateWithCommanderIn(Zone.GRAVEYARD, format))
+
+        result.isPaused shouldBe true
+        result.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+    }
+
     test("prompt text names both the commander and the source zone") {
         val state = stateWithCommanderIn(Zone.EXILE)
         val result = check.check(state)

--- a/web-client/src/components/lobby/LobbyAxes.tsx
+++ b/web-client/src/components/lobby/LobbyAxes.tsx
@@ -14,11 +14,13 @@
  * indented rows directly under **Cards**, never a peer row. That rule is what stopped "Format"
  * from meaning two different things again.
  */
+import { useEffect } from 'react'
 import { SettingsLabel } from '../ui/SettingsLabel'
 import {
   COMMANDER_LIMITED_HAS_NO_AI,
   COMMANDER_LIMITED_NEEDS_A_1V1_TABLE,
-  LEGALITY_OPTIONS,
+  isCommanderDeckFormat,
+  legalityOptionsForTable,
   cardsKindTopicId,
   cardsLabel,
   cardsSeatCap,
@@ -73,6 +75,17 @@ export function LobbyAxes({
   onRecreate: (spec: RecreateSpec) => void
 }) {
   const cards = view.axes.cards
+  const legalityOptions = legalityOptionsForTable(view.axes.table)
+
+  useEffect(() => {
+    if (
+      cards.kind === 'BRING_A_DECK' &&
+      view.axes.table === 'TWO_HEADED_GIANT' &&
+      isCommanderDeckFormat(cards.legality)
+    ) {
+      commands.setLegality(null)
+    }
+  }, [cards, commands, view.axes.table])
 
   return (
     <>
@@ -100,7 +113,7 @@ export function LobbyAxes({
             title="Restrict submitted decks to a constructed format. No restriction = anything the engine implements."
           >
             <option value="">No restriction</option>
-            {LEGALITY_OPTIONS.map((f) => (
+            {legalityOptions.map((f) => (
               <option key={f.value} value={f.value}>{f.label}</option>
             ))}
           </select>

--- a/web-client/src/components/lobby/axes.test.ts
+++ b/web-client/src/components/lobby/axes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { legalityOptionsForTable } from './axes'
+
+describe('legalityOptionsForTable', () => {
+  it('does not offer Commander-shaped formats for Two-Headed Giant', () => {
+    const values = legalityOptionsForTable('TWO_HEADED_GIANT').map((option) => option.value)
+
+    expect(values).not.toContain('COMMANDER')
+    expect(values).not.toContain('BRAWL')
+    expect(values).not.toContain('STANDARD_BRAWL')
+    expect(values).toContain('STANDARD')
+  })
+
+  it('keeps Commander-shaped formats available for Team vs Team', () => {
+    const values = legalityOptionsForTable('TEAM_VS_TEAM').map((option) => option.value)
+
+    expect(values).toContain('COMMANDER')
+    expect(values).toContain('BRAWL')
+    expect(values).toContain('STANDARD_BRAWL')
+  })
+})

--- a/web-client/src/components/lobby/axes.ts
+++ b/web-client/src/components/lobby/axes.ts
@@ -56,6 +56,16 @@ export interface AxisTriple {
 export const LEGALITY_OPTIONS: ReadonlyArray<{ value: DeckFormat; label: string }> =
   DECK_FORMATS.map((f) => ({ value: f.value.toUpperCase() as DeckFormat, label: f.label }))
 
+export function isCommanderDeckFormat(format: DeckFormat | null): boolean {
+  return format === 'COMMANDER' || format === 'BRAWL' || format === 'STANDARD_BRAWL'
+}
+
+export function legalityOptionsForTable(table: TableAxis): typeof LEGALITY_OPTIONS {
+  return table === 'TWO_HEADED_GIANT'
+    ? LEGALITY_OPTIONS.filter((option) => !isCommanderDeckFormat(option.value))
+    : LEGALITY_OPTIONS
+}
+
 export function cardsLabel(cards: CardsAxis): string {
   switch (cards.kind) {
     case 'BRING_A_DECK':


### PR DESCRIPTION
## Summary
- reject Commander, Brawl, and Standard Brawl decks at Two-Headed Giant tables before game initialization
- let Team vs. Team opt into Commander capabilities so commanders enter the command zone and commander damage/zone rules remain active
- remove Commander-shaped legality options from the 2HG lobby UI and clear stale selections
- add engine, server WebSocket, and client option regression coverage
- document the new format capability in the SDK reference

## Verification
- `just test`
- `cd web-client && npm run typecheck`
- focused Vitest startup was blocked by the host Node runtime lacking `node:util.styleText`

Closes #1457