### PR TITLE
Add fair hidden-information determinization to engine AI

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -4,6 +4,8 @@ import com.wingedsheep.ai.engine.advisor.CardAdvisorModule
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
 import com.wingedsheep.ai.engine.evaluation.*
 import com.wingedsheep.ai.engine.knowledge.IntentCatalog
+import com.wingedsheep.ai.engine.hidden.Determinizer
+import com.wingedsheep.ai.engine.hidden.OpponentModel
 import com.wingedsheep.ai.engine.rollout.CandidateEvaluator
 import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
 import com.wingedsheep.ai.engine.rollout.PlayoutEngine
@@ -176,7 +178,8 @@ class AIPlayer(
         fun create(
             cardRegistry: CardRegistry,
             playerId: EntityId,
-            profile: AiProfile
+            profile: AiProfile,
+            opponentModels: Map<EntityId, OpponentModel> = emptyMap(),
         ): AIPlayer {
             val advisorRegistry = CardAdvisorRegistry()
             profile.advisorModules.forEach { it.register(advisorRegistry) }
@@ -216,6 +219,15 @@ class AIPlayer(
                     candidateEvaluator = candidateEvaluatorFor(
                         cardRegistry, profile, evaluator, advisorRegistry, intents
                     ),
+                    stateSampler = if (profile.determinizeHiddenInformation) {
+                        val determinizer = Determinizer(cardRegistry)
+                        val sampler: (GameState, EntityId) -> GameState = { state, viewer ->
+                            determinizer.sampleForSearch(state, viewer, opponentModels)
+                        }
+                        sampler
+                    } else {
+                        null
+                    },
                 ),
                 responder = responder,
                 useMeaningfulFilter = profile.useMeaningfulFilter,
@@ -252,7 +264,11 @@ class AIPlayer(
                 decisions = FastDecisionResponder(intents),
                 settings = settings,
             )
-            return RolloutCandidateEvaluator(engine, evaluator, settings)
+            return RolloutCandidateEvaluator(
+                playouts = engine,
+                staticEvaluator = evaluator,
+                settings = settings,
+            )
         }
 
         /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -134,6 +134,11 @@ data class AiProfile(
      * makes `v0-rollout` an attributable one-variable change from `v0`.
      */
     val rollouts: RolloutSettings? = null,
+    /**
+     * Phase 8: sample opponent hand identities and library order before rollout evaluation.
+     * Off preserves the historical full-information agents used as arena controls.
+     */
+    val determinizeHiddenInformation: Boolean = false,
 ) {
     companion object {
         /**
@@ -200,6 +205,13 @@ data class AiProfile(
         val PHASE7 = AiProfile(
             id = "v0-rollout",
             rollouts = RolloutSettings.DEFAULT,
+        )
+
+        /** Phase 7 search over a fair, sampled hidden-information state. */
+        val PHASE8 = AiProfile(
+            id = "v0-rollout-determinized",
+            rollouts = RolloutSettings.DEFAULT,
+            determinizeHiddenInformation = true,
         )
 
         /** Everything Phases 4, 6 and 7 add — what the plan proposes to ship. */

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -75,6 +75,8 @@ class Strategist(
      * a caller that doesn't opt in gets the greedy 1-ply AI unchanged.
      */
     private val candidateEvaluator: CandidateEvaluator = StaticCandidateEvaluator(evaluator),
+    /** Phase 8: a fair complete world, sampled once before any candidate simulation. */
+    private val stateSampler: ((GameState, EntityId) -> GameState)? = null,
 ) {
     private val holdPolicy = HoldPolicy(intents)
 
@@ -83,13 +85,14 @@ class Strategist(
         legalActions: List<LegalAction>,
         playerId: EntityId
     ): LegalAction {
+        val evaluationState = stateSampler?.invoke(state, playerId) ?: state
         // Combat declaration steps need the CombatAdvisor to fill in attacker/blocker maps
         // even when there's only one legal action (which is the common case — the enumerator
         // returns a single DeclareAttackers/DeclareBlockers with an empty default map).
         val combatAction = legalActions.find { it.actionType == "DeclareAttackers" || it.actionType == "DeclareBlockers" }
         if (combatAction != null) {
             val budget = budgetPolicy.budgetFor(state, playerId, listOf(combatAction))
-            return handleCombatDeclaration(state, combatAction, playerId, budget)
+            return handleCombatDeclaration(evaluationState, combatAction, playerId, budget)
         }
 
         if (legalActions.size == 1) return legalActions.first()
@@ -112,29 +115,29 @@ class Strategist(
         val leafStates = mutableListOf<GameState>()
         if (pass != null) {
             leaves += pass
-            leafStates += simulator.simulate(state, pass.action).state
+            leafStates += simulator.simulate(evaluationState, pass.action).state
         }
         for (action in affordable) {
             leaves += action
             leafStates += simulator.simulate(
-                state, chooseCommittedTargets(state, action, playerId, budget)
+                evaluationState, chooseCommittedTargets(evaluationState, action, playerId, budget)
             ).state
             if (budget.expired()) break
         }
 
         // ── Pass 2: score every leaf at once ──
-        val leafScores = candidateEvaluator.scoreAll(state, leafStates, playerId, budget)
+        val leafScores = candidateEvaluator.scoreAll(evaluationState, leafStates, playerId, budget)
         val passScore = if (pass != null) {
             leafScores.first()
         } else {
             // No pass on offer: the "do nothing" reference is the current position itself.
-            candidateEvaluator.score(state, state, playerId, budget)
+            candidateEvaluator.score(evaluationState, evaluationState, playerId, budget)
         }
 
         // ── Pass 3: per-card timing and advisor adjustments, in raw evaluator units ──
         val firstCandidate = if (pass != null) 1 else 0
         val scored = (firstCandidate until leaves.size).map { i ->
-            leaves[i] to adjustScore(state, leaves[i], playerId, leafScores[i], passScore)
+            leaves[i] to adjustScore(evaluationState, leaves[i], playerId, leafScores[i], passScore)
         }
 
         // On the opponent's end step, unspent mana is about to be wasted. Reduce the pass threshold
@@ -158,7 +161,7 @@ class Strategist(
             // AI sees the real resolved board, including effects already on the stack.
             val chosen = best.first
             if (chosen.requiresTargets) {
-                chosen.copy(action = chooseCommittedTargets(state, chosen, playerId, budget))
+                chosen.copy(action = chooseCommittedTargets(evaluationState, chosen, playerId, budget))
             } else {
                 chosen
             }

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -1,0 +1,195 @@
+package com.wingedsheep.ai.engine.hidden
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.CantBeCopiedComponent
+import com.wingedsheep.engine.state.components.identity.CantBeCounteredComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
+import com.wingedsheep.engine.state.components.identity.HexproofFromComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.state.components.identity.ProtectionComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.identity.SelfZoneRedirectComponent
+import com.wingedsheep.engine.state.components.identity.ToxicComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.engine.view.Visibility
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+
+/**
+ * Samples a complete state consistent with what [viewerId] is allowed to know.
+ *
+ * Entities and zone membership never change. Only hidden card identities and opponent library
+ * ordering are sampled, which keeps continuations, targets and pending decisions structurally
+ * valid. Cards carrying runtime components are pinned because changing their definition could make
+ * those components nonsensical.
+ */
+class Determinizer(
+    private val cardRegistry: CardRegistry,
+    private val visibility: Visibility = Visibility(cardRegistry),
+) {
+    /** Pure per-position entry point used by the Strategist before it simulates any candidate. */
+    fun sampleForSearch(
+        state: GameState,
+        viewerId: EntityId,
+        models: Map<EntityId, OpponentModel> = emptyMap(),
+    ): GameState = sample(
+        state,
+        viewerId,
+        models,
+        GameRng.seeded(
+            state.rng.state xor
+                (state.turnNumber.toLong() shl 32) xor
+                (state.step.ordinal.toLong() shl 16) xor
+                viewerId.value.hashCode().toLong()
+        ),
+    )
+
+    fun sample(
+        state: GameState,
+        viewerId: EntityId,
+        model: OpponentModel,
+        rng: GameRng,
+    ): GameState = sample(state, viewerId, emptyMap(), rng, model)
+
+    fun sample(
+        state: GameState,
+        viewerId: EntityId,
+        models: Map<EntityId, OpponentModel>,
+        rng: GameRng,
+        fallback: OpponentModel = OpponentModel.IdentityPermutation,
+    ): GameState {
+        var sampled = state
+        var currentRng = rng
+
+        // Even the viewer's own library order is hidden. Teammate hands are visible, but teammate
+        // libraries are not. Walk every player and let Visibility decide which cards are hidden.
+        for (opponentId in state.turnOrder) {
+            val hidden = hiddenCards(state, opponentId, viewerId)
+            if (hidden.isEmpty()) continue
+
+            val definitions = when (val model = models[opponentId] ?: fallback) {
+                is OpponentModel.KnownDecklist -> fromKnownDecklist(state, opponentId, hidden, model, currentRng)
+                    .also { currentRng = it.second }
+                    .first
+                OpponentModel.IdentityPermutation -> {
+                    val existing = hidden.mapNotNull { id ->
+                        state.getEntity(id)?.get<CardComponent>()?.let { cardRegistry.getCard(it.cardDefinitionId) }
+                    }
+                    currentRng.shuffle(existing).also { currentRng = it.second }.first
+                }
+            }
+
+            if (definitions.size != hidden.size) continue
+            for ((entityId, cardDef) in hidden.zip(definitions)) {
+                val old = sampled.getEntity(entityId) ?: continue
+                val ownerId = old.get<OwnerComponent>()?.playerId ?: opponentId
+                var replacement = CardEntityFactory.create(cardDef, ownerId)
+                old.get<RevealedToComponent>()?.let { replacement = replacement.with(it) }
+                sampled = sampled.withEntity(entityId, replacement)
+            }
+
+            val libraryKey = ZoneKey(opponentId, Zone.LIBRARY)
+            val library = sampled.getZone(libraryKey)
+            val hiddenLibraryIds = hidden.filterTo(mutableSetOf()) { it in library }
+            val (shuffledHidden, next) = currentRng.shuffle(library.filter { it in hiddenLibraryIds })
+            currentRng = next
+            val iterator = shuffledHidden.iterator()
+            val shuffledLibrary = library.map { id ->
+                if (id in hiddenLibraryIds) iterator.next() else id
+            }
+            sampled = sampled.copy(zones = sampled.zones + (libraryKey to shuffledLibrary))
+        }
+        return sampled
+    }
+
+    private fun hiddenCards(
+        state: GameState,
+        opponentId: EntityId,
+        viewerId: EntityId,
+    ): List<EntityId> {
+        val handKey = ZoneKey(opponentId, Zone.HAND)
+        val handHidden = !visibility.isZoneVisibleTo(state, handKey, viewerId)
+        val candidates = buildList {
+            addAll(state.getLibrary(opponentId))
+            if (handHidden) addAll(state.getHand(opponentId))
+        }
+        val visibleTop = state.getLibrary(opponentId).firstOrNull()?.takeIf {
+            visibility.revealsTopOfLibraryPublicly(state, opponentId) ||
+                (opponentId == viewerId && visibility.hasLookAtTopOfLibrary(state, viewerId))
+        }
+        val referencedByStack = state.stack.flatMapTo(mutableSetOf()) { stackId ->
+            state.getEntity(stackId)?.get<TargetsComponent>()?.targets.orEmpty().mapNotNull {
+                when (it) {
+                    is ChosenTarget.Card -> it.cardId
+                    is ChosenTarget.Permanent -> it.entityId
+                    is ChosenTarget.Spell -> it.spellEntityId
+                    is ChosenTarget.Player -> null
+                }
+            }
+        }
+        return candidates.filter { id ->
+            id != visibleTop &&
+                id !in referencedByStack &&
+                // Continuation frames carry entity references in several different shapes.
+                // Quiet search roots normally have none; pinning while one exists is the safe
+                // fallback until those shapes share a common reference visitor.
+                state.continuationStack.isEmpty() &&
+                !visibility.isCardRevealedTo(state, id, viewerId) &&
+                isSafeToRewrite(state.getEntity(id))
+        }
+    }
+
+    /**
+     * A normal hidden card has only definition-derived identity/ownership components. Anything
+     * else may be referenced by an in-flight effect or carry state that a different definition
+     * cannot legally inherit, so it is pinned.
+     */
+    private fun isSafeToRewrite(container: ComponentContainer?): Boolean {
+        if (container == null) return false
+        return container.all().all {
+            it is CardComponent ||
+                it is OwnerComponent ||
+                it is ControllerComponent ||
+                it is RevealedToComponent ||
+                it is CantBeCounteredComponent ||
+                it is CantBeCopiedComponent ||
+                it is HasMorphAbilityComponent ||
+                it is ProtectionComponent ||
+                it is SelfZoneRedirectComponent ||
+                it is HexproofFromComponent ||
+                it is ToxicComponent
+        }
+    }
+
+    private fun fromKnownDecklist(
+        state: GameState,
+        opponentId: EntityId,
+        hidden: List<EntityId>,
+        model: OpponentModel.KnownDecklist,
+        rng: GameRng,
+    ): Pair<List<CardDefinition>, GameRng> {
+        val remaining = model.cards.toMutableMap()
+        val sampledIds = hidden.toSet()
+        for ((id, container) in state.entities) {
+            if (id in sampledIds || container.get<OwnerComponent>()?.playerId != opponentId) continue
+            val name = container.get<CardComponent>()?.name ?: continue
+            remaining.computeIfPresent(name) { _, n -> (n - 1).coerceAtLeast(0) }
+        }
+        val pool = remaining.flatMap { (name, copies) ->
+            val definition = cardRegistry.getCard(name) ?: return@flatMap emptyList()
+            List(copies) { definition }
+        }
+        if (pool.size < hidden.size) return emptyList<CardDefinition>() to rng
+        val (shuffled, next) = rng.shuffle(pool)
+        return shuffled.take(hidden.size) to next
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/OpponentModel.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/OpponentModel.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.ai.engine.hidden
+
+/**
+ * Prior knowledge available when sampling an opponent's hidden cards.
+ *
+ * A known list is appropriate for open-decklist formats and the arena. When no list is available,
+ * identity permutation removes knowledge of which hidden card occupies which slot without
+ * inventing cards outside the game. The latter is intentionally "cheating-lite": it knows the
+ * hidden multiset, but not hand contents or library order.
+ */
+sealed interface OpponentModel {
+    data class KnownDecklist(val cards: Map<String, Int>) : OpponentModel {
+        init {
+            require(cards.values.all { it >= 0 }) { "Decklist counts must be non-negative" }
+        }
+    }
+
+    data object IdentityPermutation : OpponentModel
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
 import com.wingedsheep.ai.engine.budget.RolloutBudgetPolicy
 import com.wingedsheep.ai.engine.budget.TieredBudgetPolicy
 import com.wingedsheep.ai.engine.rollout.RolloutSettings
+import com.wingedsheep.ai.engine.hidden.OpponentModel
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.EntityId
 
@@ -20,8 +21,17 @@ import com.wingedsheep.sdk.model.EntityId
  * recursion guard across concurrent games.
  */
 data class ArenaAgent(val name: String, val profile: AiProfile) {
-    fun createPlayer(registry: CardRegistry, playerId: EntityId): AIPlayer =
-        AIPlayer.create(registry, playerId, profile)
+    fun createPlayer(
+        registry: CardRegistry,
+        playerId: EntityId,
+        opponentDecks: Map<EntityId, Map<String, Int>> = emptyMap(),
+    ): AIPlayer =
+        AIPlayer.create(
+            registry,
+            playerId,
+            profile,
+            opponentDecks.mapValues { OpponentModel.KnownDecklist(it.value) },
+        )
 }
 
 /**
@@ -83,6 +93,7 @@ object ArenaAgents {
         // is what makes its number attributable to the rollouts. Still ~50× a `v0` game, so size
         // runs accordingly.
         ArenaAgent("v0-rollout", AiProfile.PHASE7),
+        ArenaAgent("v0-rollout-determinized", AiProfile.PHASE8),
         // The rollout ladder: the same agent at four playout counts. Two jobs. It makes the arena
         // affordable, and it is Phase 7's safety net — the direct analogue of
         // `ArenaBudgetScalingTest`. What it measured: strength rises from 4 to 8 playouts and then

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/TableGameRunner.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/TableGameRunner.kt
@@ -202,7 +202,15 @@ object TableGameRunner {
         // startingPlayerIndex = 0 keeps turnOrder aligned with the configured player order, so
         // seat index and turnOrder index are the same thing.
         val seatIds = init.state.turnOrder
-        val players = seatIds.mapIndexed { seat, id -> agents[seat].createPlayer(registry, id) }
+        val decklistsByPlayer = seatIds.mapIndexed { seat, id ->
+            val deck = decks[seat]
+            val names = if (deck.cardEntries.isNotEmpty()) deck.cardEntries.map { it.name } else deck.cards
+            val allNames = names + listOfNotNull(deck.commander)
+            id to allNames.groupingBy { it }.eachCount()
+        }.toMap()
+        val players = seatIds.mapIndexed { seat, id ->
+            agents[seat].createPlayer(registry, id, decklistsByPlayer)
+        }
         val bySeat = seatIds.withIndex().associate { (seat, id) -> id to seat }
         fun seatOf(playerId: EntityId) = bySeat[playerId] ?: -1
         fun aiFor(playerId: EntityId) = players[seatOf(playerId)]

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/hidden/DeterminizerInvariantsTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.ai.engine.hidden
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.sdk.model.GameRng
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class DeterminizerInvariantsTest : ScenarioTestBase() {
+
+    init {
+        test("sampling preserves structure and everything visible to the viewer") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Forest")
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Craw Wurm")
+                .withCardOnBattlefield(2, "Forest")
+                .build()
+            val before = game.state
+            val sampled = Determinizer(cardRegistry).sample(
+                before,
+                game.player1Id,
+                OpponentModel.IdentityPermutation,
+                GameRng.seeded(991L),
+            )
+
+            sampled.entities.keys shouldBe before.entities.keys
+            sampled.zones.keys shouldBe before.zones.keys
+            sampled.zones.forEach { (key, ids) ->
+                ids.shouldContainExactlyInAnyOrder(before.zones.getValue(key))
+            }
+
+            val transformer = ClientStateTransformer(cardRegistry)
+            val visibleBefore = transformer.transform(before, game.player1Id)
+            val visibleAfter = transformer.transform(sampled, game.player1Id)
+            visibleAfter.cards shouldBe visibleBefore.cards
+            visibleAfter.zones.map { it.zoneId to it.size } shouldBe
+                visibleBefore.zones.map { it.zoneId to it.size }
+        }
+
+        test("the same seed samples the same world and a different seed can change it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears")
+                .withCardInLibrary(2, "Craw Wurm")
+                .build()
+            val determinizer = Determinizer(cardRegistry)
+
+            val first = determinizer.sample(
+                game.state, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(7L)
+            )
+            val replay = determinizer.sample(
+                game.state, game.player1Id, OpponentModel.IdentityPermutation, GameRng.seeded(7L)
+            )
+            first shouldBe replay
+            val worlds = (7L..22L).map { seed ->
+                hiddenNames(
+                    determinizer.sample(
+                        game.state,
+                        game.player1Id,
+                        OpponentModel.IdentityPermutation,
+                        GameRng.seeded(seed),
+                    ),
+                    game.player2Id,
+                )
+            }
+            worlds.distinct().size shouldNotBe 1
+        }
+
+        test("an individually revealed hand card is pinned") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(2, "Mountain")
+                .withCardInHand(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears")
+                .build()
+            val revealedId = game.state.getHand(game.player2Id).first()
+            val before = game.state.updateEntity(revealedId) {
+                it.with(RevealedToComponent.to(game.player1Id))
+            }
+
+            val sampled = Determinizer(cardRegistry).sample(
+                before,
+                game.player1Id,
+                OpponentModel.IdentityPermutation,
+                GameRng.seeded(4L),
+            )
+
+            sampled.getEntity(revealedId)?.get<CardComponent>() shouldBe
+                before.getEntity(revealedId)?.get<CardComponent>()
+        }
+
+        test("known decklists subtract visible cards before sampling the hidden remainder") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Forest")
+                .withCardInHand(2, "Mountain")
+                .withCardInLibrary(2, "Grizzly Bears")
+                .build()
+
+            val sampled = Determinizer(cardRegistry).sample(
+                game.state,
+                game.player1Id,
+                OpponentModel.KnownDecklist(
+                    mapOf("Forest" to 1, "Mountain" to 1, "Grizzly Bears" to 1)
+                ),
+                GameRng.seeded(11L),
+            )
+
+            hiddenNames(sampled, game.player2Id).sorted() shouldBe
+                listOf("Grizzly Bears", "Mountain")
+        }
+
+        test("a publicly revealed top card stays pinned in the top library slot") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Goblin Spy")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Hill Giant")
+                .withCardInLibrary(2, "Grizzly Bears")
+                .build()
+            val topId = game.state.getLibrary(game.player2Id).first()
+            val topCard = game.state.getEntity(topId)!!.require<CardComponent>()
+
+            val sampled = Determinizer(cardRegistry).sample(
+                game.state,
+                game.player1Id,
+                OpponentModel.IdentityPermutation,
+                GameRng.seeded(81L),
+            )
+
+            sampled.getLibrary(game.player2Id).first() shouldBe topId
+            sampled.getEntity(topId)!!.require<CardComponent>() shouldBe topCard
+        }
+
+        test("the viewer does not retain knowledge of their own library order") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .build()
+            val originalOrder = game.state.getLibrary(game.player1Id)
+
+            val sampledOrders = (1L..16L).map { seed ->
+                Determinizer(cardRegistry).sample(
+                    game.state,
+                    game.player1Id,
+                    OpponentModel.IdentityPermutation,
+                    GameRng.seeded(seed),
+                ).getLibrary(game.player1Id)
+            }
+
+            sampledOrders.distinct().size shouldNotBe 1
+            sampledOrders.first().shouldContainExactlyInAnyOrder(originalOrder)
+        }
+    }
+
+    private fun hiddenNames(
+        state: com.wingedsheep.engine.state.GameState,
+        opponentId: com.wingedsheep.sdk.model.EntityId,
+    ): List<String> = (state.getHand(opponentId) + state.getLibrary(opponentId)).map {
+        state.getEntity(it)!!.require<CardComponent>().name
+    }
+}

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -3,16 +3,17 @@
 A phased plan to make the in-game engine AI measurably stronger, on a scoreboard we trust, using
 mechanisms that generalize across the whole card catalog rather than per-card special cases.
 
-**Status:** **Phases 0–7 shipped**, plus 3 of Phase 2b's 6 categories (Phase 7 on 2026-07-29) —
+**Status:** **Phases 0–8 shipped**, plus 3 of Phase 2b's 6 categories (Phase 8 on 2026-07-29) —
 baselines in [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md), measurement guide in
 [`docs/ai/measurement.md`](../docs/ai/measurement.md). Four scoreboards now exist: the arena
 (`just arena`), the 66-puzzle suite (`just arena-puzzles`, **60/66 today**), the multiplayer pod
 arena (`just arena-pod`) and the budget-scaling ladder (`just arena-budget-scaling`, **monotone**).
 The primary strength lever is in: the rollout evaluator beats `v0` **56.0%, CI [52.0%, 59.7%]**.
-Next up is **Phase 8, determinization** — the one phase that deliberately *costs* strength, because
-search over a cheated state is search over a lie, and a search is exactly the thing that turns
-cheating into an advantage. Phases are individually shippable and ordered by dependency, not by
-appeal.
+Phase 8 removes exact opponent-hand and library-order knowledge from rollout search. Its paired
+smoke found no detectable dip against the full-information control (49%, CI [43%, 55%]) and retained
+the Phase 7 strength point estimate against `v0` (55%, CI [48%, 62%]); the merge-sized measurement
+remains intentionally separate because rollout arenas are expensive. Next up is **Phase 9,
+Texel-style evaluation tuning**.
 
 **Related:** [`engine-performance.md`](engine-performance.md) — the CPU profile this plan's
 performance phase built on. **Every step in that document is now closed**; Phase 5a was its Step 4
@@ -1265,7 +1266,7 @@ puzzle gains in sequencing / race math / board-wipe timing; p95 latency ≤5 s.
 
 ---
 
-### Phase 8 — Determinization (fair play) · *5–7 d*
+### Phase 8 — Determinization (fair play) · *5–7 d* — ✅ **DONE 2026-07-29**
 
 #### 8a. Extract the visibility oracle
 
@@ -1425,7 +1426,7 @@ but tanks a puzzle category, look hard before shipping.
 0̶ → 1̶ → 2̶ → 3̶ → 4̶ → 5̶ → 6̶ → 2b🟡 → 7̶ → 8 → 9 → 10
 ```
 
-Phases 0–7 are done — all four scoreboards exist, the evaluator is no longer one-eyed at a pod
+Phases 0–8 are done — all four scoreboards exist, the evaluator is no longer one-eyed at a pod
 table, the budget ladder is calibrated and monotone before any rollout depends on it, the engine's
 quadratic battlefield scans are gone (−21% engine CPU, and `engine-performance.md` is now fully
 closed out), the leaf evaluator can see a permanent that has no power and toughness, and the primary
@@ -1433,10 +1434,9 @@ strength lever is in at **57.3%, CI [53.0%, 61.7%]** against `v0`. **Phase 5 nev
 critical path** — simulation was already ~2× the speed the rollout budget needs — so it was taken as
 a standing engine win, not a prerequisite.
 
-Next up is **Phase 8, determinization** — the one phase that deliberately *costs* strength, and the
-one to do next anyway, because a search is exactly the thing that turns cheating into an advantage.
-The AI reads the opponent's unmasked hand and library order, and Phase 7 just gave it the machinery
-to play twenty lines against that knowledge instead of one.
+Next up is **Phase 9, Texel-style evaluation tuning**. Phase 8 now samples one viewer-consistent
+world before any candidate simulation, so search no longer plays twenty lines against exact hidden
+hand identities and library order.
 
 Phase 7 leaves three pieces of homework of its own. **`ThreatAssessment`'s 99-turn sentinel** is now
 a measured hazard rather than a suspected one (correction 1 above): it puts ±176 of uncalibrated
@@ -1456,7 +1456,7 @@ Ranked by strength-per-effort, independent of ordering:
 
 | Rank | Phase | Effort | Why |
 |---|---|---|---|
-| — | **6̶** CardIntent | 5–7 d | **Done.** Was ranked 1. Removed the flat-0.5 blindness to every artifact/enchantment/PW; puzzles 39/48 → 44/48, arena neutral. Two of its five planned consumers (rollout policy, determinization prior) are Phases 7 and 8 and are still to come. |
+| — | **6̶** CardIntent | 5–7 d | **Done.** Was ranked 1. Removed the flat-0.5 blindness to every artifact/enchantment/PW; puzzles 39/48 → 44/48, arena neutral. Its rollout-policy and determinization-prior consumers shipped in Phases 7 and 8. |
 | — | **3̶** multiplayer eval | 1–2 d | **Done.** Was ranked 1: the evaluator scored a whole pod as a duel against one arbitrary neighbour, and read a stale life component in 2HG. |
 | 1 | **9** Texel tuning | 4–6 d | Replaces ~25 guessed constants with fitted ones, and each later phase raises the stakes: two of the remaining puzzle failures are *one* constant (`CardAdvantage.cardValue(0) = −3.0`), Phase 7 added a fifth guess (`staticWeight`), and `ThreatAssessment`'s 99-turn sentinel is now a measured hazard rather than a suspected one. Cheap once the arena exists. |
 | — | **7̶** rollout evaluator | 6–9 d | **Done.** The real lever, and it delivered against `v0`; the Fog puzzle Phase 2 assigned to it is closed. Two surprises worth carrying forward: squashing an *absolute* board score destroys the search, and a *pure* rollout is weaker than the greedy AI it replaces. |
@@ -1464,7 +1464,7 @@ Ranked by strength-per-effort, independent of ordering:
 | 4 | **1̶ / 2̶** arena + puzzles | 7–10 d | No direct strength — but nothing above is *knowable* without them. Both done. |
 | — | **4̶a** auto-pass filter | 3–5 d | **Done.** Demoted by Phase 0 and rescoped to "skip the enumeration": 40% of priority windows now never call the enumerator. Also closed Phase 1's 889-of-945 illegal-action finding, which turned out to be a targeting bug. |
 | — | **4̶b** DecisionBudget | 2–3 d | **Done.** Enabling infrastructure, and it measures like it — neutral in the arena, monotone in the scaling ladder. |
-| 2 | **8** determinization | 5–7 d | **Costs** strength (fairness price). Do it because search over a cheated state is search over a lie. |
+| — | **8̶** determinization | 5–7 d | **Done.** Search samples a shared viewer-consistent world; the paired smoke found no detectable dip and retained a 55% point estimate against `v0`. |
 | — | **5̶a** hoist O(n²) scans | 3–5 d | **Done.** Demoted by Phase 0 (not a rollout prerequisite), taken as a standing engine win anyway: `findAvailableManaSources` 59% → 3.1% inclusive, −21% engine CPU. Closed `engine-performance.md` Step 4. |
 | — | **5̶c** persistent collections | 4–6 d | **Dropped**, gate checked. Post-5a profile puts the allocation cluster at ~2% (`Arena::grow` 1.37%). The top leaf is now `PredicateEvaluator.matchesCardPredicate` at 20.4% self. |
 | — | projection incrementalization | 2+ wk | **Skip.** 7.4% in the profile, 11% measured cold, and already cached. |

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -56,6 +56,27 @@ is `map(::score)`, so `LEGACY_V0` is bit-identical; `FrozenBaselineTest` is what
 
 ---
 
+## Hidden information (Phase 8)
+
+Rollout profiles may enable determinization. Before any candidate is simulated, `Strategist` asks
+`Determinizer` for one world consistent with the acting player's view and uses that same root for
+every candidate. Sampling before the one-ply simulation matters because pending decisions reached
+by that simulation can inspect hidden zones too. Sharing the world is essential: independently
+sampling candidates would make hidden-information variance look like move quality.
+
+`Visibility` in `rules-engine/view` is the common oracle for both client masking and AI
+determinization. The determinizer rewrites identities, never entities: entity IDs, zone membership,
+pending decisions, targets and continuations remain intact. Individually revealed cards and cards
+carrying runtime state are pinned. With a known decklist it samples from `decklist − seen`;
+otherwise it permutes the existing hidden multiset. That fallback removes exact hand and
+library-order knowledge, but remains “cheating-lite” because it knows which cards exist unseen.
+
+Phase 8 starts with one shared determinization per search. More worlds compete directly with rollout
+count, so raising K requires an arena result showing it buys more strength at the same wall-clock
+budget.
+
+---
+
 ## Scores are in raw evaluator units, everywhere above the leaf
 
 The pass comparison, the hold policy's `±1.5`, and a `CardAdvisor` returning `defaultScore + 2.0`

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1126,3 +1126,31 @@ that sees one candidate cannot decide to spend four times as much on it as on it
 no override and `LEGACY_V0` comes out bit-identical — `FrozenBaselineTest` is what proves it. The
 Strategist's loop became three passes (simulate all, score all, adjust all) which is also simply a
 clearer shape than the old interleaving.
+
+---
+
+# Phase 8 — Determinization
+
+Measured 2026-07-29, 8-core M1 Pro, BLB sealed, seed 20260727.
+
+```bash
+just arena v0-rollout v0-rollout-determinized 100
+just arena v0 v0-rollout-determinized 100
+```
+
+The initial paired smoke found no detectable fairness cost:
+
+| Matchup | Win share for A | Pair CI | Games | Completed |
+|---|---:|---:|---:|---:|
+| full-information rollout vs determinized rollout | 49.0% | [43.0%, 55.0%] | 100 | 100% |
+| determinized rollout vs frozen `v0` | **55.0%** | [48.0%, 62.0%] | 100 | 100% |
+
+This sample prices only a large regression; it does not prove equivalence. Its useful result is that
+sampling one shared known-deck world did not produce the expected catastrophic dip or destabilize
+games. The fair agent's 55% point estimate against `v0` retains Phase 7's strength signal, while the
+smoke-sized interval still spans parity. The 1,000-game merge-sized run remains the
+publication-quality measurement.
+
+The run reported three `CastSpell: Not enough mana to cast this spell` rejections, all on one paired
+seed and present in both seat orientations. That is the same pre-existing enumerator/processor
+disagreement Phase 7 records above, not a new error class introduced by determinization.

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1159,6 +1159,11 @@ The server's responsibilities are strictly limited to:
 
 ### 3.2 State Masking (Fog of War)
 
+Hidden-zone visibility is centralized in `rules-engine/view/Visibility`. Both
+`ClientStateTransformer` and the engine AI's determinizer consume it, so a reveal effect cannot be
+visible to the client while remaining hidden from the AI (or vice versa). Consumers must not
+reimplement hand, library, teammate, turn-control, or individually-revealed-card rules.
+
 **Principle:** Each player sees a filtered view of the game state.
 
 In Magic, players cannot see each other's hands or libraries. The `ClientStateTransformer` produces a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -75,6 +75,7 @@ class ClientStateTransformer(
 ) {
 
     private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
+    private val visibility = Visibility(cardRegistry, debugMode)
     // Reused (with conditionEvaluator + cardRegistry) to surface each player's effective maximum
     // hand size via the shared com.wingedsheep.engine.core.MaximumHandSize source of truth.
     private val dynamicAmountEvaluator = DynamicAmountEvaluator(conditionEvaluator)
@@ -102,7 +103,7 @@ class ClientStateTransformer(
         val zones = mutableListOf<ClientZone>()
 
         for ((zoneKey, entityIds) in state.zones) {
-            val isZoneVisible = isZoneVisibleTo(state, zoneKey, viewingPlayerId, isSpectator)
+            val isZoneVisible = visibility.isZoneVisibleTo(state, zoneKey, viewingPlayerId, isSpectator)
 
             // For libraries we always send the full ordered list of entity IDs so the client can
             // render a correctly sized stack. Individual card *details* are only populated for cards
@@ -113,7 +114,7 @@ class ClientStateTransformer(
                 entityIds
             } else {
                 entityIds.filter { entityId ->
-                    isCardRevealedTo(state, entityId, viewingPlayerId)
+                    visibility.isCardRevealedTo(state, entityId, viewingPlayerId)
                 }
             }
             val zoneCardIds = if (isLibrary) entityIds else cardsWithDetails
@@ -403,8 +404,8 @@ class ClientStateTransformer(
         if (!isInFaceDownZone || !container.has<FaceDownComponent>()) return true
         val controllerId = container.get<ControllerComponent>()?.playerId
         return controllerId == viewingPlayerId ||
-            isCardRevealedTo(state, entityId, viewingPlayerId) ||
-            (zoneType == Zone.BATTLEFIELD && hasLookAtFaceDownCreatures(state, viewingPlayerId))
+            visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
+            (zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
     }
 
     /**
@@ -477,43 +478,6 @@ class ClientStateTransformer(
         return false
     }
 
-    private fun isZoneVisibleTo(
-        state: GameState,
-        zoneKey: ZoneKey,
-        viewingPlayerId: EntityId,
-        isSpectator: Boolean
-    ): Boolean {
-        return when (zoneKey.zoneType) {
-            Zone.LIBRARY -> false
-            // During a Mindslaver-style hijack the controller (actor) sees what the
-            // affected player sees of their own hand. Spectators never gain visibility.
-            // A non-spectator viewer also sees an opponent's hand while they control a
-            // permanent that makes their opponents play with hands revealed (Seer's Vision).
-            // In Two-Headed Giant (CR 810.2b) teammates share strategy openly, so a player
-            // always sees their teammate's hand; [teammatesOf] is empty in non-team games, so
-            // this clause is inert for 2-player / Free-for-All. (Library stays hidden — teams
-            // share life and turns, not card knowledge of each other's library order.)
-            Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-                (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
-                (!isSpectator && state.teammatesOf(viewingPlayerId).contains(zoneKey.ownerId)) ||
-                (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
-                    revealsOpponentHandsTo(state, viewingPlayerId))
-            // The sideboard is private "outside the game" knowledge (CR 100.4 / 400.11a): only its
-            // owner ever sees it, never opponents or spectators. (The wish *choice* itself is driven
-            // by the SelectFromCollection decision, which sends the deciding player the gathered
-            // cards directly — it doesn't depend on this passive zone visibility.) The actorFor
-            // clause keeps a Mindslaver-style controller able to see the sideboard of the player
-            // whose turn they're piloting.
-            Zone.SIDEBOARD -> debugMode || zoneKey.ownerId == viewingPlayerId ||
-                (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
-            Zone.BATTLEFIELD,
-            Zone.GRAVEYARD,
-            Zone.STACK,
-            Zone.EXILE,
-            Zone.COMMAND -> true
-        }
-    }
-
     /**
      * Resolve a static ability that may be gated by a [ConditionalStaticAbility] (e.g. The
      * Belligerent's play-from-top window, a [LookAtTopOfLibrary] gated on "attacked this turn").
@@ -522,81 +486,31 @@ class ClientStateTransformer(
      * otherwise. Mirrors `CastPermissionUtils.activeStaticAbility` so that what a player can SEE
      * stays in sync with what the legal-actions layer lets them DO.
      */
-    private fun activeStaticAbility(
-        state: GameState,
-        ability: com.wingedsheep.sdk.scripting.StaticAbility,
-        sourceId: EntityId,
-        controllerId: EntityId
-    ): com.wingedsheep.sdk.scripting.StaticAbility? = when (ability) {
-        is ConditionalStaticAbility -> {
-            val context = EffectContext(sourceId = sourceId, controllerId = controllerId)
-            if (conditionEvaluator.evaluate(state, ability.condition, context)) ability.ability else null
-        }
-        else -> ability
-    }
-
-    /**
-     * Check whether any static ability active on [playerId]'s battlefield satisfies [predicate],
-     * honoring [ConditionalStaticAbility] gates via [activeStaticAbility].
-     */
-    private fun hasActiveStaticAbility(
-        state: GameState,
-        playerId: EntityId,
-        predicate: (com.wingedsheep.sdk.scripting.StaticAbility) -> Boolean
-    ): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { ability ->
-                    activeStaticAbility(state, ability, entityId, playerId)?.let(predicate) == true
-                }
-            ) {
-                return true
-            }
-        }
-        return false
-    }
-
     /**
      * Check if a player controls a permanent that reveals the top card of their library to all
      * players — either [PlayFromTopOfLibrary] (Future Sight) or [RevealTopOfLibrary] (Goblin Spy).
      * The two abilities share the public-reveal visibility; they diverge only in play permission,
      * which is handled by the cast/play-from-top paths (keyed on [PlayFromTopOfLibrary] alone).
      */
-    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
-        hasActiveStaticAbility(state, playerId) { it is PlayFromTopOfLibrary || it is RevealTopOfLibrary }
-
-    /**
-     * Check if [playerId] controls a permanent with [OpponentsPlayWithHandsRevealed]
-     * (e.g., Seer's Vision). While they do, their opponents' hands are visible to them.
-     */
-    private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean =
-        hasActiveStaticAbility(state, playerId) { it is OpponentsPlayWithHandsRevealed }
-
     /**
      * Check if a player controls a permanent with an active LookAtTopOfLibrary (e.g., Lens of
      * Clarity; The Belligerent's is gated behind "attacked this turn").
      * This reveals the top card of the controller's library privately (only to them).
      */
-    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
-        hasActiveStaticAbility(state, playerId) { it is LookAtTopOfLibrary }
-
     /**
      * Check if a player controls a permanent with LookAtFaceDownCreatures (e.g., Lens of Clarity).
      * This reveals the identity of opponent's face-down battlefield creatures to the controller.
      */
-    private fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
-        hasActiveStaticAbility(state, playerId) { it is LookAtFaceDownCreatures }
-
     /**
      * Check if an individual card has been revealed to a specific player.
      * This is used for "look at hand" or "reveal hand" effects where the viewing player
      * can see specific cards in an otherwise hidden zone.
      */
-    private fun isCardRevealedTo(state: GameState, entityId: EntityId, viewingPlayerId: EntityId): Boolean {
-        val revealedComponent = state.getEntity(entityId)?.get<RevealedToComponent>()
-        return revealedComponent?.isRevealedTo(viewingPlayerId) == true
-    }
+    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
+        visibility.revealsTopOfLibraryPublicly(state, playerId)
+
+    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
+        visibility.hasLookAtTopOfLibrary(state, playerId)
 
     /**
      * Transform an activated or triggered ability on the stack into a ClientCard DTO.
@@ -894,8 +808,8 @@ class ClientStateTransformer(
             // Also check LookAtFaceDownCreatures (e.g., Lens of Clarity) — only for battlefield creatures,
             // not face-down spells on the stack (per ruling).
             val isRevealedToViewer = !isSpectator && (
-                isCardRevealedTo(state, entityId, viewingPlayerId) ||
-                (zoneKey.zoneType == Zone.BATTLEFIELD && hasLookAtFaceDownCreatures(state, viewingPlayerId))
+                visibility.isCardRevealedTo(state, entityId, viewingPlayerId) ||
+                (zoneKey.zoneType == Zone.BATTLEFIELD && visibility.hasLookAtFaceDownCreatures(state, viewingPlayerId))
             )
 
             // Face-down exiled cards show minimal info (not creatures, no P/T)
@@ -2886,7 +2800,7 @@ class ClientStateTransformer(
         val restrictionController = state.projectedState.getController(entityId)
         if (cardDefForRestrictions != null && restrictionController != null) {
             for (ability in cardDefForRestrictions.script.staticAbilities) {
-                val active = activeStaticAbility(state, ability, entityId, restrictionController)
+                val active = visibility.activeStaticAbility(state, ability, entityId, restrictionController)
                 if (active is com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan &&
                     active.filter.scope is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self
                 ) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
+import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.RevealTopOfLibrary
+import com.wingedsheep.sdk.scripting.StaticAbility
+
+/**
+ * The engine's single source of truth for which hidden-zone identities a player may see.
+ *
+ * Client masking and AI determinization deliberately share this service. Adding a reveal rule to
+ * one without the other would either leak information to the AI or hide information it is legally
+ * entitled to use.
+ */
+class Visibility(
+    private val cardRegistry: CardRegistry,
+    private val debugMode: Boolean = false,
+) {
+    private val conditionEvaluator = ConditionEvaluator()
+
+    fun isZoneVisibleTo(
+        state: GameState,
+        zoneKey: ZoneKey,
+        viewingPlayerId: EntityId,
+        isSpectator: Boolean = false,
+    ): Boolean = when (zoneKey.zoneType) {
+        Zone.LIBRARY -> false
+        Zone.HAND -> debugMode || zoneKey.ownerId == viewingPlayerId ||
+            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId) ||
+            (!isSpectator && zoneKey.ownerId in state.teammatesOf(viewingPlayerId)) ||
+            (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
+                revealsOpponentHandsTo(state, viewingPlayerId))
+        Zone.SIDEBOARD -> debugMode || zoneKey.ownerId == viewingPlayerId ||
+            (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
+        Zone.BATTLEFIELD,
+        Zone.GRAVEYARD,
+        Zone.STACK,
+        Zone.EXILE,
+        Zone.COMMAND -> true
+    }
+
+    fun isCardRevealedTo(
+        state: GameState,
+        entityId: EntityId,
+        viewingPlayerId: EntityId,
+    ): Boolean = state.getEntity(entityId)
+        ?.get<RevealedToComponent>()
+        ?.isRevealedTo(viewingPlayerId) == true
+
+    fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is LookAtFaceDownCreatures }
+
+    fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) {
+            it is PlayFromTopOfLibrary || it is RevealTopOfLibrary
+        }
+
+    fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is LookAtTopOfLibrary }
+
+    private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is OpponentsPlayWithHandsRevealed }
+
+    private fun hasActiveStaticAbility(
+        state: GameState,
+        playerId: EntityId,
+        predicate: (StaticAbility) -> Boolean,
+    ): Boolean {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.any { ability ->
+                    activeStaticAbility(state, ability, entityId, playerId)?.let(predicate) == true
+                }
+            ) return true
+        }
+        return false
+    }
+
+    fun activeStaticAbility(
+        state: GameState,
+        ability: StaticAbility,
+        sourceId: EntityId,
+        controllerId: EntityId,
+    ): StaticAbility? = when (ability) {
+        is ConditionalStaticAbility -> {
+            val context = EffectContext(sourceId = sourceId, controllerId = controllerId)
+            if (conditionEvaluator.evaluate(state, ability.condition, context)) ability.ability else null
+        }
+        else -> ability
+    }
+}


### PR DESCRIPTION
## Summary

- centralize card and zone visibility rules for reuse by client masking and AI search
- determinize hidden hands and libraries once per search root using known decklists, with identity permutation fallback
- add the `v0-rollout-determinized` profile, arena wiring, invariant coverage, and Phase 8 documentation

## Verification

- `just test` (passed before final focused refinements)
- `just test-ai` (passed after all implementation changes)
- post-rebase diff check passed; a duplicate post-rebase AI run was skipped because another agent held the serialized Gradle lock

## Smoke measurement

- full-information rollout vs determinized rollout, 100 games: 49% / 51%
- v0 baseline vs determinized rollout, 100 games: 45% / 55%
- both runs completed 100%; three pre-existing insufficient-mana illegal-action incidents were recorded in each run

The longer merge-sized arena run was intentionally stopped to release the shared test lock; these results are smoke measurements rather than a promotion claim.