### PR TITLE
Add five Aetherdrift cards, with a draw-count multiplier

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7713,8 +7713,9 @@ replacementEffect {
   cast as a spell (resolved off the stack) **and** when it enters the battlefield directly — a land
   played (Echoing Deeps) pauses via `PermanentEntryReplacements.pauseForEntersAsCopy`, its resumer
   `CloneEntersOnBattlefieldContinuation` copying onto the already-placed permanent in place.
-- `ModifyDrawAmount(modifier, restrictions, appliesTo)` — modify the number of cards a draw
-  instruction announces by a fixed amount, optionally gated by extra `restrictions: List<Condition>`
+- `ModifyDrawAmount(modifier, multiplier, restrictions, appliesTo)` — modify the number of cards a draw
+  instruction announces to `(count * multiplier) + modifier`, clamped to ≥ 0, optionally gated by extra
+  `restrictions: List<Condition>`
   evaluated against the drawing player as controller. Applied **once** per draw instruction at the
   announcement site — `DrawCardsExecutor.execute` for spell/ability draws and
   `DrawPhaseManager.performDrawStep` for the draw step (CR 121.2a: "An instruction to draw multiple
@@ -7723,9 +7724,14 @@ replacementEffect {
   resumed per-card loop doesn't double-modify. Note that "you" in restriction text reads as the
   drawing player, not the source's controller; for `DrawEvent(player = Player.You)` they coincide,
   but `DrawEvent(player = Player.EachOpponent)` cards needing "you" = source controller would have to
-  use a source-relative condition instead. Use for "if you would draw one or more cards, you draw
-  that many cards plus N instead" (Quantum Riddler:
-  `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`).
+  use a source-relative condition instead. Use `modifier` for the additive wording — "if you would
+  draw one or more cards, you draw that many cards plus N instead" (Quantum Riddler:
+  `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`)
+  — and `multiplier` for the doubling wording, which per the Vnwxt rulings multiplies the *announced*
+  count so a "draw three cards" spell draws six (Vnwxt, Verbose Host:
+  `ModifyDrawAmount(multiplier = 2, restrictions = listOf(Conditions.YouHaveMaxSpeed), appliesTo = DrawEvent(player = Player.You))`).
+  Several applicable effects are cumulative — two doublers quadruple the draw. `restrictions` is also
+  the seam for a "Max speed —" gate, which `maxSpeed { }` cannot apply to a replacement effect.
 - `ModifyMillAmount(modifier, restrictions, appliesTo)` — modify the number of cards a *mill* announces
   by a fixed amount (the mill twin of `ModifyDrawAmount`): a player who would mill N instead mills
   `N + modifier`, clamped to ≥ 0. `appliesTo` is an `EventPattern.MillEvent` whose `player` filter

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
@@ -76,11 +76,19 @@ fun CardBuilder.startYourEngines() {
  * }
  * ```
  *
- * **Not covered:** a max-speed-gated *replacement* effect (Vnwxt, Verbose Host's "If you would draw
- * a card, draw two cards instead"; Far Fortune, End Boss's damage rider). Replacement effects are
- * read straight off `ReplacementEffectSourceComponent` at ~20 independent interception sites, none of
- * which evaluates a condition, so gating one needs a shared conditional-replacement seam that
- * doesn't exist yet — deliberately left out rather than approximated per site.
+ * **Not covered:** a max-speed-gated *replacement* effect (Far Fortune, End Boss's damage rider).
+ * Replacement effects are read straight off `ReplacementEffectSourceComponent` at ~20 independent
+ * interception sites, none of which evaluates a condition, so gating one *in general* needs a shared
+ * conditional-replacement seam that doesn't exist yet — deliberately left out rather than
+ * approximated per site.
+ *
+ * The exception, and why it isn't in this block: a replacement type that already carries its own
+ * condition slot can fold the gate in itself, the same trick this builder uses for
+ * [ModifySpellCost] and [MayCastSelfFromZones]. Vnwxt, Verbose Host's "Max speed — If you would draw
+ * a card, draw two cards instead" is a `ModifyDrawAmount` with
+ * `restrictions = listOf(Conditions.YouHaveMaxSpeed)`, declared through the ordinary
+ * `replacementEffect(…)` on [CardBuilder] plus a hand-written [Keyword.MAX_SPEED] badge. Route a
+ * second such card through here only once there are two of them to share the path.
  */
 fun CardBuilder.maxSpeed(init: MaxSpeedBuilder.() -> Unit) {
     val builder = MaxSpeedBuilder()

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -781,21 +781,29 @@ data class SetMinimumDamage(
 // =============================================================================
 
 /**
- * Modify the number of cards a draw event draws by a fixed amount, optionally gated by
- * additional [restrictions]. Applied at the call site where the original draw count is
- * announced (spell/ability resolution and the draw step), so the modifier fires once per
- * draw instruction (CR 121.2a: "An instruction to draw multiple cards can be modified by
- * replacement effects that refer to the number of cards drawn. This modification occurs
- * before considering any of the individual card draws.") and is not re-applied when a
- * paused per-card draw loop resumes.
+ * Modify the number of cards a draw event draws — `(count * multiplier) + modifier`, clamped
+ * to ≥ 0 — optionally gated by additional [restrictions]. Applied at the call site where the
+ * original draw count is announced (spell/ability resolution and the draw step), so the
+ * modification fires once per draw instruction (CR 121.2a: "An instruction to draw multiple
+ * cards can be modified by replacement effects that refer to the number of cards drawn. This
+ * modification occurs before considering any of the individual card draws.") and is not
+ * re-applied when a paused per-card draw loop resumes.
+ *
+ * Two independent knobs so one type covers the whole family: [multiplier] for the doubling
+ * wording ("if you would draw a card, draw two cards instead" — which per the Vnwxt rulings
+ * multiplies the *announced* count, so a "draw three cards" spell draws six) and [modifier]
+ * for the additive wording ("you draw that many cards plus one instead"). Multiple such
+ * effects are cumulative: two doublers quadruple the draw, matching the Vnwxt ruling about
+ * controlling both Vnwxt and Thought Reflection.
  *
  * Each entry in [restrictions] is a [Condition] evaluated against the drawing player as
  * the controller context; the modification only applies when ALL restrictions hold. This
  * mirrors [ModifyLifeLoss]'s shape — use it for cards whose extra-draw clause is gated by
- * arbitrary additional conditions. Note that "you" in restriction text reads as the drawing
- * player, not the source's controller — for `DrawEvent(player = Player.You)` they're the
- * same, but a future `DrawEvent(player = Player.EachOpponent)` card whose restriction means
- * "you" = source controller would need a source-relative condition instead.
+ * arbitrary additional conditions, including a "Max speed —" gate. Note that "you" in
+ * restriction text reads as the drawing player, not the source's controller — for
+ * `DrawEvent(player = Player.You)` they're the same, but a future
+ * `DrawEvent(player = Player.EachOpponent)` card whose restriction means "you" = source
+ * controller would need a source-relative condition instead.
  *
  * Examples:
  * - Quantum Riddler ("As long as you have one or fewer cards in hand, if you would draw
@@ -803,16 +811,23 @@ data class SetMinimumDamage(
  *     `ModifyDrawAmount(modifier = 1,
  *                       restrictions = listOf(Conditions.CardsInHandAtMost(1)),
  *                       appliesTo = DrawEvent(player = Player.You))`
+ * - Vnwxt, Verbose Host ("Max speed — If you would draw a card, draw two cards instead"):
+ *     `ModifyDrawAmount(multiplier = 2,
+ *                       restrictions = listOf(Conditions.YouHaveMaxSpeed),
+ *                       appliesTo = DrawEvent(player = Player.You))`
  *
- * @param modifier Flat amount added to the draw count when the event fires for a matching
- *        player. Negative values reduce the draw (clamped to ≥ 0 by the caller).
- * @param restrictions Additional [Condition]s gating when the modifier applies. Evaluated
+ * @param multiplier Factor the announced draw count is multiplied by. `2` is the "draw twice
+ *        that many instead" wording; the default `1` leaves the count alone.
+ * @param modifier Flat amount added after multiplying. Negative values reduce the draw
+ *        (clamped to ≥ 0 by the caller).
+ * @param restrictions Additional [Condition]s gating when the modification applies. Evaluated
  *        against the drawing player as controller; ALL must hold.
  */
 @SerialName("ModifyDrawAmount")
 @Serializable
 data class ModifyDrawAmount(
-    val modifier: Int,
+    val modifier: Int = 0,
+    val multiplier: Int = 1,
     val restrictions: List<Condition> = emptyList(),
     override val appliesTo: EventPattern = EventPattern.DrawEvent()
 ) : ReplacementEffect {
@@ -825,7 +840,16 @@ data class ModifyDrawAmount(
             append("If ")
         }
         append(appliesTo.description)
-        append(", they draw that many cards plus $modifier instead")
+        // Pick the natural English for each shape rather than spelling out the formula.
+        append(
+            when {
+                multiplier != 1 && modifier != 0 ->
+                    ", they draw that many cards times $multiplier plus $modifier instead"
+                multiplier == 2 -> ", they draw twice that many cards instead"
+                multiplier != 1 -> ", they draw that many cards times $multiplier instead"
+                else -> ", they draw that many cards plus $modifier instead"
+            }
+        )
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AlacrianArmory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AlacrianArmory.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Alacrian Armory — Aetherdrift #2
+ * {3}{W} · Artifact
+ *
+ * Creatures you control get +0/+1 and have vigilance.
+ * At the beginning of combat on your turn, choose up to one target Mount or Vehicle you control.
+ * Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact
+ * creature if it's a Vehicle.
+ *
+ * The two halves of the trigger are gated separately on the chosen permanent's own type, because
+ * neither is a safe no-op on the wrong one: saddling is a bare marker with no Mount check in the
+ * executor, so an ungated `BecomeSaddled` would stamp a Vehicle as saddled. Both gates read the
+ * *chosen* target at resolution (CR 608.2), so a Mount that has since become a Vehicle — or an
+ * absent optional target — resolves correctly.
+ *
+ * "Becomes an artifact creature" is `Effects.AddCardType`, not `BecomeCreature`: a Vehicle already
+ * has printed P/T, and this effect only needs to add the CREATURE type. `BecomeCreature` would have
+ * to invent a base P/T for a target whose printed stats aren't knowable when the card is authored.
+ */
+private val MountOrVehicleYouControl = GameObjectFilter(
+    cardPredicates = listOf(
+        CardPredicate.Or(
+            listOf(
+                CardPredicate.HasSubtype(Subtype("Mount")),
+                CardPredicate.HasSubtype(Subtype.VEHICLE)
+            )
+        )
+    )
+).youControl()
+
+private val Mount = GameObjectFilter.Any.withSubtype(Subtype("Mount"))
+private val Vehicle = GameObjectFilter.Any.withSubtype(Subtype.VEHICLE)
+
+val AlacrianArmory = card("Alacrian Armory") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "Creatures you control get +0/+1 and have vigilance.\n" +
+        "At the beginning of combat on your turn, choose up to one target Mount or Vehicle you " +
+        "control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes " +
+        "an artifact creature if it's a Vehicle."
+
+    staticAbility {
+        ability = ModifyStats(0, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.AllCreaturesYouControl)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val permanent = target(
+            "up to one target Mount or Vehicle you control",
+            TargetPermanent(optional = true, filter = TargetFilter(MountOrVehicleYouControl))
+        )
+        effect = Effects.Composite(
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(Mount),
+                effect = Effects.BecomeSaddled(permanent)
+            ),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(Vehicle),
+                effect = Effects.AddCardType(
+                    cardType = "CREATURE",
+                    target = permanent,
+                    duration = Duration.EndOfTurn
+                )
+            ),
+        )
+        description = "At the beginning of combat on your turn, choose up to one target Mount or " +
+            "Vehicle you control. Until end of turn, that permanent becomes saddled if it's a " +
+            "Mount and becomes an artifact creature if it's a Vehicle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg?1783907923"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FearlessSwashbuckler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FearlessSwashbuckler.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Fearless Swashbuckler — Aetherdrift #204
+ * {1}{U}{R} · Creature — Fish Pirate · 3/3
+ *
+ * Haste
+ * Vehicles you control have haste.
+ * Whenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then
+ * discard two cards.
+ *
+ * The intervening "if" is two independent existence checks over `attackedThisCombat()`, not one
+ * filter. That is what makes the ruling work: a single permanent that is both a Pirate and a
+ * Vehicle satisfies both halves, because each half only asks whether *something* matching it
+ * attacked. A single conjunctive filter would have demanded two separate attackers.
+ *
+ * Scoped to permanents you control, which costs nothing in fidelity — only the attacking player
+ * declares attackers in a combat (CR 508.1), and "whenever you attack" makes that you.
+ */
+private val VehiclesYouControl = GameObjectFilter.Any.withSubtype(Subtype.VEHICLE).youControl()
+
+val FearlessSwashbuckler = card("Fearless Swashbuckler") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Fish Pirate"
+    power = 3
+    toughness = 3
+    oracleText = "Haste\n" +
+        "Vehicles you control have haste.\n" +
+        "Whenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, " +
+        "then discard two cards."
+
+    keywords(Keyword.HASTE)
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter(VehiclesYouControl))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        triggerCondition = Conditions.All(
+            Conditions.YouControlAtLeast(
+                1,
+                GameObjectFilter.Creature.withSubtype("Pirate").attackedThisCombat()
+            ),
+            Conditions.YouControlAtLeast(
+                1,
+                GameObjectFilter.Any.withSubtype(Subtype.VEHICLE).attackedThisCombat()
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(3),
+            Effects.Discard(2),
+        )
+        description = "Whenever you attack, if a Pirate and a Vehicle attacked this combat, " +
+            "draw three cards, then discard two cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "Konstantin Porubov"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg?1783907859"
+
+        ruling(
+            "2025-02-07",
+            "If you attack with a single creature that is both a Pirate and a Vehicle, the last " +
+                "ability triggers."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SitaVarmaMaskedRacer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SitaVarmaMaskedRacer.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/** Sita Varma's power at resolution — read off the ability's source, not the iteration entity. */
+private val SitaVarmasPower: DynamicAmount = DynamicAmount.EntityProperty(
+    EntityReference.Source,
+    EntityNumericProperty.Power
+)
+
+/**
+ * Sita Varma, Masked Racer — Aetherdrift #223
+ * {G}{U} · Legendary Creature — Human Rogue · 2/3
+ *
+ * Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and
+ * toughness of each other creature you control become equal to Sita Varma's power until end of
+ * turn. (Activate each exhaust ability only once.)
+ *
+ * Order is load-bearing and matches the printed "Then": the counters land first, so the power the
+ * rest of the team copies is already `2 + X`. Inside the `ForEachInGroup` body, `EffectTarget.Self`
+ * is the creature being set (the iteration entity) while `EntityReference.Source` is still Sita
+ * Varma — which is what lets one body both read her power and write each other creature's.
+ *
+ * `SetBasePowerAndToughness` sets Layer 7b, so each affected creature's own +1/+1 counters still
+ * add on top in 7d — the base is replaced, not the final value.
+ */
+val SitaVarmaMaskedRacer = card("Sita Varma, Masked Racer") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Human Rogue"
+    power = 2
+    toughness = 3
+    oracleText = "Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have " +
+        "the base power and toughness of each other creature you control become equal to Sita " +
+        "Varma's power until end of turn. (Activate each exhaust ability only once.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{X}{G}{G}{U}")
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                DynamicAmount.XValue,
+                EffectTarget.Self
+            ),
+            MayEffect(
+                Effects.ForEachInGroup(
+                    filter = GroupFilter.OtherCreaturesYouControl,
+                    effect = Effects.SetBasePowerAndToughness(
+                        target = EffectTarget.Self,
+                        power = SitaVarmasPower,
+                        toughness = SitaVarmasPower,
+                        duration = Duration.EndOfTurn
+                    )
+                ),
+                descriptionOverride = "You may have the base power and toughness of each other " +
+                    "creature you control become equal to Sita Varma's power until end of turn."
+            ),
+        )
+        description = "Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may " +
+            "have the base power and toughness of each other creature you control become equal " +
+            "to Sita Varma's power until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg?1783907851"
+
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its " +
+                "exhaust ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpireMechcycle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SpireMechcycle.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Spire Mechcycle — Aetherdrift #147
+ * {4}{R} · Artifact — Vehicle · 5/4
+ *
+ * Haste
+ * Exhaust — Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact
+ * creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this
+ * Vehicle. (Activate each exhaust ability only once.)
+ * Crew 2
+ *
+ * Same shape as Marshals' Pathcruiser — no "until end of turn" clause on the animate, so
+ * [Duration.Permanent] with the printed 5/4 as the base P/T and the counters layering on top in
+ * 7d. The cost's "untapped … you control" is intrinsic to `CostAtom.TapPermanents` (the engine
+ * offers only controlled untapped candidates), so the filter carries the subtype test alone.
+ *
+ * The permanent tapped to pay the cost is still on the battlefield when the ability resolves, so
+ * it counts toward the counters — which is why the count is taken at resolution, not at activation.
+ */
+private val MountOrVehicle = GameObjectFilter(
+    cardPredicates = listOf(
+        CardPredicate.Or(
+            listOf(
+                CardPredicate.HasSubtype(Subtype("Mount")),
+                CardPredicate.HasSubtype(Subtype.VEHICLE)
+            )
+        )
+    )
+)
+
+val SpireMechcycle = card("Spire Mechcycle") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 4
+    oracleText = "Haste\n" +
+        "Exhaust — Tap another untapped Mount or Vehicle you control: This Vehicle becomes an " +
+        "artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control " +
+        "other than this Vehicle. (Activate each exhaust ability only once.)\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.TapAnotherPermanent(MountOrVehicle)
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 5,
+                toughness = 4,
+                duration = Duration.Permanent
+            ),
+            Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = MountOrVehicle,
+                    excludeSelf = true
+                ),
+                EffectTarget.Self
+            )
+        )
+        description = "Exhaust — Tap another untapped Mount or Vehicle you control: This Vehicle " +
+            "becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or " +
+            "Vehicle you control other than this Vehicle."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Adam Volker"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg?1783907876"
+
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its " +
+                "exhaust ability can be activated again."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VnwxtVerboseHost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VnwxtVerboseHost.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyDrawAmount
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Vnwxt, Verbose Host
+ * {1}{U}
+ * Legendary Creature — Homunculus
+ * 0/4
+ *
+ * Start your engines!
+ * You have no maximum hand size.
+ * Max speed — If you would draw a card, draw two cards instead.
+ *
+ * The max-speed clause is a *replacement* effect, so it can't go through the `maxSpeed { }`
+ * block — that gates static/activated/triggered abilities, and replacement effects are read
+ * straight off `ReplacementEffectSourceComponent` at interception sites that don't evaluate a
+ * gate. [ModifyDrawAmount] carries its own `restrictions` slot, evaluated in the drawing
+ * player's context at the one announcement site (CR 121.2a), so the gate folds into the
+ * effect itself exactly the way `maxSpeed { }` folds it into `ModifySpellCost.gating`. The
+ * display-only [Keyword.MAX_SPEED] badge is added by hand for the same reason.
+ *
+ * `multiplier = 2` rather than `modifier = 1`: the rulings are explicit that this multiplies
+ * the announced count, so Harmonize draws six, and two such effects quadruple it.
+ */
+val VnwxtVerboseHost = card("Vnwxt, Verbose Host") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Homunculus"
+    power = 0
+    toughness = 4
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "You have no maximum hand size.\n" +
+        "Max speed — If you would draw a card, draw two cards instead."
+
+    startYourEngines()
+    keywords(Keyword.MAX_SPEED)
+
+    staticAbility {
+        ability = NoMaximumHandSize
+    }
+
+    replacementEffect(
+        ModifyDrawAmount(
+            multiplier = 2,
+            restrictions = listOf(Conditions.YouHaveMaxSpeed),
+            appliesTo = EventPattern.DrawEvent(player = Player.You),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "73"
+        artist = "Izzy"
+        flavorText = "\"Racers! Start! Your! Engiiiiiines!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg?1783907900"
+
+        ruling(
+            "2025-02-07",
+            "If a spell or ability causes you to draw multiple cards, this creature's last ability " +
+                "doubles each card draw. For example, if you cast Harmonize (\"Draw three cards\"), " +
+                "you'll draw six cards."
+        )
+        ruling(
+            "2025-02-07",
+            "The effects of multiple such effects are cumulative. For example, if you have max speed " +
+                "and control both Vnwxt and Thought Reflection (an enchantment with the same ability), " +
+                "you'll draw four times the original number of cards."
+        )
+        ruling(
+            "2025-02-07",
+            "If two or more replacement effects would apply to a card-drawing event, the player who's " +
+                "drawing the card chooses what order to apply them."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -368,6 +368,110 @@
     ]
 }
 
+// Alacrian Armory
+{
+    "name": "Alacrian Armory",
+    "manaCost": "{3}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "Creatures you control get +0/+1 and have vigilance.\nAt the beginning of combat on your turn, choose up to one target Mount or Vehicle you control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "Mount"
+                                }
+                            },
+                            "then": {
+                                "type": "BecomeSaddled",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target Mount or Vehicle you control"
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "Vehicle"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCardType",
+                                "cardType": "CREATURE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target Mount or Vehicle you control"
+                                },
+                                "duration": "EndOfTurn"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "Mount|Vehicle ctrl:you"
+                    },
+                    "id": "up to one target Mount or Vehicle you control"
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, choose up to one target Mount or Vehicle you control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d39f7f98-ad5e-4e5e-9f7b-abe0984ffe17.jpg?1783907923"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Alacrian Jaguar
 {
     "name": "Alacrian Jaguar",
@@ -3955,6 +4059,155 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Fearless Swashbuckler
+{
+    "name": "Fearless Swashbuckler",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Creature — Fish Pirate",
+    "oracleText": "Haste\nVehicles you control have haste.\nWhenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 2 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "HasSubtype",
+                                            "subtype": "Pirate"
+                                        }
+                                    ],
+                                    "statePredicates": [
+                                        "AttackedThisCombat"
+                                    ]
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "HasSubtype",
+                                            "subtype": "Vehicle"
+                                        }
+                                    ],
+                                    "statePredicates": [
+                                        "AttackedThisCombat"
+                                    ]
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then discard two cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "Vehicle ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "RARE",
+        "artist": "Konstantin Porubov",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d86d66b-481f-44ec-86d8-6fc91b52ef38.jpg?1783907859",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If you attack with a single creature that is both a Pirate and a Vehicle, the last ability triggers."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -11547,6 +11800,94 @@
     ]
 }
 
+// Sita Varma, Masked Racer
+{
+    "name": "Sita Varma, Masked Racer",
+    "manaCost": "{G}{U}",
+    "typeLine": "Legendary Creature — Human Rogue",
+    "oracleText": "Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{X}{G}{G}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": "XValue",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "body": {
+                                    "type": "SetBaseStats",
+                                    "target": "Self",
+                                    "power": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": "Power"
+                                    },
+                                    "toughness": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": "Power"
+                                    },
+                                    "duration": "EndOfTurn"
+                                }
+                            },
+                            "descriptionOverride": "You may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn."
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "RARE",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb523c06-6f3e-4e19-b777-19aefc4a4e02.jpg?1783907851",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Skybox Ferry
 {
     "name": "Skybox Ferry",
@@ -12132,6 +12473,92 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Spire Mechcycle
+{
+    "name": "Spire Mechcycle",
+    "manaCost": "{4}{R}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Haste\nExhaust — Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle. (Activate each exhaust ability only once.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "Mount|Vehicle",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "Mount|Vehicle",
+                                "excludeSelf": true
+                            },
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Volker",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f483debe-9c54-4323-aec5-226587ece2c9.jpg?1783907876",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -13742,6 +14169,68 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Vnwxt, Verbose Host
+{
+    "name": "Vnwxt, Verbose Host",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Creature — Homunculus",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nYou have no maximum hand size.\nMax speed — If you would draw a card, draw two cards instead.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "staticAbilities": [
+            "NoMaximumHandSize"
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyDrawAmount",
+                "multiplier": 2,
+                "restrictions": [
+                    {
+                        "type": "Compare",
+                        "left": "Speed",
+                        "operator": "EQ",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "flavorText": "\"Racers! Start! Your! Engiiiiiines!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/893254c7-64cc-4cb9-b79f-2c41a8935ea0.jpg?1783907900",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If a spell or ability causes you to draw multiple cards, this creature's last ability doubles each card draw. For example, if you cast Harmonize (\"Draw three cards\"), you'll draw six cards."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "The effects of multiple such effects are cumulative. For example, if you have max speed and control both Vnwxt and Thought Reflection (an enchantment with the same ability), you'll draw four times the original number of cards."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If two or more replacement effects would apply to a card-drawing event, the player who's drawing the card chooses what order to apply them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawReplacementDispatcher.kt
@@ -365,8 +365,17 @@ class DrawReplacementDispatcher(
      *
      * Iterates every battlefield permanent's replacement effects, gates each by the
      * [DrawEvent]'s `player` filter relative to [playerId] and the source's controller,
-     * and (if all `restrictions` hold) sums the modifier into [originalCount]. The
-     * final result is clamped to `≥ 0`.
+     * and (if all `restrictions` hold) folds `(count * multiplier) + modifier` into
+     * [originalCount]. The final result is clamped to `≥ 0`.
+     *
+     * Effects compose in battlefield-iteration order. Multipliers commute with multipliers
+     * and modifiers with modifiers, so that order is unobservable while every applicable
+     * effect is of one kind — the whole corpus today. It *is* observable when a multiplier
+     * and a modifier apply to the same draw (Vnwxt's ×2 alongside Quantum Riddler's +1:
+     * `(1*2)+1 = 3` vs `(1+1)*2 = 4`), where CR 616.1 gives the drawing player the choice of
+     * order and we pick one for them. Known simplification: adding a decision point here
+     * would pause every draw in a two-replacement board state, so it waits for a card that
+     * makes the difference matter.
      */
     fun applyDrawAmountModifier(
         state: GameState,
@@ -403,7 +412,7 @@ class DrawReplacementDispatcher(
                 }
                 if (!restrictionsHold) continue
 
-                adjusted += effect.modifier
+                adjusted = adjusted * effect.multiplier + effect.modifier
             }
         }
         return adjusted.coerceAtLeast(0)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlacrianArmoryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlacrianArmoryScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alacrian Armory (DFT #2) — {3}{W} Artifact.
+ *
+ * "Creatures you control get +0/+1 and have vigilance.
+ *  At the beginning of combat on your turn, choose up to one target Mount or Vehicle you control.
+ *  Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact
+ *  creature if it's a Vehicle."
+ *
+ * The trigger's two halves are separately gated on the chosen permanent's type, so the tests care
+ * about which half fires for which target: a Vehicle must be animated and *not* stamped saddled
+ * (the `BecomeSaddled` executor has no Mount check of its own), and a Mount must be saddled and not
+ * spuriously re-typed. The lord half is checked on the same board so the +0/+1 doesn't get lost
+ * behind the animate.
+ */
+class AlacrianArmoryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Alacrian Armory") {
+
+            test("a targeted Vehicle becomes an artifact creature and is not marked saddled") {
+                val game = armoryGame("Skybox Ferry")
+                val ferry = game.findPermanent("Skybox Ferry")!!
+
+                withClue("a Vehicle is not a creature before the trigger resolves") {
+                    game.state.projectedState.isCreature(ferry) shouldBe false
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveTriggerTargeting(ferry)
+
+                val projected = game.state.projectedState
+                withClue("the Vehicle half fired") {
+                    projected.isCreature(ferry) shouldBe true
+                    projected.hasType(ferry, "ARTIFACT") shouldBe true
+                }
+                withClue("the Mount half must not fire on a Vehicle") {
+                    game.state.getEntity(ferry)!!.has<SaddledComponent>() shouldBe false
+                }
+                withClue("the printed 4/4 is the base P/T, plus the Armory's own +0/+1 -> 4/5") {
+                    projected.getPower(ferry) shouldBe 4
+                    projected.getToughness(ferry) shouldBe 5
+                }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("\"until end of turn\" — the Vehicle stops being a creature") {
+                    game.state.projectedState.isCreature(ferry) shouldBe false
+                }
+            }
+
+            test("a targeted Mount becomes saddled") {
+                val game = armoryGame("Gilded Ghoda")
+                val mount = game.findPermanent("Gilded Ghoda")!!
+
+                withClue("nothing has saddled it yet") {
+                    game.state.getEntity(mount)!!.has<SaddledComponent>() shouldBe false
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveTriggerTargeting(mount)
+
+                withClue("the Mount half fired") {
+                    game.state.getEntity(mount)!!.has<SaddledComponent>() shouldBe true
+                }
+            }
+
+            test("creatures you control get +0/+1 and vigilance") {
+                val game = armoryGame("Hill Giant")
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val projected = game.state.projectedState
+                withClue("printed 3/3 plus +0/+1") {
+                    projected.getPower(giant) shouldBe 3
+                    projected.getToughness(giant) shouldBe 4
+                }
+                withClue("and vigilance") {
+                    projected.hasKeyword(giant, com.wingedsheep.sdk.core.Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolve the begin-combat trigger, choosing [choice] for its "up to one target". The trigger
+     * pauses for target selection before it goes on the stack.
+     */
+    private fun TestGame.resolveTriggerTargeting(choice: com.wingedsheep.sdk.model.EntityId) {
+        if (hasPendingDecision()) selectTargets(listOf(choice))
+        resolveStack()
+    }
+
+    /**
+     * The Armory plus one companion permanent, starting in the upkeep so passing forward reaches the
+     * begin-combat trigger. The companion is named by the test: an ability-free Vehicle, a Mount, or
+     * a vanilla creature for the lord check.
+     */
+    private fun armoryGame(companion: String): TestGame = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Alacrian Armory")
+        .withCardOnBattlefield(1, companion, summoningSickness = false)
+        .withActivePlayer(1)
+        .withTurnNumber(3)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearlessSwashbucklerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearlessSwashbucklerScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fearless Swashbuckler (DFT #204) — {1}{U}{R} Creature — Fish Pirate 3/3.
+ *
+ * "Haste
+ *  Vehicles you control have haste.
+ *  Whenever you attack, if a Pirate and a Vehicle attacked this combat, draw three cards, then
+ *  discard two cards."
+ *
+ * The intervening "if" is modelled as two independent existence checks over `attackedThisCombat()`
+ * rather than one conjunctive filter, so the tests separate the two failure modes: attacking with
+ * the Pirate alone must *not* trigger, and attacking with a Pirate plus a crewed Vehicle must. The
+ * haste grant is what makes the second case reachable on the Vehicle's first turn.
+ */
+class FearlessSwashbucklerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Fearless Swashbuckler") {
+
+            test("Vehicles you control have haste") {
+                val game = swashbucklerGame()
+                val ferry = game.findPermanent("Skybox Ferry")!!
+
+                withClue("the grant reaches a Vehicle even while it is not a creature") {
+                    game.state.projectedState.hasKeyword(ferry, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("attacking with the Pirate alone does not trigger — no Vehicle attacked") {
+                val game = swashbucklerGame()
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                val attack = game.declareAttackers(mapOf("Fearless Swashbuckler" to 2))
+                withClue("the attack itself must land, or this proves nothing: ${attack.error}") {
+                    attack.error shouldBe null
+                    game.state.getEntity(game.findPermanent("Fearless Swashbuckler")!!)!!
+                        .has<AttackingComponent>() shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("the intervening 'if' must fail with no Vehicle among the attackers") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("a Pirate and a crewed Vehicle attacking draws three and discards two") {
+                val game = swashbucklerGame()
+                val handBefore = game.handSize(1)
+
+                // Crew the Ferry with the Swashbuckler's teammate so both can attack; the
+                // Vehicle's haste comes from the Swashbuckler itself.
+                val crew = game.execute(
+                    CrewVehicle(
+                        game.player1Id,
+                        game.findPermanent("Skybox Ferry")!!,
+                        listOf(game.findPermanent("Hill Giant")!!)
+                    )
+                )
+                withClue("crew should succeed: ${crew.error}") { crew.error shouldBe null }
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf("Fearless Swashbuckler" to 2, "Skybox Ferry" to 2)
+                )
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    // The discard is a choose-2-from-hand selection.
+                    game.selectCards(game.findCardsInHand(1, "Grizzly Bears").take(2))
+                    game.resolveStack()
+                }
+
+                withClue("draw 3 then discard 2 is a net +1") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+
+    /**
+     * The Swashbuckler, an ability-free Vehicle to be the attacking Vehicle, and a Hill Giant with
+     * enough power to crew it. Turn 3 with the players' libraries stocked so the draw-three can't
+     * deck anyone, and starting in the precombat main phase so the crew happens before combat.
+     */
+    private fun swashbucklerGame(): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Fearless Swashbuckler", summoningSickness = false)
+            .withCardOnBattlefield(1, "Skybox Ferry")
+            .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+        repeat(15) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .withTurnNumber(3)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SitaVarmaMaskedRacerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SitaVarmaMaskedRacerScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sita Varma, Masked Racer (DFT #223) — {G}{U} Legendary Creature — Human Rogue 2/3.
+ *
+ * "Exhaust — {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and
+ *  toughness of each other creature you control become equal to Sita Varma's power until end of
+ *  turn."
+ *
+ * The composition puts a `ForEachInGroup` inside a "you may", and its body reads two different
+ * entities at once: `EntityReference.Source` for Sita Varma's power and `EffectTarget.Self` for the
+ * creature being rewritten. If those collapsed onto one entity, every creature would set its base
+ * P/T to its own power — a silent no-op the card snapshot cannot catch. Hence a 3/3 Hill Giant as
+ * the other creature, so a wrong answer and a right one differ at every X. The tests pin:
+ *
+ * - the copied number is `2 + X`, i.e. the counters landed *before* the base-setting ("Then");
+ * - Sita Varma herself is excluded ("each **other** creature");
+ * - declining the "may" leaves the team alone but keeps the counters;
+ * - the base-setting is "until end of turn" while the counters are not.
+ */
+class SitaVarmaMaskedRacerScenarioTest : ScenarioTestBase() {
+
+    private val exhaustAbilityId
+        get() = cardRegistry.getCard("Sita Varma, Masked Racer")!!.script.activatedAbilities[0].id
+
+    init {
+        context("Sita Varma's exhaust ability") {
+
+            test("each other creature's base P/T becomes Sita Varma's post-counter power") {
+                val game = sitaGame(lands = 7)
+                val sita = game.findPermanent("Sita Varma, Masked Racer")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.activateExhaust(sita, x = 3, accept = true)
+
+                val projected = game.state.projectedState
+                withClue("2 printed power + 3 counters = 5") {
+                    projected.getPower(sita) shouldBe 5
+                    projected.getToughness(sita) shouldBe 6
+                }
+                withClue("Hill Giant's base 3/3 is replaced by 5/5 — Sita Varma's power, not its own") {
+                    projected.getPower(giant) shouldBe 5
+                    projected.getToughness(giant) shouldBe 5
+                }
+            }
+
+            test("X = 0 adds no counters and copies Sita Varma's printed power of 2") {
+                val game = sitaGame(lands = 4)
+                val sita = game.findPermanent("Sita Varma, Masked Racer")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.activateExhaust(sita, x = 0, accept = true)
+
+                val projected = game.state.projectedState
+                withClue("no counters, so Sita Varma is still a 2/3") {
+                    projected.getPower(sita) shouldBe 2
+                    projected.getToughness(sita) shouldBe 3
+                }
+                withClue("the base-set can shrink too — Hill Giant goes from 3/3 to 2/2") {
+                    projected.getPower(giant) shouldBe 2
+                    projected.getToughness(giant) shouldBe 2
+                }
+            }
+
+            test("declining the 'may' keeps the counters and leaves the team alone") {
+                val game = sitaGame(lands = 7)
+                val sita = game.findPermanent("Sita Varma, Masked Racer")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.activateExhaust(sita, x = 3, accept = false)
+
+                val projected = game.state.projectedState
+                withClue("the counters are not part of the optional clause") {
+                    projected.getPower(sita) shouldBe 5
+                }
+                withClue("Hill Giant keeps its printed 3/3") {
+                    projected.getPower(giant) shouldBe 3
+                    projected.getToughness(giant) shouldBe 3
+                }
+            }
+
+            test("the base-setting wears off at end of turn but the counters do not") {
+                val game = sitaGame(lands = 7)
+                val sita = game.findPermanent("Sita Varma, Masked Racer")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.activateExhaust(sita, x = 3, accept = true)
+                game.state.projectedState.getPower(giant) shouldBe 5
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                val projected = game.state.projectedState
+                withClue("\"until end of turn\" — Hill Giant reverts to 3/3") {
+                    projected.getPower(giant) shouldBe 3
+                    projected.getToughness(giant) shouldBe 3
+                }
+                withClue("+1/+1 counters are permanent") {
+                    projected.getPower(sita) shouldBe 5
+                }
+            }
+        }
+    }
+
+    /** Activate the exhaust ability for [x], pay, then answer its "you may" with [accept]. */
+    private fun TestGame.activateExhaust(sita: EntityId, x: Int, accept: Boolean) {
+        val result = execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = sita,
+                abilityId = exhaustAbilityId,
+                xValue = x
+            )
+        )
+        withClue("activation with X=$x should succeed: ${result.error}") { result.error shouldBe null }
+        if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+
+        // The ability resolves up to the "you may", which pauses the stack.
+        resolveStack()
+        withClue("the optional clause should have raised a yes/no") {
+            hasPendingDecision() shouldBe true
+        }
+        answerYesNo(accept)
+        resolveStack()
+    }
+
+    /**
+     * Sita Varma plus one vanilla 3/3 Hill Giant as the "other creature you control", and [lands]
+     * lands — enough for {X}{G}{G}{U} at the X the test uses. Neither creature has summoning
+     * sickness, so the ability is activatable on the turn the scenario starts.
+     */
+    private fun sitaGame(lands: Int): TestGame = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Sita Varma, Masked Racer", summoningSickness = false)
+        .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+        .withLandsOnBattlefield(1, "Forest", lands - 1)
+        .withLandsOnBattlefield(1, "Island", 1)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpireMechcycleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpireMechcycleScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Spire Mechcycle (DFT #147) — {4}{R} Artifact — Vehicle 5/4.
+ *
+ * "Haste
+ *  Exhaust — Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact
+ *  creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this
+ *  Vehicle.
+ *  Crew 2"
+ *
+ * Three claims worth pinning:
+ *
+ * - the cost's "**another**" — the Mechcycle cannot tap itself to pay, and with nothing else to tap
+ *   the ability is unactivatable;
+ * - the counter count excludes the Mechcycle but *includes* the permanent tapped to pay, since that
+ *   one is still on the battlefield when the ability resolves;
+ * - the animate has no "until end of turn" clause, so it survives cleanup (as on Marshals'
+ *   Pathcruiser).
+ */
+class SpireMechcycleScenarioTest : ScenarioTestBase() {
+
+    private val exhaustAbilityId
+        get() = cardRegistry.getCard("Spire Mechcycle")!!.script.activatedAbilities[0].id
+
+    init {
+        context("Spire Mechcycle's exhaust ability") {
+
+            test("animates permanently with one counter per other Mount/Vehicle") {
+                // Three other Vehicles: one gets tapped to pay, and all three still count.
+                val game = mechcycleGame(otherVehicles = 3)
+                val mechcycle = game.findPermanent("Spire Mechcycle")!!
+                val ferries = game.findPermanents("Skybox Ferry")
+
+                withClue("a Vehicle is not a creature until something animates it") {
+                    game.state.projectedState.isCreature(mechcycle) shouldBe false
+                }
+
+                val result = game.activateTapping(mechcycle, ferries.first())
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                withClue("the chosen Vehicle was tapped to pay") {
+                    game.state.getEntity(ferries.first())!!.has<TappedComponent>() shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("the tapped-as-cost Vehicle is still on the battlefield, so all 3 count") {
+                    game.state.getEntity(mechcycle)!!.get<CountersComponent>()!!
+                        .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 3
+                }
+                val projected = game.state.projectedState
+                withClue("5/4 base plus three +1/+1 counters, still an artifact") {
+                    projected.isCreature(mechcycle) shouldBe true
+                    projected.hasType(mechcycle, "ARTIFACT") shouldBe true
+                    projected.getPower(mechcycle) shouldBe 8
+                    projected.getToughness(mechcycle) shouldBe 7
+                }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("no 'until end of turn' clause — cleanup must not undo it") {
+                    game.state.projectedState.isCreature(mechcycle) shouldBe true
+                }
+            }
+
+            test("the Mechcycle cannot tap itself to pay") {
+                val game = mechcycleGame(otherVehicles = 1)
+                val mechcycle = game.findPermanent("Spire Mechcycle")!!
+
+                val result = game.activateTapping(mechcycle, mechcycle)
+                withClue("'another' excludes the source even when it is untapped") {
+                    result.error shouldNotBe null
+                }
+                game.state.projectedState.isCreature(mechcycle) shouldBe false
+            }
+
+            test("with no other Mount or Vehicle the ability cannot be activated") {
+                val game = mechcycleGame(otherVehicles = 0)
+                val mechcycle = game.findPermanent("Spire Mechcycle")!!
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, mechcycle, exhaustAbilityId)
+                )
+                withClue("nothing legal to tap, so the cost is unpayable") {
+                    result.error shouldNotBe null
+                }
+                game.state.projectedState.isCreature(mechcycle) shouldBe false
+            }
+
+            test("it is an exhaust ability — activate only once") {
+                val game = mechcycleGame(otherVehicles = 2)
+                val mechcycle = game.findPermanent("Spire Mechcycle")!!
+                val ferries = game.findPermanents("Skybox Ferry")
+
+                game.activateTapping(mechcycle, ferries[0]).error shouldBe null
+                game.resolveStack()
+
+                val second = game.activateTapping(mechcycle, ferries[1])
+                withClue("a second activation must be rejected even with an untapped Vehicle left") {
+                    second.error shouldNotBe null
+                }
+                game.state.getEntity(mechcycle)!!.get<CountersComponent>()!!
+                    .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+            }
+        }
+    }
+
+    /** Activate the exhaust ability, paying by tapping [tapped]. */
+    private fun TestGame.activateTapping(mechcycle: EntityId, tapped: EntityId) = execute(
+        ActivateAbility(
+            playerId = player1Id,
+            sourceId = mechcycle,
+            abilityId = exhaustAbilityId,
+            costPayment = AdditionalCostPayment(tappedPermanents = listOf(tapped))
+        )
+    )
+
+    /**
+     * Spire Mechcycle plus [otherVehicles] copies of Skybox Ferry — an ability-free Vehicle, so the
+     * only things in play that could tap, animate or count are the ones under test.
+     */
+    private fun mechcycleGame(otherVehicles: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Spire Mechcycle")
+        repeat(otherVehicles) {
+            builder.withCardOnBattlefield(1, "Skybox Ferry")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VnwxtVerboseHostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VnwxtVerboseHostScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vnwxt, Verbose Host (DFT #73) — {1}{U} Legendary Creature — Homunculus, 0/4.
+ *
+ * "Start your engines!
+ *  You have no maximum hand size.
+ *  Max speed — If you would draw a card, draw two cards instead."
+ *
+ * Exercises the `multiplier` knob added to [com.wingedsheep.sdk.scripting.ModifyDrawAmount], and
+ * the max-speed gate folded into that effect's own `restrictions` slot (replacement effects can't
+ * go through `maxSpeed { }`). The two things worth proving:
+ *
+ * - the doubling applies to the *announced* count, so Harmonize's "draw three cards" draws six —
+ *   the literal example in the card's rulings, and the reason this is a multiplier and not a `+1`;
+ * - below max speed the effect does nothing at all, at every announcement site.
+ */
+class VnwxtVerboseHostScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vnwxt's max-speed draw doubling") {
+
+            test("Harmonize's draw three becomes draw six at max speed") {
+                val game = vnwxtGame(maxSpeed = true, libraryCards = 20)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Harmonize")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.payManaIfAsked()
+                game.resolveStack()
+
+                // Harmonize leaves hand as it's cast, so the delta is drawn cards only.
+                withClue("Draw 3 × 2 = 6, not 3 + 1 = 4") {
+                    game.handSize(1) - (handBefore - 1) shouldBe 6
+                }
+            }
+
+            test("Harmonize draws its printed three below max speed") {
+                val game = vnwxtGame(maxSpeed = false, libraryCards = 20)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Harmonize").error shouldBe null
+                game.payManaIfAsked()
+                game.resolveStack()
+
+                withClue("Start your engines! only sets speed 1 — the gate must hold") {
+                    game.handSize(1) - (handBefore - 1) shouldBe 3
+                }
+            }
+
+            test("the draw step draws two at max speed") {
+                // The second announcement site: DrawPhaseManager.performDrawStep. Turn 2 so the
+                // step isn't skipped for the starting player.
+                val game = vnwxtGame(maxSpeed = true, libraryCards = 20, turnNumber = 2)
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("Draw step's draw 1 doubles to 2") {
+                    game.handSize(1) - handBefore shouldBe 2
+                }
+            }
+
+            test("the draw step draws one below max speed") {
+                val game = vnwxtGame(maxSpeed = false, libraryCards = 20, turnNumber = 2)
+                val handBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                withClue("Draw step's draw 1 stays 1") {
+                    game.handSize(1) - handBefore shouldBe 1
+                }
+            }
+        }
+    }
+
+    /** Clear the mana-source prompt when casting Harmonize opens one. */
+    private fun TestGame.payManaIfAsked() {
+        if (getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+            submitManaSourcesAutoPay()
+        }
+    }
+
+    /**
+     * Vnwxt already on the battlefield with enough Forests for Harmonize ({3}{G}{G}) plus the
+     * Island for Vnwxt's own colour, and a stocked library so a doubled draw can't deck anyone.
+     * Speed is stamped directly rather than raced up through opponent life loss — the state-based
+     * action for Start your engines! has already put the controller at 1 by then.
+     */
+    private fun vnwxtGame(
+        maxSpeed: Boolean,
+        libraryCards: Int,
+        turnNumber: Int = 1
+    ): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Vnwxt, Verbose Host", summoningSickness = false)
+            .withCardInHand(1, "Harmonize")
+            .withLandsOnBattlefield(1, "Forest", 5)
+        repeat(libraryCards) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        val game = builder
+            .withActivePlayer(1)
+            .withTurnNumber(turnNumber)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        if (maxSpeed) {
+            game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+        }
+        return game
+    }
+}


### PR DESCRIPTION
Five Aetherdrift cards, all canonical in DFT (their only other printings are `pdft` promos). DFT goes from 218/276 to 223/276.

| Card | Cost | What it needed |
|---|---|---|
| Vnwxt, Verbose Host | `{1}{U}` | new `multiplier` on `ModifyDrawAmount` |
| Fearless Swashbuckler | `{1}{U}{R}` | existing primitives |
| Alacrian Armory | `{3}{W}` | existing primitives |
| Spire Mechcycle | `{4}{R}` | existing primitives |
| Sita Varma, Masked Racer | `{G}{U}` | existing primitives |

## The one SDK addition

`ModifyDrawAmount` gains a `multiplier`, so the type covers "draw twice that many instead" alongside the existing "that many plus N" wording — `(count * multiplier) + modifier`, clamped to ≥ 0.

This is not cosmetic. Vnwxt's rulings are explicit that the doubling applies to the **announced** count ("if you cast Harmonize, you'll draw six cards") and that two such effects **quadruple** the draw. A `modifier = 1` would have drawn four from Harmonize — a plausible-looking card that resolves wrong. The math folds into the single announcement site in `DrawReplacementDispatcher.applyDrawAmountModifier`, which every draw path already funnels through (spell/ability resolution, the draw step, cycling). Descriptions for `multiplier = 1` are byte-identical, so no existing card's golden moved — the only snapshot change is the five new entries.

Following the project preference for one parameterized amount-modifier over split `DoubleX` / `ModifyX` types.

## Vnwxt's max-speed gate

"Max speed —" on a replacement effect is exactly the case `maxSpeed { }` documents as not covered: replacements are read off `ReplacementEffectSourceComponent` at ~20 sites that don't evaluate conditions.

Rather than build the general conditional-replacement seam for one card, the gate folds into `ModifyDrawAmount.restrictions` — which already exists, is already evaluated in the drawing player's context, and is the same trick `MaxSpeedBuilder` uses for `ModifySpellCost.gating` and `MayCastSelfFromZones.condition`. `SpeedDsl`'s "not covered" note is updated to explain this, keeping Far Fortune, End Boss as the remaining genuinely-uncovered case, and to say when it would be worth routing a second such card through the builder.

## The other four

- **Fearless Swashbuckler** — the intervening "if" is two *independent* existence checks over `attackedThisCombat()`, not one conjunctive filter. That's what makes the ruling work when a single permanent is both a Pirate and a Vehicle: each half only asks whether *something* matching it attacked. A conjunctive filter would have demanded two separate attackers.
- **Alacrian Armory** — the two halves are separately gated on the chosen permanent's type, because neither is a safe no-op on the wrong one: `BecomeSaddledExecutor` has no Mount check, so an ungated version would stamp a Vehicle as saddled. "Becomes an artifact creature" is `AddCardType("CREATURE")`, not `BecomeCreature` — a Vehicle already has printed P/T, and `BecomeCreature` would have to invent a base P/T for a target whose stats aren't knowable at authoring time.
- **Spire Mechcycle** — mirrors Marshals' Pathcruiser: no "until end of turn" clause, so `Duration.Permanent`. "Untapped … you control" is intrinsic to `CostAtom.TapPermanents`, so the filter carries only the subtype test.
- **Sita Varma** — one `ForEachInGroup` body reads two entities at once: `EntityReference.Source` for her power, `EffectTarget.Self` for the creature being rewritten. Counters land before the base-setting, per the printed "Then", so the team copies `2 + X`.

## Known simplification

When a multiplier and a modifier both apply to the same draw, CR 616.1 gives the drawing player the order and we pick one for them (`(1*2)+1 = 3` vs `(1+1)*2 = 4`). Unobservable today — no board state in the corpus can have both apply — and documented at the call site rather than silently skipped. Adding a decision point would pause every draw in a two-replacement board.

## Cards considered and skipped

Several DFT cards were passed over as needing engine capability rather than card wiring: the "saddles Mounts and crews Vehicles as though its power were 2 greater" cycle (no such static exists), cycling-`{X}` with X visible to the cycle trigger (Webstrike Elite, Valor's Flagship), "whenever you activate an exhaust ability" triggers, variable-count sacrifice as a cost (Radiant Lotus), and a "creature card with no abilities" filter.

## Testing

One scenario test per card, 18 tests total, all passing. `just build`, `just test` and `just check-card-printing` for each card are green; all five image URIs verified HTTP 200 and every mechanical field re-checked field-by-field against Scryfall.

Coverage beyond the happy path: X = 0, declining each "may", the intervening "if" failing (with an assertion that the attack itself landed, so it can't pass vacuously), tapping the source to pay its own "another" cost, second activation of an exhaust ability, and end-of-turn expiry versus permanence for each duration-bearing effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)