### PR TITLE
Add four Aetherdrift legends (+ CostReductionSource.YourSpeed)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4557,6 +4557,9 @@ staticAbility {
   *history*, from the union of each player's `PlayerAttackersThisTurnComponent.attackerIds`, not a
   battlefield scan: an attacker that has since died still counts, which
   `PermanentsOnBattlefieldMatching(Creature.attackedThisTurn())` would miss),
+  `YourSpeed` (the casting player's speed, 0–4, CR 702.179 — Samut, the Driving Force's "Noncreature
+  spells you cast cost {X} less to cast, where X is your speed"; "no speed" reads as 0 per CR
+  702.179f, so a player who never started their engines simply gets no reduction),
   `CardsInGraveyardMatchingFilter`, `FixedIfAnyTargetMatches`,
   `GreatestPropertyAmongPermanentsYouControl(property, filter)` — "{X} less, where X is the greatest
   `<property>` among `<filter>` you control", parameterized over `EntityNumericProperty`:

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -424,6 +424,20 @@ sealed interface CostReductionSource {
     }
 
     /**
+     * Reduces cost by your speed, 0–4 (CR 702.179) — "Noncreature spells you cast cost {X} less to
+     * cast, where X is your speed" (Samut, the Driving Force).
+     *
+     * "No speed" reads as 0 (CR 702.179f), so there is no has-speed distinction to make here: a
+     * player who never started their engines simply gets no reduction. Speed is per-player and never
+     * pooled in team games, so this always reads the *casting* player's speed.
+     */
+    @SerialName("YourSpeed")
+    @Serializable
+    data object YourSpeed : CostReductionSource {
+        override val description: String = "your speed"
+    }
+
+    /**
      * Reduces cost by number of creatures you control.
      */
     @SerialName("CreaturesYouControl")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HazoretGodseeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HazoretGodseeker.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+
