### PR TITLE
Add four Wilds of Eldraine cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3060,6 +3060,17 @@ work for abilities-on-stack (which carry no `CardComponent`).
   Skitter's Blessing's `Conditions.YouControlAtLeast(1, …)` draw-step gate). Role tokens are Auras
   (CR 113.2c), which makes this the Wilds of Eldraine Roles payoff predicate. Resolves in both
   `PredicateEvaluator` (targets/conditions) and `AffectsFilterResolver` (layer-7c group projection).
+- `IsEnchantedByAura(auraController)` (filter builder `enchantedByAura(controller = ControlledByYou)`)
+  — the aura-control-scoped `IsEnchanted`: has at least one attached Aura whose **controller** matches
+  the given `ControllerPredicate`. "Enchanted by Auras you control" (Archon of the Wild Rose) is a
+  genuinely different adjective from plain `enchanted()` — an opponent's Aura or Role on your creature
+  does *not* satisfy it. Compose with `youControl()` to constrain the enchanted permanent's controller
+  as well; the two bind to different objects:
+  `GameObjectFilter.Creature.youControl().enchantedByAura()`. The "you" is the controller of the
+  ability doing the filtering — the static's source controller during layer projection, the evaluation
+  context's controller for targets/conditions — and both evaluators **fail closed** with no controller
+  rather than matching every Aura. The Aura's control is read through the projection (Layer 2), so an
+  Aura that changes hands turns the predicate off continuously.
 - `IsModified` — has an Equipment attached, an Aura attached, **or** any counter (the MTG "modified"
   definition). For the source-relative form use `Conditions.SourceIsModified`.
 - `AttachedToCardType(cardType)` — Aura/Equipment whose `AttachedToComponent` points to a
@@ -7813,6 +7824,10 @@ substitution.
   tutor ability spends one via `Costs.RemoveCounterFromSelf(Counters.WISH, 1)`). A pure "uses left" counter
   with no inherent rule — when it hits zero the activation cost is simply unpayable, which is exactly the
   printed ruling that the Talisman then sits inert on the battlefield.
