### PR TITLE
Add five Aetherdrift cards, with variable-count exile-X cost support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -294,8 +294,15 @@ excluded.
   counters first, so the resolving effect can still read them via
   `DynamicAmounts.lastKnownSourceCounters(...)`.
 - `Costs.ExileFromGraveyard(count, filter)` — exile N matching cards from your graveyard.
-- `Costs.ExileXFromGraveyard(filter)` — exile X cards from your graveyard (X = the ability's
-  chosen X value).
+- `Costs.ExileXFromGraveyard(filter)` — **variable-count** "exile X cards from your graveyard".
+  X *is* the size of the graveyard selection, so activating raises a single `SelectCardsDecision`
+  over the matching graveyard cards and the count the player picks becomes the ability's X — read it
+  back with `DynamicAmount.XValue`. A `{X}` in the mana cost is therefore optional: **Winter, Cursed
+  Rider** ("{2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact
+  creature gets -X/-X") has none and the selection is free (0..matching cards); **Necropolis Fiend**
+  ("{X}, {T}, Exile X cards from your graveyard") pays X in mana too, so the mana-X picker fixes the
+  count first and the selection is pinned to exactly that many. Selecting nothing is legal and
+  settles as X = 0.
 - `Costs.ExilePermanents(filter = Any, minCount = 1, excludeSelf = true)` — **variable-count** "exile
   one or more permanents you control matching `filter`" activated-ability cost (CR 601.2b — the
   player chooses how many, at least `minCount`, as the ability is activated). With `excludeSelf` the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CaradoraHeartOfAlacria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CaradoraHeartOfAlacria.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyCounterPlacement
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Caradora, Heart of Alacria — Aetherdrift #195
+ * {2}{G}{W} · Legendary Creature — Human Knight · 4/2
+ *
+ * When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put
+ * it into your hand, then shuffle.
+ * If one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus
+ * one +1/+1 counters are put on it instead.
+ *
+ * The tutor is [Patterns.Library.searchLibrary] with `reveal = true`: the pattern selects with
+ * `ChooseUpTo(1)`, so choosing nothing *is* the declined "you may" — no separate optional gate,
+ * and a shuffle still happens either way (CR 701.19c).
+ *
+ * The counter clause is Hardened Scales' [ModifyCounterPlacement] with a widened recipient. The
+ * default `appliesTo` is "a creature you control"; Caradora also covers uncrewed Vehicles, which
+ * aren't creatures, so the recipient becomes a [RecipientFilter.Matching] over the
+ * creature-or-Vehicle union. Modelling it as the counter-placement *replacement* (rather than a
+ * trigger that adds one more counter) is what makes the printed rulings fall out for free:
+ * a permanent entering with +1/+1 counters enters with one extra, two Caradoras stack, and the
+ * controller orders it against other placement replacements per CR 616.1.
+ */
+private val MountOrVehicleCard = GameObjectFilter.Any
+    .withAnyOfSubtypes(listOf(Subtype("Mount"), Subtype.VEHICLE))
+
+private val CreatureOrVehicleYouControl =
+    (GameObjectFilter.Creature or GameObjectFilter.Permanent.withSubtype(Subtype.VEHICLE))
+        .youControl()
+
+val CaradoraHeartOfAlacria = card("Caradora, Heart of Alacria") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 4
+    toughness = 2
+    oracleText = "When Caradora enters, you may search your library for a Mount or Vehicle card, " +
+        "reveal it, put it into your hand, then shuffle.\n" +
+        "If one or more +1/+1 counters would be put on a creature or Vehicle you control, that " +
+        "many plus one +1/+1 counters are put on it instead."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = MountOrVehicleCard,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+        description = "When Caradora enters, you may search your library for a Mount or Vehicle " +
+            "card, reveal it, put it into your hand, then shuffle."
+    }
+
+    replacementEffect(
+        ModifyCounterPlacement(
+            modifier = 1,
+            appliesTo = EventPattern.CounterPlacementEvent(
+                counterType = CounterTypeFilter.PlusOnePlusOne,
+                recipient = RecipientFilter.Matching(CreatureOrVehicleYouControl)
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "195"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg?1783907860"
+        ruling(
+            "2025-02-07",
+            "If a creature or Vehicle you control would enter the battlefield with a number of " +
+                "+1/+1 counters on it, it enters with that many plus one instead."
+        )
+        ruling(
+            "2025-02-07",
+            "If you somehow control multiple copies of Caradora, they would each increase the " +
+                "number of +1/+1 counters put on a creature or Vehicle you control by one."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KolodinTriumphCaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KolodinTriumphCaster.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kolodin, Triumph Caster — Aetherdrift #210
+ * {R}{W} · Legendary Creature — Human Pilot · 2/3
+ *
+ * Mounts and Vehicles you control have haste.
+ * Whenever a Mount you control enters, it becomes saddled until end of turn.
+ * Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn.
+ *
+ * The two triggers are the free halves of Guidelight Matrix's two activated abilities, so they
+ * reuse the same primitives:
+ *  - Mount half → [Effects.BecomeSaddled], the marker half of a Saddle ability (CR 702.171b):
+ *    an until-end-of-turn "saddled" status with no P/T or type change, which saddled-gated
+ *    payoffs (Lagorin, Soul of Alacria) read.
+ *  - Vehicle half → [Effects.AddCardType] "Creature" for the turn. A Vehicle is already an
+ *    artifact (CR 301.7) and its printed P/T and keywords apply once it's a creature, so the
+ *    Layer-4 type grant alone is the whole animation — exactly what crew does.
+ *
+ * Both fire off the entering permanent itself ([EffectTarget.TriggeringEntity], "it"), so they
+ * are non-targeted and can't be fizzled. [TriggerBinding.ANY] rather than OTHER because the
+ * oracle text says "a Mount/Vehicle you control", with no "another" clause — Kolodin is a Human
+ * Pilot so it can never satisfy either filter itself, but a copy effect that made it a Mount
+ * should still see its own entry.
+ *
+ * Haste is granted by a single Layer-6 [GrantKeyword] over the union filter rather than two
+ * statics, matching the one printed ability.
+ */
+private val MountsAndVehiclesYouControl = GroupFilter(
+    GameObjectFilter.Permanent
+        .withAnyOfSubtypes(listOf(Subtype("Mount"), Subtype.VEHICLE))
+        .youControl()
+)
+
+val KolodinTriumphCaster = card("Kolodin, Triumph Caster") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Pilot"
+    power = 2
+    toughness = 3
+    oracleText = "Mounts and Vehicles you control have haste.\n" +
+        "Whenever a Mount you control enters, it becomes saddled until end of turn.\n" +
+        "Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn."
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, MountsAndVehiclesYouControl)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype("Mount")).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.BecomeSaddled(EffectTarget.TriggeringEntity)
+        description = "Whenever a Mount you control enters, it becomes saddled until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.VEHICLE).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCardType("Creature", EffectTarget.TriggeringEntity, Duration.EndOfTurn)
+        description =
+            "Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "210"
+        artist = "Michal Ivan"
+        flavorText = "\"Stay in formation! We win this together, or not at all.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg?1783907857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LagorinSoulOfAlacria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LagorinSoulOfAlacria.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Lagorin, Soul of Alacria — Aetherdrift #211
+ * {G}{W} · Legendary Creature — Beast Mount · 1/1
+ *
+ * Flying
+ * Whenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target
+ * Mounts and/or Vehicles.
+ * Saddle 1
+ *
+ * "Attacks while saddled" is [Triggers.Attacks] gated by [Conditions.SourceIsSaddled] as an
+ * intervening-if (CR 603.4) — per the printed rulings the ability triggers only if Lagorin was
+ * saddled *when it was declared as an attacker*, which is exactly when the attack trigger is
+ * checked. Same shape as Brightfield Glider and the rest of the DFT saddled-attacker cycle.
+ *
+ * The reward targets *permanents*, not creatures: an uncrewed Vehicle is a legal target even
+ * though it isn't a creature, so the filter is [GameObjectFilter.Permanent] over the Mount /
+ * Vehicle subtype union rather than `GameObjectFilter.Creature`. There is no "you control"
+ * clause — an opponent's Mount is a legal (if unlikely) choice.
+ *
+ * `optional = true` on a `count = 2` requirement is the SDK's "up to two" shape, so the
+ * controller may pick zero, one, or two; [ForEachTargetEffect] then applies one counter per
+ * chosen target, each rebound as `ContextTarget(0)`.
+ */
+private val MountsAndVehicles = GameObjectFilter.Permanent
+    .withAnyOfSubtypes(listOf(Subtype("Mount"), Subtype.VEHICLE))
+
+val LagorinSoulOfAlacria = card("Lagorin, Soul of Alacria") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Beast Mount"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two " +
+        "target Mounts and/or Vehicles.\n" +
+        "Saddle 1 (Tap any number of other creatures you control with total power 1 or more: " +
+        "This Mount becomes saddled until end of turn. Saddle only as a sorcery.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.SourceIsSaddled
+        target = TargetPermanent(
+            count = 2,
+            optional = true,
+            filter = TargetFilter(MountsAndVehicles),
+            id = "two target Mounts and/or Vehicles"
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+        )
+        description = "Whenever Lagorin attacks while saddled, put a +1/+1 counter on each of " +
+            "up to two target Mounts and/or Vehicles."
+    }
+
+    keywordAbility(KeywordAbility.saddle(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg?1783907856"
+        ruling(
+            "2025-02-07",
+            "An ability that triggers when a creature \"attacks while saddled\" will trigger only " +
+                "if that creature was saddled when it was declared as an attacker."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PushTheLimit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PushTheLimit.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Push the Limit — Aetherdrift #143
+ * {5}{R}{R} · Sorcery
+ *
+ * Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at
+ * the beginning of the next end step.
+ * Vehicles you control become artifact creatures until end of turn. Creatures you control gain
+ * haste until end of turn.
+ *
+ * Four steps, in printed order — the order is load-bearing, not cosmetic:
+ *
+ *  1. Mass reanimation. `moveTracked` is used rather than plain `move` so the pipeline holds the
+ *     cards that *actually* arrived on the battlefield; a card that couldn't be returned must not
+ *     be scheduled for sacrifice.
+ *  2. The sacrifice clause becomes one delayed trigger *per* returned permanent, scheduled inside
+ *     [ForEachInCollectionEffect] where `EffectTarget.Self` is the current permanent.
+ *     `CreateDelayedTriggerExecutor` bakes that into a concrete entity id at scheduling time, so
+ *     each trigger still finds its permanent at the end step. N single-permanent triggers firing
+ *     together at the same step are indistinguishable from the printed one-ability-sacrifices-all:
+ *     same controller, same time, same permanents. (A whole-collection reference would *not*
+ *     survive — the executor bakes per-target effects, not pipeline collections, so the trigger
+ *     would fire against an empty pipeline and quietly sacrifice nothing.)
+ *  3. Vehicles gain the Creature card type for the turn ([Effects.AddCardType], the same Layer-4
+ *     change crew makes; a Vehicle is already an artifact per CR 301.7). This runs *after* the
+ *     reanimation, so the Vehicles that just came back are animated too.
+ *  4. Creatures gain haste — after step 3, so the freshly animated Vehicles are creatures by the
+ *     time this group is snapshotted and get haste as well. That is the whole point of the card:
+ *     the wrecks come back, wake up, and attack the turn they return.
+ *
+ * Note the asymmetry in the last two clauses: step 3 is Vehicles only (a returned Mount is
+ * already a creature and needs no animation), step 4 is every creature you control, not just the
+ * returned ones — the printed text says "Creatures you control", so an unrelated board also
+ * gains haste.
+ */
+private val MountOrVehicleCardInGraveyard = GameObjectFilter.Any
+    .withAnyOfSubtypes(listOf(Subtype("Mount"), Subtype.VEHICLE))
+
+private val VehiclesYouControl =
+    GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.VEHICLE).youControl())
+
+val PushTheLimit = card("Push the Limit") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Return all Mount and Vehicle cards from your graveyard to the battlefield. " +
+        "Sacrifice them at the beginning of the next end step.\n" +
+        "Vehicles you control become artifact creatures until end of turn. Creatures you control " +
+        "gain haste until end of turn."
+
+    spell {
+        effect = Effects.Pipeline {
+            val wrecks = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.You,
+                    filter = MountOrVehicleCardInGraveyard,
+                ),
+                name = "wrecks",
+            )
+            val returned = moveTracked(
+                wrecks,
+                CardDestination.ToZone(Zone.BATTLEFIELD),
+                underOwnersControl = true,
+                name = "returned",
+            )
+            run(
+                ForEachInCollectionEffect(
+                    collection = returned.key,
+                    effect = CreateDelayedTriggerEffect(
+                        step = Step.END,
+                        effect = Effects.SacrificeTarget(EffectTarget.Self),
+                    ),
+                )
+            )
+            run(
+                Effects.ForEachInGroup(
+                    VehiclesYouControl,
+                    Effects.AddCardType("Creature", EffectTarget.Self, Duration.EndOfTurn),
+                )
+            )
+            run(
+                Effects.ForEachInGroup(
+                    GroupFilter.AllCreaturesYouControl,
+                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn),
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg?1783907878"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WinterCursedRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WinterCursedRider.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantWard
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Winter, Cursed Rider — Aetherdrift #228
+ * {U}{B} · Legendary Creature — Human Warlock · 3/2
+ *
+ * Ward—Pay 2 life.
+ * Artifacts you control have "Ward—Pay 2 life."
+ * Exhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact
+ * creature gets -X/-X until end of turn. (Activate each exhaust ability only once.)
+ *
+ * Two distinct instances of ward, printed separately and modelled separately: the intrinsic
+ * [KeywordAbility.wardLife] on Winter, and a [GrantWard] lord over the artifacts. Per the printed
+ * ruling, an effect that makes Winter an artifact gives it a *second* instance of ward — which is
+ * exactly what falls out of the lord filter matching Winter once it's an artifact, since the
+ * filter carries no `excludeSelf`.
+ *
+ * The exhaust ability's X is not a mana {X} — the printed cost has none. It is bound entirely by
+ * [Costs.ExileXFromGraveyard]: activating pauses for a selection over the artifact cards in your
+ * graveyard, and however many you pick *is* X, read back here as [DynamicAmount.XValue]. Picking
+ * none is legal and makes X zero. The -X/-X is the negation of that same X, applied through
+ * [Effects.ForEachInGroup] with `excludeSelf` for the printed "each **other** nonartifact
+ * creature" — a board-wide sweep across all players, not just yours, and one Winter itself dodges
+ * (it is a nonartifact creature).
+ */
+private val OtherNonartifactCreatures =
+    GroupFilter(GameObjectFilter.Creature.nonartifact(), excludeSelf = true)
+
+val WinterCursedRider = card("Winter, Cursed Rider") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 2
+    oracleText = "Ward—Pay 2 life.\n" +
+        "Artifacts you control have \"Ward—Pay 2 life.\"\n" +
+        "Exhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other " +
+        "nonartifact creature gets -X/-X until end of turn. (Activate each exhaust ability only once.)"
+
+    keywordAbility(KeywordAbility.wardLife(2))
+
+    staticAbility {
+        ability = GrantWard(
+            cost = WardCost.Life(2),
+            filter = GroupFilter(GameObjectFilter.Artifact.youControl())
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{U}{B}"),
+            Costs.Tap,
+            Costs.ExileXFromGraveyard(GameObjectFilter.Artifact)
+        )
+        isExhaust = true
+        val negX = DynamicAmount.Multiply(DynamicAmount.XValue, -1)
+        effect = Effects.ForEachInGroup(
+            OtherNonartifactCreatures,
+            Effects.ModifyStats(negX, negX, EffectTarget.Self)
+        )
+        description = "Exhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: " +
+            "Each other nonartifact creature gets -X/-X until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Daren Bader"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg?1783907852"
+        ruling("2025-02-07", "Multiple instances of ward each trigger separately.")
+        ruling(
+            "2025-02-07",
+            "If an effect causes Winter to become an artifact, its second ability will cause it " +
+                "to gain a second instance of ward."
+        )
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves " +
+                "the battlefield and returns to the battlefield, it becomes a new object so its " +
+                "exhaust ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2027,6 +2027,130 @@
     "colorIdentityOverride": []
 }
 
+// Caradora, Heart of Alacria
+{
+    "name": "Caradora, Heart of Alacria",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle.\nIf one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus one +1/+1 counters are put on it instead.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "HasAnyOfSubtypes",
+                                            "subtypes": [
+                                                "Mount",
+                                                "Vehicle"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "descriptionOverride": "When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it into your hand, then shuffle."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyCounterPlacement",
+                "appliesTo": {
+                    "type": "CounterPlacementEvent",
+                    "counterType": "PlusOnePlusOne",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "And",
+                                            "predicates": [
+                                                "IsPermanent",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Vehicle"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "RARE",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/1256d22d-a2a9-41fb-b669-0661ba230bc7.jpg?1783907860",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If a creature or Vehicle you control would enter the battlefield with a number of +1/+1 counters on it, it enters with that many plus one instead."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If you somehow control multiple copies of Caradora, they would each increase the number of +1/+1 counters put on a creature or Vehicle you control by one."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Carrion Cruiser
 {
     "name": "Carrion Cruiser",
@@ -6332,6 +6456,174 @@
     ]
 }
 
+// Kolodin, Triumph Caster
+{
+    "name": "Kolodin, Triumph Caster",
+    "manaCost": "{R}{W}",
+    "typeLine": "Legendary Creature — Human Pilot",
+    "oracleText": "Mounts and Vehicles you control have haste.\nWhenever a Mount you control enters, it becomes saddled until end of turn.\nWhenever a Vehicle you control enters, it becomes an artifact creature until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Mount ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "BecomeSaddled",
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Whenever a Mount you control enters, it becomes saddled until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Vehicle ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCardType",
+                    "cardType": "Creature",
+                    "target": "TriggeringEntity",
+                    "duration": "EndOfTurn"
+                },
+                "descriptionOverride": "Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsPermanent",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Mount",
+                                    "Vehicle"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "RARE",
+        "artist": "Michal Ivan",
+        "flavorText": "\"Stay in formation! We win this together, or not at all.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36bcd476-a236-4434-b191-5c8b6fa7be7b.jpg?1783907857"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Lagorin, Soul of Alacria
+{
+    "name": "Lagorin, Soul of Alacria",
+    "manaCost": "{G}{W}",
+    "typeLine": "Legendary Creature — Beast Mount",
+    "oracleText": "Flying\nWhenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target Mounts and/or Vehicles.\nSaddle 1 (Tap any number of other creatures you control with total power 1 or more: This Mount becomes saddled until end of turn. Saddle only as a sorcery.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "SADDLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "SADDLE",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsPermanent",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Mount",
+                                        "Vehicle"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "id": "two target Mounts and/or Vehicles"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsSaddled"
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target Mounts and/or Vehicles."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b04e3f4-103b-4845-b3f0-5417971c7666.jpg?1783907856",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "An ability that triggers when a creature \"attacks while saddled\" will trigger only if that creature was saddled when it was declared as an attacker."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Leonin Surveyor
 {
     "name": "Leonin Surveyor",
@@ -9163,6 +9455,103 @@
         "artist": "Konstantin Porubov",
         "flavorText": "\"Don't you know it's dangerous to go faster than us?\"",
         "imageUri": "https://cards.scryfall.io/normal/front/a/f/affbc8db-4ff7-4a86-954a-910493e5a2ef.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Push the Limit
+{
+    "name": "Push the Limit",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the beginning of the next end step.\nVehicles you control become artifact creatures until end of turn. Creatures you control gain haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Mount",
+                                        "Vehicle"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "storeAs": "wrecks"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "wrecks",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "storeMovedAs": "returned",
+                    "underOwnersControl": true
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "returned"
+                    },
+                    "body": {
+                        "type": "CreateDelayedTrigger",
+                        "step": "END",
+                        "effect": {
+                            "type": "SacrificeTarget",
+                            "target": "Self"
+                        }
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Vehicle ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCardType",
+                        "cardType": "Creature",
+                        "target": "Self",
+                        "duration": "EndOfTurn"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21de84a2-2654-4e1a-a569-bf385bb43685.jpg?1783907878"
     },
     "colorIdentityOverride": [
         "RED"
@@ -13529,6 +13918,119 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Winter, Cursed Rider
+{
+    "name": "Winter, Cursed Rider",
+    "manaCost": "{U}{B}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Ward—Pay 2 life.\nArtifacts you control have \"Ward—Pay 2 life.\"\nExhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 2
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostExileXFromGraveyard",
+                            "filter": "artifact"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature nonartifact",
+                            "excludeSelf": true
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Multiply",
+                            "amount": "XValue",
+                            "multiplier": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Multiply",
+                            "amount": "XValue",
+                            "multiplier": -1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.",
+                "isExhaust": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantWard",
+                "cost": {
+                    "type": "WardCost.Life",
+                    "amount": 2
+                },
+                "filter": {
+                    "baseFilter": "artifact ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Daren Bader",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02d46d0e-3161-45b5-a49e-5cd592c67ddd.jpg?1783907852",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Multiple instances of ward each trigger separately."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an effect causes Winter to become an artifact, its second ability will cause it to gain a second instance of ward."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -612,6 +612,30 @@ data class ActivateAbilityExileFromGraveyardContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after a player picks the graveyard cards for an
+ * [com.wingedsheep.sdk.scripting.AbilityCost.ExileXFromGraveyard] cost.
+ *
+ * X *is* the size of that selection, so this is a single decision rather than a number picker
+ * followed by a selection: the resumer re-enters the handler with the chosen cards in
+ * `costPayment.exiledCards` **and** `xValue` set to how many were chosen.
+ *
+ * @property action The original [ActivateAbility] (`costPayment.exiledCards` still empty).
+ * @property exileCandidates The graveyard cards matching the cost's filter, offered as options;
+ *   used to validate the response is a subset of the originally legal candidates.
+ * @property fixedCount Non-null when a `{X}` mana symbol already fixed X (Necropolis Fiend:
+ *   "{X}, {T}, Exile X cards from your graveyard"), in which case the selection must be exactly
+ *   this many. Null when the cost has no mana X (Winter, Cursed Rider), in which case any number
+ *   of candidates may be chosen and the count becomes X.
+ */
+@Serializable
+data class ActivateAbilityExileXFromGraveyardContinuation(
+    override val decisionId: String,
+    val action: ActivateAbility,
+    val exileCandidates: List<EntityId>,
+    val fixedCount: Int? = null
+) : ContinuationFrame
+
+/**
  * Resume after an opponent picks the target(s) for an activated ability's "… of an opponent's
  * choice" requirement (Cuombajj Witches: "{T}: This creature deals 1 damage to any target and 1
  * damage to any target of an opponent's choice").

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -338,6 +338,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ActivateAbilityChooseManaXContinuation::class)
         subclass(ActivateAbilityTapXTargetsContinuation::class)
         subclass(ActivateAbilityExileFromGraveyardContinuation::class)
+        subclass(ActivateAbilityExileXFromGraveyardContinuation::class)
         subclass(ActivateAbilityOpponentChooserContinuation::class)
         subclass(ActivateAbilityOpponentTargetContinuation::class)
         subclass(ActivateAbilitySacrificeContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -732,6 +732,84 @@ class ActivateAbilityHandler(
         }
 
         // -------------------------------------------------------------------
+        // ExileXFromGraveyard pause (legal-actions submission path).
+        //
+        // "Exile X cards from your graveyard" needs exactly one decision, because X *is* the size
+        // of the graveyard selection: pick the cards, and X is how many you picked. So there is no
+        // number picker — the engine pauses for the cards and derives X from the count.
+        //
+        // Winter, Cursed Rider ("{2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each
+        // other nonartifact creature gets -X/-X") has no `{X}` mana at all, so without this block
+        // the handler falls through to `action.xValue ?: 0` — paying nothing and resolving a no-op.
+        // Necropolis Fiend ("{X}, {T}, Exile X cards from your graveyard") pays X in mana too, so
+        // the mana-X pause above has already bound `xValue`; here the selection is then pinned to
+        // exactly that many rather than being free.
+        //
+        // Skipped when `exiledCards` is pre-filled (engine-direct path / resumed replay) or when
+        // there is no real choice — X == candidates, which CostHandler pays without a prompt.
+        // -------------------------------------------------------------------
+        // Settled already when cards are pre-filled (engine-direct path, or the resume after this
+        // very pause) or when X is a bound zero — a zero selection is a legal answer, and
+        // re-pausing on it would spin forever.
+        val exileXCost = extractExileXFromGraveyardCost(effectiveCost)
+        val exileXSettled = (action.costPayment?.exiledCards?.isNotEmpty() == true) || action.xValue == 0
+        if (exileXCost != null && !exileXSettled && tapXCost == null) {
+            val exileXCandidates = costHandler.findMatchingCardsUnified(
+                state,
+                state.getZone(com.wingedsheep.engine.state.ZoneKey(action.playerId, Zone.GRAVEYARD)),
+                exileXCost.filter,
+                action.playerId
+            )
+            // A mana `{X}` already fixed the count; otherwise the player is free to exile any
+            // number of matching cards (including none) and that count becomes X.
+            val fixedCount = action.xValue
+            val minSelections = fixedCount ?: 0
+            val maxSelections = fixedCount ?: exileXCandidates.size
+            val isRealChoice = exileXCandidates.size > minSelections
+            if (isRealChoice) {
+                val decisionId = java.util.UUID.randomUUID().toString()
+                val prompt = if (fixedCount != null) {
+                    "Select $fixedCount card${if (fixedCount > 1) "s" else ""} to exile from " +
+                        "graveyard for ${cardComponent.name}"
+                } else {
+                    "Select any number of cards to exile from graveyard for ${cardComponent.name} " +
+                        "(X is the number you choose)"
+                }
+                val decision = com.wingedsheep.engine.core.SelectCardsDecision(
+                    id = decisionId,
+                    playerId = action.playerId,
+                    prompt = prompt,
+                    context = com.wingedsheep.engine.core.DecisionContext(
+                        sourceId = action.sourceId,
+                        sourceName = cardComponent.name,
+                        phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
+                    ),
+                    options = exileXCandidates,
+                    minSelections = minSelections,
+                    maxSelections = maxSelections
+                )
+                val continuation = com.wingedsheep.engine.core.ActivateAbilityExileXFromGraveyardContinuation(
+                    decisionId = decisionId,
+                    action = action,
+                    exileCandidates = exileXCandidates,
+                    fixedCount = fixedCount
+                )
+                val pausedState = state
+                    .withPendingDecision(decision)
+                    .pushContinuation(continuation)
+                val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = action.playerId,
+                    decisionType = "SELECT_CARDS",
+                    prompt = prompt
+                )
+                return ExecutionResult.paused(pausedState, decision, listOf(event))
+            }
+            // Not a real choice, so no prompt: either the graveyard has nothing matching (X = 0,
+            // legal) or a mana-fixed X consumes every candidate, which CostHandler pays as-is.
+        }
+
+        // -------------------------------------------------------------------
         // ExileFromGraveyard cost-choice pause (legal-actions submission path).
         //
         // When the cost is `ExileFromGraveyard(count, filter)` (Rust Harvester:
@@ -2878,6 +2956,18 @@ class ActivateAbilityHandler(
         }
         else -> null
     }
+
+    /**
+     * Pull the [AbilityCost.ExileXFromGraveyard] sub-cost out of an ability cost, or null if none.
+     * Used by the legal-actions submission path to bind X (Winter, Cursed Rider — X with no `{X}`
+     * mana symbol) and to pause for *which* graveyard cards the player exiles.
+     */
+    private fun extractExileXFromGraveyardCost(cost: AbilityCost): AbilityCost.ExileXFromGraveyard? =
+        when (cost) {
+            is AbilityCost.ExileXFromGraveyard -> cost
+            is AbilityCost.Composite -> cost.costs.filterIsInstance<AbilityCost.ExileXFromGraveyard>().firstOrNull()
+            else -> null
+        }
 
     /**
      * Pull the [CostAtom.Sacrifice] sub-cost out of an ability cost (top-level [AbilityCost.Atom] or

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation
 import com.wingedsheep.engine.core.ActivateAbilityControllerTargetContinuation
 import com.wingedsheep.engine.core.ActivateAbilityExileFromGraveyardContinuation
 import com.wingedsheep.engine.core.ActivateAbilityExilePermanentsContinuation
+import com.wingedsheep.engine.core.ActivateAbilityExileXFromGraveyardContinuation
 import com.wingedsheep.engine.core.ActivateAbilitySacrificeContinuation
 import com.wingedsheep.engine.core.ActivateAbilityTapXTargetsContinuation
 import com.wingedsheep.engine.core.CancelDecisionResponse
@@ -52,6 +53,7 @@ class ActivateAbilityXCostContinuationResumer(
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(ActivateAbilityChooseXContinuation::class, ::resumeChooseX),
         resumer(ActivateAbilityChooseManaXContinuation::class, ::resumeChooseManaX),
+        resumer(ActivateAbilityExileXFromGraveyardContinuation::class, ::resumeExileXFromGraveyard),
         resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets),
         resumer(ActivateAbilityExileFromGraveyardContinuation::class, ::resumeExileFromGraveyard),
         resumer(ActivateAbilitySacrificeContinuation::class, ::resumeSacrifice),
@@ -168,6 +170,47 @@ class ActivateAbilityXCostContinuationResumer(
         val replay = action.copy(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
                 .copy(exiledCards = response.selectedCards)
+        )
+        return reenter(handler.execute(state, replay), checkForMore)
+    }
+
+    /**
+     * Resume after the player picks the graveyard cards for an `ExileXFromGraveyard` cost. X *is*
+     * the size of that selection, so a single decision settles both: re-enter the handler with the
+     * chosen cards in `costPayment.exiledCards` and `xValue` bound to how many were chosen.
+     *
+     * When a `{X}` mana symbol already fixed X (Necropolis Fiend), [fixedCount] pins the selection
+     * size and `xValue` on the action is left as it was — the two agree by construction.
+     */
+    private fun resumeExileXFromGraveyard(
+        state: GameState,
+        continuation: ActivateAbilityExileXFromGraveyardContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(
+                state,
+                "Expected card-selection response for ActivateAbility ExileXFromGraveyard"
+            )
+        }
+        val selected = response.selectedCards
+        if (selected.any { it !in continuation.exileCandidates }) {
+            return ExecutionResult.error(state, "Selected card is not in the list of valid exile candidates")
+        }
+        val fixedCount = continuation.fixedCount
+        if (fixedCount != null && selected.size != fixedCount) {
+            return ExecutionResult.error(
+                state,
+                "Expected $fixedCount cards to exile, got ${selected.size}"
+            )
+        }
+
+        val action = continuation.action
+        val replay = action.copy(
+            xValue = fixedCount ?: selected.size,
+            costPayment = (action.costPayment ?: AdditionalCostPayment())
+                .copy(exiledCards = selected)
         )
         return reenter(handler.execute(state, replay), checkForMore)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -748,6 +748,12 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
 
                 // Reuse the early checks for X-variable costs
                 val hasRemoveXCountersCost = hasRemoveXCountersCostEarly
+                // Note: an `ExileXFromGraveyard` cost is deliberately NOT an X-picker cost. There X
+                // *is* the size of the graveyard selection, so the engine pauses for the cards and
+                // derives X from the count rather than asking for a number up front (see
+                // ActivateAbilityHandler's ExileXFromGraveyard pause). A `{X}` alongside it
+                // (Necropolis Fiend) still flags here through [abilityHasXInManaCost], because
+                // there X also has to be paid in mana.
                 val abilityHasXCost = abilityHasXInManaCost || hasRemoveXCountersCost || hasTapXPermanentsCost
 
                 val abilityMaxAffordableX: Int? = if (abilityHasXCost) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -549,14 +549,27 @@ class CostEnumerationUtils(
             Int.MAX_VALUE
         }
 
-        // Cap by graveyard size if ExileXFromGraveyard
-        val hasExileXCost = when (abilityCost) {
-            is AbilityCost.Composite -> abilityCost.costs.any { it is AbilityCost.ExileXFromGraveyard }
-            else -> false
+        // Cap by the graveyard cards an ExileXFromGraveyard cost could actually exile. The cap must
+        // honor the cost's own filter, not just the graveyard size: Winter, Cursed Rider exiles X
+        // *artifact* cards, so a graveyard of five with two artifacts affords X = 2, not X = 5.
+        // Offering the larger X would let the player pick an activation whose payment then fails in
+        // CostHandler (which does apply the filter). A filter-less cost (Necropolis Fiend) matches
+        // every card, so this stays the plain graveyard size there.
+        val exileXCosts = when (abilityCost) {
+            is AbilityCost.Composite -> abilityCost.costs.filterIsInstance<AbilityCost.ExileXFromGraveyard>()
+            is AbilityCost.ExileXFromGraveyard -> listOf(abilityCost)
+            else -> emptyList()
         }
-        if (hasExileXCost) {
-            val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
-            maxX = minOf(maxX, state.getZone(graveyardZone).size)
+        if (exileXCosts.isNotEmpty()) {
+            val graveyard = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
+            val projected = state.projectedState
+            val context = PredicateContext(controllerId = playerId)
+            exileXCosts.forEach { cost ->
+                val matching = graveyard.count { cardId ->
+                    predicateEvaluator.matches(state, projected, cardId, cost.filter, context)
+                }
+                maxX = minOf(maxX, matching)
+            }
         }
 
         // Cap by the counters available for any X-valued counter-removal cost. Use projected

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaradoraHeartOfAlacriaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaradoraHeartOfAlacriaScenarioTest.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Caradora, Heart of Alacria (DFT #195).
+ *
+ * Caradora, Heart of Alacria {2}{G}{W} — Legendary Creature — Human Knight 4/2
+ * When Caradora enters, you may search your library for a Mount or Vehicle card, reveal it, put it
+ * into your hand, then shuffle.
+ * If one or more +1/+1 counters would be put on a creature or Vehicle you control, that many plus
+ * one +1/+1 counters are put on it instead.
+ *
+ * The load-bearing claim is the widened recipient on the counter-placement replacement. Hardened
+ * Scales' default covers "a creature you control"; Caradora also covers a Vehicle, which is not a
+ * creature until something animates it. So the interesting case is an **uncrewed** Vehicle getting
+ * the bonus counter, and an opponent's permanent not getting it.
+ */
+class CaradoraHeartOfAlacriaScenarioTest : ScenarioTestBase() {
+
+    private val mechanicAbilityId
+        get() = cardRegistry.getCard("Daring Mechanic")!!.script.activatedAbilities[0].id
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Caradora, Heart of Alacria") {
+
+            test("an uncrewed Vehicle you control gets the extra counter even though it isn't a creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Caradora, Heart of Alacria")
+                    .withCardOnBattlefield(1, "Daring Mechanic")
+                    .withCardOnBattlefield(1, "Air Response Unit") // Artifact — Vehicle, uncrewed
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val unit = game.findPermanent("Air Response Unit")!!
+                withClue("the Vehicle is not a creature — Hardened Scales' default wouldn't fire") {
+                    game.state.projectedState.isCreature(unit) shouldBe false
+                }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Daring Mechanic")!!,
+                        abilityId = mechanicAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(unit))
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("one counter plus Caradora's one") {
+                    plusOneCounters(game, unit) shouldBe 2
+                }
+            }
+
+            test("a creature you control gets the extra counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Caradora, Heart of Alacria")
+                    .withCardOnBattlefield(1, "Daring Mechanic")
+                    .withCardOnBattlefield(1, "Brightfield Glider") // Creature — Possum Mount
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glider = game.findPermanent("Brightfield Glider")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Daring Mechanic")!!,
+                        abilityId = mechanicAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(glider))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                plusOneCounters(game, glider) shouldBe 2
+            }
+
+            test("an opponent's permanent gets no bonus — the replacement is scoped to you") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Caradora, Heart of Alacria")
+                    .withCardOnBattlefield(1, "Daring Mechanic")
+                    .withCardOnBattlefield(2, "Air Response Unit")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val theirUnit = game.findPermanent("Air Response Unit")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Daring Mechanic")!!,
+                        abilityId = mechanicAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(theirUnit))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Daring Mechanic's counter lands, but Caradora doesn't add to it") {
+                    plusOneCounters(game, theirUnit) shouldBe 1
+                }
+            }
+
+            test("the enters tutor finds a Mount or Vehicle card and nothing else") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Caradora, Heart of Alacria")
+                    .withCardInLibrary(1, "Air Response Unit") // Vehicle — a legal find
+                    .withCardInLibrary(1, "Brightfield Glider") // Mount — a legal find
+                    .withCardInLibrary(1, "Centaur Courser") // neither — must not be offered
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Caradora, Heart of Alacria").error shouldBe null
+                game.resolveStack()
+
+                withClue("the search pauses for a selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val vehicle = game.findCardsInLibrary(1, "Air Response Unit").single()
+                game.selectCards(listOf(vehicle)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the chosen Vehicle card is in hand") {
+                    game.isInHand(1, "Air Response Unit") shouldBe true
+                }
+                withClue("the ineligible creature card stays in the library") {
+                    game.isInHand(1, "Centaur Courser") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KolodinTriumphCasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KolodinTriumphCasterScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kolodin, Triumph Caster (DFT #210).
+ *
+ * Kolodin, Triumph Caster {R}{W} — Legendary Creature — Human Pilot 2/3
+ * Mounts and Vehicles you control have haste.
+ * Whenever a Mount you control enters, it becomes saddled until end of turn.
+ * Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn.
+ *
+ * The two triggers key on the *entering* permanent ("it"), so what's being pinned is that each one
+ * fires for the right card type and applies to the entrant rather than to Kolodin. The haste lord
+ * covers both types under one static.
+ */
+class KolodinTriumphCasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kolodin, Triumph Caster") {
+
+            test("a Mount entering becomes saddled, and the marker clears at end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kolodin, Triumph Caster")
+                    .withCardInHand(1, "Brightfield Glider") // {W} Creature — Possum Mount
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Brightfield Glider").error shouldBe null
+                game.resolveStack()
+
+                val glider = game.findPermanent("Brightfield Glider")!!
+                withClue("the entering Mount is saddled by Kolodin's trigger") {
+                    game.state.getEntity(glider)!!.get<SaddledComponent>().shouldNotBeNull()
+                }
+                withClue("BecomeSaddled is a marker only — the Mount keeps its printed 1/1") {
+                    game.state.projectedState.getPower(glider) shouldBe 1
+                    game.state.projectedState.getToughness(glider) shouldBe 1
+                }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("\"until end of turn\" — the saddled marker is cleared in cleanup") {
+                    game.state.getEntity(glider)!!.get<SaddledComponent>() shouldBe null
+                }
+            }
+
+            test("a Vehicle entering becomes an artifact creature for the turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kolodin, Triumph Caster")
+                    .withCardInHand(1, "Air Response Unit") // {2}{W} Artifact — Vehicle 3/3
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Air Response Unit").error shouldBe null
+                game.resolveStack()
+
+                val unit = game.findPermanent("Air Response Unit")!!
+                val projected = game.state.projectedState
+                withClue("the Vehicle is animated at its printed P/T and stays an artifact") {
+                    projected.isCreature(unit) shouldBe true
+                    projected.hasType(unit, "ARTIFACT") shouldBe true
+                    projected.getPower(unit) shouldBe 3
+                    projected.getToughness(unit) shouldBe 3
+                }
+                withClue("no saddled marker — a Vehicle isn't a Mount, so only one trigger fired") {
+                    game.state.getEntity(unit)!!.get<SaddledComponent>() shouldBe null
+                }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("the animation is until end of turn, not permanent") {
+                    game.state.projectedState.isCreature(unit) shouldBe false
+                }
+            }
+
+            test("the haste lord covers Mounts and Vehicles you control but not other creatures") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Kolodin, Triumph Caster")
+                    .withCardOnBattlefield(1, "Brightfield Glider") // Mount
+                    .withCardOnBattlefield(1, "Air Response Unit") // Vehicle
+                    .withCardOnBattlefield(1, "Grizzly Bears") // neither
+                    .withCardOnBattlefield(2, "Brightfield Glider") // an opponent's Mount
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = game.state.projectedState
+                val yourGlider = game.findAllPermanents("Brightfield Glider")
+                    .single { projected.getController(it) == game.player1Id }
+                val theirGlider = game.findAllPermanents("Brightfield Glider")
+                    .single { projected.getController(it) == game.player2Id }
+
+                withClue("your Mount and Vehicle have haste") {
+                    projected.hasKeyword(yourGlider, Keyword.HASTE) shouldBe true
+                    projected.hasKeyword(game.findPermanent("Air Response Unit")!!, Keyword.HASTE) shouldBe true
+                }
+                withClue("a plain creature you control is not a Mount or Vehicle") {
+                    projected.hasKeyword(game.findPermanent("Grizzly Bears")!!, Keyword.HASTE) shouldBe false
+                }
+                withClue("the lord is scoped to permanents YOU control") {
+                    projected.hasKeyword(theirGlider, Keyword.HASTE) shouldBe false
+                }
+                withClue("Kolodin is a Human Pilot — it grants haste but doesn't have it") {
+                    projected.hasKeyword(
+                        game.findPermanent("Kolodin, Triumph Caster")!!,
+                        Keyword.HASTE
+                    ) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LagorinSoulOfAlacriaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LagorinSoulOfAlacriaScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lagorin, Soul of Alacria (DFT #211).
+ *
+ * Lagorin, Soul of Alacria {G}{W} — Legendary Creature — Beast Mount 1/1
+ * Flying
+ * Whenever Lagorin attacks while saddled, put a +1/+1 counter on each of up to two target Mounts
+ * and/or Vehicles.
+ * Saddle 1
+ *
+ * Two claims: the reward is gated on being saddled *when declared as an attacker* (the printed
+ * ruling), and its targets are **permanents** — an uncrewed Vehicle is legal even though it isn't a
+ * creature, while a plain creature isn't.
+ */
+class LagorinSoulOfAlacriaScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun saddledAttackGame(): TestGame = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Lagorin, Soul of Alacria")
+        .withCardOnBattlefield(1, "Grizzly Bears") // the saddler, and not a legal target itself
+        .withCardOnBattlefield(1, "Air Response Unit") // uncrewed Vehicle — a legal target
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Lagorin, Soul of Alacria") {
+
+            test("attacking while saddled offers only Mounts and Vehicles, and counters both") {
+                val game = saddledAttackGame()
+                val lagorin = game.findPermanent("Lagorin, Soul of Alacria")!!
+                val vehicle = game.findPermanent("Air Response Unit")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    com.wingedsheep.engine.core.SaddleMount(game.player1Id, lagorin, listOf(bears))
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Lagorin, Soul of Alacria" to 2)).error shouldBe null
+
+                val decision = game.getPendingDecision() as ChooseTargetsDecision
+                withClue("Lagorin is itself a Mount, and the uncrewed Vehicle qualifies") {
+                    decision.legalTargets.getValue(0) shouldContain vehicle
+                    decision.legalTargets.getValue(0) shouldContain lagorin
+                }
+                withClue("a plain creature is neither a Mount nor a Vehicle") {
+                    decision.legalTargets.getValue(0) shouldNotContain bears
+                }
+
+                game.selectTargets(listOf(lagorin, vehicle)).error shouldBe null
+                game.resolveStack()
+
+                withClue("one counter on each of the two chosen permanents") {
+                    plusOneCounters(game, lagorin) shouldBe 1
+                    plusOneCounters(game, vehicle) shouldBe 1
+                }
+            }
+
+            test("\"up to two\" means one target is a legal answer") {
+                val game = saddledAttackGame()
+                val lagorin = game.findPermanent("Lagorin, Soul of Alacria")!!
+                val vehicle = game.findPermanent("Air Response Unit")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    com.wingedsheep.engine.core.SaddleMount(game.player1Id, lagorin, listOf(bears))
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Lagorin, Soul of Alacria" to 2)).error shouldBe null
+
+                game.selectTargets(listOf(vehicle)).error shouldBe null
+                game.resolveStack()
+
+                plusOneCounters(game, vehicle) shouldBe 1
+                plusOneCounters(game, lagorin) shouldBe 0
+            }
+
+            test("attacking unsaddled does not trigger the reward") {
+                val game = saddledAttackGame()
+                val lagorin = game.findPermanent("Lagorin, Soul of Alacria")!!
+                val vehicle = game.findPermanent("Air Response Unit")!!
+
+                // No saddle this turn — the intervening "if" fails when Lagorin is declared.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Lagorin, Soul of Alacria" to 2)).error shouldBe null
+
+                withClue("no trigger, so nothing asks for targets") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                game.resolveStack()
+                plusOneCounters(game, vehicle) shouldBe 0
+                plusOneCounters(game, lagorin) shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PushTheLimitScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PushTheLimitScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Push the Limit (DFT #143).
+ *
+ * Push the Limit {5}{R}{R} — Sorcery
+ * Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the
+ * beginning of the next end step.
+ * Vehicles you control become artifact creatures until end of turn. Creatures you control gain
+ * haste until end of turn.
+ *
+ * Three claims worth pinning:
+ *
+ *  1. The reanimation is filtered — only Mount and Vehicle cards come back.
+ *  2. The clause order matters. The Vehicles are animated *after* they return, and haste is granted
+ *     *after* that, so a Vehicle that came back this turn is a hasty creature and can attack.
+ *  3. The sacrifice actually fires. It is scheduled as one delayed trigger per returned permanent
+ *     with the entity baked in, so a whole-pipeline reference going stale would show up here as
+ *     permanents that quietly survive the end step.
+ */
+class PushTheLimitScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Push the Limit") {
+
+            test("returns only Mounts and Vehicles, animates them, and gives everything haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Push the Limit")
+                    .withCardInGraveyard(1, "Marshals' Pathcruiser") // Artifact — Vehicle 6/5
+                    .withCardInGraveyard(1, "Guardian Sunmare") // Creature — Horse Mount 5/5
+                    .withCardInGraveyard(1, "Centaur Courser") // plain creature — must stay put
+                    .withCardOnBattlefield(1, "Grizzly Bears") // already in play, gains haste too
+                    .withLandsOnBattlefield(1, "Mountain", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(1, "Push the Limit")
+                withClue("cast should succeed: ${castResult.error}") { castResult.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the Vehicle and the Mount came back") {
+                    game.isOnBattlefield("Marshals' Pathcruiser") shouldBe true
+                    game.isOnBattlefield("Guardian Sunmare") shouldBe true
+                }
+                withClue("a plain creature card is neither a Mount nor a Vehicle — it stays dead") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe true
+                }
+
+                val pathcruiser = game.findPermanent("Marshals' Pathcruiser")!!
+                val sunmare = game.findPermanent("Guardian Sunmare")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("the returned Vehicle is animated for the turn") {
+                    projected.isCreature(pathcruiser) shouldBe true
+                    projected.hasType(pathcruiser, "ARTIFACT") shouldBe true
+                }
+                withClue("haste is granted after the animation, so the Vehicle gets it too") {
+                    projected.hasKeyword(pathcruiser, Keyword.HASTE) shouldBe true
+                }
+                withClue("the returned Mount and the pre-existing creature also gain haste") {
+                    projected.hasKeyword(sunmare, Keyword.HASTE) shouldBe true
+                    projected.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("every returned permanent is sacrificed at the beginning of the next end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Push the Limit")
+                    .withCardInGraveyard(1, "Marshals' Pathcruiser")
+                    .withCardInGraveyard(1, "Guardian Sunmare")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Push the Limit").error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Marshals' Pathcruiser") shouldBe true
+                game.isOnBattlefield("Guardian Sunmare") shouldBe true
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("both returned permanents are sacrificed, not just the first one") {
+                    game.isOnBattlefield("Marshals' Pathcruiser") shouldBe false
+                    game.isOnBattlefield("Guardian Sunmare") shouldBe false
+                    game.isInGraveyard(1, "Marshals' Pathcruiser") shouldBe true
+                    game.isInGraveyard(1, "Guardian Sunmare") shouldBe true
+                }
+                withClue("a creature that was already in play is untouched by the sacrifice") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("with an empty graveyard the spell still resolves and grants haste") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Push the Limit")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Push the Limit").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("nothing to reanimate is not a failure — the last two clauses still apply") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinterCursedRiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WinterCursedRiderScenarioTest.kt
@@ -1,0 +1,207 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Winter, Cursed Rider (DFT #228).
+ *
+ * Winter, Cursed Rider {U}{B} — Legendary Creature — Human Warlock 3/2
+ * Ward—Pay 2 life.
+ * Artifacts you control have "Ward—Pay 2 life."
+ * Exhaust — {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact
+ * creature gets -X/-X until end of turn.
+ *
+ * The load-bearing claim is the **X binding**: the printed cost has no `{X}` mana symbol, so X is
+ * bound purely by the `ExileXFromGraveyard` cost — X *is* how many graveyard cards you choose to
+ * exile. So activating pauses for one card selection over the artifact cards in your graveyard, and
+ * the size of that selection becomes X. Nonartifact cards must not be offered, and a zero selection
+ * has to settle as X = 0 rather than re-prompting.
+ */
+class WinterCursedRiderScenarioTest : ScenarioTestBase() {
+
+    private val exhaustAbilityId
+        get() = cardRegistry.getCard("Winter, Cursed Rider")!!.script.activatedAbilities[0].id
+
+    init {
+        context("Winter, Cursed Rider") {
+
+            test("only artifact cards are offered for the exile cost, and the count becomes X") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Winter, Cursed Rider")
+                    .withCardOnBattlefield(1, "Centaur Courser") // 3/3 nonartifact, yours
+                    // Two artifact cards — the only legal fodder for the exhaust cost …
+                    .withCardInGraveyard(1, "Guidelight Matrix")
+                    .withCardInGraveyard(1, "Guidelight Matrix")
+                    // … alongside three nonartifact cards that must not be offered.
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("five cards in the graveyard, only two of them artifacts") {
+                    game.graveyardSize(1) shouldBe 5
+                }
+                val artifactCards = game.findCardsInGraveyard(1, "Guidelight Matrix")
+                artifactCards.size shouldBe 2
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Winter, Cursed Rider")!!,
+                        abilityId = exhaustAbilityId
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("only the artifact cards are selectable — X can't exceed them") {
+                    decision.options.toSet() shouldBe artifactCards.toSet()
+                    decision.maxSelections shouldBe 2
+                }
+                withClue("exiling nothing is a legal answer (X = 0)") {
+                    decision.minSelections shouldBe 0
+                }
+
+                game.selectCards(artifactCards).error shouldBe null
+                game.resolveStack()
+
+                withClue("both chosen artifact cards went to exile, X = 2") {
+                    game.isInExile(1, "Guidelight Matrix") shouldBe true
+                    game.findCardsInGraveyard(1, "Guidelight Matrix").size shouldBe 0
+                }
+                withClue("-2/-2 from a 3/3 leaves a 1/1") {
+                    game.state.projectedState.getPower(game.findPermanent("Centaur Courser")!!) shouldBe 1
+                }
+            }
+
+            test("the sweep is -X/-X to each OTHER nonartifact creature, and Winter is spared") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Winter, Cursed Rider")
+                    .withCardOnBattlefield(1, "Centaur Courser") // 3/3 nonartifact, yours
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 nonartifact, theirs
+                    .withCardOnBattlefield(2, "Marshals' Pathcruiser") // artifact Vehicle, theirs
+                    .withCardInGraveyard(1, "Guidelight Matrix")
+                    .withCardInGraveyard(1, "Guidelight Matrix")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val winter = game.findPermanent("Winter, Cursed Rider")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val theirVehicle = game.findPermanent("Marshals' Pathcruiser")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = winter,
+                        abilityId = exhaustAbilityId,
+                        xValue = 2,
+                        costPayment = AdditionalCostPayment(
+                            exiledCards = game.findCardsInGraveyard(1, "Guidelight Matrix")
+                        )
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                withClue("both artifact cards left the graveyard for exile") {
+                    game.graveyardSize(1) shouldBe 0
+                    game.isInExile(1, "Guidelight Matrix") shouldBe true
+                }
+
+                val projected = game.state.projectedState
+                withClue("your own nonartifact creature is hit too — the text isn't 'you control'") {
+                    projected.getPower(courser) shouldBe 1
+                    projected.getToughness(courser) shouldBe 1
+                }
+                withClue("the opponent's nonartifact creature dies to -2/-2 (2/2)") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("an artifact Vehicle is not a nonartifact creature — untouched") {
+                    game.isOnBattlefield("Marshals' Pathcruiser") shouldBe true
+                    projected.getPower(theirVehicle) shouldBe 6
+                }
+                withClue("Winter itself is a nonartifact creature but 'each other' excludes it") {
+                    projected.getPower(winter) shouldBe 3
+                    projected.getToughness(winter) shouldBe 2
+                }
+            }
+
+            test("selecting no cards settles as X = 0 instead of re-prompting") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Winter, Cursed Rider")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardInGraveyard(1, "Guidelight Matrix")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Winter, Cursed Rider")!!,
+                        abilityId = exhaustAbilityId
+                    )
+                ).error shouldBe null
+
+                game.selectCards(emptyList()).error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing exiled, and -0/-0 leaves the board alone") {
+                    game.isInExile(1, "Guidelight Matrix") shouldBe false
+                    game.state.projectedState.getPower(game.findPermanent("Centaur Courser")!!) shouldBe 3
+                }
+                withClue("the decision is done — the engine did not ask again") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+
+            test("both instances of ward exist: Winter's own and the one it grants artifacts") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Winter, Cursed Rider")
+                    .withCardOnBattlefield(1, "Guidelight Matrix")
+                    .withCardOnBattlefield(2, "Guidelight Matrix")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val winter = game.findPermanent("Winter, Cursed Rider")!!
+                val yourMatrix = game.findAllPermanents("Guidelight Matrix")
+                    .single { game.state.projectedState.getController(it) == game.player1Id }
+                val theirMatrix = game.findAllPermanents("Guidelight Matrix")
+                    .single { game.state.projectedState.getController(it) == game.player2Id }
+
+                val projected = game.state.projectedState
+                withClue("Winter has its printed ward") {
+                    projected.hasKeyword(winter, Keyword.WARD) shouldBe true
+                }
+                withClue("your artifacts pick ward up from the lord") {
+                    projected.hasKeyword(yourMatrix, Keyword.WARD) shouldBe true
+                }
+                withClue("the lord is scoped to artifacts YOU control") {
+                    projected.hasKeyword(theirMatrix, Keyword.WARD) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Aetherdrift cards. All five are DFT-original printings per Scryfall, so each canonical `CardDefinition` lives in `definitions/dft/cards/` — no reprint rows needed. `just check-card-printing` passes for all five.

| Card | | Shape |
|---|---|---|
| **Kolodin, Triumph Caster** | `{R}{W}` 2/3 | Haste lord over Mounts+Vehicles; a Mount entering becomes saddled, a Vehicle entering becomes an artifact creature |
| **Lagorin, Soul of Alacria** | `{G}{W}` 1/1 | Flying, Saddle 1; attacks-while-saddled → +1/+1 counter on each of up to two target Mounts/Vehicles |
| **Caradora, Heart of Alacria** | `{2}{G}{W}` 4/2 | ETB Mount-or-Vehicle tutor; +1/+1 counters on your creatures *and Vehicles* get one extra |
| **Push the Limit** | `{5}{R}{R}` | Mass Mount/Vehicle reanimation → animate the Vehicles → haste, all sacrificed at the next end step |
| **Winter, Cursed Rider** | `{U}{B}` 3/2 | Ward—Pay 2 life, and a ward lord on your artifacts; exhaust "exile X artifact cards" → -X/-X board sweep |

## Modelling notes

**Caradora's counter clause** is Hardened Scales' `ModifyCounterPlacement` with the recipient widened from the default "a creature you control" to a creature-or-Vehicle union — an uncrewed Vehicle isn't a creature, so the default wouldn't have fired on it. Modelling it as the *placement replacement* rather than a trigger that adds one more counter is what makes the printed rulings fall out for free: a permanent entering with counters enters with one extra, two Caradoras stack, and the controller orders it against other placement replacements per CR 616.1.

**Push the Limit** schedules the sacrifice as one delayed trigger per returned permanent, created inside `ForEachInCollection` where `EffectTarget.Self` is the current entity. `CreateDelayedTriggerExecutor` bakes per-target effects into concrete entity ids but *not* pipeline collections, so a whole-collection reference would have gone stale and quietly sacrificed nothing. N single-permanent triggers firing together at the same step are indistinguishable from the printed one-ability-sacrifices-all. Clause order is load-bearing rather than cosmetic: the Vehicles are animated *after* they return and haste is granted *after* that, so a Vehicle that came back this turn is a hasty creature and can attack — the whole point of the card.

## Two fail-open paths in `ExileXFromGraveyard`

Winter needed a genuinely variable exile-X cost, and turned up two paths where the card would have looked right and resolved as a no-op.

**1. X was only ever bound by a `{X}` mana symbol.** Winter's printed cost has none — `{2}{U}{B}, {T}, Exile X artifact cards from your graveyard` — so the activation arrived with `xValue` null, fell through to `?: 0`, paid nothing and swept for -0/-0. `ActivateAbilityHandler` now pauses for a single `SelectCardsDecision` over the matching graveyard cards and derives X from the size of that selection: X *is* how many cards you chose, so one decision settles both rather than a number picker followed by a selection.

That also hands the player the "which cards" choice `CostHandler` used to make for them by taking the first N. Necropolis Fiend (`{X}, {T}, Exile X cards from your graveyard`) gets the same selection, with its mana `{X}` pinning the count. Selecting nothing is legal and settles as X = 0 without re-prompting.

**2. `calculateMaxAffordableX` capped X by total graveyard size, ignoring the cost's filter.** A graveyard of five cards with two artifacts in it offered X up to 5, and payment then failed in `CostHandler` (which does apply the filter). Now capped by the cards that actually match. A filter-less cost still gets the plain graveyard size.

No new SDK vocabulary — `Costs.ExileXFromGraveyard` already existed; its entry in the SDK reference is updated to describe the variable-count semantics.

## Verification

- **19 scenario tests** across the five cards, one file per card. Beyond the happy paths they pin: the saddled-attacker intervening "if" not firing when unsaddled, "up to two" accepting one target, `Push the Limit` leaving a non-Mount/Vehicle in the graveyard and resolving fine on an empty graveyard, every returned permanent being sacrificed (not just the first), Caradora skipping an opponent's permanent, Kolodin's lord not reaching an opponent's Mount, Winter sparing itself and artifact Vehicles, and a zero exile selection settling as X = 0.
- Full `just test` green.
- Each card re-verified field-by-field against Scryfall: mana cost, type line, P/T, rarity, collector number, artist, oracle text line-by-line, and `image_uris.normal` (all HTTP 200).
- DFT snapshot golden re-blessed — pure additions, only these five cards move.
- No Aetherdrift backlog file exists, so no backlog bookkeeping.

## Not covered

No new decision UI: Winter's graveyard selection routes to the existing full-screen `CardSelectionDecision` (single-zone, `useTargetingUI` false — the same path Rust Harvester's fixed-count exile cost already uses), and Lagorin's up-to-two targeting to `BattlefieldTargetingUI`. So no client change and no e2e spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)