+/**
+ * Hazoret, Godseeker — Aetherdrift #133
+ * {1}{R} · Legendary Creature — God · 5/3
+ *
+ * Indestructible, haste
+ * Start your engines!
+ * {1}, {T}: Target creature with power 2 or less can't be blocked this turn.
+ * Hazoret can't attack or block unless you have max speed.
+ *
+ * The combat restriction is *not* a "Max speed — [ability]" line, so it is a plain pair of statics
+ * rather than a [com.wingedsheep.sdk.dsl.maxSpeed] block: the printed ability exists at all speeds
+ * and only its condition reads speed. Modelling it the other way round would be observably wrong —
+ * `maxSpeed { }` also stamps the display-only [Keyword.MAX_SPEED] badge, and Scryfall lists only
+ * "Start your engines!" for this card.
+ *
+ * `CantAttackUnless` / `CantBlockUnless` route their condition through the standard
+ * `ConditionEvaluator`, so [Conditions.YouHaveMaxSpeed] (speed == 4) is re-read at each restriction
+ * check — losing max speed mid-turn correctly re-imposes the restriction, and a creature that is
+ * already attacking is unaffected (CR 506.4: restrictions are checked only as attackers/blockers are
+ * declared).
+ *
+ * The activated ability is the Crafty Pathmage shape: a targeting restriction on power (the target
+ * must have power 2 or less when the ability is activated *and* when it resolves, CR 608.2b), then a
+ * flat [AbilityFlag.CANT_BE_BLOCKED] grant for the turn. Per the ruling, later power growth does not
+ * strip the grant, which falls out of granting the flag rather than re-checking power in combat.
+ */
+val HazoretGodseeker = card("Hazoret, Godseeker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — God"
+    oracleText = "Indestructible, haste\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\n" +
+        "Hazoret can't attack or block unless you have max speed."
+    power = 5
+    toughness = 3
+
+    keywords(Keyword.INDESTRUCTIBLE, Keyword.HASTE)
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val creature = target("creature", Targets.CreatureWithPowerAtMost(2))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+        description = "Target creature with power 2 or less can't be blocked this turn."
+    }
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.YouHaveMaxSpeed)
+    }
+    staticAbility {
+        ability = CantBlockUnless(Conditions.YouHaveMaxSpeed)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "133"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg?1783907881"
+        ruling(
+            "2025-02-07",
+            "Hazoret's activated ability must be used prior to declaring blockers to be effective. " +
+                "Activating it targeting a creature that has already been blocked will not cause that " +
+                "creature to become unblocked."
+        )
+        ruling(
+            "2025-02-07",
+            "After the activated ability resolves, the creature can't be blocked this turn even if " +
+                "its power later increases to 3 or greater."
+        )
+        ruling(
+            "2025-02-07",
+            "A player \"has max speed\" if their speed is 4."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SabSunenLuxaEmbodied.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SabSunenLuxaEmbodied.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sab-Sunen, Luxa Embodied — Aetherdrift #221
+ * {3}{G}{U} · Legendary Creature — God · 6/6
+ *
+ * Reach, trample, indestructible
+ * Sab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)
+ * At the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd
+ * number of counters on it, draw two cards.
+ *
+ * The card is a parity clock: the upkeep-side trigger flips it every turn, so it attacks on even
+ * turns and draws on odd ones.
+ *
+ * Two things the wording pins down and the model must honor:
+ *
+ * - **"counters on it" means counters of *every* kind**, not just +1/+1 — a stun, shield or oil
+ *   counter shifts the parity. Hence [CounterTypeFilter.Any] rather than `PlusOnePlusOne`. The
+ *   reminder text "(Zero is even.)" is not an exception but a consequence: a freshly-resolved
+ *   Sab-Sunen has zero counters, which is even, so it can attack immediately.
+ * - **"Then if …" is checked on resolution, not as an intervening-if.** The draw is a
+ *   [ConditionalEffect] chained after the counter is added, so it reads the post-counter total (CR
+ *   608.2) — that is what makes the ability draw on the turns it cannot attack.
+ *
+ * The combat restriction is a plain pair of statics whose condition routes through the standard
+ * `ConditionEvaluator`; [DynamicAmounts.countersOnSelf] reads `EntityReference.Source`, which for a
+ * static ability on Sab-Sunen is Sab-Sunen. Because the condition is re-read at each restriction
+ * check, a counter gained or lost between declare-attackers and declare-blockers correctly changes
+ * whether it may block.
+ */
+val SabSunenLuxaEmbodied = card("Sab-Sunen, Luxa Embodied") {
+    manaCost = "{3}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — God"
+    oracleText = "Reach, trample, indestructible\n" +
+        "Sab-Sunen can't attack or block unless it has an even number of counters on it. " +
+        "(Zero is even.)\n" +
+        "At the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it " +
+        "has an odd number of counters on it, draw two cards."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE, Keyword.INDESTRUCTIBLE)
+
+    val countersOnSabSunen = DynamicAmounts.countersOnSelf(CounterTypeFilter.Any)
+    val hasEvenCounters = Conditions.AmountIsEven(countersOnSabSunen)
+
+    staticAbility {
+        ability = CantAttackUnless(hasEvenCounters)
+    }
+    staticAbility {
+        ability = CantBlockUnless(hasEvenCounters)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self).then(
+            ConditionalEffect(
+                condition = Conditions.AmountIsOdd(countersOnSabSunen),
+                effect = Effects.DrawCards(2),
+            )
+        )
+        description = "At the beginning of your first main phase, put a +1/+1 counter on " +
+            "Sab-Sunen. Then if it has an odd number of counters on it, draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "221"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg?1783907852"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SamutTheDrivingForce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SamutTheDrivingForce.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Samut, the Driving Force — Aetherdrift #222
+ * {3}{R}{G}{W} · Legendary Creature — Human Warrior Cleric · 4/5
+ *
+ * First strike, vigilance, haste
+ * Start your engines!
+ * Other creatures you control get +X/+0, where X is your speed.
+ * Noncreature spells you cast cost {X} less to cast, where X is your speed.
+ *
+ * Both scaling abilities read the *same* value — `DynamicAmount.Speed(Player.You)` / the new
+ * [CostReductionSource.YourSpeed] — through two different seams, because the engine reads costs and
+ * stats through different machinery:
+ *
+ * - The lord is an ordinary dynamic layer-7c bonus ([GrantDynamicStatsEffect]), re-evaluated every
+ *   projection, so the buff grows the instant your speed ticks up and `excludeSelf` keeps Samut out
+ *   of its own "other creatures" clause. Toughness is a literal `Fixed(0)`, not the speed amount —
+ *   the card grants +X/+0.
+ * - Cost calculation never touches the layer system: `CostCalculator` scans the raw static-ability
+ *   list for `ModifySpellCost`, so the reduction is expressed as a `ReduceGenericBy` over a
+ *   [CostReductionSource], evaluated against the casting player at cost-calculation time.
+ *
+ * "No speed" is 0 (CR 702.179f), so before your engines start Samut is a plain 4/5 with no reduction
+ * — Start your engines! then makes that self-correcting, since a state-based action raises your speed
+ * to 1 as soon as Samut hits the battlefield.
+ */
+val SamutTheDrivingForce = card("Samut, the Driving Force") {
+    manaCost = "{3}{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Creature — Human Warrior Cleric"
+    oracleText = "First strike, vigilance, haste\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Other creatures you control get +X/+0, where X is your speed.\n" +
+        "Noncreature spells you cast cost {X} less to cast, where X is your speed."
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.VIGILANCE, Keyword.HASTE)
+
+    startYourEngines()
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.OtherCreaturesYouControl,
+            powerBonus = DynamicAmounts.speed(Player.You),
+            toughnessBonus = DynamicAmount.Fixed(0),
+        )
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Noncreature),
+            modification = CostModification.ReduceGenericBy(CostReductionSource.YourSpeed),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg?1783907852"
+        ruling(
+            "2025-02-07",
+            "If an effect needs to know what a player's speed is and that player doesn't have a " +
+                "speed, their speed is considered 0."
+        )
+        ruling(
+            "2025-02-07",
+            "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something " +
+                "that happens as a state-based action as soon as you control a permanent with the " +
+                "ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ZahurGlorysPast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ZahurGlorysPast.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Zahur, Glory's Past — Aetherdrift #229
+ * {W}{B} · Legendary Creature — Zombie Cat Warrior · 3/2
+ *
+ * Start your engines!
+ * Sacrifice another creature: Surveil 1. Activate only once each turn.
+ * Max speed — Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie
+ * creature token.
+ *
+ * Two details the wording turns on:
+ *
+ * - **The death trigger is not "another".** Zahur is itself a nontoken creature you control, so its
+ *   own death fires the ability — hence [TriggerBinding.ANY] rather than `OTHER`. The engine reads
+ *   last-known information off the `ZoneChangeEvent`, which is what makes the self-death case work at
+ *   all (the entity is gone by resolution).
+ * - **Sacrificing to the activated ability feeds the death trigger.** At max speed, `Sacrifice
+ *   another creature: Surveil 1` also produces a Zombie, because a sacrifice is a battlefield →
+ *   graveyard move that matches the trigger. That is the card's whole engine, so the trigger is
+ *   deliberately *not* built with `excludeSacrifice`.
+ *
+ * The activated ability has no mana cost at all — sacrificing another creature is the entire cost —
+ * and [ActivationRestriction.OncePerTurn] carries "Activate only once each turn" (reset each turn,
+ * unlike the per-object `Once` used by exhaust).
+ */
+val ZahurGlorysPast = card("Zahur, Glory's Past") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Zombie Cat Warrior"
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Sacrifice another creature: Surveil 1. Activate only once each turn.\n" +
+        "Max speed — Whenever a nontoken creature you control dies, create a tapped 2/2 black " +
+        "Zombie creature token."
+    power = 3
+    toughness = 2
+
+    startYourEngines()
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.Creature)
+        effect = Patterns.Library.surveil(1)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        description = "Surveil 1. Activate only once each turn."
+    }
+
+    maxSpeed {
+        triggeredAbility {
+            trigger = Triggers.leavesBattlefield(
+                filter = GameObjectFilter.Creature.youControl().nontoken(),
+                to = Zone.GRAVEYARD,
+                binding = TriggerBinding.ANY,
+            )
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Zombie"),
+                tapped = true,
+                imageUri = "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1783907681",
+            )
+            description = "Whenever a nontoken creature you control dies, create a tapped 2/2 " +
+                "black Zombie creature token."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "229"
+        artist = "Leroy Steinmann"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg?1783907851"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -5808,6 +5808,110 @@
     ]
 }
 
