### PR TITLE
Wire cube packs into tournament lobbies

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -347,7 +347,19 @@ deckbuilder's `setDeck`. `lockedDeck` empty = build fresh; non-empty = keep thos
 the rest (**heuristic** engine). The **draftsim** engine ignores `lockedDeck`/`targetSize` and always
 returns a fresh 40-card limited build (23 nonland + 17 lands), matching the original Auto-Build.
 
-## 3c. Free-for-All Lobby Mode (WebSocket)
+## 3c. Cube Pack Source (WebSocket)
+
+`UpdateLobbySettings` may replace the lobby's normal set source with a cube by sending the full
+`cubeCards` name list plus `cubeName`, `packSize`, and `cubeBasicLandSetCode`. Duplicate names are
+duplicate physical cards. The server resolves the entire list atomically; an unresolved card rejects
+the update, and `cubeCards: []` clears cube mode. While a cube is active, `setCodes` changes,
+`boosterDistribution`, and `chaosBoosters` are inert.
+
+`LobbySettings` broadcasts only the public summary: `cubeName`, `cubeCardCount`, and `packSize`.
+The synthetic `CUBE` set is deliberately absent from `availableSets`. The server rejects starting
+when the selected format would need more cards than the cube contains.
+
+## 3d. Free-for-All Lobby Mode (WebSocket)
 
 A lobby carries two orthogonal axes: the **format** (`SEALED` / `DRAFT` / `PREMADE_DECKS` / …,
 how the card pool is built) and a new **mode** (`gameMode`: `TOURNAMENT` or `FREE_FOR_ALL`, what

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -22,6 +22,10 @@ import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.gameserver.deck.DeckValidator
 import com.wingedsheep.gameserver.deck.EasterEggDeckInjector
+import com.wingedsheep.gameserver.cube.CubeCardEntry
+import com.wingedsheep.gameserver.cube.CubeList
+import com.wingedsheep.gameserver.cube.CubeResolution
+import com.wingedsheep.gameserver.cube.CubeResolver
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import jakarta.annotation.PostConstruct
@@ -1198,12 +1202,17 @@ class LobbyHandler(
         // Reveal any deferred "Random Set" placeholders now that the game is starting — the concrete
         // sets stay hidden in the lobby until this moment (mirrors the Quick Game deferred roll). Done
         // before the extension gate and pool generation so both see concrete, validated set codes.
-        lobby.resolveRandomSets()
+        if (!lobby.isCube) lobby.resolveRandomSets()
+
+        lobby.cubeCapacityError()?.let { error ->
+            sender.sendError(session, ErrorCode.INVALID_ACTION, error)
+            return
+        }
 
         // Booster-based formats can't run on extension sets alone (Premade brings its own decks
         // and ignores the set selection). The lobby may hold an extension-only selection while
         // the host is still assembling it, so this start gate is where the rule is enforced.
-        if (lobby.format != TournamentFormat.PREMADE_DECKS) {
+        if (lobby.format != TournamentFormat.PREMADE_DECKS && !lobby.isCube) {
             extensionOnlyError(lobby.setCodes.mapNotNull { boosterGenerator.getSetConfig(it) })?.let { error ->
                 sender.sendError(session, ErrorCode.INVALID_ACTION, error)
                 return
@@ -2014,8 +2023,54 @@ class LobbyHandler(
             return
         }
 
+        // Cube settings are a full replacement, like the ban list. Resolve immediately so an
+        // unplayable list never becomes lobby state. Empty returns to catalogued-set mode.
+        message.cubeCards?.let { rawNames ->
+            val names = rawNames.map { it.trim() }.filter { it.isNotEmpty() }
+            if (names.isEmpty()) {
+                lobby.configureCube(null)
+                lobby.setCodes = emptyList()
+                lobby.setNames = emptyList()
+                lobby.boosterDistribution = emptyMap()
+            } else {
+                val name = message.cubeName?.trim().orEmpty()
+                if (name.isEmpty()) {
+                    sender.sendError(session, ErrorCode.INVALID_ACTION, "Cube name is required")
+                    return
+                }
+                val basicLandSetCode = message.cubeBasicLandSetCode?.trim().orEmpty()
+                if (boosterGenerator.getSetConfig(basicLandSetCode) == null) {
+                    sender.sendError(session, ErrorCode.INVALID_ACTION, "Invalid cube basic-land set code: $basicLandSetCode")
+                    return
+                }
+                val cubeList = runCatching {
+                    CubeList(
+                        name = name,
+                        cards = names.map { CubeCardEntry(it) },
+                        basicLandSetCode = basicLandSetCode,
+                        packSize = message.packSize ?: CubeList.DEFAULT_PACK_SIZE,
+                    )
+                }.getOrElse {
+                    sender.sendError(session, ErrorCode.INVALID_ACTION, it.message ?: "Invalid cube settings")
+                    return
+                }
+                when (val resolution = CubeResolver(cardRegistry, printingRegistry).resolve(cubeList)) {
+                    is CubeResolution.Success -> lobby.configureCube(resolution.cube)
+                    is CubeResolution.Failure -> {
+                        val misses = resolution.unresolved.joinToString(", ") { it.name }
+                        sender.sendError(
+                            session,
+                            ErrorCode.INVALID_ACTION,
+                            "${resolution.unresolved.size} cube cards aren't implemented: $misses",
+                        )
+                        return
+                    }
+                }
+            }
+        }
+
         // Update sets if provided (can be empty to disable start)
-        message.setCodes?.let { newSetCodes ->
+        if (!lobby.isCube) message.setCodes?.let { newSetCodes ->
             // Allow empty setCodes to disable start button (but won't be able to start)
             // An extension-only selection is allowed here as an intermediate state (the host may
             // add the extension set first, then the base set) — the start handler is the gate.
@@ -2166,7 +2221,7 @@ class LobbyHandler(
         }
 
         // Manual booster distribution override (apply after boosterCount)
-        message.boosterDistribution?.let { dist ->
+        if (!lobby.isCube) message.boosterDistribution?.let { dist ->
             // Validate: all keys must be in setCodes, values must be positive, total must equal boosterCount
             val validKeys = dist.keys.all { it in lobby.setCodes }
             val allPositive = dist.values.all { it >= 0 }
@@ -2219,7 +2274,7 @@ class LobbyHandler(
             }
         }
 
-        message.chaosBoosters?.let { lobby.chaosBoosters = it }
+        if (!lobby.isCube) message.chaosBoosters?.let { lobby.chaosBoosters = it }
 
         // Host ban list — the full list is sent each time (not a delta). Trim, drop blanks and
         // duplicates; unknown names are kept as-is (they simply never match a card in the pool),

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1,8 +1,11 @@
 package com.wingedsheep.gameserver.lobby
 
 import com.wingedsheep.gameserver.deck.SideboardDerivation
+import com.wingedsheep.gameserver.cube.CubeSetConfig
+import com.wingedsheep.gameserver.cube.ResolvedCube
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.limited.CubeDealer
 import com.wingedsheep.gameserver.session.PlayerIdentity
 import com.wingedsheep.sdk.limited.BoosterStrategy
 import com.wingedsheep.sdk.limited.CommanderDraftBooster
@@ -330,6 +333,99 @@ class TournamentLobby(
      */
     var ranked: Boolean = false,
 ) {
+    var cube: ResolvedCube? = null
+        private set
+
+    val isCube: Boolean get() = cube != null
+    val packSize: Int get() = cube?.packSize ?: 0
+
+    private var cubeBoosterGenerator: BoosterGenerator? = null
+    private var cubeDealer: CubeDealer? = null
+
+    fun cubeDealerRemainingCards(): List<CardDefinition> = cubeDealer?.remainingCards().orEmpty()
+
+    fun restoreCubeDealer(remainingCards: List<CardDefinition>) {
+        val resolvedCube = requireNotNull(cube) { "Cannot restore a cube dealer without a cube" }
+        cubeDealer = CubeDealer.resume(remainingCards, resolvedCube.packSize)
+    }
+
+    fun configureCube(resolvedCube: ResolvedCube?) {
+        require(state == LobbyState.WAITING_FOR_PLAYERS) { "Cannot change cube after start" }
+        cube = resolvedCube
+        cubeDealer = null
+        cubeBoosterGenerator = resolvedCube?.let {
+            boosterGenerator.withSets(mapOf(CubeSetConfig.SET_CODE to CubeSetConfig.of(it, boosterGenerator)))
+        }
+        if (resolvedCube != null) {
+            setCodes = listOf(CubeSetConfig.SET_CODE)
+            setNames = listOf(resolvedCube.name)
+            boosterDistribution = emptyMap()
+            chaosBoosters = false
+        }
+    }
+
+    fun cubeCapacityError(): String? {
+        val resolvedCube = cube ?: return null
+        if (format == TournamentFormat.PREMADE_DECKS) return null
+        val packsNeeded = when (format) {
+            TournamentFormat.SEALED, TournamentFormat.COMMANDER_SEALED,
+            TournamentFormat.DRAFT, TournamentFormat.COMMANDER_DRAFT -> players.size * boosterCount
+            TournamentFormat.WINSTON_DRAFT, TournamentFormat.GRID_DRAFT -> boosterCount
+            TournamentFormat.PREMADE_DECKS -> 0
+        }
+        val usableCards = resolvedCube.cards.count { card ->
+            bannedCardNames.none { it.equals(card.name, ignoreCase = true) }
+        }
+        val cardsNeeded = packsNeeded * resolvedCube.packSize
+        if (cardsNeeded <= usableCards) return null
+        val calculation = when (format) {
+            TournamentFormat.SEALED, TournamentFormat.COMMANDER_SEALED,
+            TournamentFormat.DRAFT, TournamentFormat.COMMANDER_DRAFT ->
+                "${players.size} players × $boosterCount packs × ${resolvedCube.packSize}"
+            else -> "$boosterCount packs × ${resolvedCube.packSize}"
+        }
+        return "$calculation = $cardsNeeded cards needed, cube has $usableCards"
+    }
+
+    private fun prepareCubeDealer(): Boolean {
+        val resolvedCube = cube ?: return true
+        if (cubeCapacityError() != null) return false
+        val cards = resolvedCube.cards.filterNot { card ->
+            bannedCardNames.any { it.equals(card.name, ignoreCase = true) }
+        }
+        cubeDealer = CubeDealer(cards, resolvedCube.packSize, System.nanoTime())
+        return true
+    }
+
+    private fun packsFor(count: Int): List<List<CardDefinition>> {
+        cubeDealer?.let { return it.deal(count) }
+
+        val strategy = strategyOverrideForFormat()
+        val sequence = if (!chaosBoosters && boosterDistribution.isNotEmpty()) {
+            boosterDistribution.flatMap { (code, packs) -> List(packs) { code } }
+        } else {
+            emptyList()
+        }
+        return List(count) { index ->
+            val sequenceIndex =
+                if (format == TournamentFormat.DRAFT || format == TournamentFormat.COMMANDER_DRAFT) {
+                    currentPackNumber - 1
+                } else {
+                    index
+                }
+            val setCode = sequence.getOrNull(sequenceIndex)
+            if (setCode != null) {
+                boosterGenerator.generateBooster(setCode, strategy, bannedCardNames)
+            } else {
+                boosterGenerator.generateBooster(
+                    setCodes,
+                    strategy,
+                    chaos = chaosBoosters,
+                    bannedCardNames = bannedCardNames,
+                )
+            }
+        }
+    }
 
     /** Whether this lobby may be ranked at all: only a TOURNAMENT-mode bracket has 1v1 matches. */
     val rankedEligible: Boolean get() = gameMode == LobbyGameMode.TOURNAMENT
@@ -381,6 +477,7 @@ class TournamentLobby(
      */
     fun updateSets(newSetCodes: List<String>): Boolean {
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
+        if (isCube) return false
         if (newSetCodes.isEmpty()) return false
 
         // Validate concrete codes; random placeholders are validated only when resolved at start.
@@ -429,7 +526,7 @@ class TournamentLobby(
      * Recalculate the booster distribution after boosterCount changes.
      */
     fun recalculateDistribution() {
-        boosterDistribution = calculateDefaultDistribution(setCodes, boosterCount)
+        boosterDistribution = if (isCube) emptyMap() else calculateDefaultDistribution(setCodes, boosterCount)
     }
 
     /** Players indexed by player ID */
@@ -473,9 +570,9 @@ class TournamentLobby(
      * Basic lands available for deck building: the set's standard art, one printing per type. Shown
      * to the player while building and stamped onto the submitted deck, so both agree.
      */
-    val basicLands: Map<String, CardDefinition> by lazy {
-        if (setCodes.isEmpty()) emptyMap() else boosterGenerator.getBasicLands(setCodes)
-    }
+    val basicLands: Map<String, CardDefinition>
+        get() = if (setCodes.isEmpty()) emptyMap()
+        else (cubeBoosterGenerator ?: boosterGenerator).getBasicLands(setCodes)
 
     /** Players who are ready for the next round */
     private val playersReadyForNextRound = mutableSetOf<EntityId>()
@@ -702,6 +799,15 @@ class TournamentLobby(
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
         if (players.size < 2) return false
         if (format != TournamentFormat.SEALED && format != TournamentFormat.COMMANDER_SEALED) return false
+        if (!prepareCubeDealer()) return false
+
+        if (isCube) {
+            players.forEach { (playerId, playerState) ->
+                players[playerId] = playerState.copy(cardPool = packsFor(boosterCount).flatten())
+            }
+            state = LobbyState.DECK_BUILDING
+            return true
+        }
 
         val strategy = strategyOverrideForFormat()
 
@@ -752,6 +858,7 @@ class TournamentLobby(
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
         if (players.size < 2) return false
         if (format != TournamentFormat.DRAFT && format != TournamentFormat.COMMANDER_DRAFT) return false
+        if (!prepareCubeDealer()) return false
 
         // Set up player order (for pack passing)
         playerOrder = players.keys.toList().shuffled()
@@ -773,24 +880,17 @@ class TournamentLobby(
      * E.g., with {ONS: 1, LGN: 1, SCG: 1}, pack 1 = ONS, pack 2 = LGN, pack 3 = SCG.
      */
     private fun distributeNewPacks() {
-        // Build a sequence of set codes from the distribution (e.g., [ONS, LGN, SCG] for 1/1/1).
-        // Chaos mode ignores per-pack assignments and pulls every pack from the combined pool.
-        val setSequence = if (!chaosBoosters && boosterDistribution.isNotEmpty()) {
-            boosterDistribution.flatMap { (code, count) -> List(count) { code } }
-        } else {
-            null
+        if (isCube) {
+            players.values.zip(packsFor(players.size)).forEach { (playerState, newPack) ->
+                playerState.currentPack = newPack
+                playerState.packQueue.clear()
+                playerState.poolSizeAtRoundStart = playerState.cardPool.size
+            }
+            return
         }
-        // Pick the set for this pack round (1-indexed currentPackNumber)
-        val packSetCode = setSequence?.getOrNull(currentPackNumber - 1)
-
-        val strategy = strategyOverrideForFormat()
 
         players.forEach { (_, playerState) ->
-            val newPack = if (packSetCode != null) {
-                boosterGenerator.generateBooster(packSetCode, strategy, bannedCardNames)
-            } else {
-                boosterGenerator.generateBooster(setCodes, strategy, chaos = chaosBoosters, bannedCardNames = bannedCardNames)
-            }
+            val newPack = packsFor(1).single()
             playerState.currentPack = newPack
             playerState.packQueue.clear()
             playerState.poolSizeAtRoundStart = playerState.cardPool.size
@@ -946,15 +1046,13 @@ class TournamentLobby(
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
         if (players.size != 2) return false
         if (format != TournamentFormat.WINSTON_DRAFT) return false
+        if (!prepareCubeDealer()) return false
 
         // Set up player order (randomize who goes first)
         playerOrder = players.keys.toList().shuffled()
 
         // Generate boosters and shuffle into main deck
-        val allCards = mutableListOf<CardDefinition>()
-        repeat(boosterCount) {
-            allCards.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames))
-        }
+        val allCards = packsFor(boosterCount).flatten().toMutableList()
         allCards.shuffle()
 
         winstonMainDeck.clear()
@@ -990,6 +1088,7 @@ class TournamentLobby(
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
         if (players.size < 2 || players.size > 4) return false
         if (format != TournamentFormat.GRID_DRAFT) return false
+        if (!prepareCubeDealer()) return false
 
         val allPlayers = players.keys.toList().shuffled()
 
@@ -998,8 +1097,7 @@ class TournamentLobby(
             // (ensures balanced rarity distribution per group)
             val boostersPerGroup = boosterCount / 2
             fun generateGroupPool(count: Int): MutableList<CardDefinition> {
-                val pool = mutableListOf<CardDefinition>()
-                repeat(count) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames)) }
+                val pool = packsFor(count).flatten().toMutableList()
                 pool.shuffle()
                 return pool
             }
@@ -1009,8 +1107,7 @@ class TournamentLobby(
             )
         } else {
             // 2-3 players: 1 group with all players
-            val pool = mutableListOf<CardDefinition>()
-            repeat(boosterCount) { pool.addAll(boosterGenerator.generateBooster(setCodes, chaos = chaosBoosters, bannedCardNames = bannedCardNames)) }
+            val pool = packsFor(boosterCount).flatten().toMutableList()
             pool.shuffle()
             gridGroups = listOf(
                 GridGroup(mainDeck = pool, playerOrder = allPlayers)
@@ -1623,6 +1720,9 @@ class TournamentLobby(
                 commanderPreset = commanderPreset.name,
                 chaosBoosters = chaosBoosters,
                 bannedCardNames = bannedCardNames.sorted(),
+                cubeName = cube?.name,
+                cubeCardCount = cube?.cards?.size,
+                packSize = cube?.packSize,
                 aiAssistEnabled = aiAssistEnabled,
                 gameMode = gameMode.name,
                 attackMode = attackMode.name,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.gameserver.lobby.LobbyPlayerState
 import com.wingedsheep.gameserver.lobby.LobbyState
 import com.wingedsheep.gameserver.lobby.TournamentFormat
 import com.wingedsheep.gameserver.lobby.TournamentLobby
+import com.wingedsheep.gameserver.cube.ResolvedCube
 import com.wingedsheep.gameserver.persistence.dto.*
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.gameserver.sealed.SealedPlayerState
@@ -53,6 +54,12 @@ fun TournamentLobby.toPersistent(): PersistentTournamentLobby {
                 submittedSideboard = playerState.submittedSideboard
             )
         },
+        cubeName = cube?.name,
+        cubeCardNames = cube?.cards?.map { it.name }.orEmpty(),
+        cubeBasicLandSetCode = cube?.basicLandSetCode,
+        cubePackSize = cube?.packSize,
+        cubeDealerRemainingCardNames = cubeDealerRemainingCards().map { it.name },
+        bannedCardNames = bannedCardNames,
         currentPackNumber = currentPackNumber,
         currentPickNumber = currentPickNumber,
         playerOrder = getPlayerOrderForPersistence(),
@@ -111,6 +118,26 @@ fun restoreTournamentLobby(
             .getOrDefault(com.wingedsheep.sdk.core.AttackMode.MULTIPLE),
         randomTeams = persistent.randomTeams
     )
+    lobby.bannedCardNames = persistent.bannedCardNames
+    if (persistent.cubeName != null &&
+        persistent.cubeBasicLandSetCode != null &&
+        persistent.cubePackSize != null
+    ) {
+        val cubeCards = persistent.cubeCardNames.mapNotNull(cardRegistry::getCard)
+        lobby.configureCube(
+            ResolvedCube(
+                name = persistent.cubeName,
+                cards = cubeCards,
+                basicLandSetCode = persistent.cubeBasicLandSetCode,
+                packSize = persistent.cubePackSize,
+            )
+        )
+        if (persistent.cubeDealerRemainingCardNames.isNotEmpty()) {
+            lobby.restoreCubeDealer(
+                persistent.cubeDealerRemainingCardNames.mapNotNull(cardRegistry::getCard)
+            )
+        }
+    }
     // FFA in-flight state (last standings are deliberately not persisted — after a restart the
     // pod simply readies up for the next game).
     lobby.ffaGameSessionId = persistent.ffaGameSessionId

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
@@ -18,6 +18,13 @@ data class PersistentTournamentLobby(
     val state: String,  // LobbyState enum name
     val hostPlayerId: String?,
     val players: Map<String, PersistentLobbyPlayer>,  // playerId.value -> player state
+    /** Cube definition plus the ordered undealt tail, so a restart cannot redeal drafted cards. */
+    val cubeName: String? = null,
+    val cubeCardNames: List<String> = emptyList(),
+    val cubeBasicLandSetCode: String? = null,
+    val cubePackSize: Int? = null,
+    val cubeDealerRemainingCardNames: List<String> = emptyList(),
+    val bannedCardNames: Set<String> = emptySet(),
     // Draft-specific state
     val currentPackNumber: Int = 0,
     val currentPickNumber: Int = 0,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -286,6 +286,14 @@ sealed interface ClientMessage {
          * full list is sent each time (not a delta); null leaves the current ban list unchanged.
          */
         val bannedCardNames: List<String>? = null,
+        /**
+         * Replace the cube card list. Each name is one physical cube card, so duplicates represent
+         * intentional duplicate entries. An empty list returns to normal set-based play.
+         */
+        val cubeCards: List<String>? = null,
+        val cubeName: String? = null,
+        val packSize: Int? = null,
+        val cubeBasicLandSetCode: String? = null,
         /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Null = unchanged. */
         val aiAssistEnabled: Boolean? = null,
         /** Lobby mode axis: "TOURNAMENT" or "FREE_FOR_ALL". Null = unchanged. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -470,6 +470,10 @@ sealed interface ServerMessage {
          * UI order. Empty = no exclusions. Ignored by [TournamentFormat.PREMADE_DECKS].
          */
         val bannedCardNames: List<String> = emptyList(),
+        /** Per-lobby cube summary. Null fields mean catalogued sets are the pack source. */
+        val cubeName: String? = null,
+        val cubeCardCount: Int? = null,
+        val packSize: Int? = null,
         /**
          * Master switch for in-app AI assistance (draft "Suggest Pick" + deckbuild "Auto-build").
          * When false the client hides the controls and the server rejects assist requests.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobbyCubeTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobbyCubeTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.gameserver.cube.ResolvedCube
+import com.wingedsheep.gameserver.persistence.restoreTournamentLobby
+import com.wingedsheep.gameserver.persistence.toPersistent
+import com.wingedsheep.gameserver.session.PlayerIdentity
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+class TournamentLobbyCubeTest : FunSpec({
+    val forest = CardDefinition.basicLand("Forest", Subtype.FOREST)
+    val generator = BoosterGenerator(
+        mapOf(
+            "TST" to BoosterGenerator.SetConfig(
+                setCode = "TST",
+                setName = "Test",
+                cards = emptyList(),
+                basicLands = listOf(forest),
+            )
+        )
+    )
+    val cards = (1..40).map { number ->
+        CardDefinition.creature(
+            name = "Cube Bear $number",
+            manaCost = ManaCost.parse("{1}{G}"),
+            subtypes = setOf(Subtype.BEAR),
+            power = 2,
+            toughness = 2,
+        )
+    }
+
+    fun lobby(format: TournamentFormat, boosterCount: Int, packSize: Int): TournamentLobby {
+        val lobby = TournamentLobby(
+            setCodes = listOf("TST"),
+            setNames = listOf("Test"),
+            boosterGenerator = generator,
+            format = format,
+            boosterCount = boosterCount,
+        )
+        lobby.addPlayer(PlayerIdentity(playerId = EntityId("host"), playerName = "Host"))
+        lobby.addPlayer(PlayerIdentity(playerId = EntityId("guest"), playerName = "Guest"))
+        lobby.configureCube(
+            ResolvedCube(
+                name = "Friends Cube",
+                cards = cards,
+                basicLandSetCode = "TST",
+                packSize = packSize,
+            )
+        )
+        return lobby
+    }
+
+    test("sealed deals every player complete pools without replacement and uses cube basic lands") {
+        val lobby = lobby(TournamentFormat.SEALED, boosterCount = 3, packSize = 4)
+
+        lobby.startDeckBuilding(EntityId("host")) shouldBe true
+
+        val dealt = lobby.players.values.flatMap { it.cardPool }
+        dealt.size shouldBe 24
+        dealt.map { it.name }.toSet().size shouldBe 24
+        lobby.basicLands.keys shouldContainExactlyInAnyOrder setOf("Forest")
+    }
+
+    test("booster draft deals one unique cube pack per player") {
+        val lobby = lobby(TournamentFormat.DRAFT, boosterCount = 1, packSize = 4)
+
+        lobby.startDraft(EntityId("host")) shouldBe true
+
+        val dealt = lobby.players.values.flatMap { it.currentPack.orEmpty() }
+        dealt.size shouldBe 8
+        dealt.map { it.name }.toSet().size shouldBe 8
+    }
+
+    test("Winston and Grid use the shared cube dealer") {
+        val winston = lobby(TournamentFormat.WINSTON_DRAFT, boosterCount = 4, packSize = 4)
+        winston.startWinstonDraft(EntityId("host")) shouldBe true
+        val winstonCards = winston.winstonMainDeck + winston.winstonPiles.flatMap { it }
+        winstonCards.size shouldBe 16
+        winstonCards.map { it.name }.toSet().size shouldBe 16
+
+        val grid = lobby(TournamentFormat.GRID_DRAFT, boosterCount = 2, packSize = 10)
+        grid.startGridDraft(EntityId("host")) shouldBe true
+        val gridCards = grid.gridGroups.flatMap { group ->
+            group.mainDeck + group.gridCards.filterNotNull()
+        }
+        gridCards.size shouldBe 20
+        gridCards.map { it.name }.toSet().size shouldBe 20
+    }
+
+    test("capacity gate reports the full host-readable calculation") {
+        val lobby = lobby(TournamentFormat.SEALED, boosterCount = 6, packSize = 4)
+
+        lobby.cubeCapacityError() shouldBe
+            "2 players × 6 packs × 4 = 48 cards needed, cube has 40"
+        lobby.startDeckBuilding(EntityId("host")) shouldBe false
+        lobby.state shouldBe LobbyState.WAITING_FOR_PLAYERS
+    }
+
+    test("cube broadcasts its summary without adding CUBE to available sets") {
+        val lobby = lobby(TournamentFormat.DRAFT, boosterCount = 3, packSize = 5)
+
+        val settings = lobby.buildLobbyUpdate(EntityId("host")).settings
+
+        settings.cubeName shouldBe "Friends Cube"
+        settings.cubeCardCount shouldBe 40
+        settings.packSize shouldBe 5
+        settings.setCodes shouldBe listOf("CUBE")
+        settings.availableSets.any { it.code == "CUBE" } shouldBe false
+    }
+
+    test("persistence restores the cube and exact undealt tail") {
+        val lobby = lobby(TournamentFormat.DRAFT, boosterCount = 2, packSize = 4)
+        lobby.startDraft(EntityId("host")) shouldBe true
+        val remainingNames = lobby.cubeDealerRemainingCards().map { it.name }
+        val registry = CardRegistry().also { it.register(cards) }
+
+        val (restored, _) = restoreTournamentLobby(lobby.toPersistent(), registry, generator)
+
+        restored.cube?.name shouldBe "Friends Cube"
+        restored.cube?.packSize shouldBe 4
+        restored.cubeDealerRemainingCards().map { it.name } shouldBe remainingNames
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/CubeDealer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/CubeDealer.kt
@@ -15,15 +15,25 @@ class CubeDealer(
     private val packSize: Int,
     seed: Long,
 ) {
+    private constructor(
+        remainingCards: List<CardDefinition>,
+        packSize: Int,
+    ) : this(emptyList(), packSize, 0L) {
+        shuffledCube = remainingCards
+    }
+
     init {
         require(packSize > 0) { "Cube pack size must be positive, got $packSize" }
     }
 
-    private val shuffledCube = cube.shuffled(Random(seed))
+    private var shuffledCube = cube.shuffled(Random(seed))
     private var dealt = 0
 
     val remaining: Int
         get() = shuffledCube.size - dealt
+
+    /** Ordered undealt tail, used only to persist and resume an in-flight cube draft safely. */
+    fun remainingCards(): List<CardDefinition> = shuffledCube.subList(dealt, shuffledCube.size).toList()
 
     /**
      * Deal [packs] complete packs and consume them from this dealer.
@@ -44,5 +54,10 @@ class CubeDealer(
             .chunked(packSize)
         dealt += requestedCards
         return result
+    }
+
+    companion object {
+        fun resume(remainingCards: List<CardDefinition>, packSize: Int): CubeDealer =
+            CubeDealer(remainingCards, packSize)
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/CubeDealerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/CubeDealerTest.kt
@@ -67,4 +67,16 @@ class CubeDealerTest : FunSpec({
         dealer.deal(0) shouldBe emptyList()
         dealer.remaining shouldBeExactly cube.size
     }
+
+    test("resumes from the ordered undealt tail without reshuffling") {
+        val dealer = CubeDealer(cube, packSize = 3, seed = 42L)
+        val firstPack = dealer.deal(1).single()
+        val remaining = dealer.remainingCards()
+
+        val resumed = CubeDealer.resume(remaining, packSize = 3)
+        val resumedPacks = resumed.deal(2).flatten()
+
+        (firstPack + resumedPacks).map { it.name }.toSet().size shouldBe 9
+        resumedPacks shouldBe remaining.take(6)
+    }
 })

--- a/web-client/src/components/lobby/TournamentLobbySettings.tsx
+++ b/web-client/src/components/lobby/TournamentLobbySettings.tsx
@@ -70,6 +70,7 @@ export function TournamentLobbySettings({
   const isAnyDraft = isDraft || isWinston || isGridDraft || isCommanderDraft
   const isAnyCommander = isCommanderDraft || isCommanderSealed
   const isFfa = s.gameMode === 'FREE_FOR_ALL'
+  const isCube = Boolean(s.cubeName)
 
   const allSets = s.availableSets
   // A selected-set chip is either a concrete set or a deferred "Random Set" placeholder.
@@ -172,7 +173,16 @@ export function TournamentLobbySettings({
 
       {/* Set selection — chips here, the full searchable browser behind a modal. Premade Decks
           generates no boosters, so it needs none of this. */}
-      {!isPremade && (
+      {!isPremade && isCube && (
+        <div className={styles.settingsRow}>
+          <span className={styles.settingsLabel}>Cube</span>
+          <div className={styles.variantCaption}>
+            {s.cubeName} · {s.cubeCardCount ?? 0} cards · {s.packSize ?? 15}-card packs
+          </div>
+        </div>
+      )}
+
+      {!isPremade && !isCube && (
         <>
           <div className={styles.settingsRow} style={{ alignItems: 'flex-start' }}>
             <span className={styles.settingsLabel} style={{ paddingTop: 7 }}>Sets</span>

--- a/web-client/src/components/lobby/lobbyViewModel.ts
+++ b/web-client/src/components/lobby/lobbyViewModel.ts
@@ -275,6 +275,7 @@ function tournamentTeams(lobbyState: LobbyState): LobbyTeams {
 
 function tournamentTitle(lobbyState: LobbyState): string {
   const s = lobbyState.settings
+  if (s.cubeName) return s.cubeName
   if (s.format !== 'PREMADE_DECKS') return s.setNames.join(' + ') || 'Lobby'
   switch (s.gameMode) {
     case 'TWO_HEADED_GIANT': return 'Premade Decks Two-Headed Giant'
@@ -316,10 +317,13 @@ function tournamentSubtitle(lobbyState: LobbyState): string {
         return distText ?? `${s.boosterCount} boosters per player`
     }
   })()
+  const source = s.cubeName
+    ? `Cube · ${s.cubeCardCount ?? 0} cards · ${s.packSize ?? 15}-card packs · ${base}`
+    : base
 
   const isMultiplayer = s.gameMode !== 'TOURNAMENT'
   const games = s.gamesPerMatch ?? 1
-  return !isMultiplayer && games > 1 ? `${base} · ${games} games per matchup` : base
+  return !isMultiplayer && games > 1 ? `${source} · ${games} games per matchup` : source
 }
 
 function startLabel(lobbyState: LobbyState): string {
@@ -376,6 +380,19 @@ function startBlockReason(lobbyState: LobbyState): string | null {
   if (s.format === 'PREMADE_DECKS') {
     const allSubmitted = lobbyState.players.filter((p) => p.isConnected).every((p) => p.deckSubmitted)
     return allSubmitted ? null : 'All connected players must submit a deck first'
+  }
+  if (s.cubeName) {
+    const packSize = s.packSize ?? 15
+    const sharedPool = s.format === 'WINSTON_DRAFT' || s.format === 'GRID_DRAFT'
+    const packsNeeded = sharedPool ? s.boosterCount : n * s.boosterCount
+    const cardsNeeded = packsNeeded * packSize
+    const cubeCards = s.cubeCardCount ?? 0
+    if (cardsNeeded > cubeCards) {
+      return sharedPool
+        ? `${s.boosterCount} packs × ${packSize} = ${cardsNeeded} cards needed, cube has ${cubeCards}`
+        : `${n} players × ${s.boosterCount} packs × ${packSize} = ${cardsNeeded} cards needed, cube has ${cubeCards}`
+    }
+    return null
   }
   if (s.setCodes.length === 0) return 'Select at least one set'
   // Extension sets (bonus sheets) can't carry a pool alone. Unknown codes count as regular; the

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -38,7 +38,7 @@ export interface LobbySliceActions {
   startLobby: () => void
   leaveLobby: () => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number>; ranked?: boolean }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; chaosBoosters?: boolean; bannedCardNames?: string[]; cubeCards?: string[]; cubeName?: string; packSize?: number; cubeBasicLandSetCode?: string; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number>; ranked?: boolean }) => void
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   readyForNextRound: () => void

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -901,7 +901,7 @@ export type GameStore = {
   addAiToLobby: () => void
   removeAiFromLobby: (playerId: string) => void
   stopLobby: () => void
-  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean; bannedCardNames?: string[]; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number>; ranked?: boolean }) => void
+  updateLobbySettings: (settings: { setCodes?: string[]; format?: TournamentFormat; boosterCount?: number; boosterDistribution?: Record<string, number>; maxPlayers?: number; gamesPerMatch?: number; pickTimeSeconds?: number; picksPerRound?: number; isPublic?: boolean; deckFormat?: DeckFormat | '' | null; deckSizeMin?: number; allowDuplicates?: boolean; commanderPreset?: CommanderPreset; chaosBoosters?: boolean; bannedCardNames?: string[]; cubeCards?: string[]; cubeName?: string; packSize?: number; cubeBasicLandSetCode?: string; aiAssistEnabled?: boolean; gameMode?: LobbyGameMode; attackMode?: AttackMode; randomTeams?: boolean; teamAssignments?: Record<string, number>; ranked?: boolean }) => void
   /** Disconnected tournament players: playerId -> info */
   disconnectedPlayers: Record<string, { playerName: string; secondsRemaining: number; disconnectedAt: number }>
   readyForNextRound: () => void

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1288,6 +1288,10 @@ export interface LobbySettings {
   readonly chaosBoosters: boolean
   /** Host ban list — oracle card names excluded from generated boosters (sorted). */
   readonly bannedCardNames: readonly string[]
+  /** Per-lobby cube summary. Undefined means catalogued sets are the pack source. */
+  readonly cubeName?: string | null
+  readonly cubeCardCount?: number | null
+  readonly packSize?: number | null
   /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). */
   readonly aiAssistEnabled: boolean
   /** Lobby mode axis: bracket of 2-player matches vs one multiplayer Free-for-All game. */
@@ -2268,6 +2272,11 @@ export interface UpdateLobbySettingsMessage {
   readonly chaosBoosters?: boolean
   /** Replace the host ban list (full list, not a delta). Omit to leave unchanged. */
   readonly bannedCardNames?: readonly string[]
+  /** Full cube list; duplicate names represent duplicate physical cards. Empty clears cube mode. */
+  readonly cubeCards?: readonly string[]
+  readonly cubeName?: string
+  readonly packSize?: number
+  readonly cubeBasicLandSetCode?: string
   /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Omit to leave unchanged. */
   readonly aiAssistEnabled?: boolean
   /** Lobby mode axis ('TOURNAMENT' / 'FREE_FOR_ALL'). Omit to leave unchanged. */
@@ -2506,6 +2515,10 @@ export function createUpdateLobbySettingsMessage(
     deckFormat?: DeckFormat | '' | null
     chaosBoosters?: boolean
     bannedCardNames?: readonly string[]
+    cubeCards?: readonly string[]
+    cubeName?: string
+    packSize?: number
+    cubeBasicLandSetCode?: string
     aiAssistEnabled?: boolean
     gameMode?: LobbyGameMode
     attackMode?: AttackMode


### PR DESCRIPTION
## Summary
- route Sealed, Booster Draft, Winston, and Grid pack generation through the lobby cube dealer
- add atomic cube settings resolution, capacity gating, inert set/chaos controls, and cube lobby broadcasts
- persist the cube definition and ordered dealer remainder so restarts cannot redeal opened cards
- show cube summaries and capacity failures in the lobby client without leaking CUBE into the set catalog

## Verification
- `just test-server`
- `just test-rules`
- `cd web-client && npm run typecheck`
- `git diff --check`

Closes the Phase 2 portion of #1454.