+  `skewer` (`Counters.SKEWER`): WOE — Rotisserie Elemental (its combat-damage trigger adds one via
+  `AddCounters(Counters.SKEWER, 1, EffectTarget.Self)`, and the optional self-sacrifice cashes the tally in
+  for an impulse-exile sized by `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.SKEWER))`).
+  A pure tally counter with no inherent rule.
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -78,6 +78,7 @@ enum class CounterType {
     REVIVAL,
     INGENUITY,
     FILM,
+    SKEWER,
     ENERGY;
 
     companion object {
@@ -370,6 +371,15 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val FILM = "film"
+
+    /**
+     * Skewer counter (WOE — Rotisserie Elemental). A tally counter with no inherent rule: the
+     * Elemental accumulates one per combat-damage hit, and the size of the impulse-exile it can
+     * cash itself in for is read straight off the tally. Same shape as `Counters.FILM` /
+     * `Counters.WISH`. NOT a keyword counter, so it is intentionally absent from
+     * `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val SKEWER = "skewer"
 
     /**
      * Energy counter (Kaladesh block onward, CR 107.14). Unlike every other entry in this object,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -942,6 +942,16 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must have at least one attached Aura controlled by [auraController] — the aura-control-scoped
+     * form of [enchanted] ("enchanted by Auras you control", Archon of the Wild Rose). Compose with
+     * [youControl] to constrain the enchanted permanent's controller too; the two bind to different
+     * objects. See [StatePredicate.IsEnchantedByAura].
+     */
+    fun enchantedByAura(auraController: ControllerPredicate = ControllerPredicate.ControlledByYou) = copy(
+        statePredicates = statePredicates + StatePredicate.IsEnchantedByAura(auraController)
+    )
+
+    /**
      * Must be marked as a "warped card in exile" (CR 702.185b) — i.e., the
      * engine wrote a `WarpExiledComponent` when the warped permanent left the
      * battlefield at end of turn. Use this when filtering candidates in the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -421,6 +421,29 @@ sealed interface StatePredicate {
         override val description: String = "enchanted"
     }
 
+    /**
+     * Has at least one attached Aura whose *controller* satisfies [auraController] — the narrower
+     * "enchanted by Auras you control" (Archon of the Wild Rose) as opposed to plain [IsEnchanted],
+     * which is agnostic about who controls the Aura (CR 303.4).
+     *
+     * The two are genuinely different adjectives and both appear in print: A Tale for the Ages
+     * buffs your creatures whoever's Aura is on them, while Archon of the Wild Rose only cares
+     * about Auras *you* control. Control is read off the Aura at evaluation time, so an Aura
+     * changing hands turns the predicate on or off continuously.
+     *
+     * "You" is the controller of the ability doing the filtering — the source's controller during
+     * layer projection, the evaluation context's controller for targets and conditions.
+     */
+    @SerialName("IsEnchantedByAura")
+    @Serializable
+    data class IsEnchantedByAura(val auraController: ControllerPredicate) : Entity {
+        override val description: String = when (auraController) {
+            ControllerPredicate.ControlledByYou -> "enchanted by Auras you control"
+            ControllerPredicate.ControlledByOpponent -> "enchanted by Auras an opponent controls"
+            else -> "enchanted"
+        }
+    }
+
     /** Has an Equipment attached, an Aura attached, or any counter (MTG "modified" definition) */
     @SerialName("IsModified")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArchonOfTheWildRose.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ArchonOfTheWildRose.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Archon of the Wild Rose
+ * {2}{W}{W}
+ * Creature — Archon
+ * 4/4
+ *
+ * Flying
+ * Other creatures you control that are enchanted by Auras you control have base power and
+ * toughness 4/4 and have flying.
+ *
+ * The two adjectives bind to *different* objects: `youControl()` constrains the creature's
+ * controller, `enchantedByAura(ControlledByYou)` constrains the controller of the Aura attached to
+ * it. That is the whole reason this is not A Tale for the Ages' plain `enchanted()` — an opponent's
+ * Aura (or Role) on your creature does not switch the Archon on, and your Aura on their creature
+ * does not either. `excludeSelf` covers "other", and the Archon's own printed flying is unaffected.
+ *
+ * The base-P/T set (Layer 7b) and the flying grant (Layer 6) are one printed ability, so they go in
+ * a single [CompositeStaticAbility] rather than two `staticAbility { }` blocks (CR 613.6): the
+ * engine locks the affected set once and applies both layers to it, instead of each part
+ * re-resolving its own set as the layers are walked. Per the printed rulings this only overwrites
+ * *earlier* base-P/T-setting effects — a later one (or any +N/+N modifier or counter, whenever it
+ * started) still applies on top, which the layer system gives us for free.
+ */
+val ArchonOfTheWildRose = card("Archon of the Wild Rose") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Archon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Other creatures you control that are enchanted by Auras you control have base power and " +
+        "toughness 4/4 and have flying."
+
+    keywords(Keyword.FLYING)
+
+    val enchantedByYourAuras = GroupFilter(
+        GameObjectFilter.Creature.youControl().enchantedByAura(),
+        excludeSelf = true
+    )
+
+    staticAbility {
+        ability = CompositeStaticAbility(
+            listOf(
+                SetBasePowerToughnessStatic(4, 4, enchantedByYourAuras),
+                GrantKeyword(Keyword.FLYING, enchantedByYourAuras),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Chris Rahn"
+        flavorText = "The curse of Redtooth Keep could only be broken by a mystical rose that " +
+            "blooms in moonlight."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1783915137"
+
+        ruling(
+            "2023-09-01",
+            "Archon of the Wild Rose's ability overwrites all previous effects that set the " +
+                "affected creatures' power and/or toughness to specific values. Other effects that " +
+                "set these characteristics to specific values that start to apply after Archon of " +
+                "the Wild Rose enters the battlefield will overwrite this effect."
+        )
+        ruling(
+            "2023-09-01",
+            "Effects that modify a creature's power and/or toughness without setting it will apply " +
+                "to the affected creatures no matter when they started to take effect. The same is " +
+                "true for counters that change a creature's power and/or toughness."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DiscerningFinancier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/DiscerningFinancier.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Discerning Financier
+ * {2}{W}
+ * Creature — Human Noble
+ * 2/3
+ *
+ * At the beginning of your upkeep, if an opponent controls more lands than you, create a Treasure
+ * token.
+ * {2}{W}: Choose another player. That player gains control of target Treasure you control. You draw
+ * a card.
+ *
+ * The upkeep ability is an intervening-if trigger (CR 603.4) over the shared
+ * [Conditions.OpponentControlsMoreLands] land comparison — checked both when the ability would go
+ * on the stack and again on resolution, so playing a land in between (or an opponent losing one)
+ * turns it off.
+ *
+ * The activated ability is the donate half of a Treasure payoff: the recipient is *chosen*, not
+ * targeted (only the Treasure is a target), so it goes through
+ * [Effects.ChooseOpponent] — a resolution-time choice stored in the source's `ChoiceSlot.OPPONENT`
+ * — and is read back as [Player.ChosenOpponent] by [GiveControlToTargetPlayerEffect]. The control
+ * change is permanent, matching the printed text's lack of a duration. The draw is a separate
+ * sentence and so is unconditional, but the whole ability still fizzles if the targeted Treasure
+ * is gone on resolution, which also means no card.
+ *
+ * Oracle "another player" is broader than "an opponent" only in formats with teammates; in a
+ * two-player game and in free-for-all multiplayer every other player is an opponent, so the
+ * opponent-scoped choice is the faithful modelling for the formats the engine supports.
+ */
+val DiscerningFinancier = card("Discerning Financier") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Noble"
+    power = 2
+    toughness = 3
+    oracleText = "At the beginning of your upkeep, if an opponent controls more lands than you, " +
+        "create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana " +
+        "of any color.\")\n" +
+        "{2}{W}: Choose another player. That player gains control of target Treasure you control. " +
+        "You draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.OpponentControlsMoreLands
+        effect = Effects.CreateTreasure(1)
+        description = "At the beginning of your upkeep, if an opponent controls more lands than " +
+            "you, create a Treasure token."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}")
+        val treasure = target(
+            "target Treasure you control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact.withSubtype(Subtype.TREASURE).youControl()
+                )
+            )
+        )
+        effect = Effects.Composite(
+            Effects.ChooseOpponent("Choose another player to gain control of the Treasure"),
+            GiveControlToTargetPlayerEffect(
+                permanent = treasure,
+                newController = EffectTarget.PlayerRef(Player.ChosenOpponent)
+            ),
+            Effects.DrawCards(1)
+        )
+        description = "Choose another player. That player gains control of target Treasure you " +
+            "control. You draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg?1783915133"
+
+        ruling(
+            "2023-09-01",
+            "If the target Treasure is an illegal target as Discerning Financier's last ability " +
+                "tries to resolve, it won't resolve. You won't draw a card."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RotisserieElemental.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RotisserieElemental.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rotisserie Elemental
+ * {R}
+ * Creature — Elemental
+ * 1/1
+ *
+ * Menace
+ * Whenever this creature deals combat damage to a player, put a skewer counter on this creature.
+ * Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the
+ * number of skewer counters on this creature. You may play those cards this turn.
+ *
+ * Skewer counters are a plain tally ([Counters.SKEWER]) — no keyword, no rule of their own — so the
+ * only interesting part is the ordering inside the trigger.
+ *
+ * X is "the number of skewer counters on this creature", read *after* the new counter goes on but
+ * for a permanent that the same resolution is about to sacrifice. Counters cease to exist on a zone
+ * change (CR 122.2), and a mid-resolution `SacrificeSelfEffect` leaves no last-known-counters
+ * snapshot for a `Source` read to fall back on, so the top-of-library gather runs one step *before*
+ * the sacrifice and the exile one step after. Nothing can observe the difference: no player gets
+ * priority inside a resolving ability (the printed ruling says exactly this), triggers from the
+ * sacrifice wait until the ability finishes, and sacrificing a creature cannot reorder a library —
+ * so the cards gathered are the same cards the printed sequence would exile.
+ *
+ * `sourceRequiredZone = BATTLEFIELD` carries the "If you do" clause for the case the ordering can't:
+ * if the Elemental is already gone when the trigger resolves (bounced or killed in response), there
+ * is nothing to sacrifice, the player is never prompted, and nothing is exiled.
+ *
+ * The exiled cards are playable, not free — [GrantMayPlayFromExileEffect] defaults to an
+ * end-of-turn permission and normal timing rules, so a land among them is still a land drop during
+ * your main phase.
+ */
+val RotisserieElemental = card("Rotisserie Elemental") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 1
+    toughness = 1
+    oracleText = "Menace\n" +
+        "Whenever this creature deals combat damage to a player, put a skewer counter on this " +
+        "creature. Then you may sacrifice it. If you do, exile the top X cards of your library, " +
+        "where X is the number of skewer counters on this creature. You may play those cards this turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.SKEWER, 1, EffectTarget.Self)
+            .then(
+                MayEffect(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(
+                            DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.SKEWER))
+                        ),
+                        storeAs = "skeweredCards"
+                    )
+                        .then(SacrificeSelfEffect)
+                        .then(
+                            MoveCollectionEffect(
+                                from = "skeweredCards",
+                                destination = CardDestination.ToZone(Zone.EXILE)
+                            )
+                        )
+                        .then(GrantMayPlayFromExileEffect("skeweredCards")),
+                    descriptionOverride = "You may sacrifice Rotisserie Elemental to exile that " +
+                        "many cards from the top of your library and play them this turn.",
+                    sourceRequiredZone = Zone.BATTLEFIELD
+                )
+            )
+        description = "Whenever this creature deals combat damage to a player, put a skewer " +
+            "counter on this creature. Then you may sacrifice it. If you do, exile the top X " +
+            "cards of your library, where X is the number of skewer counters on this creature. " +
+            "You may play those cards this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "148"
+        artist = "Leonardo Santanna"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg?1783915089"
+
+        ruling(
+            "2023-09-01",
+            "You choose whether to sacrifice Rotisserie Elemental as its triggered ability " +
+                "resolves. No player may respond between the time you sacrifice it and the time " +
+                "you exile cards from the top of your library."
+        )
+        ruling(
+            "2023-09-01",
+            "You pay all costs and follow all normal timing rules for cards played from exile this " +
+                "way. For example, if the exiled card is a land card, you may play it only during " +
+                "your main phase while the stack is empty."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThePrincessTakesFlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThePrincessTakesFlight.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * The Princess Takes Flight
+ * {2}{W}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Exile up to one target creature.
+ * II — Target creature you control gets +2/+2 and gains flying until end of turn.
+ * III — Return the exiled card to the battlefield under its owner's control.
+ *
+ * The blink is held together by the Saga's *linked exile*, not by a remembered entity id: chapter I
+ * moves the creature to exile with `linkToSource = true`, and chapter III gathers back over
+ * [CardSource.FromLinkedExile]. That is what makes the card behave correctly when the exiled
+ * permanent is a token (it ceases to exist in exile, so chapter III finds nothing and returns
+ * nothing) and when chapter I exiled several creatures because the ability was copied — the gather
+ * picks up every linked card, which is exactly what the printed ruling calls for.
+ *
+ * Chapter I is "up to one target", so it is legal with no target at all and simply does nothing;
+ * chapter III then has nothing to return. The return is `underOwnersControl = true` — exiling an
+ * opponent's creature hands it back to them, it does not steal it.
+ */
+val ThePrincessTakesFlight = card("The Princess Takes Flight") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Exile up to one target creature.\n" +
+        "II — Target creature you control gets +2/+2 and gains flying until end of turn.\n" +
+        "III — Return the exiled card to the battlefield under its owner's control."
+
+    sagaChapter(1) {
+        val creature = target(
+            "up to one target creature",
+            TargetCreature(optional = true, filter = TargetFilter.Creature)
+        )
+        effect = Effects.Move(creature, Zone.EXILE, linkToSource = true)
+    }
+
+    sagaChapter(2) {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 2, creature)
+            .then(Effects.GrantKeyword(Keyword.FLYING, creature))
+    }
+
+    sagaChapter(3) {
+        effect = Effects.Composite(
+            GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "princessExiled"),
+            MoveCollectionEffect(
+                from = "princessExiled",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                underOwnersControl = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg?1783915128"
+
+        ruling(
+            "2023-09-01",
+            "If The Princess Takes Flight's first chapter ability exiled more than one creature " +
+                "(usually because the ability was copied), its third chapter ability will return " +
+                "all of the exiled cards to the battlefield under their owners' control."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -366,6 +366,89 @@
     ]
 }
 
+// Archon of the Wild Rose
+{
+    "name": "Archon of the Wild Rose",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nOther creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CompositeStaticAbility",
+                "abilities": [
+                    {
+                        "type": "SetBasePowerToughnessStatic",
+                        "power": 4,
+                        "toughness": 4,
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "IsEnchantedByAura",
+                                        "auraController": "ControlledByYou"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            },
+                            "excludeSelf": true
+                        }
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "IsEnchantedByAura",
+                                        "auraController": "ControlledByYou"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            },
+                            "excludeSelf": true
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "Chris Rahn",
+        "flavorText": "The curse of Redtooth Keep could only be broken by a mystical rose that blooms in moonlight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00174be7-0dc8-43b9-81b6-f25a8c3fb4eb.jpg?1783915137",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Archon of the Wild Rose's ability overwrites all previous effects that set the affected creatures' power and/or toughness to specific values. Other effects that set these characteristics to specific values that start to apply after Archon of the Wild Rose enters the battlefield will overwrite this effect."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Effects that modify a creature's power and/or toughness without setting it will apply to the affected creatures no matter when they started to take effect. The same is true for counters that change a creature's power and/or toughness."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Archon's Glory
 {
     "name": "Archon's Glory",
@@ -3166,6 +3249,113 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Discerning Financier
+{
+    "name": "Discerning Financier",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Noble",
+    "oracleText": "At the beginning of your upkeep, if an opponent controls more lands than you, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n{2}{W}: Choose another player. That player gains control of target Treasure you control. You draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "EachOpponent",
+                        "filter": "land"
+                    },
+                    "operator": "GT",
+                    "right": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, if an opponent controls more lands than you, create a Treasure token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ChooseOpponentForSource",
+                            "prompt": "Choose another player to gain control of the Treasure"
+                        },
+                        {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": {
+                                "type": "BoundVariable",
+                                "name": "target Treasure you control"
+                            },
+                            "newController": {
+                                "type": "PlayerRef",
+                                "player": "ChosenOpponent"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact Treasure ctrl:you"
+                        },
+                        "id": "target Treasure you control"
+                    }
+                ],
+                "descriptionOverride": "Choose another player. That player gains control of target Treasure you control. You draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/584774b5-640f-45e0-810b-f5faf119645b.jpg?1783915133",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If the target Treasure is an illegal target as Discerning Financier's last ability tries to resolve, it won't resolve. You won't draw a card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -10744,6 +10934,108 @@
     ]
 }
 