+// Hazoret, Godseeker
+{
+    "name": "Hazoret, Godseeker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Indestructible, haste\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{1}, {T}: Target creature with power 2 or less can't be blocked this turn.\nHazoret can't attack or block unless you have max speed.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "INDESTRUCTIBLE",
+        "HASTE",
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=2"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature with power 2 or less can't be blocked this turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2f66043-0872-4334-a91f-0e9bbbdddf66.jpg?1783907881",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Hazoret's activated ability must be used prior to declaring blockers to be effective. Activating it targeting a creature that has already been blocked will not cause that creature to become unblocked."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "After the activated ability resolves, the creature can't be blocked this turn even if its power later increases to 3 or greater."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hellish Sideswipe
 {
     "name": "Hellish Sideswipe",
@@ -10850,6 +10954,114 @@
     ]
 }
 
+// Sab-Sunen, Luxa Embodied
+{
+    "name": "Sab-Sunen, Luxa Embodied",
+    "manaCost": "{3}{G}{U}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Reach, trample, indestructible\nSab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)\nAt the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE",
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "NumberMatches",
+                                    "amount": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": "CounterAny"
+                                        }
+                                    },
+                                    "property": "Odd"
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an odd number of counters on it, draw two cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "NumberMatches",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": "CounterAny"
+                        }
+                    },
+                    "property": "Even"
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "NumberMatches",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": "CounterAny"
+                        }
+                    },
+                    "property": "Even"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "MYTHIC",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2ef555b1-666d-4386-8983-0e88f9b6cdec.jpg?1783907852"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Sabotage Strategist
 {
     "name": "Sabotage Strategist",
@@ -11002,6 +11214,72 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/4/34ed1bf2-0f3c-4528-b570-e5bdcd7ffda9.jpg"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Samut, the Driving Force
+{
+    "name": "Samut, the Driving Force",
+    "manaCost": "{3}{R}{G}{W}",
+    "typeLine": "Legendary Creature — Human Warrior Cleric",
+    "oracleText": "First strike, vigilance, haste\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nOther creatures you control get +X/+0, where X is your speed.\nNoncreature spells you cast cost {X} less to cast, where X is your speed.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "VIGILANCE",
+        "HASTE",
+        "START_YOUR_ENGINES"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                },
+                "powerBonus": "Speed",
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            },
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "noncreature"
+                },
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "YourSpeed"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8efd8222-5c37-46d8-a2ec-1d7aae25320b.jpg?1783907852",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an effect needs to know what a player's speed is and that player doesn't have a speed, their speed is considered 0."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Start your engines! isn't a triggered ability. Increasing your speed to 1 is something that happens as a state-based action as soon as you control a permanent with the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN",
         "WHITE"
     ]
 }
