### PR TITLE
Fix Coordinated Clobbering damage target

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CoordinatedClobbering.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CoordinatedClobbering.kt
@@ -25,11 +25,10 @@ import com.wingedsheep.sdk.scripting.values.EntityReference
  * Tap one or two target untapped creatures you control. They each deal damage equal to their
  * power to target creature an opponent controls.
  *
- * Two target slots: the single opponent's creature (declared first, so it stays addressable as
- * `ContextTarget(0)` across the per-attacker loop) and one or two untapped creatures you control.
- * At resolution we gather the chosen targets, filter to the creatures you control (excludes the
- * victim), then tap them all and have each deal damage equal to its own power — read per-iteration
- * via [EntityReference.IterationEntity] — to the opponent's creature.
+ * At resolution we gather the chosen targets into two collections by controller. This avoids
+ * relying on a positional target index when the one-or-two-creature group is flattened into the
+ * cast action. We then tap the clobberers and have each deal damage equal to its own power — read
+ * per-iteration via [EntityReference.IterationEntity] — to the opponent's creature.
  */
 val CoordinatedClobbering = card("Coordinated Clobbering") {
     manaCost = "{G}"
@@ -39,7 +38,8 @@ val CoordinatedClobbering = card("Coordinated Clobbering") {
         "equal to their power to target creature an opponent controls."
 
     spell {
-        // Declared first so the victim is a stable target across the per-creature loop.
+        // Keep the fixed-count victim first so the flattened target list remains unambiguous when
+        // the controller chooses only one creature from the following one-or-two target group.
         target("creature an opponent controls", Targets.CreatureOpponentControls)
         target(
             "untapped creatures you control",
@@ -51,8 +51,7 @@ val CoordinatedClobbering = card("Coordinated Clobbering") {
         )
 
         effect = Effects.Composite(
-            // Gather every chosen target, then keep only the creatures you control (the victim is
-            // an opponent's creature, so it drops out).
+            // Gather every chosen target, then separate the clobberers from the victim.
             GatherCardsEffect(
                 source = CardSource.ChosenTargets,
                 storeAs = "allTargets",
@@ -61,6 +60,11 @@ val CoordinatedClobbering = card("Coordinated Clobbering") {
                 from = "allTargets",
                 filter = CollectionFilter.MatchesFilter(GameObjectFilter.Creature.youControl()),
                 storeMatching = "clobberers",
+            ),
+            FilterCollectionEffect(
+                from = "allTargets",
+                filter = CollectionFilter.MatchesFilter(GameObjectFilter.Creature.opponentControls()),
+                storeMatching = "victim",
             ),
             // Tap all chosen creatures first ("Tap one or two target untapped creatures you control").
             ForEachInCollectionEffect(
@@ -75,7 +79,7 @@ val CoordinatedClobbering = card("Coordinated Clobbering") {
                         EntityReference.IterationEntity,
                         EntityNumericProperty.Power,
                     ),
-                    target = EffectTarget.ContextTarget(0),
+                    target = EffectTarget.PipelineTarget("victim"),
                     damageSource = EffectTarget.Self,
                 ),
             ),

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2545,6 +2545,15 @@
                     "storeMatching": "clobberers"
                 },
                 {
+                    "type": "FilterCollection",
+                    "from": "allTargets",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "creature ctrl:opponent"
+                    },
+                    "storeMatching": "victim"
+                },
+                {
                     "type": "ForEach",
                     "space": {
                         "type": "IterationSpace.Collection",
@@ -2569,8 +2578,8 @@
                             "numericProperty": "Power"
                         },
                         "target": {
-                            "type": "ContextTarget",
-                            "index": 0
+                            "type": "PipelineTarget",
+                            "collectionName": "victim"
                         },
                         "damageSource": "Self"
                     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoordinatedClobberingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoordinatedClobberingScenarioTest.kt
@@ -19,7 +19,7 @@ import io.kotest.matchers.shouldBe
  *
  * Verifies the 1-or-2 your-creature target group gets tapped and each deals damage equal to its
  * own power to the single opponent's creature; and the single-creature mode. Targets are supplied
- * at cast time in requirement order: the opponent's creature (declared first), then the clobberers.
+ * at cast time in requirement order: the opponent's creature, then the clobberers.
  */
 class CoordinatedClobberingScenarioTest : ScenarioTestBase() {
 
@@ -109,6 +109,43 @@ class CoordinatedClobberingScenarioTest : ScenarioTestBase() {
                 withClue("3 damage kills the 2/2 victim") {
                     val victimZone = game.state.getZone(com.wingedsheep.engine.state.ZoneKey(game.player2Id, Zone.GRAVEYARD))
                     (victim in victimZone) shouldBe true
+                }
+            }
+
+            test("uses power granted by an attached aura") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Coordinated Clobbering")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Overgrown Zealot") // 0/4
+                    .withCardAttachedTo(1, "Sheltered by Ghosts", "Overgrown Zealot") // now 1/4
+                    .withCardOnBattlefield(2, "Veteran Survivor") // 2/1 victim
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zealot = game.findPermanent("Overgrown Zealot")!!
+                val victim = game.findPermanent("Veteran Survivor")!!
+                val spell = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Coordinated Clobbering"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = spell,
+                        targets = listOf(
+                            ChosenTarget.Permanent(victim),
+                            ChosenTarget.Permanent(zealot),
+                        ),
+                    ),
+                )
+                cast.error shouldBe null
+                game.resolveStack()
+
+                withClue("The aura's +1/+0 makes the Zealot deal 1 damage and kill the 2/1") {
+                    game.isOnBattlefield("Veteran Survivor") shouldBe false
+                    game.isInGraveyard(2, "Veteran Survivor") shouldBe true
                 }
             }
         }


### PR DESCRIPTION
## Summary
- resolve Coordinated Clobbering’s opposing creature through a dedicated filtered pipeline collection instead of a positional target index
- preserve each clobberer’s projected power when dealing damage
- add a regression for Overgrown Zealot enchanted by Sheltered by Ghosts killing Veteran Survivor
- update the DSK card snapshot

## Verification
- just test-class CoordinatedClobberingScenarioTest
- just rebless-cards
- just build
- git diff --check