+// Rotisserie Elemental
+{
+    "name": "Rotisserie Elemental",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Menace\nWhenever this creature deals combat damage to a player, put a skewer counter on this creature. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on this creature. You may play those cards this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "skewer",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayDecide",
+                                "sourceRequiredZone": "Battlefield"
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "EntityProperty",
+                                                "entity": "Source",
+                                                "numericProperty": {
+                                                    "type": "CounterCount",
+                                                    "counterType": {
+                                                        "type": "Named",
+                                                        "name": "skewer"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "storeAs": "skeweredCards"
+                                    },
+                                    "SacrificeSelf",
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "skeweredCards",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantMayPlayFromExile",
+                                        "from": "skeweredCards"
+                                    }
+                                ]
+                            },
+                            "descriptionOverride": "You may sacrifice Rotisserie Elemental to exile that many cards from the top of your library and play them this turn."
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a skewer counter on this creature. Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the number of skewer counters on this creature. You may play those cards this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "RARE",
+        "artist": "Leonardo Santanna",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d787045-3918-4ed6-85ea-843d1f2356f2.jpg?1783915089",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You choose whether to sacrifice Rotisserie Elemental as its triggered ability resolves. No player may respond between the time you sacrifice it and the time you exile cards from the top of your library."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You pay all costs and follow all normal timing rules for cards played from exile this way. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rowan's Grim Search
 {
     "name": "Rowan's Grim Search",
@@ -13950,6 +14242,113 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// The Princess Takes Flight
+{
+    "name": "The Princess Takes Flight",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Exile up to one target creature.\nII — Target creature you control gets +2/+2 and gains flying until end of turn.\nIII — Return the exiled card to the battlefield under its owner's control.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    },
+                    "destination": "Exile",
+                    "linkToSource": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "princessExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "princessExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Metzger",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/dad7bd06-22e4-40f8-bda9-bcdbb2d8f632.jpg?1783915128",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If The Princess Takes Flight's first chapter ability exiled more than one creature (usually because the ability was copied), its third chapter ability will return all of the exiled cards to the battlefield under their owners' control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -515,5 +515,6 @@ class BeginningPhaseManager(
         is StatePredicate.WasCastFromZone -> true
         is StatePredicate.AttachedToCardType -> true
         is StatePredicate.AttachedTo -> true
+        is StatePredicate.IsEnchantedByAura -> true
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1860,6 +1860,7 @@ class TriggerMatcher(
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastFromZone,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedTo -> true
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchantedByAura -> true
         // Counter predicates require last-known-info to evaluate a creature that has already left
         // the battlefield; the zone-change path ([matchesStatePredicateForZoneChangeTrigger])
         // handles them against the event's captured counters. This entity-only fallback has no LKI,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -42,6 +42,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 import com.wingedsheep.sdk.scripting.references.Player
@@ -1172,6 +1173,31 @@ class PredicateEvaluator {
                 if (attachments == null || attachments.attachedIds.isEmpty()) return false
                 attachments.attachedIds.any { attachId ->
                     state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isAura == true
+                }
+            }
+
+            // Aura state scoped by who controls the Aura — "enchanted by Auras you control"
+            // (Archon of the Wild Rose). "You" is this evaluation's controller.
+            is StatePredicate.IsEnchantedByAura -> {
+                val attachments = container.get<AttachmentsComponent>()
+                if (attachments == null || attachments.attachedIds.isEmpty()) return false
+                // Fail closed with no context: "Auras you control" has no meaning without a "you",
+                // and matching every Aura would silently widen the filter.
+                val you = context?.controllerId ?: return false
+                attachments.attachedIds.any { attachId ->
+                    val aura = state.getEntity(attachId) ?: return@any false
+                    if (aura.get<CardComponent>()?.typeLine?.isAura != true) return@any false
+                    val auraController = aura.get<ControllerComponent>()?.playerId ?: return@any false
+                    predicate.auraController.evaluateWith { leaf ->
+                        when (leaf) {
+                            ControllerPredicate.ControlledByYou -> auraController == you
+                            ControllerPredicate.ControlledByOpponent -> auraController != you
+                            ControllerPredicate.ControlledByAny -> true
+                            ControllerPredicate.ControlledByActivePlayer ->
+                                auraController == state.activePlayerId
+                            else -> null
+                        }
+                    }
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -358,7 +358,7 @@ internal class AffectsFilterResolver {
 
             // Check state predicates
             for (predicate in baseFilter.statePredicates) {
-                if (!matchesStatePredicateForProjection(state, entityId, predicate, container, isFaceDown, projectedValues)) {
+                if (!matchesStatePredicateForProjection(state, entityId, predicate, container, isFaceDown, projectedValues, controller)) {
                     return@filter false
                 }
             }
@@ -378,7 +378,14 @@ internal class AffectsFilterResolver {
         predicate: StatePredicate,
         container: ComponentContainer,
         isFaceDown: Boolean,
-        projectedValues: Map<EntityId, MutableProjectedValues>
+        projectedValues: Map<EntityId, MutableProjectedValues>,
+        /**
+         * Controller of the permanent whose static ability is being projected — the "you" for
+         * predicates that scope some *other* object's controller (currently
+         * [StatePredicate.IsEnchantedByAura]'s Aura). Null when the source has no controller, in
+         * which case those predicates fail closed rather than matching everything.
+         */
+        sourceController: EntityId?
     ): Boolean = when (predicate) {
         StatePredicate.IsTapped -> container.has<TappedComponent>()
         StatePredicate.IsUntapped -> !container.has<TappedComponent>()
@@ -489,6 +496,26 @@ internal class AffectsFilterResolver {
                 state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isAura == true
             }
         }
+        // "…enchanted by Auras you control…" (Archon of the Wild Rose) — same attachment scan as
+        // IsEnchanted, but the Aura's own projected controller has to match the static's controller.
+        // Control is a Layer 2 effect, so read it through the projection rather than off the base
+        // ControllerComponent: an Aura stolen this turn is no longer one you control.
+        is StatePredicate.IsEnchantedByAura -> {
+            val attachments = container.get<AttachmentsComponent>()
+            attachments != null && sourceController != null && attachments.attachedIds.any { attachId ->
+                if (state.getEntity(attachId)?.get<CardComponent>()?.typeLine?.isAura != true) return@any false
+                val auraController = projectedController(state, attachId, projectedValues) ?: return@any false
+                predicate.auraController.evaluateWith { leaf ->
+                    when (leaf) {
+                        ControllerPredicate.ControlledByYou -> auraController == sourceController
+                        ControllerPredicate.ControlledByOpponent -> auraController != sourceController
+                        ControllerPredicate.ControlledByAny -> true
+                        ControllerPredicate.ControlledByActivePlayer -> auraController == state.activePlayerId
+                        else -> null
+                    }
+                }
+            }
+        }
         StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
         // A general "attached to <filter>" host constraint whose nested filter may carry a controller
         // predicate ("a creature you control"). Group-static projection has no ability controller to
@@ -525,13 +552,13 @@ internal class AffectsFilterResolver {
         StatePredicate.HasLockedDoor ->
             container.get<RoomComponent>()?.lockedFaces?.isNotEmpty() == true
         is StatePredicate.Or -> predicate.predicates.any {
-            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues)
+            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController)
         }
         is StatePredicate.And -> predicate.predicates.all {
-            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues)
+            matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues, sourceController)
         }
         is StatePredicate.Not -> !matchesStatePredicateForProjection(
-            state, entityId, predicate.predicate, container, isFaceDown, projectedValues
+            state, entityId, predicate.predicate, container, isFaceDown, projectedValues, sourceController
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchonOfTheWildRoseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchonOfTheWildRoseScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Archon of the Wild Rose — the aura-control-scoped "enchanted" predicate
+ * (`StatePredicate.IsEnchantedByAura`) resolved through layer projection.
+ */
+class ArchonOfTheWildRoseScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? = game.state.projectedState.getToughness(id)
+    private fun hasFlying(game: TestGame, id: EntityId): Boolean =
+        game.state.projectedState.hasKeyword(id, Keyword.FLYING)
+
+    init {
+        context("Archon of the Wild Rose — 'enchanted by Auras you control have base P/T 4/4 and flying'") {
+            test("your creature carrying your own Aura becomes a 4/4 flier") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Archon of the Wild Rose")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("base P/T is set to 4/4 in layer 7b") {
+                    power(game, bears) shouldBe 4
+                    toughness(game, bears) shouldBe 4
+                }
+                withClue("and the same printed ability grants flying") {
+                    hasFlying(game, bears) shouldBe true
+                }
+            }
+
+            test("an opponent's Aura on your creature does NOT switch it on") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Archon of the Wild Rose")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Player 2 controls the Aura; player 1 controls the creature.
+                    .withCardAttachedTo(2, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("this is the whole difference from A Tale for the Ages' plain 'enchanted'") {
+                    power(game, bears) shouldBe 2
+                    toughness(game, bears) shouldBe 2
+                    hasFlying(game, bears) shouldBe false
+                }
+            }
+
+            test("your Aura on an opponent's creature does not buff it either") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Archon of the Wild Rose")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("'creatures you control' scopes the creature, not the Aura") {
+                    power(game, bears) shouldBe 2
+                    toughness(game, bears) shouldBe 2
+                    hasFlying(game, bears) shouldBe false
+                }
+            }
+
+            test("Equipment is not an Aura — an equipped creature is untouched") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Archon of the Wild Rose")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Whispersilk Cloak", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                withClue("the Cloak is Equipment, so the Archon does not see the Bears") {
+                    power(game, bears) shouldBe 2
+                    toughness(game, bears) shouldBe 2
+                }
+            }
+
+            test("'other' excludes the Archon itself even if it is enchanted") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Archon of the Wild Rose")
+                    .withCardAttachedTo(1, "Pacifism", "Archon of the Wild Rose")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val archon = game.findPermanent("Archon of the Wild Rose").shouldNotBeNull()
+
+                withClue("the Archon keeps its printed 4/4 rather than re-setting its own base P/T") {
+                    power(game, archon) shouldBe 4
+                    toughness(game, archon) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningFinancierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscerningFinancierScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.DiscerningFinancier
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Discerning Financier (WOE) — {2}{W} Creature — Human Noble, 2/3.
+ *
+ * - "At the beginning of your upkeep, if an opponent controls more lands than you, create a
+ *   Treasure token."
+ * - "{2}{W}: Choose another player. That player gains control of target Treasure you control.
+ *   You draw a card."
+ *
+ * The upkeep half is an intervening-if trigger, so it's pinned both ways — behind on lands and
+ * not. The activated half is the donate: the Treasure has to end up under the *other* player's
+ * control while the card goes to us.
+ */
+class DiscerningFinancierScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.allTokens + listOf(DiscerningFinancier))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.treasures(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { getCardName(it) == "Treasure" }
+
+    /** Advance to the upkeep of the starting player's [nth] turn (turn `2n - 1` in a duel). */
+    fun GameTestDriver.advanceToUpkeep(nth: Int) {
+        val targetTurn = nth * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.UPKEEP) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+            guard++
+        }
+        if (guard >= 500) error("Failed to reach turn $targetTurn upkeep")
+    }
+
+    test("upkeep makes a Treasure only while an opponent is ahead on lands") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putPermanentOnBattlefield(me, "Discerning Financier")
+        // Both players on one land: nobody is ahead, so the intervening-if fails.
+        driver.putPermanentOnBattlefield(me, "Plains")
+        driver.putPermanentOnBattlefield(opponent, "Plains")
+
+        driver.advanceToUpkeep(2)
+        driver.drain()
+
+        withClue("equal land counts — 'more lands than you' is strict, so no Treasure") {
+            driver.treasures(me).size shouldBe 0
+        }
+
+        // Put the opponent ahead and come back round to our next upkeep.
+        driver.putPermanentOnBattlefield(opponent, "Plains")
+        driver.advanceToUpkeep(3)
+        driver.drain()
+
+        withClue("the opponent now controls more lands, so the trigger creates a Treasure") {
+            driver.treasures(me).size shouldBe 1
+        }
+    }
+
+    test("the activated ability donates the Treasure and draws us a card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val financier = driver.putPermanentOnBattlefield(me, "Discerning Financier")
+        val treasure = driver.putPermanentOnBattlefield(me, "Treasure")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val handBefore = driver.getHandSize(me)
+        driver.giveMana(me, Color.WHITE, 3)
+
+        val donate = DiscerningFinancier.activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = financier,
+                abilityId = donate,
+                targets = listOf(ChosenTarget.Permanent(treasure))
+            )
+        )
+        driver.drain()
+
+        withClue("the chosen other player ends up controlling the Treasure") {
+            // Control change is a Layer 2 continuous effect, so read it off the projection.
+            driver.state.projectedState.getController(treasure) shouldBe opponent
+        }
+        withClue("and we draw the card") {
+            driver.getHandSize(me) shouldBe handBefore + 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RotisserieElementalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RotisserieElementalScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.RotisserieElemental
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rotisserie Elemental (WOE) — {R} Creature — Elemental, 1/1, menace.
+ *
+ * "Whenever this creature deals combat damage to a player, put a skewer counter on this creature.
+ * Then you may sacrifice it. If you do, exile the top X cards of your library, where X is the
+ * number of skewer counters on this creature. You may play those cards this turn."
+ *
+ * The two things worth pinning are the ones the implementation had to reason about: the skewer
+ * tally accumulates across combats and survives a declined sacrifice, and X is the *post-increment*
+ * count even though the same resolution sacrifices the creature that carried the counters.
+ */
+class RotisserieElementalScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RotisserieElemental))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Fully resolve the stack, resolving every triggered ability that lands on it. */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.skewerCount(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.SKEWER) ?: 0
+
+    fun GameTestDriver.exileSize(playerId: EntityId): Int =
+        state.getZone(ZoneKey(playerId, Zone.EXILE)).size
+
+    fun GameTestDriver.librarySize(playerId: EntityId): Int =
+        state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size
+
+    test("connecting adds a skewer counter; declining the sacrifice leaves it on the battlefield") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val elemental = driver.putCreatureOnBattlefield(me, "Rotisserie Elemental")
+        driver.removeSummoningSickness(elemental)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(elemental), opponent)
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        driver.resolveStack()
+
+        // The may-sacrifice prompt is the trigger resolving; decline it.
+        driver.submitYesNo(me, false)
+        driver.resolveStack()
+
+        driver.skewerCount(elemental) shouldBe 1
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(elemental) shouldBe true
+        driver.exileSize(me) shouldBe 0
+    }
+
+    test("accepting the sacrifice exiles that many cards and puts the Elemental in the graveyard") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val elemental = driver.putCreatureOnBattlefield(me, "Rotisserie Elemental")
+        driver.removeSummoningSickness(elemental)
+
+        val libraryBefore = driver.librarySize(me)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(elemental), opponent)
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        driver.resolveStack()
+
+        driver.submitYesNo(me, true)
+        driver.resolveStack()
+
+        // One skewer counter had just been added, so X is 1 — read off the creature the same
+        // resolution sacrifices.
+        driver.exileSize(me) shouldBe 1
+        driver.librarySize(me) shouldBe libraryBefore - 1
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(elemental) shouldBe true
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(elemental) shouldBe false
+    }
+
+    test("skewer counters accumulate across combats, so X grows") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val elemental = driver.putCreatureOnBattlefield(me, "Rotisserie Elemental")
+        driver.removeSummoningSickness(elemental)
+
+        // First combat — decline.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(elemental), opponent)
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        driver.resolveStack()
+        driver.submitYesNo(me, false)
+        driver.resolveStack()
+        driver.skewerCount(elemental) shouldBe 1
+
+        // Cycle back round to our next combat and connect again.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(elemental), opponent)
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        driver.resolveStack()
+        driver.skewerCount(elemental) shouldBe 2
+
+        val libraryBefore = driver.librarySize(me)
+        driver.submitYesNo(me, true)
+        driver.resolveStack()
+
+        driver.exileSize(me) shouldBe 2
+        driver.librarySize(me) shouldBe libraryBefore - 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrincessTakesFlightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrincessTakesFlightScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.ThePrincessTakesFlight
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Princess Takes Flight (WOE) — {2}{W} Enchantment — Saga.
+ *
+ * I — Exile up to one target creature.
+ * II — Target creature you control gets +2/+2 and gains flying until end of turn.
+ * III — Return the exiled card to the battlefield under its owner's control.
+ *
+ * The blink is held by the Saga's linked exile, so the tests pin the two things that depends on:
+ * chapter III returns the card to its *owner*, not to the Saga's controller, and a chapter I that
+ * exiled nothing (the target is "up to one") leaves chapter III with nothing to return.
+ */
+class ThePrincessTakesFlightScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThePrincessTakesFlight))
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    /** Drain the stack, answering every target request with [targets]. */
+    fun GameTestDriver.drainTargeting(chooser: EntityId, targets: List<EntityId>) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            val decision = state.pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> submitTargetSelection(chooser, targets)
+                decision != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    /** Advance to the precombat main of the starting player's [nth] turn (turn `2n - 1` in a duel). */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+            guard++
+        }
+        if (guard >= 500) error("Failed to reach turn $targetTurn precombat main")
+    }
+
+    test("exiles an opponent's creature and hands it back to them on chapter III") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        val bears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val ours = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.WHITE, 3)
+        val saga = driver.putCardInHand(controller, "The Princess Takes Flight")
+        driver.castSpell(controller, saga)
+        driver.drainTargeting(controller, listOf(bears))
+
+        withClue("chapter I exiles the targeted creature") {
+            driver.getPermanents(opponent).contains(bears) shouldBe false
+        }
+
+        driver.advanceToMain(2)
+        driver.drainTargeting(controller, listOf(ours))
+
+        withClue("chapter II pumps our own creature and gives it flying until end of turn") {
+            driver.state.projectedState.getPower(ours) shouldBe 4
+            driver.state.projectedState.getToughness(ours) shouldBe 4
+            driver.state.projectedState.hasKeyword(ours, Keyword.FLYING) shouldBe true
+        }
+
+        driver.advanceToMain(3)
+        driver.drain()
+
+        withClue("chapter III returns the exiled card under its OWNER's control, not ours") {
+            driver.getPermanents(opponent).count { driver.getCardName(it) == "Grizzly Bears" } shouldBe 1
+            driver.getPermanents(controller).count { driver.getCardName(it) == "Grizzly Bears" } shouldBe 1
+        }
+        withClue("a three-chapter Saga is sacrificed after chapter III") {
+            driver.getGraveyardCardNames(controller).contains("The Princess Takes Flight") shouldBe true
+        }
+    }
+
+    test("chapter I with no target leaves chapter III with nothing to return") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.WHITE, 3)
+        val saga = driver.putCardInHand(controller, "The Princess Takes Flight")
+        driver.castSpell(controller, saga)
+        // No creatures anywhere, so "up to one target creature" is satisfied by choosing none.
+        driver.drainTargeting(controller, emptyList())
+
+        driver.advanceToMain(2)
+        driver.drainTargeting(controller, emptyList())
+        driver.advanceToMain(3)
+        driver.drain()
+
+        withClue("nothing was exiled, so nothing comes back and the Saga still finishes") {
+            driver.getPermanents(controller).none { driver.getCardName(it) == "Grizzly Bears" } shouldBe true
+            driver.getGraveyardCardNames(controller).contains("The Princess Takes Flight") shouldBe true
+        }
+    }
+})

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -422,6 +422,7 @@ export enum CounterType {
   REVIVAL = 'REVIVAL',
   INGENUITY = 'INGENUITY',
   FILM = 'FILM',
+  SKEWER = 'SKEWER',
   ENERGY = 'ENERGY',
 }
 