@@ -14214,6 +14492,90 @@
         "imageUri": "https://cards.scryfall.io/normal/front/4/9/4983177d-fbf4-47fa-997f-9d08294870f2.jpg"
     },
     "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zahur, Glory's Past
+{
+    "name": "Zahur, Glory's Past",
+    "manaCost": "{W}{B}",
+    "typeLine": "Legendary Creature — Zombie Cat Warrior",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nSacrifice another creature: Surveil 1. Activate only once each turn.\nMax speed — Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/8/b82be730-c63b-4c2b-99f4-476befdb95cb.jpg?1783907681",
+                    "tapped": true
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Max speed — Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie creature token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ],
+                "descriptionOverride": "Surveil 1. Activate only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "RARE",
+        "artist": "Leroy Steinmann",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31944ea5-045d-481d-9aff-3c7ed663813a.jpg?1783907851"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLACK"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -399,6 +399,9 @@ class CostCalculator(
     ): Int {
         return when (source) {
             is CostReductionSource.Fixed -> source.amount
+            // CR 702.179f — "no speed" is 0, which GameState.speed already returns, so no has-speed
+            // branch is needed. playerId is the casting player, and speed is never team-pooled.
+            is CostReductionSource.YourSpeed -> state.speed(playerId)
             is CostReductionSource.CreaturesYouControl -> countCreatures(state, playerId)
             is CostReductionSource.TotalPowerYouControl -> sumPower(state, playerId)
             is CostReductionSource.ArtifactsYouControl -> countArtifacts(state, playerId)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HazoretGodseekerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HazoretGodseekerScenarioTest.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Hazoret, Godseeker.
+ *
+ * Oracle:
+ * - Indestructible, haste
+ * - Start your engines!
+ * - "{1}, {T}: Target creature with power 2 or less can't be blocked this turn."
+ * - "Hazoret can't attack or block unless you have max speed."
+ *
+ * The restriction is the card: a 5/3 haste indestructible body for {1}{R} that cannot attack until
+ * speed 4. It is *not* a "Max speed — [ability]" line, so it must exist at every speed with only its
+ * condition reading speed — and it must be checked at declare-*blockers* as well as
+ * declare-attackers, which a single `CantAttackUnless` would silently half-implement.
+ */
+class HazoretGodseekerScenarioTest : ScenarioTestBase() {
+
+    private val unblockableAbilityId by lazy {
+        cardRegistry.requireCard("Hazoret, Godseeker").activatedAbilities[0].id
+    }
+
+    init {
+        context("can't attack or block unless you have max speed") {
+
+            test("cannot attack at the speed 1 that its own keyword grants") {
+                val game = hazoretGame()
+
+                withClue("Start your engines! leaves you at 1, well short of max") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("the restriction blocks the attack below max speed") {
+                    game.declareAttackers(mapOf("Hazoret, Godseeker" to 2)).error shouldNotBe null
+                }
+            }
+
+            test("can attack at max speed") {
+                val game = hazoretGame()
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("speed 4 lifts the restriction; haste covers the summoning-sickness side") {
+                    game.declareAttackers(mapOf("Hazoret, Godseeker" to 2)).error shouldBe null
+                }
+            }
+
+            test("speed 3 is not enough — max speed is exactly 4") {
+                val game = hazoretGame()
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX - 1, "test").first
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("3 is not max speed") {
+                    game.declareAttackers(mapOf("Hazoret, Godseeker" to 2)).error shouldNotBe null
+                }
+            }
+
+            test("cannot block below max speed either") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .also { b -> repeat(12) { b.withCardInLibrary(1, "Mountain"); b.withCardInLibrary(2, "Mountain") } }
+                    .withCardOnBattlefield(1, "Hazoret, Godseeker", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("player 1 is at speed 1, so Hazoret cannot block") {
+                    game.declareBlockers(
+                        mapOf("Hazoret, Godseeker" to listOf("Grizzly Bears"))
+                    ).error shouldNotBe null
+                }
+            }
+        }
+
+        context("{1}, {T}: target creature with power 2 or less can't be blocked") {
+
+            test("grants the flag to a 2/2 and works below max speed") {
+                // The activated ability carries no speed gate at all — only the combat restriction
+                // does — so it must work at speed 1.
+                val game = hazoretGame(extraLands = 1) {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+                val hazoret = game.findPermanent("Hazoret, Godseeker")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hazoret,
+                        abilityId = unblockableAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 2/2 Bears now can't be blocked") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+            }
+
+            test("cannot target a creature with power 3 or greater") {
+                val game = hazoretGame(extraLands = 1) {
+                    withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                }
+                val hazoret = game.findPermanent("Hazoret, Godseeker")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("Hill Giant is a 3/3, outside \"power 2 or less\"") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = hazoret,
+                            abilityId = unblockableAbilityId,
+                            targets = listOf(ChosenTarget.Permanent(giant)),
+                        )
+                    ).error shouldNotBe null
+                }
+            }
+        }
+    }
+
+    /**
+     * Hazoret on player 1's battlefield, reaching the main phase through a real step sequence so the
+     * Start your engines! state-based action has been polled. [extraLands] stocks Mountains for the
+     * `{1}` in the activated ability.
+     */
+    private fun hazoretGame(extraLands: Int = 0, extra: ScenarioBuilder.() -> Unit = {}): TestGame {
+        val builder = scenario().withPlayers("Player1", "Player2")
+        repeat(12) {
+            builder.withCardInLibrary(1, "Mountain")
+            builder.withCardInLibrary(2, "Mountain")
+        }
+        builder.withCardOnBattlefield(1, "Hazoret, Godseeker", summoningSickness = false)
+        if (extraLands > 0) builder.withLandsOnBattlefield(1, "Mountain", extraLands)
+        builder.extra()
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SabSunenLuxaEmbodiedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SabSunenLuxaEmbodiedScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Sab-Sunen, Luxa Embodied.
+ *
+ * Oracle:
+ * - Reach, trample, indestructible
+ * - "Sab-Sunen can't attack or block unless it has an even number of counters on it. (Zero is even.)"
+ * - "At the beginning of your first main phase, put a +1/+1 counter on Sab-Sunen. Then if it has an
+ *   odd number of counters on it, draw two cards."
+ *
+ * The card is a parity clock, so the tests are about parity rather than about counters: fresh (zero,
+ * even → can attack), after one trigger (one, odd → drew two, cannot attack), after two (even again).
+ *
+ * The "Then if …" clause is the subtle one — it resolves *after* the counter is added, not as an
+ * intervening-if before it, so the very first trigger draws. An implementation that checked parity
+ * first would draw on the opposite turns and pass a naive "does it ever draw" test.
+ */
+class SabSunenLuxaEmbodiedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the first-main-phase trigger") {
+
+            test("adds a counter and draws two, because one counter is odd") {
+                val game = sabSunenGame()
+                val sabSunen = game.findPermanent("Sab-Sunen, Luxa Embodied")!!
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("the counter went on") {
+                    game.state.projectedState.getPower(sabSunen) shouldBe 7
+                    game.state.projectedState.getToughness(sabSunen) shouldBe 7
+                }
+                withClue("one counter is odd, so the post-counter check draws two") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+            }
+        }
+
+        context("can't attack or block unless it has an even number of counters") {
+
+            test("a fresh Sab-Sunen can attack — zero is even") {
+                val game = sabSunenGame()
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("no counters yet, and zero is an even number") {
+                    game.declareAttackers(mapOf("Sab-Sunen, Luxa Embodied" to 2)).error shouldBe null
+                }
+            }
+
+            test("after one trigger it cannot attack — one counter is odd") {
+                val game = sabSunenGame()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("one counter is odd, so the attack restriction bites") {
+                    game.declareAttackers(mapOf("Sab-Sunen, Luxa Embodied" to 2)).error shouldNotBe null
+                }
+            }
+
+            test("it cannot block on an odd turn either") {
+                // Opponent attacks with a 2/2 while Sab-Sunen sits on one counter.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .also { b -> repeat(12) { b.withCardInLibrary(1, "Grizzly Bears"); b.withCardInLibrary(2, "Grizzly Bears") } }
+                    .withCardOnBattlefield(1, "Sab-Sunen, Luxa Embodied", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UPKEEP)
+                    .build()
+
+                // Player 1's own first main phase puts the odd counter on.
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                // Round the table to the opponent's combat.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.state.activePlayerId shouldBe game.player2Id
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("Sab-Sunen has an odd number of counters, so it can't block") {
+                    game.declareBlockers(
+                        mapOf("Sab-Sunen, Luxa Embodied" to listOf("Grizzly Bears"))
+                    ).error shouldNotBe null
+                }
+            }
+
+            test("a second trigger restores even parity and it can attack again") {
+                val game = sabSunenGame()
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                // Round the table back to player 1's next first main phase.
+                do {
+                    game.passUntilPhase(Phase.ENDING, Step.END)
+                    game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                } while (game.state.activePlayerId != game.player1Id)
+                game.resolveStack()
+
+                val sabSunen = game.findPermanent("Sab-Sunen, Luxa Embodied")!!
+                withClue("two counters now") {
+                    game.state.projectedState.getPower(sabSunen) shouldBe 8
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("two is even, so it may attack") {
+                    game.declareAttackers(mapOf("Sab-Sunen, Luxa Embodied" to 2)).error shouldBe null
+                }
+            }
+        }
+    }
+
+    /**
+     * Sab-Sunen on player 1's battlefield at the upkeep of player 1's turn — the trigger under test
+     * fires on the *first main phase*, so tests advance into it deliberately rather than building
+     * there. Libraries are stocked so the two-card draw can't deck anyone.
+     */
+    private fun sabSunenGame(): TestGame {
+        val builder = scenario().withPlayers("Player1", "Player2")
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        builder.withCardOnBattlefield(1, "Sab-Sunen, Luxa Embodied", summoningSickness = false)
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SamutTheDrivingForceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SamutTheDrivingForceScenarioTest.kt
@@ -1,0 +1,175 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Samut, the Driving Force — i.e. for the new
+ * `CostReductionSource.YourSpeed`, plus the speed-scaled lord that has to agree with it.
+ *
+ * Oracle:
+ * - "Other creatures you control get +X/+0, where X is your speed."
+ * - "Noncreature spells you cast cost {X} less to cast, where X is your speed."
+ *
+ * The two clauses read the same number through different machinery — the lord through the layer
+ * system, the reduction through `CostCalculator`, which never touches layers — so they are tested
+ * separately and then against each other. The cases that would pass a naive implementation and still
+ * be wrong: a *creature* spell getting the discount, the discount eating a colored pip, and the
+ * discount following speed rather than being frozen at whatever it was when Samut entered.
+ */
+class SamutTheDrivingForceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Samut's cost reduction — noncreature spells cost {X} less, X = your speed") {
+
+            test("speed 1 (from Start your engines!) discounts a noncreature spell by 1") {
+                val game = samutGame {
+                    withCardInHand(1, "Divination")
+                }
+
+                withClue("Samut's own Start your engines! sets speed to 1 via the SBA") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+
+                withClue("Divination {2}{U} loses 1 generic") {
+                    genericCostOf(game, "Divination", game.player1Id) shouldBe 1
+                }
+            }
+
+            test("the discount tracks speed rather than being frozen at Samut's arrival") {
+                val game = samutGame {
+                    withCardInHand(1, "Harmonize")
+                }
+
+                withClue("Harmonize {2}{G}{G} at speed 1 loses 1 of its 2 generic") {
+                    genericCostOf(game, "Harmonize", game.player1Id) shouldBe 1
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, 3, "test").first
+                withClue("speed 3 exceeds the 2 generic, which bottoms out at 0") {
+                    genericCostOf(game, "Harmonize", game.player1Id) shouldBe 0
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.STARTING, "test").first
+                withClue("dropping back to speed 1 restores the discount to 1") {
+                    genericCostOf(game, "Harmonize", game.player1Id) shouldBe 1
+                }
+            }
+
+            test("the reduction never eats the colored pip") {
+                val game = samutGame {
+                    withCardInHand(1, "Harmonize")
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Harmonize"),
+                    game.player1Id,
+                )
+
+                withClue("max speed (4) exceeds Harmonize's 2 generic but leaves {G}{G} intact") {
+                    cost.genericAmount shouldBe 0
+                    cost.colorCount[Color.GREEN] shouldBe 2
+                }
+            }
+
+            test("creature spells are not discounted") {
+                val game = samutGame {
+                    withCardInHand(1, "Hill Giant")
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                withClue("Hill Giant {3}{R} is a creature spell, so its 3 generic stands") {
+                    genericCostOf(game, "Hill Giant", game.player1Id) shouldBe 3
+                }
+            }
+
+            test("the discount is the caster's speed, not the highest speed at the table") {
+                val game = samutGame {
+                    withCardInHand(2, "Divination")
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                withClue("the opponent controls no Samut, so their Divination is undiscounted") {
+                    game.state.hasSpeed(game.player2Id) shouldBe false
+                    genericCostOf(game, "Divination", game.player2Id) shouldBe 2
+                }
+            }
+        }
+
+        context("Samut's lord — other creatures you control get +X/+0") {
+
+            test("scales other creatures with speed and leaves Samut alone") {
+                val game = samutGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val samut = game.findPermanent("Samut, the Driving Force")!!
+
+                withClue("at speed 1 the 2/2 Bears is a 3/2") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+                withClue("at max speed the Bears is a 6/2 — toughness is +0, not +X") {
+                    game.state.projectedState.getPower(bears) shouldBe 6
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("\"other creatures\" excludes Samut, who stays a printed 4/5") {
+                    game.state.projectedState.getPower(samut) shouldBe 4
+                    game.state.projectedState.getToughness(samut) shouldBe 5
+                }
+            }
+
+            test("does not pump creatures an opponent controls") {
+                val game = samutGame {
+                    withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the lord is \"you control\"-scoped") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                }
+            }
+        }
+    }
+
+    /**
+     * Samut on player 1's battlefield, both libraries stocked, arriving at player 1's main phase
+     * through a real step sequence — the state-based action that starts speed is polled by the game
+     * loop, so building straight into the main phase would leave speed unset.
+     */
+    private fun samutGame(extra: ScenarioBuilder.() -> Unit): TestGame {
+        val builder = scenario().withPlayers("Player1", "Player2")
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        builder.withCardOnBattlefield(1, "Samut, the Driving Force", summoningSickness = false)
+        builder.extra()
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+
+    private fun genericCostOf(game: TestGame, cardName: String, playerId: EntityId): Int =
+        CostCalculator(cardRegistry).calculateEffectiveCost(
+            game.state,
+            cardRegistry.requireCard(cardName),
+            playerId,
+        ).genericAmount
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZahurGlorysPastScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZahurGlorysPastScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Zahur, Glory's Past.
+ *
+ * Oracle:
+ * - Start your engines!
+ * - "Sacrifice another creature: Surveil 1. Activate only once each turn."
+ * - "Max speed — Whenever a nontoken creature you control dies, create a tapped 2/2 black Zombie
+ *   creature token."
+ *
+ * The card is an engine only if its two halves feed each other, and both of the ways to get that
+ * wrong are silent:
+ *
+ * - modelling the trigger with `excludeSacrifice` (or with `TriggerBinding.OTHER` and a sacrifice
+ *   check) would leave "sacrifice a creature: surveil" producing no Zombie at max speed;
+ * - modelling it as "another nontoken creature" would drop Zahur's own death, which the card does
+ *   not say.
+ *
+ * Both get an explicit test, plus the nontoken clause (a Zombie the ability itself made must not
+ * loop) and the max-speed gate (below speed 4 the trigger does not exist at all).
+ */
+class ZahurGlorysPastScenarioTest : ScenarioTestBase() {
+
+    private val surveilAbilityId by lazy {
+        cardRegistry.requireCard("Zahur, Glory's Past").activatedAbilities[0].id
+    }
+
+    init {
+        context("Sacrifice another creature: Surveil 1") {
+
+            test("sacrifices the chosen creature and surveils") {
+                val game = zahurGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+                val zahur = game.findPermanent("Zahur, Glory's Past")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val libraryBefore = game.librarySize(1)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = zahur,
+                        abilityId = surveilAbilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Bears paid the cost") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+
+                // Surveil 1 pauses for the keep-or-bin choice over the top card.
+                val surveil = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                surveil.options.size shouldBe 1
+                game.selectCards(surveil.options).error shouldBe null
+
+                withClue("binning the surveiled card moves it out of the library") {
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                }
+            }
+
+            test("cannot be activated twice in a turn") {
+                val game = zahurGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                }
+                val zahur = game.findPermanent("Zahur, Glory's Past")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = zahur,
+                        abilityId = surveilAbilityId,
+                        costPayment = AdditionalCostPayment(
+                            sacrificedPermanents = listOf(game.findPermanent("Grizzly Bears")!!)
+                        ),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("\"Activate only once each turn\" rejects the second activation") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = zahur,
+                            abilityId = surveilAbilityId,
+                            costPayment = AdditionalCostPayment(
+                                sacrificedPermanents = listOf(game.findPermanent("Hill Giant")!!)
+                            ),
+                        )
+                    ).error shouldNotBe null
+                }
+                withClue("the Hill Giant survived the rejected activation") {
+                    game.findPermanent("Hill Giant") shouldNotBe null
+                }
+            }
+        }
+
+        context("Max speed — whenever a nontoken creature you control dies") {
+
+            test("the ability's own sacrifice makes a Zombie at max speed") {
+                // The whole point of the card: a sacrifice is a battlefield → graveyard move, so it
+                // matches the death trigger. An `excludeSacrifice` trigger would produce nothing.
+                val game = zahurGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val zahur = game.findPermanent("Zahur, Glory's Past")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = zahur,
+                        abilityId = surveilAbilityId,
+                        costPayment = AdditionalCostPayment(
+                            sacrificedPermanents = listOf(game.findPermanent("Grizzly Bears")!!)
+                        ),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the sacrificed Bears triggered the max-speed ability") {
+                    game.findAllPermanents("Zombie Token").size shouldBe 1
+                }
+            }
+
+            test("Zahur's own death triggers it — the clause is not \"another\"") {
+                val game = zahurGame {
+                    withCardInHand(1, "Murder")
+                    withLandsOnBattlefield(1, "Swamp", 3)
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                val zahur = game.findPermanent("Zahur, Glory's Past")!!
+                game.castSpell(1, "Murder", targetId = zahur).error shouldBe null
+                game.resolveStack()
+
+                withClue("Zahur is dead") {
+                    game.findPermanent("Zahur, Glory's Past") shouldBe null
+                }
+                withClue("it still saw its own death and left a Zombie behind") {
+                    game.findAllPermanents("Zombie Token").size shouldBe 1
+                }
+            }
+
+            test("a token creature dying does not trigger it") {
+                // Guards against a runaway loop: the Zombies the ability makes are tokens.
+                val game = zahurGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", isToken = true, summoningSickness = false)
+                    withCardInHand(1, "Murder")
+                    withLandsOnBattlefield(1, "Swamp", 3)
+                }
+                game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+
+                game.castSpell(
+                    1, "Murder", targetId = game.findPermanent("Grizzly Bears")!!
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the token died but it is not a nontoken creature") {
+                    game.findAllPermanents("Zombie Token").size shouldBe 0
+                }
+            }
+
+            test("below max speed the trigger does not fire") {
+                val game = zahurGame {
+                    withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                }
+
+                withClue("Start your engines! leaves you at speed 1, not 4") {
+                    game.state.speed(game.player1Id) shouldBe Speed.STARTING
+                }
+
+                val zahur = game.findPermanent("Zahur, Glory's Past")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = zahur,
+                        abilityId = surveilAbilityId,
+                        costPayment = AdditionalCostPayment(
+                            sacrificedPermanents = listOf(game.findPermanent("Grizzly Bears")!!)
+                        ),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the max-speed ability doesn't exist at speed 1") {
+                    game.findAllPermanents("Zombie Token").size shouldBe 0
+                }
+            }
+        }
+    }
+
+    /**
+     * Zahur on player 1's battlefield, arriving at the main phase through a real step sequence so
+     * the Start your engines! state-based action has actually been polled. Libraries are stocked so
+     * surveil and the draw step can't deck anyone.
+     */
+    private fun zahurGame(extra: ScenarioBuilder.() -> Unit): TestGame {
+        val builder = scenario().withPlayers("Player1", "Player2")
+        repeat(12) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        builder.withCardOnBattlefield(1, "Zahur, Glory's Past", summoningSickness = false)
+        builder.extra()
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        return game
+    }
+}


