### PR TITLE
SPM Batch 4: Electro, Assaulting Battery + Hydro-Man, Fluid Felon

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 173 / 188
+**Implemented:** 174 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -33,7 +33,7 @@
 - [x] Eddie Brock // Venom, Lethal Protector
 - [x] Eerie Gravestone
 - [x] Electro's Bolt
-- [ ] Electro, Assaulting Battery
+- [x] Electro, Assaulting Battery
 - [x] Ezekiel Sims, Spider-Totem
 - [x] Flash Thompson, Spider-Fan
 - [x] Flying Octobot

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 174 / 188
+**Implemented:** 175 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -48,7 +48,7 @@
 - [x] Hide on the Ceiling
 - [x] Hobgoblin, Mantled Marauder
 - [x] Hot Dog Cart
-- [ ] Hydro-Man, Fluid Felon
+- [x] Hydro-Man, Fluid Felon
 - [x] Impostor Syndrome
 - [x] Inner Demons Gangsters
 - [x] Interdimensional Web Watch

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -385,7 +385,7 @@ grant-holder's controller (the `GrantedActivatedAbility` record needs a controll
 field, like the player-component grants).
 
 Blocked cards:
-- **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'". The **granted-activated `UntilYourNextTurn` expiry** half is now **fixed** on branch `spm-costs-mana` (`CleanupPhaseManager.expireUntilYourNextTurnEffects` drops `grantedActivatedAbilities` with that duration, keyed to the granted entity's controller). BUT the card is still blocked on a **second, unplanned primitive**: "becomes a **non-creature land**" is a type-*replacement* (lose creature card type + become a Land), and only `AddCardTypeEffect` (additive "in addition to its types") exists — there is no "becomes only a land" effect. Deferred until that type-replacement primitive is built.
+- **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'". *(Resolved — see the section header above.* Both halves shipped: `expireUntilYourNextTurnEffects` now drops `grantedActivatedAbilities` with `UntilYourNextTurn` duration, and the "becomes a non-creature land" half needed **no** new primitive after all — the mid-review worry that only additive `AddCardTypeEffect` existed was wrong: `BecomeArtifactEffect` sets `SetCardTypes(setOf("LAND"))`, a full type-*replacement* that drops the creature type. *)*
 </details>
 
 ## Static damage redirect to the enchanted/equipped creature (Pariah-style) — ✅ IMPLEMENTED

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -356,7 +356,17 @@ Blocked cards:
 - **Anti-Venom, Horrifying Healer** [1] — `{W}{W}{W}{W}{W}` Symbiote Hero; ETB "if cast, reanimate a creature" is fine, but the damage-prevention-to-counters self-replacement is the blocker.
 </details>
 
-## Granted activated ability with `UntilYourNextTurn` duration never expires
+## Granted activated ability with `UntilYourNextTurn` duration never expires — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-costs-mana`. `CleanupPhaseManager.expireUntilYourNextTurnEffects` now also
+drops `grantedActivatedAbilities` whose duration is `UntilYourNextTurn`, keyed to the granted entity's
+current controller (correct for the self-grant case). The "becomes a non-creature land" half was *not* a
+missing primitive after all — `BecomeArtifactEffect` is a general "becomes [cardTypes]" effect;
+`BecomeArtifactEffect(cardTypes = setOf("LAND"), colors = null, loseAllAbilities = false, grantedAbility =
+"{T}: Add {U}", duration = UntilYourNextTurn)` expresses Hydro-Man's transform, and its granted mana
+ability expires via the fix above. Card: **Hydro-Man, Fluid Felon** [33].
+
+<details><summary>Original analysis</summary>
 
 > …until your next turn, he becomes a land and **gains "{T}: Add {U}."**
 
@@ -376,6 +386,7 @@ field, like the player-component grants).
 
 Blocked cards:
 - **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'". The **granted-activated `UntilYourNextTurn` expiry** half is now **fixed** on branch `spm-costs-mana` (`CleanupPhaseManager.expireUntilYourNextTurnEffects` drops `grantedActivatedAbilities` with that duration, keyed to the granted entity's controller). BUT the card is still blocked on a **second, unplanned primitive**: "becomes a **non-creature land**" is a type-*replacement* (lose creature card type + become a Land), and only `AddCardTypeEffect` (additive "in addition to its types") exists — there is no "becomes only a land" effect. Deferred until that type-replacement primitive is built.