@@ -490,6 +491,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.REVIVAL]: 'Revival',
   [CounterType.INGENUITY]: 'Ingenuity',
   [CounterType.FILM]: 'Film',
+  [CounterType.SKEWER]: 'Skewer',
   [CounterType.ENERGY]: 'Energy',
 }
 


### PR DESCRIPTION
Adds **Archon of the Wild Rose**, **Discerning Financier**, **The Princess Takes Flight**, and **Rotisserie Elemental**. WOE goes 216/266 → 220/266.

## Cards on existing primitives

**Discerning Financier** ({2}{W} 2/3 Human Noble) — the upkeep half is an intervening-if trigger over the shared `Conditions.OpponentControlsMoreLands`, so a land drop between trigger and resolution turns it off. The activated half is a donate: `Effects.ChooseOpponent` + `GiveControlToTargetPlayerEffect` reading back `Player.ChosenOpponent`. The recipient is *chosen*, not targeted — only the Treasure is a target, so the printed "you won't draw a card" fizzle ruling falls out for free.

**The Princess Takes Flight** ({2}{W} Saga) — the blink is held by the Saga's linked exile rather than a remembered entity id: chapter I moves with `linkToSource = true`, chapter III gathers `FromLinkedExile` and returns `underOwnersControl`. That gets the token case right (a token ceases to exist in exile, so nothing returns) and matches the printed ruling for a copied chapter I (every linked card comes back).

