### PR TITLE
Scale suggested basics with the cards picked, not with 40/60

### DIFF
--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -4619,9 +4619,10 @@ function effectiveCopyCap(card: CardSummary, isCommanderShape: boolean): number 
 /**
  * Adapter: build `DeckEntry[]` from the standalone deckbuilder's deck +
  * catalog and call the shared `suggestBasicLands`. The standalone builder
- * doesn't know its target format, so no minDeckSize floor is applied — basics
- * scale purely off the spell curve. The validation panel surfaces undersized
- * decks so the user can re-run Suggest after adding more spells.
+ * doesn't know its target format, so no minDeckSize is passed — basics scale
+ * purely off the spell curve and the current spell count. The validation panel
+ * surfaces undersized decks so the user can re-run Suggest after adding more
+ * spells.
  */
 function suggestLandsForDeck(
   deck: Record<string, number>,

--- a/web-client/src/utils/landSuggestion.test.ts
+++ b/web-client/src/utils/landSuggestion.test.ts
@@ -283,6 +283,65 @@ describe('suggestBasicLands', () => {
     expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(0)
   })
 
+  it('scales with the cards picked instead of filling a partial sealed deck with basics', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('Green two-drop', '{1}{G}', 2, 6),
+        spell('Green three-drop', '{2}{G}', 3, 4),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    // 10 spells at a ~0.425 ratio wants ~7 lands, not the 30 that filling out
+    // a 40-card deck would demand.
+    expect(result.Forest).toBe(7)
+    expect(Object.values(result).reduce((sum, count) => sum + count, 0)).toBe(7)
+  })
+
+  it('scales with the cards picked when no deck size is known', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White two-drop', '{1}{W}', 2, 6),
+        spell('White three-drop', '{2}{W}', 3, 6),
+      ],
+      availableBasics: basics,
+    })
+
+    expect(result.Plains).toBe(9)
+  })
+
+  it('grows the suggestion monotonically as more cards are picked', () => {
+    const totals = [6, 12, 18, 23].map((count) => {
+      const result = suggestBasicLands({
+        entries: [spell('Blue three-drop', '{2}{U}', 3, count)],
+        availableBasics: basics,
+        minDeckSize: 40,
+      })
+      return Object.values(result).reduce((sum, n) => sum + n, 0)
+    })
+
+    expect(totals).toEqual([...totals].sort((a, b) => a - b))
+    expect(totals[0]).toBeLessThan(10)
+    expect(totals[3]).toBe(17)
+  })
+
+  it('shares a partial deck of too-few lands across all its colors', () => {
+    const result = suggestBasicLands({
+      entries: [
+        spell('White one-drop', '{W}', 1, 2),
+        spell('Blue one-drop', '{U}', 1, 2),
+        spell('Black one-drop', '{B}', 1, 2),
+      ],
+      availableBasics: basics,
+      minDeckSize: 40,
+    })
+
+    for (const color of ['Plains', 'Island', 'Swamp']) {
+      expect(result[color] ?? 0).toBeGreaterThan(0)
+    }
+  })
+
   it('uses only the first available printing for a basic-land color', () => {
     const result = suggestBasicLands({
       entries: [spell('White spell', '{1}{W}', 2, 23)],

--- a/web-client/src/utils/landSuggestion.ts
+++ b/web-client/src/utils/landSuggestion.ts
@@ -7,8 +7,10 @@
  * available basic land.
  *
  * Algorithm (Karsten-flavoured):
- *   1. Curve-based total land target — aggro decks want fewer lands than
- *      control. We pick a land ratio off the average non-land CMC.
+ *   1. Curve-based land target, scaled to the number of cards actually picked —
+ *      aggro decks want fewer lands than control. We pick a land ratio off the
+ *      average non-land CMC and apply it to the current spell count, so a
+ *      half-built deck gets a half-sized mana base rather than a full one.
  *   2. Discount the target by non-basic lands (full credit) and by
  *      mana-producing non-lands like rocks/dorks (half credit).
  *   3. Turn every colored cost into an on-curve castability requirement.
@@ -52,11 +54,24 @@ export interface SuggestLandsInput {
   readonly entries: readonly DeckEntry[]
   readonly availableBasics: readonly BasicLand[]
   /**
-   * Floor on total deck size — basics will be padded so spells + lands ≥ this.
-   * Use 40 for sealed, 60 for constructed, 0 / undefined for no floor.
+   * Target total deck size — 40 for sealed, 60 for constructed, 0 / undefined
+   * when the format is unknown. It is a floor on the finished deck, not on
+   * every intermediate one: basics fill the remaining slots exactly, but only
+   * once the picked cards can carry a deck that size (see
+   * `MAX_LAND_RATIO`). While the deck is still short, the target scales with
+   * what's picked instead, so a 10-card pile doesn't get 30 basics.
+   * It also serves as the statistical baseline for castability, so a
+   * work-in-progress is evaluated against the deck it will become.
    */
   readonly minDeckSize?: number
 }
+
+/**
+ * The most lands any curve justifies (the control end of `curveBasedLandCount`).
+ * Its complement is the share of `minDeckSize` that must already be picked
+ * before basics are allowed to fill the deck out to that size.
+ */
+const MAX_LAND_RATIO = 0.45
 
 /**
  * Returns target counts keyed by basic-land name. Every entry in
@@ -94,16 +109,19 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
   }
   if (spellCount === 0 && nonBasicLandCount === 0) return result
 
-  // Curve-based total land target.
+  // Curve-based land target, sized off the cards picked so far.
   const manaRockReduction = Math.floor(nonLandManaSourceCount / 2)
-  const curveTotal = curveBasedLandCount(spells)
-  const ratioBasedBasics = curveTotal - nonBasicLandCount - manaRockReduction
+  const ratioBasedBasics = curveBasedLandCount(spells) - nonBasicLandCount - manaRockReduction
   const minBasedBasics = Math.max(minDeckSize - spellCount - nonBasicLandCount, 0)
-  // When the caller names a deck size and the deck is still short, fill
-  // exactly that many slots. The curve estimate is useful when no target is
-  // known, but must not turn a 36-spell constructed deck into 63 cards.
+  // Filling a named deck size exactly is only right for a deck that's nearly
+  // there — it's what keeps a 23-spell sealed deck at 17 lands rather than 15,
+  // and a 36-spell constructed deck at 60 cards rather than 63. Applied to a
+  // half-built deck it degenerates into an all-basics pile (10 spells → 30
+  // Forests), so below that point the curve ratio drives the target instead.
+  const nonBasics = spellCount + nonBasicLandCount
+  const canFillToDeckSize = minDeckSize > 0 && nonBasics >= minDeckSize * (1 - MAX_LAND_RATIO)
   const targetBasics =
-    minDeckSize > 0 && minBasedBasics > 0 ? minBasedBasics : Math.max(ratioBasedBasics, 0)
+    canFillToDeckSize && minBasedBasics > 0 ? minBasedBasics : Math.max(ratioBasedBasics, 0)
   if (targetBasics === 0) return result
 
   const requirements = deckColorRequirements(spells)
@@ -123,12 +141,18 @@ export function suggestBasicLands(input: SuggestLandsInput): Record<string, numb
 
   // A color represented in the spell suite should not be stranded at zero.
   // Seed up to three total sources, then let probability gains decide every
-  // remaining slot. Existing duals/fixing count toward this floor.
+  // remaining slot. Existing duals/fixing count toward this floor. Seeding goes
+  // source-by-source rather than color-by-color: when the target is too small to
+  // seed everyone — a work-in-progress deck with more colors than lands — the
+  // shortfall is shared instead of handed to whichever color sorts first.
   let remaining = targetBasics
-  for (const color of allocatable) {
-    const seed = Math.min(remaining, Math.max(0, Math.ceil(3 - existingSources[color])))
-    basicsByColor[color] += seed
-    remaining -= seed
+  for (let floor = 1; floor <= 3 && remaining > 0; floor++) {
+    for (const color of allocatable) {
+      if (remaining === 0) break
+      if (existingSources[color] + basicsByColor[color] >= floor) continue
+      basicsByColor[color]++
+      remaining--
+    }
   }
 
   while (remaining > 0 && allocatable.length > 0) {
@@ -357,14 +381,19 @@ function combination(n: number, k: number): number {
   return value
 }
 
-/** Total land target driven by avg non-land CMC. Aggro 16, midrange 17, control 18. */
+/**
+ * Land target driven by avg non-land CMC, scaled to the spells picked so far:
+ * at a 40-card deck that's aggro 16, midrange 17, control 18, and at half that
+ * many spells it's half as many lands. No 40-card floor — the caller decides
+ * whether a deck size is known (`minDeckSize`), and a partial deck should get a
+ * partial mana base.
+ */
 function curveBasedLandCount(spells: readonly DeckEntry[]): number {
   if (spells.length === 0) return 0
   const totalCmc = spells.reduce((s, c) => s + c.cmc, 0)
   const avg = totalCmc / spells.length
   const ratio = avg < 2.3 ? 0.4 : avg < 3.2 ? 0.425 : 0.45
-  const total = Math.max(Math.round(spells.length / (1 - ratio)), 40)
-  return Math.round(total * ratio)
+  return Math.round((spells.length * ratio) / (1 - ratio))
 }
 
 function mapColorsToLands(basics: readonly BasicLand[]): Partial<Record<LandColor, string>> {


### PR DESCRIPTION
Suggest lands anchored its target to a *finished* deck, so a work-in-progress got a full mana base — a 10-card sealed pile got 30 basics, and a 12-spell deck in the standalone builder got 17 lands.

## Changes

**Dropped the 40-card floor** in `curveBasedLandCount`. It computed `max(round(spells / (1 - ratio)), 40)`, so any deck under ~23 spells was sized as if it were finished. It now applies the curve ratio to the actual spell count: `round(spells * ratio / (1 - ratio))`.

**Gated the `minDeckSize` pad.** It fired whenever the deck was short of the target, which for a partial deck degenerates into an all-basics pile. It now fires only once the picked cards can carry a deck that size — `nonBasics >= minDeckSize * (1 - MAX_LAND_RATIO)`, where `MAX_LAND_RATIO = 0.45` is the control end of the curve. That threshold is exactly the point below which filling to the target would push lands past 45% of the deck, so it reuses the existing constant rather than inventing a new one. Below it, the curve ratio drives the target.

**Made the per-color seed floor round-robin.** It seeded 3 sources color-by-color — invisible at 17 lands, but with a small target it handed the first color everything: 3 colors and 7 lands gave `3/3/1` by W-U-B-R-G sort order. It now walks source-by-source, so the shortfall is shared (`3/2/2`).

`minDeckSize` keeps its second job as the statistical baseline for the hypergeometric castability math, so a partial sealed deck is still evaluated against the 40 cards it will become — only the count scales.

## Effect

Lands suggested, by spells picked:

| spells picked | 4 | 8 | 12 | 16 | 20 | 22 | 23 | 26 | 36 |
|---|---|---|---|---|---|---|---|---|---|
| sealed (40) — before | 36 | 32 | 17* | 24 | 20 | 18 | 17 | 14 | 4 |
| sealed (40) — after | 3 | 6 | 9 | 12 | 15 | 18 | 17 | 14 | 4 |
| no deck size — before | 17 | 17 | 17 | 17 | 17 | 16 | 17 | 19 | 27 |
| no deck size — after | 3 | 6 | 9 | 12 | 15 | 16 | 17 | 19 | 27 |

\* the 40-card floor and the min-size pad crossed over around there.

## Note

For sealed, deck *total* is no longer monotonic across the handoff — 20 spells yields a 35-card suggestion, 22 yields 40. That's inherent to wanting both "scale with picks" and "a finished sealed deck is exactly 40 cards"; the validation panel already surfaces the undersized state. Making the sealed button always produce a legal 40 regardless of how little is picked is a one-line change to the gate.

No screenshot: this changes computed counts, not layout or styling.

## Verification

- All 18 pre-existing `landSuggestion` tests pass **unchanged** — each uses a ~23-spell deck, which lands in the fill-to-target regime and is unaffected.
- 4 new tests: partial sealed deck, the unknown-format path, monotonic growth as picks accumulate, and small-multicolor seeding.
- Full web-client unit suite green (285 tests); `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)