### PR DESCRIPTION
Implements four self-contained **Start your engines!** legends from Aetherdrift. DFT goes 214/276 → **218/276**.

## Cards

| Card | Cost | Notes |
|---|---|---|
| **Hazoret, Godseeker** | `{1}{R}` | Indestructible/haste 5/3, `{1},{T}` can't-be-blocked, can't attack or block below max speed |
| **Zahur, Glory's Past** | `{W}{B}` | Once-per-turn sacrifice-for-surveil + max-speed nontoken-dies Zombie |
| **Sab-Sunen, Luxa Embodied** | `{3}{G}{U}` | Parity clock — even counters to attack/block, odd counters to draw |
| **Samut, the Driving Force** | `{3}{R}{G}{W}` | Speed-scaled lord + speed-scaled cost reduction |

## Modelling decisions worth review

- **Hazoret's combat restriction is *not* a `maxSpeed { }` block.** The printed ability exists at every speed and only its *condition* reads speed, so it's a plain `CantAttackUnless` + `CantBlockUnless` pair on `Conditions.YouHaveMaxSpeed`. Wrapping it in `maxSpeed { }` would also stamp the display-only `MAX_SPEED` badge, which Scryfall does not list for this card.
- **Zahur's death trigger deliberately omits `excludeSacrifice` and binds `ANY`, not `OTHER`.** A sacrifice is a battlefield → graveyard move, so the card's own activated ability feeds its trigger — that's the whole engine. And the clause isn't "another", so Zahur's own death triggers it. Both are pinned by tests; both failure modes are silent.
- **Sab-Sunen reads counters of *every* kind** (`CounterTypeFilter.Any`) — a stun or shield counter shifts the parity. The reminder text "(Zero is even.)" is a consequence, not an exception. "Then if …" is a `ConditionalEffect` chained *after* the counter, so it reads the post-counter total (CR 608.2) and draws on the first trigger; checking parity first would draw on the opposite turns and still pass a naive test.