## Cards that needed new SDK vocabulary

**Archon of the Wild Rose** ({2}{W}{W} 4/4 flier) needed `StatePredicate.IsEnchantedByAura(auraController)` — the aura-control-scoped sibling of `IsEnchanted`. Plain `enchanted()` is deliberately agnostic about who controls the Aura (CR 303.4), which is correct for A Tale for the Ages and wrong here: an opponent's Aura or Role on your creature must *not* switch the Archon on.

- Resolved in `PredicateEvaluator` (targets/conditions) and `AffectsFilterResolver` (layer projection). The projection path now threads the static's source controller into state-predicate matching so "you" has a referent; both evaluators **fail closed** without one rather than matching every Aura.
- The Layer 7b base-P/T set and the Layer 6 flying grant are one printed ability, so they share a single `CompositeStaticAbility` and one locked affected set (CR 613.6).

**Rotisserie Elemental** ({R} 1/1 menace) needed `Counters.SKEWER`, a plain tally counter (SDK enum + string constant + client display name).

Its trigger gathers the top X *before* sacrificing and exiles *after*. Counters cease to exist on a zone change (CR 122.2) and a mid-resolution `SacrificeSelfEffect` leaves no last-known-counters snapshot for a `Source` read to fall back on. Nothing can observe the reorder — no player gets priority inside a resolving ability (which is exactly what the printed ruling says), triggers from the sacrifice wait until the ability finishes, and sacrificing a creature cannot reorder a library. `sourceRequiredZone = BATTLEFIELD` carries the "If you do" clause for the one case the ordering can't: an Elemental bounced in response is never prompted for and exiles nothing.

## Verification

- One scenario test per card (4 new files, 15 tests) — including the Archon's four-way aura-control matrix, the Princess returning an opponent's creature to *them*, and skewer counters accumulating across combats.
- `just build` green; `just rebless-cards` moved only WOE (additions only); `just check-card-printing` clean for all four; web-client `tsc --noEmit` clean.
- `docs/card-sdk-language-reference.md` updated for the new predicate and counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)