+</details>
 
 ## Static damage redirect to the enchanted/equipped creature (Pariah-style) — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -223,7 +223,16 @@ reference + `CardLinter`).
 Blocked cards:
 - **Behold the Sinister Six!** [51] — `{6}{B}` Sorcery; "Return up to six target creature cards with different names from your graveyard to the battlefield." Dropping the constraint would wrongly allow six copies of the same-named creature, so it is not approximated.
 
-## Color-filtered permanent "don't lose unspent [color] mana" static
+## Color-filtered permanent "don't lose unspent [color] mana" static — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-costs-mana`. Added `RetainUnspentColoredMana(color)` StaticAbility (scan-based,
+controller-scoped, single-colour, durable) merged into the `retain` colour set in
+`CleanupPhaseManager.emptyManaPools` (control-aware, via a `retainedColorsFromStatics` helper). `endCombat`
+needs no change — it only touches firebending `END_OF_COMBAT` mana, not ordinary red. Card: **Electro,
+Assaulting Battery** [76] (the cast-instant/sorcery→add-{R} and LTB `MayPayXForEffect` deal-X clauses use
+existing primitives).
+
+<details><summary>Original analysis</summary>
 
 > You don't lose unspent **red** mana as steps and phases end.
 
@@ -238,6 +247,7 @@ to a permanent's presence. Fix (add-feature): a color-parameterized `RetainUnspe
 
 Blocked cards:
 - **Electro, Assaulting Battery** [76] — `{1}{R}{R}` Flying; "You don't lose unspent red mana as steps and phases end." Its other clauses (Flying; cast-instant/sorcery → add {R}; LTB pay-{X} deal X to a player) are all expressible today.
+</details>
 
 ## "Discard a card OR pay {2}" additional cost (DiscardOrPay) — ✅ IMPLEMENTED
 
@@ -365,7 +375,7 @@ grant-holder's controller (the `GrantedActivatedAbility` record needs a controll
 field, like the player-component grants).
 
 Blocked cards:
-- **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'" — the type-change + untap work, but the granted mana ability never expires.
+- **Hydro-Man, Fluid Felon** [33] — `{U}{U}`; blue-cast pump (fine) + end-step "untap; until your next turn becomes a non-creature land with '{T}: Add {U}'". The **granted-activated `UntilYourNextTurn` expiry** half is now **fixed** on branch `spm-costs-mana` (`CleanupPhaseManager.expireUntilYourNextTurnEffects` drops `grantedActivatedAbilities` with that duration, keyed to the granted entity's controller). BUT the card is still blocked on a **second, unplanned primitive**: "becomes a **non-creature land**" is a type-*replacement* (lose creature card type + become a Land), and only `AddCardTypeEffect` (additive "in addition to its types") exists — there is no "becomes only a land" effect. Deferred until that type-replacement primitive is built.
 
 ## Static damage redirect to the enchanted/equipped creature (Pariah-style) — ✅ IMPLEMENTED
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4722,6 +4722,12 @@ staticAbility {
   *controller's* would-be-lost mana becomes that many red mana instead of emptying (CR 500.5 / 703.4q
   emptying replaced per CR 614). Scoped to the controller of the bearing permanent, unlike Upwelling's
   all-players prevention. (Ozai, the Phoenix King)
+- `RetainUnspentColoredMana(color)` — "You don't lose unspent [color] mana as steps and phases end."
+  The durable, single-colour, controller-scoped mana-retention static (Electro, Assaulting Battery —
+  red). Where `PreventManaPoolEmptying` keeps *all* colours for *everyone* and `ConvertEmptyingManaToRed`
+  *replaces* other colours with red, this simply keeps that one colour and lets every other colour empty.
+  Merged into the `retain` set at `CleanupPhaseManager.emptyManaPools` (control-aware). The static twin of
+  the turn-scoped one-shot `RetainUnspentMana(vararg colors)` effect (The Last Agni Kai).
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source

--- a/manual-scenarios/sets/spm/batch4-new-cards-castable.json
+++ b/manual-scenarios/sets/spm/batch4-new-cards-castable.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Electro, Assaulting Battery", "Hydro-Man, Fluid Felon", "Lightning Bolt", "Opt"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain", "Island", "Mountain", "Island", "Mountain", "Island", "Mountain", "Island", "Mountain", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Smother", "Swamp", "Mountain", "Island", "Mountain", "Island", "Mountain", "Lightning Bolt", "Island", "Mountain", "Island", "Mountain", "Mountain", "Island", "Mountain", "Island", "Mountain", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -804,8 +804,9 @@ data object ConvertEmptyingManaToRed : StaticAbility {
  * (The Last Agni Kai). Unlike [PreventManaPoolEmptying] (all colours, all players) and
  * [ConvertEmptyingManaToRed] (converts other colours to red), this simply keeps that one colour for
  * the controller and lets every other colour empty normally. The engine merges the colour into the
- * `retain` set at every step/phase-end mana emptying (`CleanupPhaseManager.emptyManaPools`) and the
- * end-of-combat firebending emptying (`CombatManager.endCombat`).
+ * `retain` set at every step/phase-end mana emptying (`CleanupPhaseManager.emptyManaPools`), which is
+ * the single path for ordinary mana loss — the combat phase ends through it too, so end-of-combat
+ * needs no separate handling (`CombatManager.endCombat` only discards firebending mana).
  */
 @SerialName("RetainUnspentColoredMana")
 @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -796,6 +796,24 @@ data object ConvertEmptyingManaToRed : StaticAbility {
 }
 
 /**
+ * The controller doesn't lose unspent mana of [color] as steps and phases end (Electro, Assaulting
+ * Battery: "You don't lose unspent red mana as steps and phases end").
+ *
+ * A single-colour, controller-scoped, *permanent* mana-retention static — the durable static twin of
+ * the turn-scoped one-shot [com.wingedsheep.engine.state.components.player.RetainUnspentManaComponent]
+ * (The Last Agni Kai). Unlike [PreventManaPoolEmptying] (all colours, all players) and
+ * [ConvertEmptyingManaToRed] (converts other colours to red), this simply keeps that one colour for
+ * the controller and lets every other colour empty normally. The engine merges the colour into the
+ * `retain` set at every step/phase-end mana emptying (`CleanupPhaseManager.emptyManaPools`) and the
+ * end-of-combat firebending emptying (`CombatManager.endCombat`).
+ */
+@SerialName("RetainUnspentColoredMana")
+@Serializable
+data class RetainUnspentColoredMana(val color: Color) : StaticAbility {
+    override val description: String = "You don't lose unspent ${color.name.lowercase()} mana as steps and phases end"
+}
+
+/**
  * Removes the maximum hand size limit for the controller.
  * Used for cards like Thought Vessel and Reliquary Tower: "You have no maximum hand size."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ElectroAssaultingBattery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ElectroAssaultingBattery.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.RetainUnspentColoredMana
+import com.wingedsheep.sdk.scripting.effects.MayPayXForEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Electro, Assaulting Battery — Marvel's Spider-Man #76
+ * {1}{R}{R} · Legendary Creature — Human Villain · 2/3
+ *
+ * Flying
+ * You don't lose unspent red mana as steps and phases end.
+ * Whenever you cast an instant or sorcery spell, add {R}.
+ * When Electro leaves the battlefield, you may pay {X}. When you do, he deals X damage to target
+ * player.
+ *
+ * The mana-retention clause is the new `RetainUnspentColoredMana(Color.RED)` static.
+ */
+val ElectroAssaultingBattery = card("Electro, Assaulting Battery") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Villain"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "You don't lose unspent red mana as steps and phases end.\n" +
+        "Whenever you cast an instant or sorcery spell, add {R}.\n" +
+        "When Electro leaves the battlefield, you may pay {X}. When you do, he deals X damage to " +
+        "target player."
+
+    keywords(Keyword.FLYING)
+
+    // You don't lose unspent red mana as steps and phases end.
+    staticAbility {
+        ability = RetainUnspentColoredMana(Color.RED)
+    }
+
+    // Whenever you cast an instant or sorcery spell, add {R}.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.InstantOrSorcery)
+        effect = Effects.AddMana(Color.RED)
+    }
+
+    // When Electro leaves the battlefield, you may pay {X}. When you do, he deals X damage to a player.
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        val target = target("target player", Targets.Player)
+        effect = MayPayXForEffect(
+            effect = Effects.DealDamage(DynamicAmount.XValue, target)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "76"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d672cfad-e656-47f8-bf93-64f262aff33e.jpg?1783905338"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/HydroManFluidFelon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/HydroManFluidFelon.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.BecomeArtifactEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hydro-Man, Fluid Felon — Marvel's Spider-Man #33
+ * {U}{U} · Legendary Creature — Elemental Villain · 2/2
+ *
+ * Whenever you cast a blue spell, if Hydro-Man is a creature, he gets +1/+1 until end of turn.
+ * At the beginning of your end step, untap Hydro-Man. Until your next turn, he becomes a land and
+ * gains "{T}: Add {U}." (He's not a creature during that time.)
+ *
+ * The end-step transform uses `BecomeArtifactEffect(cardTypes = setOf("LAND"), …)` — a general
+ * "becomes [types]" effect — with `UntilYourNextTurn` duration; the granted "{T}: Add {U}" now
+ * correctly expires via `CleanupPhaseManager.expireUntilYourNextTurnEffects`.
+ */
+val HydroManFluidFelon = card("Hydro-Man, Fluid Felon") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Elemental Villain"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast a blue spell, if Hydro-Man is a creature, he gets +1/+1 until " +
+        "end of turn.\n" +
+        "At the beginning of your end step, untap Hydro-Man. Until your next turn, he becomes a " +
+        "land and gains \"{T}: Add {U}.\" (He's not a creature during that time.)"
+
+    // Whenever you cast a blue spell, if Hydro-Man is a creature, he gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLUE))
+        triggerCondition = Conditions.SourceMatches(GameObjectFilter.Creature)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // End step: untap, then become a non-creature land with "{T}: Add {U}" until your next turn.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Composite(
+            Effects.Untap(EffectTarget.Self),
+            BecomeArtifactEffect(
+                target = EffectTarget.Self,
+                cardTypes = setOf("LAND"),
+                colors = null,          // keep Hydro-Man's blue color
+                loseAllAbilities = false,
+                grantedAbility = ActivatedAbility(
+                    cost = Costs.Tap,
+                    effect = Effects.AddMana(Color.BLUE),
+                    isManaAbility = true,
+                    descriptionOverride = "{T}: Add {U}."
+                ),
+                duration = Duration.UntilYourNextTurn
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e53115a4-8959-40fa-b763-931504a1c5a2.jpg?1783905353"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -3011,6 +3011,101 @@
     "colorIdentityOverride": []
 }
 
+// Hydro-Man, Fluid Felon
+{
+    "name": "Hydro-Man, Fluid Felon",
+    "manaCost": "{U}{U}",
+    "typeLine": "Legendary Creature — Elemental Villain",
+    "oracleText": "Whenever you cast a blue spell, if Hydro-Man is a creature, he gets +1/+1 until end of turn.\nAt the beginning of your end step, untap Hydro-Man. Until your next turn, he becomes a land and gains \"{T}: Add {U}.\" (He's not a creature during that time.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        },
+                        {
+                            "type": "BecomeArtifact",
+                            "target": "Self",
+                            "cardTypes": [
+                                "LAND"
+                            ],
+                            "colors": null,
+                            "loseAllAbilities": false,
+                            "grantedAbility": {
+                                "id": "ability_3",
+                                "cost": "CostTap",
+                                "effect": {
+                                    "type": "AddMana",
+                                    "color": "BLUE"
+                                },
+                                "isManaAbility": true,
+                                "descriptionOverride": "{T}: Add {U}."
+                            },
+                            "duration": "UntilYourNextTurn"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "RARE",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e53115a4-8959-40fa-b763-931504a1c5a2.jpg?1783905353"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Impostor Syndrome
 {
     "name": "Impostor Syndrome",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1936,6 +1936,85 @@
     ]
 }
 
+// Electro, Assaulting Battery
+{
+    "name": "Electro, Assaulting Battery",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Legendary Creature — Human Villain",
+    "oracleText": "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhenever you cast an instant or sorcery spell, add {R}.\nWhen Electro leaves the battlefield, you may pay {X}. When you do, he deals X damage to target player.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayPayX",
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "RetainUnspentColoredMana",
+                "color": "RED"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d672cfad-e656-47f8-bf93-64f262aff33e.jpg?1783905338"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ezekiel Sims, Spider-Totem
 {
     "name": "Ezekiel Sims, Spider-Totem",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -416,7 +416,7 @@ class CleanupPhaseManager(
                     // per-colour static (Electro, Assaulting Battery: "you don't lose unspent red
                     // mana as steps and phases end").
                     val retained = (container.get<RetainUnspentManaComponent>()?.colors ?: emptySet()) +
-                        retainedColorsFromStatics(state, playerId)
+                        retainedColorsFromStatics(state, cardRegistry, playerId)
                     container.with(
                         manaPool.emptyAtBoundary(
                             convertToRed = playerId in convertToRedPlayers,
@@ -445,28 +445,6 @@ class CleanupPhaseManager(
             }
         }
         return false
-    }
-
-    /**
-     * Colours [playerId] keeps at step/phase-end because they control a permanent with a
-     * [com.wingedsheep.sdk.scripting.RetainUnspentColoredMana] static (Electro, Assaulting Battery).
-     * Control-aware (projected), so a stolen Electro retains for its new controller.
-     */
-    private fun retainedColorsFromStatics(
-        state: GameState,
-        playerId: com.wingedsheep.sdk.model.EntityId
-    ): Set<com.wingedsheep.sdk.core.Color> {
-        val projected = state.projectedState
-        val colors = mutableSetOf<com.wingedsheep.sdk.core.Color>()
-        for (entityId in state.getBattlefield()) {
-            if (projected.getController(entityId) != playerId) continue
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            for (ability in cardDef.script.staticAbilities) {
-                if (ability is com.wingedsheep.sdk.scripting.RetainUnspentColoredMana) colors.add(ability.color)
-            }
-        }
-        return colors
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -178,12 +178,24 @@ class CleanupPhaseManager(
             !(grant.duration is Duration.UntilYourNextTurn &&
                 grant.controllerId == activePlayer)
         }
+        // Granted *activated* abilities with UntilYourNextTurn duration (Hydro-Man's temporary
+        // "{T}: Add {U}"). The record carries no expiry-player, so key the expiry to the granted
+        // entity's current controller — correct for the self-grant case (a permanent granting
+        // itself an ability "until your next turn").
+        val remainingGrantedActivated = state.grantedActivatedAbilities.filter { grant ->
+            !(grant.duration is Duration.UntilYourNextTurn &&
+                state.getEntity(grant.entityId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                    ?.playerId == activePlayer)
+        }
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
-        var result = if (floatingChanged || globalChanged) {
+        val grantedActivatedChanged = remainingGrantedActivated.size != state.grantedActivatedAbilities.size
+        var result = if (floatingChanged || globalChanged || grantedActivatedChanged) {
             state.copy(
                 floatingEffects = if (floatingChanged) remainingFloating else state.floatingEffects,
-                globalGrantedTriggeredAbilities = if (globalChanged) remainingGlobal else state.globalGrantedTriggeredAbilities
+                globalGrantedTriggeredAbilities = if (globalChanged) remainingGlobal else state.globalGrantedTriggeredAbilities,
+                grantedActivatedAbilities = if (grantedActivatedChanged) remainingGrantedActivated else state.grantedActivatedAbilities
             )
         } else {
             state
@@ -400,7 +412,11 @@ class CleanupPhaseManager(
             newState = newState.updateEntity(playerId) { container ->
                 val manaPool = container.get<ManaPoolComponent>()
                 if (manaPool != null && !manaPool.isEmpty) {
-                    val retained = container.get<RetainUnspentManaComponent>()?.colors ?: emptySet()
+                    // Turn-scoped retention (The Last Agni Kai) unioned with the durable
+                    // per-colour static (Electro, Assaulting Battery: "you don't lose unspent red
+                    // mana as steps and phases end").
+                    val retained = (container.get<RetainUnspentManaComponent>()?.colors ?: emptySet()) +
+                        retainedColorsFromStatics(state, playerId)
                     container.with(
                         manaPool.emptyAtBoundary(
                             convertToRed = playerId in convertToRedPlayers,
@@ -429,6 +445,28 @@ class CleanupPhaseManager(
             }
         }
         return false
+    }
+
+    /**
+     * Colours [playerId] keeps at step/phase-end because they control a permanent with a
+     * [com.wingedsheep.sdk.scripting.RetainUnspentColoredMana] static (Electro, Assaulting Battery).
+     * Control-aware (projected), so a stolen Electro retains for its new controller.
+     */
+    private fun retainedColorsFromStatics(
+        state: GameState,
+        playerId: com.wingedsheep.sdk.model.EntityId
+    ): Set<com.wingedsheep.sdk.core.Color> {
+        val projected = state.projectedState
+        val colors = mutableSetOf<com.wingedsheep.sdk.core.Color>()
+        for (entityId in state.getBattlefield()) {
+            if (projected.getController(entityId) != playerId) continue
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is com.wingedsheep.sdk.scripting.RetainUnspentColoredMana) colors.add(ability.color)
+            }
+        }
+        return colors
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaEmptyingStatics.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaEmptyingStatics.kt
@@ -3,8 +3,10 @@ package com.wingedsheep.engine.core
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ConvertEmptyingManaToRed
+import com.wingedsheep.sdk.scripting.RetainUnspentColoredMana
 
 /**
  * Players who control a permanent with the [ConvertEmptyingManaToRed] static ability
@@ -28,4 +30,33 @@ fun playersConvertingEmptyingManaToRed(state: GameState, cardRegistry: CardRegis
         }
     }
     return result
+}
+
+/**
+ * Colours [playerId] keeps at every step/phase-end because they control a permanent with a
+ * [RetainUnspentColoredMana] static (Electro, Assaulting Battery: "You don't lose unspent red mana
+ * as steps and phases end"). Consulted by [CleanupPhaseManager.emptyManaPools], which unions these
+ * into the per-player `retain` set alongside the turn-scoped [RetainUnspentManaComponent] marker.
+ * Controller is read from projected state so a stolen Electro retains for its new controller.
+ *
+ * Sibling of [playersConvertingEmptyingManaToRed]; both scan printed static abilities. A permanent
+ * whose abilities are removed by a Layer-6 wipe would still be counted here — an accepted, shared
+ * limitation, not modelled by either scan.
+ */
+fun retainedColorsFromStatics(
+    state: GameState,
+    cardRegistry: CardRegistry,
+    playerId: EntityId
+): Set<Color> {
+    val projected = state.projectedState
+    val colors = mutableSetOf<Color>()
+    for (entityId in state.getBattlefield()) {
+        if (projected.getController(entityId) != playerId) continue
+        val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+        val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+        for (ability in cardDef.script.staticAbilities) {
+            if (ability is RetainUnspentColoredMana) colors.add(ability.color)
+        }
+    }
+    return colors
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -148,6 +148,7 @@ import com.wingedsheep.sdk.scripting.PreventCycling
 import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
 import com.wingedsheep.sdk.scripting.ConvertEmptyingManaToRed
 import com.wingedsheep.sdk.scripting.PreventManaPoolEmptying
+import com.wingedsheep.sdk.scripting.RetainUnspentColoredMana
 import com.wingedsheep.sdk.scripting.ReplaceLandManaColor
 import com.wingedsheep.sdk.scripting.RestrictSpellsCastPerTurn
 import com.wingedsheep.sdk.scripting.RevealFirstDrawEachTurn
@@ -913,6 +914,7 @@ class StaticAbilityHandler(
             is SetMaximumHandSize,
             is PreventManaPoolEmptying,
             is ConvertEmptyingManaToRed,
+            is RetainUnspentColoredMana,
             is UntapDuringOtherUntapSteps,
             is UntapFilteredDuringOtherUntapSteps,
             is UntapSelfDuringOtherUntapSteps,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectroAssaultingBatteryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectroAssaultingBatteryScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Electro, Assaulting Battery (SPM) — "You don't lose unspent red mana as steps and phases end."
+ * Pins the new `RetainUnspentColoredMana(Color.RED)` static wired into
+ * `CleanupPhaseManager.emptyManaPools`.
+ */
+class ElectroAssaultingBatteryScenarioTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, com.wingedsheep.sdk.model.EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    test("red mana survives a step/phase boundary; other colors still empty") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Electro, Assaulting Battery")
+        driver.giveMana(you, Color.RED, 2)
+        driver.giveMana(you, Color.GREEN, 1)
+
+        // Cross into combat — the precombat-main → combat boundary empties mana pools.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val pool = driver.state.getEntity(you)?.get<ManaPoolComponent>()
+        pool?.red shouldBe 2   // retained by Electro
+        pool?.green shouldBe 0 // still emptied
+    }
+
+    test("without Electro, red mana empties at the boundary too") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Centaur Courser") // so combat reaches declare-attackers
+        driver.giveMana(you, Color.RED, 2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        (driver.state.getEntity(you)?.get<ManaPoolComponent>()?.red ?: 0) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroManFluidFelonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroManFluidFelonScenarioTest.kt
@@ -37,6 +37,12 @@ class HydroManFluidFelonScenarioTest : FunSpec({
         while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
     }
 
+    /** Advance to the active player's *next* precombat main (stepping out via END first). */
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
     test("casting a blue spell pumps Hydro-Man +1/+1 while he is a creature") {
         val (driver, you) = newGame()
         val hydro = driver.putCreatureOnBattlefield(you, "Hydro-Man, Fluid Felon") // 2/2
@@ -62,5 +68,30 @@ class HydroManFluidFelonScenarioTest : FunSpec({
 
         driver.state.projectedState.isCreature(hydro) shouldBe false
         driver.state.projectedState.hasType(hydro, "LAND") shouldBe true
+    }
+
+    test("the temporary land + granted '{T}: Add {U}' expire on your next turn") {
+        val (driver, you) = newGame()
+        val hydro = driver.putCreatureOnBattlefield(you, "Hydro-Man, Fluid Felon")
+        driver.removeSummoningSickness(hydro)
+
+        // End step: he becomes a non-creature land and gains the granted "{T}: Add {U}".
+        driver.passPriorityUntil(Step.END)
+        resolveStack(driver)
+        driver.state.projectedState.isCreature(hydro) shouldBe false
+        driver.state.grantedActivatedAbilities.any { it.entityId == hydro } shouldBe true
+
+        // Out to the opponent's turn — still a land while it isn't yet your next turn.
+        advanceToNextTurnMain(driver)
+        driver.state.projectedState.isCreature(hydro) shouldBe false
+        driver.state.grantedActivatedAbilities.any { it.entityId == hydro } shouldBe true
+
+        // Your next turn: after the untap step the UntilYourNextTurn effects expire — he is a
+        // creature again and the granted mana ability is gone.
+        advanceToNextTurnMain(driver)
+        driver.state.activePlayerId shouldBe you
+        driver.state.projectedState.isCreature(hydro) shouldBe true
+        driver.state.projectedState.hasType(hydro, "LAND") shouldBe false
+        driver.state.grantedActivatedAbilities.any { it.entityId == hydro } shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroManFluidFelonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HydroManFluidFelonScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hydro-Man, Fluid Felon (SPM) — blue-cast pump + the end-step "becomes a non-creature land with
+ * '{T}: Add {U}' until your next turn". Pins `BecomeArtifactEffect(cardTypes = setOf("LAND"))` with
+ * `UntilYourNextTurn` duration and the granted-activated-ability expiry fix.
+ */
+class HydroManFluidFelonScenarioTest : FunSpec({
+
+    val testBlueInstant = card("Hydro Test Bolt") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell { effect = Effects.DealDamage(1, com.wingedsheep.sdk.scripting.targets.EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.TargetOpponent)) }
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testBlueInstant))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("casting a blue spell pumps Hydro-Man +1/+1 while he is a creature") {
+        val (driver, you) = newGame()
+        val hydro = driver.putCreatureOnBattlefield(you, "Hydro-Man, Fluid Felon") // 2/2
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        driver.giveMana(you, Color.BLUE, 1)
+        val bolt = driver.putCardInHand(you, "Hydro Test Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Player(opponent)))
+        driver.bothPass()
+        resolveStack(driver)
+
+        driver.state.projectedState.getPower(hydro) shouldBe 3 // 2 + 1
+    }
+
+    test("at your end step Hydro-Man becomes a non-creature land") {
+        val (driver, you) = newGame()
+        val hydro = driver.putCreatureOnBattlefield(you, "Hydro-Man, Fluid Felon")
+        driver.removeSummoningSickness(hydro)
+        driver.state.projectedState.isCreature(hydro) shouldBe true
+
+        driver.passPriorityUntil(Step.END)
+        resolveStack(driver) // resolve the end-step trigger (untap + become a land)
+
+        driver.state.projectedState.isCreature(hydro) shouldBe false
+        driver.state.projectedState.hasType(hydro, "LAND") shouldBe true
+    }
+})


### PR DESCRIPTION
## SPM Batch 4 — mana-costs cluster: Electro & Hydro-Man

Implements two Marvel's Spider-Man cards, plus the two small engine capabilities they needed. SPM
now at **175 / 188**.

### Cards

- **Electro, Assaulting Battery** [76] — `{1}{R}{R}` Legendary Creature. Flying; "You don't lose
  unspent red mana as steps and phases end"; cast-instant/sorcery → add `{R}`; LTB `MayPayX` deal X
  to target player. Only the mana-retention clause needed new engine support.
- **Hydro-Man, Fluid Felon** [33] — `{U}{U}` Legendary Creature. Blue-cast pump (intervening-if
  "while a creature"); end-step "untap; until your next turn becomes a non-creature land with
  '{T}: Add {U}'." Composes the existing `BecomeArtifactEffect` (`SetCardTypes(setOf("LAND"))`) —
  no new "becomes a land" primitive; only the granted mana ability's expiry needed a fix.

### Engine

1. **`RetainUnspentColoredMana(color)`** static (`mtg-sdk`) — durable, single-colour,
   controller-scoped mana retention. Sits between `PreventManaPoolEmptying` (all colours/all
   players) and `ConvertEmptyingManaToRed` (replace-with-red). Merged into the per-player `retain`
   set at the one ordinary-mana-loss path, `CleanupPhaseManager.emptyManaPools`, via
   `retainedColorsFromStatics` (co-located with its twin `playersConvertingEmptyingManaToRed` in
   `ManaEmptyingStatics.kt`). Control-aware (projected controller).
2. **`grantedActivatedAbilities` `UntilYourNextTurn` expiry** — `expireUntilYourNextTurnEffects` now
   also prunes granted *activated* abilities with that duration (keyed to the granted entity's
   current controller), so Hydro-Man's temporary `{T}: Add {U}` disappears when he reverts to a
   creature.

### Tests

- `ElectroAssaultingBatteryScenarioTest` — red survives a step/phase boundary while other colours
  empty; control (no Electro → red empties too).
- `HydroManFluidFelonScenarioTest` — blue-cast pump; end-step becomes a non-creature land; and the
  land + granted mana ability both expire on the controller's next turn.

All scenario tests green (`just test-class`). Card-SDK language reference updated for the new static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
