### PR TITLE
Add cube resolution and dealing primitives

### DIFF
--- a/backlog/cube-draft-format.md
+++ b/backlog/cube-draft-format.md
@@ -145,23 +145,23 @@ must be inert (not merely ignored) in cube mode.
 
 ## Phase 1 — `Cube` model, resolution, and `CubeDealer` (engine + tests)
 
-- [ ] **1.1 — `CubeList` SDK/server model.** Card **names + counts** (a cube is usually singleton but
+- [x] **1.1 — `CubeList` SDK/server model.** Card **names + counts** (a cube is usually singleton but
   some run duplicates), optional pinned `PrintingRef` per card (so a cube can specify art), a
   `basicLandSetCode` for the basic-land art source, `name`, and `packSize` default. Where it lives
   depends on 1.2 — if only the server resolves cubes, `game-server/.../cube/` is the right home and
   `mtg-sdk` stays untouched.
-- [ ] **1.2 — `CubeResolver`.** `(CubeList, CardRegistry, PrintingRegistry) → ResolvedCube` with an
+- [x] **1.2 — `CubeResolver`.** `(CubeList, CardRegistry, PrintingRegistry) → ResolvedCube` with an
   explicit failure list for unresolvable names. **A cube with unresolved names is not playable** —
   return the misses so the host sees "47 cards in this cube aren't implemented yet" rather than
   silently drafting a 313-card cube. Applies pinned printings via `CardDefinition.withPrinting`.
-- [ ] **1.3 — `CubeDealer`** in `rules-engine/.../engine/limited/`. Shuffle once with a seeded
+- [x] **1.3 — `CubeDealer`** in `rules-engine/.../engine/limited/`. Shuffle once with a seeded
   `Random(seed)`, deal by slicing, expose `remaining`. Pure, no Spring. Unit tests: no duplicate card
   identity across all dealt packs; exact pack sizes; `deal` past capacity fails loudly with a message
   naming the shortfall; same seed ⇒ same deal.
-- [ ] **1.4 — `BoosterGenerator.withSets(extra)`** returning a new generator with
+- [x] **1.4 — `BoosterGenerator.withSets(extra)`** returning a new generator with
   `availableSets + extra`. Keeps the generator immutable and the global bean untouched. Tiny, but it
   is what makes the synthetic-`SetConfig` trick safe.
-- [ ] **1.5 — `CubeSetConfig.of(resolvedCube, boosterGenerator)`** building the synthetic
+- [x] **1.5 — `CubeSetConfig.of(resolvedCube, boosterGenerator)`** building the synthetic
   `SetConfig`: `cards` from the cube, `basicLands` from `basicLandSetCode`, `sealedSupported = true`,
   `incomplete = false`, `extensionSet = false`, `variantChance = 0.0`, `boosterStrategy` =
   a strategy that is never actually consulted in cube mode (dealer path) — assert that rather than

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeList.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeList.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.gameserver.cube
+
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.PrintingRef
+
+/**
+ * User-authored cube definition. Entries retain counts because singleton is conventional, not a
+ * rule, and may pin a printing for presentation without changing the card's oracle identity.
+ */
+data class CubeList(
+    val name: String,
+    val cards: List<CubeCardEntry>,
+    val basicLandSetCode: String,
+    val packSize: Int = DEFAULT_PACK_SIZE,
+) {
+    init {
+        require(name.isNotBlank()) { "Cube name must not be blank" }
+        require(packSize > 0) { "Cube pack size must be positive, got $packSize" }
+    }
+
+    companion object {
+        const val DEFAULT_PACK_SIZE = 15
+    }
+}
+
+data class CubeCardEntry(
+    val name: String,
+    val count: Int = 1,
+    val printing: PrintingRef? = null,
+) {
+    init {
+        require(name.isNotBlank()) { "Cube card name must not be blank" }
+        require(count > 0) { "Cube card count must be positive for $name, got $count" }
+    }
+}
+
+/** A fully resolved, playable cube. [cards] is expanded according to each entry's count. */
+data class ResolvedCube(
+    val name: String,
+    val cards: List<CardDefinition>,
+    val basicLandSetCode: String,
+    val packSize: Int,
+)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeResolver.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeResolver.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.gameserver.cube
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.registry.PrintingRegistry
+
+/**
+ * Resolves user-authored names and optional printing pins against the authoritative registries.
+ *
+ * Resolution is all-or-nothing: callers receive every miss and no partial playable cube.
+ */
+class CubeResolver(
+    private val cardRegistry: CardRegistry,
+    private val printingRegistry: PrintingRegistry,
+) {
+    fun resolve(cube: CubeList): CubeResolution {
+        val unresolved = mutableListOf<UnresolvedCubeCard>()
+        val resolvedCards = buildList {
+            for (entry in cube.cards) {
+                val canonical = cardRegistry.getCard(entry.name)
+                if (canonical == null) {
+                    unresolved += UnresolvedCubeCard(entry.name, "Card is not implemented")
+                    continue
+                }
+
+                val resolved = entry.printing?.let { ref ->
+                    val printing = printingRegistry.getPrinting(ref)
+                    when {
+                        printing == null -> {
+                            unresolved += UnresolvedCubeCard(
+                                entry.name,
+                                "Printing ${ref.identifier()} is not available",
+                            )
+                            null
+                        }
+                        printing.name != canonical.name -> {
+                            unresolved += UnresolvedCubeCard(
+                                entry.name,
+                                "Printing ${ref.identifier()} belongs to ${printing.name}",
+                            )
+                            null
+                        }
+                        else -> canonical.withPrinting(printing)
+                    }
+                } ?: if (entry.printing == null) canonical else null
+
+                if (resolved != null) {
+                    repeat(entry.count) { add(resolved) }
+                }
+            }
+        }
+
+        if (unresolved.isNotEmpty()) return CubeResolution.Failure(unresolved)
+        return CubeResolution.Success(
+            ResolvedCube(
+                name = cube.name,
+                cards = resolvedCards,
+                basicLandSetCode = cube.basicLandSetCode,
+                packSize = cube.packSize,
+            )
+        )
+    }
+}
+
+sealed interface CubeResolution {
+    data class Success(val cube: ResolvedCube) : CubeResolution
+    data class Failure(val unresolved: List<UnresolvedCubeCard>) : CubeResolution
+}
+
+data class UnresolvedCubeCard(
+    val name: String,
+    val reason: String,
+)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeSetConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/cube/CubeSetConfig.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.gameserver.cube
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.sdk.limited.BoosterStrategy
+
+/** Builds the synthetic set config that lets existing limited infrastructure describe a cube. */
+object CubeSetConfig {
+    const val SET_CODE = "CUBE"
+
+    private val unsupportedBoosterStrategy = BoosterStrategy { _, _ ->
+        error("Cube packs must be dealt through CubeDealer, not BoosterStrategy")
+    }
+
+    fun of(
+        cube: ResolvedCube,
+        boosterGenerator: BoosterGenerator,
+    ): BoosterGenerator.SetConfig {
+        val basicLandSource = requireNotNull(
+            boosterGenerator.getSetConfig(cube.basicLandSetCode)
+        ) {
+            "Unknown cube basic-land set code: ${cube.basicLandSetCode}"
+        }
+
+        return BoosterGenerator.SetConfig(
+            setCode = SET_CODE,
+            setName = cube.name,
+            cards = cube.cards,
+            basicLands = basicLandSource.basicLands,
+            incomplete = false,
+            sealedSupported = true,
+            extensionSet = false,
+            boosterStrategy = unsupportedBoosterStrategy,
+            variantChance = 0.0,
+        )
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/cube/CubeResolverTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/cube/CubeResolverTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.gameserver.cube
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.registry.PrintingRegistry
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.PrintingRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class CubeResolverTest : FunSpec({
+
+    fun card(name: String, oracleId: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype.BEAR),
+        power = 2,
+        toughness = 2,
+    ).copy(oracleId = oracleId)
+
+    val grizzly = card("Grizzly Bears", "grizzly-oracle")
+    val runeclaw = card("Runeclaw Bear", "runeclaw-oracle")
+
+    fun resolver(printings: List<Printing> = emptyList()) = CubeResolver(
+        cardRegistry = CardRegistry().apply { register(listOf(grizzly, runeclaw)) },
+        printingRegistry = PrintingRegistry().apply { register(printings) },
+    )
+
+    test("resolves names, expands counts, and preserves cube settings") {
+        val result = resolver().resolve(
+            CubeList(
+                name = "Bear Cube",
+                cards = listOf(
+                    CubeCardEntry("Grizzly Bears", count = 2),
+                    CubeCardEntry("Runeclaw Bear"),
+                ),
+                basicLandSetCode = "BLB",
+                packSize = 12,
+            )
+        ) as CubeResolution.Success
+
+        result.cube.name shouldBe "Bear Cube"
+        result.cube.cards.map { it.name } shouldContainExactly
+            listOf("Grizzly Bears", "Grizzly Bears", "Runeclaw Bear")
+        result.cube.basicLandSetCode shouldBe "BLB"
+        result.cube.packSize shouldBe 12
+    }
+
+    test("applies a pinned printing without changing oracle identity") {
+        val printing = Printing(
+            oracleId = "grizzly-oracle",
+            name = "Grizzly Bears",
+            setCode = "10E",
+            collectorNumber = "268",
+            imageUri = "https://example.test/bear.jpg",
+        )
+
+        val result = resolver(listOf(printing)).resolve(
+            CubeList(
+                name = "Art Cube",
+                cards = listOf(
+                    CubeCardEntry("Grizzly Bears", printing = printing.ref),
+                ),
+                basicLandSetCode = "BLB",
+            )
+        ) as CubeResolution.Success
+
+        result.cube.cards.single().let {
+            it.oracleId shouldBe grizzly.oracleId
+            it.setCode shouldBe "10E"
+            it.metadata.collectorNumber shouldBe "268"
+            it.metadata.imageUri shouldBe "https://example.test/bear.jpg"
+        }
+    }
+
+    test("reports every unresolvable card instead of returning a partial cube") {
+        val result = resolver().resolve(
+            CubeList(
+                name = "Incomplete Cube",
+                cards = listOf(
+                    CubeCardEntry("Missing One"),
+                    CubeCardEntry("Grizzly Bears"),
+                    CubeCardEntry("Missing Two", count = 4),
+                ),
+                basicLandSetCode = "BLB",
+            )
+        ) as CubeResolution.Failure
+
+        result.unresolved shouldContainExactly listOf(
+            UnresolvedCubeCard("Missing One", "Card is not implemented"),
+            UnresolvedCubeCard("Missing Two", "Card is not implemented"),
+        )
+    }
+
+    test("reports unavailable and mismatched pinned printings") {
+        val runeclawPrinting = Printing(
+            oracleId = "runeclaw-oracle",
+            name = "Runeclaw Bear",
+            setCode = "M10",
+            collectorNumber = "211",
+        )
+        val result = resolver(listOf(runeclawPrinting)).resolve(
+            CubeList(
+                name = "Bad Pins",
+                cards = listOf(
+                    CubeCardEntry("Grizzly Bears", printing = PrintingRef("M10", "999")),
+                    CubeCardEntry("Grizzly Bears", printing = runeclawPrinting.ref),
+                ),
+                basicLandSetCode = "BLB",
+            )
+        ) as CubeResolution.Failure
+
+        result.unresolved shouldContainExactly listOf(
+            UnresolvedCubeCard(
+                "Grizzly Bears",
+                "Printing M10-999 is not available",
+            ),
+            UnresolvedCubeCard(
+                "Grizzly Bears",
+                "Printing M10-211 belongs to Runeclaw Bear",
+            ),
+        )
+    }
+})

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/cube/CubeSetConfigTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/cube/CubeSetConfigTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.gameserver.cube
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.doubles.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+class CubeSetConfigTest : FunSpec({
+
+    val forest = CardDefinition.basicLand("Forest", Subtype.FOREST)
+    val cubeCard = CardDefinition.creature(
+        name = "Grizzly Bears",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype.BEAR),
+        power = 2,
+        toughness = 2,
+    )
+    val landSource = BoosterGenerator.SetConfig(
+        setCode = "BLB",
+        setName = "Bloomburrow",
+        cards = emptyList(),
+        basicLands = listOf(forest),
+    )
+    val generator = BoosterGenerator(mapOf("BLB" to landSource))
+    val cube = ResolvedCube(
+        name = "Friends Cube",
+        cards = listOf(cubeCard),
+        basicLandSetCode = "BLB",
+        packSize = 15,
+    )
+
+    test("builds a complete synthetic set with basic lands from the selected source") {
+        val config = CubeSetConfig.of(cube, generator)
+
+        config.setCode shouldBe "CUBE"
+        config.setName shouldBe "Friends Cube"
+        config.cards shouldContainExactly listOf(cubeCard)
+        config.basicLands shouldContainExactly listOf(forest)
+        config.sealedSupported shouldBe true
+        config.incomplete shouldBe false
+        config.extensionSet shouldBe false
+        config.variantChance.shouldBeExactly(0.0)
+    }
+
+    test("synthetic booster strategy fails if a caller bypasses CubeDealer") {
+        val config = CubeSetConfig.of(cube, generator)
+
+        val error = shouldThrow<IllegalStateException> {
+            config.boosterStrategy.generate(config.cards, Random(1))
+        }
+
+        error.message shouldBe
+            "Cube packs must be dealt through CubeDealer, not BoosterStrategy"
+    }
+
+    test("unknown basic land source fails with a host-facing message") {
+        val error = shouldThrow<IllegalArgumentException> {
+            CubeSetConfig.of(cube.copy(basicLandSetCode = "NOPE"), generator)
+        }
+
+        error.message shouldBe "Unknown cube basic-land set code: NOPE"
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -31,6 +31,16 @@ class BoosterGenerator(
 ) {
 
     /**
+     * Return an isolated generator containing this generator's catalogue plus [extra].
+     *
+     * The original generator and its map are left untouched. Entries in [extra] intentionally
+     * replace entries with the same set code, which lets a lobby install a scoped synthetic set
+     * without mutating the application-wide catalogue.
+     */
+    fun withSets(extra: Map<String, SetConfig>): BoosterGenerator =
+        BoosterGenerator(availableSets + extra)
+
+    /**
      * Configuration for a card set that can be used for sealed.
      */
     data class SetConfig(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/CubeDealer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/CubeDealer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.model.CardDefinition
+import kotlin.random.Random
+
+/**
+ * Stateful, deterministic dealer for a cube.
+ *
+ * The complete cube is shuffled once and then consumed in order. This is deliberately separate
+ * from [com.wingedsheep.sdk.limited.BoosterStrategy], whose per-pack API cannot preserve
+ * no-replacement state across a draft.
+ */
+class CubeDealer(
+    cube: List<CardDefinition>,
+    private val packSize: Int,
+    seed: Long,
+) {
+    init {
+        require(packSize > 0) { "Cube pack size must be positive, got $packSize" }
+    }
+
+    private val shuffledCube = cube.shuffled(Random(seed))
+    private var dealt = 0
+
+    val remaining: Int
+        get() = shuffledCube.size - dealt
+
+    /**
+     * Deal [packs] complete packs and consume them from this dealer.
+     *
+     * @throws IllegalArgumentException when [packs] is negative or the cube lacks enough cards.
+     */
+    fun deal(packs: Int): List<List<CardDefinition>> {
+        require(packs >= 0) { "Number of cube packs must not be negative, got $packs" }
+        val requestedCards = Math.multiplyExact(packs, packSize)
+        require(requestedCards <= remaining) {
+            val shortfall = requestedCards - remaining
+            "Cannot deal $packs cube packs of $packSize cards: " +
+                "$remaining cards remain, short by $shortfall"
+        }
+
+        val result = shuffledCube
+            .subList(dealt, dealt + requestedCards)
+            .chunked(packSize)
+        dealt += requestedCards
+        return result
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorWithSetsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorWithSetsTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.limited
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class BoosterGeneratorWithSetsTest : FunSpec({
+
+    fun config(code: String) = BoosterGenerator.SetConfig(
+        setCode = code,
+        setName = code,
+        cards = emptyList(),
+        basicLands = emptyList(),
+    )
+
+    test("withSets returns a derived generator without mutating the original") {
+        val originalConfig = config("OLD")
+        val addedConfig = config("NEW")
+        val original = BoosterGenerator(mapOf("OLD" to originalConfig))
+
+        val derived = original.withSets(mapOf("NEW" to addedConfig))
+
+        original.availableSets shouldContainExactly mapOf("OLD" to originalConfig)
+        original.getSetConfig("NEW").shouldBeNull()
+        derived.availableSets shouldContainExactly mapOf(
+            "OLD" to originalConfig,
+            "NEW" to addedConfig,
+        )
+    }
+
+    test("extra set replaces the same code only in the derived generator") {
+        val originalConfig = config("CUBE").copy(setName = "Old")
+        val replacement = config("CUBE").copy(setName = "Lobby Cube")
+        val original = BoosterGenerator(mapOf("CUBE" to originalConfig))
+
+        val derived = original.withSets(mapOf("CUBE" to replacement))
+
+        original.getSetConfig("CUBE") shouldBe originalConfig
+        derived.getSetConfig("CUBE") shouldBe replacement
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/CubeDealerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/CubeDealerTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+
+class CubeDealerTest : FunSpec({
+
+    fun card(index: Int) = CardDefinition.creature(
+        name = "Cube Card $index",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype.BEAR),
+        power = 2,
+        toughness = 2,
+    ).copy(oracleId = "oracle-$index")
+
+    val cube = (1..45).map(::card)
+
+    test("deals exact pack sizes without repeating an identity across packs") {
+        val dealer = CubeDealer(cube, packSize = 15, seed = 42)
+
+        val packs = dealer.deal(3)
+
+        packs.map { it.size } shouldContainExactly listOf(15, 15, 15)
+        packs.flatten().map { it.oracleId }.distinct().size shouldBeExactly 45
+        dealer.remaining shouldBeExactly 0
+    }
+
+    test("successive deals consume the same one-time shuffle") {
+        val dealer = CubeDealer(cube, packSize = 5, seed = 123)
+
+        val first = dealer.deal(2)
+        val second = dealer.deal(1)
+
+        (first + second).flatten().map { it.oracleId }.distinct().size shouldBeExactly 15
+        dealer.remaining shouldBeExactly 30
+    }
+
+    test("same seed produces the same deal") {
+        val first = CubeDealer(cube, packSize = 9, seed = 8675309).deal(4)
+        val second = CubeDealer(cube, packSize = 9, seed = 8675309).deal(4)
+
+        first.map { pack -> pack.map { it.oracleId } } shouldBe
+            second.map { pack -> pack.map { it.oracleId } }
+    }
+
+    test("dealing past capacity fails loudly with the shortfall and consumes nothing") {
+        val dealer = CubeDealer(cube.take(20), packSize = 15, seed = 1)
+
+        val error = shouldThrow<IllegalArgumentException> {
+            dealer.deal(2)
+        }
+
+        error.message shouldBe
+            "Cannot deal 2 cube packs of 15 cards: 20 cards remain, short by 10"
+        dealer.remaining shouldBeExactly 20
+    }
+
+    test("dealing zero packs is a no-op") {
+        val dealer = CubeDealer(cube, packSize = 15, seed = 1)
+
+        dealer.deal(0) shouldBe emptyList()
+        dealer.remaining shouldBeExactly cube.size
+    }
+})


### PR DESCRIPTION
## Summary

- add server-side `CubeList`, all-or-nothing `CubeResolver`, printing-pin validation, and `ResolvedCube`
- add deterministic stateful `CubeDealer` that shuffles once and deals without replacement across packs
- add immutable `BoosterGenerator.withSets` and guarded synthetic `CubeSetConfig` support
- mark phase 1 complete in the cube backlog

This implements phase 1 of #1454. Lobby wiring and player-facing cube flows remain in later phases.

## Verification

- `just test-rules`
- `just test-server`
- after rebasing onto current `main`: `just test-class CubeDealerTest` and `just test-server`