## New SDK vocabulary

Samut's `"Noncreature spells you cast cost {X} less to cast, where X is your speed"` needed one new variant:

- `CostReductionSource.YourSpeed` in `CostStaticAbilities.kt`
- the matching one-line branch in `CostCalculator.evaluateReduction` (`state.speed(playerId)`)
- documented in `docs/card-sdk-language-reference.md`

Cost calculation never touches the layer system, so Samut's two clauses read the same number through two different seams — the lord as a dynamic layer-7c bonus, the reduction through `CostCalculator`. Both are tested, including against each other.

## Cards deliberately *not* taken

Several tempting Aetherdrift cards need engine capability rather than card work, and were left for `add-feature`:

- **Vnwxt, Verbose Host** and **Far Fortune, End Boss** — max-speed-gated *replacement* effects. `SpeedDsl.kt` already documents why: replacement effects are read off `ReplacementEffectSourceComponent` at ~20 interception sites, none of which evaluates a condition.
- The **Roads** land cycle, **Dynamite Diver**, **Deathless Pilot**, **Cloudspire Captain** et al. — "saddles Mounts and crews Vehicles as though its power were 2 greater" has no SDK support.
- **Canyon Vaulter**, **Reckless Velocitaur** — no "whenever this creature saddles/crews" trigger event exists.
- **Mu Yanling**, **Chandra, Spark Hunter**, **Valor's Flagship** — need a noncreature Vehicle *token* with `crew N`; `CreateTokenEffect` has no keyword-ability channel.
- **Rangers' Refueler**, **Afterburner Expert**, **Adrenaline Jockey** — no "whenever you activate an exhaust ability" event.
- **Fang-Druid Summoner**, **Rise from the Wreck** — no "creature card with no abilities" filter.

## Verification

- `just check` — green (full build, tests, lint, coverage gates)
- Four scenario test files, one per card, 23 tests total
- `just check-card-printing` — ok for all four (canonical in earliest real printing)
- `just rebless-cards` — only these four cards moved in `DFT.json`
- All five image URIs verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)