### PR TITLE
Add tap-attribution triggers ("whenever you tap ...") to the engine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2529,6 +2529,16 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   "target" instance and stay **legal by default** (the same object may be chosen once per instance); when
   a later requirement must differ from an earlier one ("… and up to one **other** target …"), wrap it in
   `TargetOther` — `.other()`/`excludeSelf` on a filter only excludes the *source*, not another chosen target.
+  `TargetOther` is a pure wrapper: it delegates every count-shaping field (`count`, `minCount`,
+  `optional`, `unlimited`, `chooser`) to its base requirement, so `TargetOther(TargetCreature(unlimited = true, …))`
+  stays "any number of **other** target …".
+- **An unbounded (`unlimited`) requirement must be the *last* one.** Targets are matched to requirements
+  positionally (`TargetValidator`, `EffectContext.buildNamedTargets`), and an unbounded slot has no fixed
+  width, so every requirement declared after it loses its slice. When the printed order puts "any number
+  of target …" first, declare the fixed-count requirements first instead and reference them by bound name
+  / `ContextTarget(n)` — those indices then stay stable no matter how many targets the unbounded slot took
+  (Graceful Takedown declares its victim first and the "any number of target enchanted creatures you
+  control" slot last).
 - `sameController = false` — on `TargetObject` / `TargetCreature(...)`; when `true` and the requirement
   picks more than one target, every chosen target must share a controller ("**two target creatures
   controlled by the same player**"). Enforced cross-target by `TargetValidator` at cast time using
@@ -3086,6 +3096,8 @@ work for abilities-on-stack (which carry no `CardComponent`).
   Skitter's Blessing's `Conditions.YouControlAtLeast(1, …)` draw-step gate). Role tokens are Auras
   (CR 113.2c), which makes this the Wilds of Eldraine Roles payoff predicate. Resolves in both
   `PredicateEvaluator` (targets/conditions) and `AffectsFilterResolver` (layer-7c group projection).
+  Also available as a `TargetFilter` chainer — `TargetFilter.CreatureYouControl.enchanted()` for
+  "target enchanted creature you control" (Graceful Takedown).
 - `IsEnchantedByAura(auraController)` (filter builder `enchantedByAura(controller = ControlledByYou)`)
   — the aura-control-scoped `IsEnchanted`: has at least one attached Aura whose **controller** matches
   the given `ControllerPredicate`. "Enchanted by Auras you control" (Archon of the Wild Rose) is a
@@ -3422,6 +3434,7 @@ Named sugar for the common cases; reach for the factories for any other combinat
 - `takesDamage(source?, binding?)` — incoming-damage trigger. Pick `SourceFilter.{Any,Creature,Spell,Combat,NonCombat,HasColor(c),…}` and `TriggerBinding.{SELF,ATTACHED}`. Covers "damaged by a creature/spell" and "enchanted creature is dealt damage" (`binding = ATTACHED`, Aurification / Frozen Solid shape).
 - `becomesTapped(binding?, filter?)` — "becomes tapped" trigger. `BecomesTapped` is the SELF constant; pass `binding = TriggerBinding.ANY` with an optional `filter: GameObjectFilter` for "whenever a [filter] becomes tapped" (e.g. `GameObjectFilter.CreatureOrLand` — Temporal Distortion). The filter is matched against the tapped permanent via projected state. Fires once **per** tapped permanent.
 - `OneOrMoreBecomeTapped(filter)` — the **batch** sibling of `becomesTapped` (`TapEvent(batch = true)`, ANY binding). Fires at most **once** per simultaneous tap batch (CR 603.2c) regardless of how many matching permanents were tapped together — "Whenever one or more [filter] become tapped" (Deeproot Pilgrimage: `OneOrMoreBecomeTapped(GameObjectFilter.Creature.withSubtype("Merfolk").youControl().nontoken())`). Tapping several matching permanents at once (attacking, convoke, crew) makes a single payoff, not one per permanent. Handled by `TriggerDetector.detectTapBatchTriggers`; the per-event path skips batch taps. The first matching tapped permanent is bound as the triggering entity.
+- `YouTap(filter, batch = false)` — "Whenever **you tap** an untapped [filter]" (`TapEvent(tapper = Player.You)`, ANY binding) — the Wilds of Eldraine cluster: Hylda of the Icy Crown, Icewrought Sentry, Solitary Sanctuary with `GameObjectFilter.Creature.opponentControls()`, and Sharae of Numbing Depths with `batch = true` for the "one or more" wording. Two things separate it from `becomesTapped`: (1) **attribution** — the tap must have been *caused by* the trigger's controller. `TappedEvent.tappedById` carries the causing player: the `tap()` atom defaults it to the tapped permanent's own controller (right for every cost payment, mana ability, crew/saddle, and the turn-based attack tap), and the tap *effect* executors override it with the effect's `controllerId`. Because a per-player loop rebinds `controllerId`, a spell you control that instructs an **opponent** to tap their own creature is *their* tap and does not fire a `You` pattern (Tangle Wire; per the printed rulings). (2) **"untapped" is intrinsic** — tapping is a transition (CR 603.2f), so an already-tapped permanent emits no tap event and needs no condition. `batch = true` routes to `TriggerDetector.detectTapBatchTriggers`, which narrows the batch to the taps this controller caused before applying the filter; pair it with `oncePerTurn` for "This ability triggers only once each turn".
 - `OneOrMoreBecomeUntapped(filter)` — the **untap** analogue of `OneOrMoreBecomeTapped` (`UntapEvent(batch = true)`, ANY binding). Fires at most **once** per untap step (CR 603.2c) — "Whenever you untap one or more [filter] **during your untap step** …" — even though the untap step untaps all your permanents at once (The Millennium Calendar: `OneOrMoreBecomeUntapped(GameObjectFilter.Permanent.youControl())`). Handled by `TriggerDetector.detectUntapBatchTriggers`; the per-event `UntapEvent` path (`BecomesUntapped`) skips batch untaps. **Unlike the tap batch, it exposes the untapped permanents as the trigger's captured collection** (`IterationSpace.TRIGGER_CAPTURED_COLLECTION`), so a "put **that many** counters" payoff reads the count with `Effects.AddDynamicCounters(type, DynamicAmount.DistinctEntitiesInCollections(listOf(TRIGGER_CAPTURED_COLLECTION)), EffectTarget.Self)`. The **"during your untap step" scoping is intrinsic** — the detector fires it only for the active player's untap-step untaps (not instant-speed untaps, nor an opponent-turn Seedborn Muse untap of your permanents), so no `triggerCondition` is needed. (An untap-step untap advances straight to upkeep before any player gets priority, so an `IsInStep(UNTAP)` intervening-if would read false at detection time — hence the restriction lives in the detector.)
 
 ### Phase & turn

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1403,6 +1403,30 @@ object Triggers {
         TriggerSpec(event = TapEvent(filter = filter, batch = true), binding = TriggerBinding.ANY)
 
     /**
+     * Whenever **you tap** an untapped permanent matching [filter] — the active wording of the
+     * Wilds of Eldraine "tap an opponent's creature" cluster (Hylda of the Icy Crown, Icewrought
+     * Sentry, Solitary Sanctuary), typically with
+     * `GameObjectFilter.Creature.opponentControls()`.
+     *
+     * Different from [becomesTapped] on two axes:
+     * - **Attribution.** Only a tap *you* caused fires it (CR has no "you tap" rule; the printed
+     *   rulings define it as "an effect instructs you to tap"). An opponent tapping their own
+     *   creature — including as the resolution of a spell *you* control that instructs *them* to
+     *   tap, e.g. Tangle Wire — is their tap, not yours, and does not fire.
+     * - **"Untapped".** Intrinsic, not a condition: tapping is a transition (CR 603.2f), so a
+     *   permanent that is already tapped never emits a tap event.
+     *
+     * Per-permanent (ANY binding): tapping two of an opponent's creatures at once fires it twice.
+     * For the "whenever you tap **one or more** …" batch wording (Sharae of Numbing Depths) pass
+     * `batch = true`, which fires it once per simultaneous tap batch instead.
+     */
+    fun YouTap(filter: GameObjectFilter, batch: Boolean = false): TriggerSpec =
+        TriggerSpec(
+            event = TapEvent(filter = filter, batch = batch, tapper = Player.You),
+            binding = TriggerBinding.ANY
+        )
+
+    /**
      * Whenever you untap one or more permanents matching [filter] **during your untap step** — a
      * **batching** trigger (CR 603.2c) that fires at most once per untap step, not once per untapped
      * permanent. Use for "Whenever you untap one or more permanents during your untap step …"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1405,12 +1405,35 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
          * were tapped together (Deeproot Pilgrimage), instead of once per tapped permanent. Handled
          * by the dedicated batch pass; the per-event path skips it. ANY-binding only.
          */
-        val batch: Boolean = false
+        val batch: Boolean = false,
+        /**
+         * Who must have done the tapping, relative to the trigger's controller — the difference
+         * between the passive "**a** creature becomes tapped" (null, any tap from any cause) and
+         * the active "whenever **you tap** a creature an opponent controls"
+         * ([com.wingedsheep.sdk.scripting.references.Player.You], Wilds of Eldraine's Hylda of the
+         * Icy Crown / Icewrought Sentry / Solitary Sanctuary / Sharae of Numbing Depths).
+         *
+         * The tapper is the controller of the spell, ability, or cost payment that caused the
+         * permanent to become tapped; a permanent tapped as a turn-based action or to pay its own
+         * controller's cost is tapped by its controller. Per the Hylda ruling, a spell *you* control
+         * that instructs an **opponent** to tap a creature they control makes *them* the tapper, so
+         * a `You` pattern does not fire (Tangle Wire).
+         *
+         * "An **untapped** creature" needs no separate axis: tapping is a transition (CR 603.2f), so
+         * an already-tapped permanent emits no tap event at all.
+         */
+        val tapper: Player? = null
     ) : EventPattern {
         override val description: String = buildString {
-            append(if (batch) "one or more " else "a ")
-            append(filter?.description ?: "permanent")
-            append(if (batch) " become tapped" else " becomes tapped")
+            if (tapper != null) {
+                append(tapper.description.replaceFirstChar { it.uppercase() })
+                append(if (batch) " tap one or more " else " tap a ")
+                append(filter?.description ?: "permanent")
+            } else {
+                append(if (batch) "one or more " else "a ")
+                append(filter?.description ?: "permanent")
+                append(if (batch) " become tapped" else " becomes tapped")
+            }
         }
         override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
             val newFilter = filter?.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -438,6 +438,9 @@ data class TargetFilter(
     /** Must be controlled by opponent */
     fun opponentControls() = copy(baseFilter = baseFilter.opponentControls())
 
+    /** Must have an Aura attached ("target enchanted creature", Graceful Takedown). */
+    fun enchanted() = copy(baseFilter = baseFilter.enchanted())
+
     /** Must be owned by you (for cards in graveyards/exile) */
     fun ownedByYou() = copy(baseFilter = baseFilter.ownedByYou())
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -471,8 +471,15 @@ data class TargetOther(
     override val id: String? = null
 ) : TargetRequirement {
     override val description: String = baseRequirement.description
+    // Every count-shaping field is delegated, not just `count`: this wrapper only adds a
+    // distinctness rule, so dropping any of them silently reshapes how many targets the wrapped
+    // requirement accepts — an "any number of other target …" requirement would collapse to a
+    // single mandatory target (`unlimited` lost ⇒ count 1, minCount 1).
     override val count: Int = baseRequirement.count
+    override val minCount: Int = baseRequirement.minCount
     override val optional: Boolean = baseRequirement.optional
+    override val unlimited: Boolean = baseRequirement.unlimited
+    override val chooser: TargetChooser = baseRequirement.chooser
 
     override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
         val newBase = baseRequirement.applyTextReplacement(replacer)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GracefulTakedown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GracefulTakedown.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Graceful Takedown
+ * {1}{G}
+ * Sorcery
+ *
+ * Any number of target enchanted creatures you control and up to one other target creature you
+ * control each deal damage equal to their power to target creature you don't control.
+ *
+ * **Three target requirements, and the *dealers* are a subset of them** — so the damage loop can't
+ * be `IterationSpace.Targets` (that iterates *every* target, which would make the victim deal damage
+ * to itself). The pipeline expresses "iterate one slice of the targets" out of steps that already
+ * exist: gather [CardSource.ChosenTargets], `filter` it down to the creatures you control, and run
+ * the damage body once per member with `EffectTarget.Self` bound to it. Each dealer is its own damage
+ * source (`damageSource = Self`), so lifelink/deathtouch and "dealt damage by a creature" reactions
+ * see the creature, not the sorcery.
+ *
+ * **Requirement order is load-bearing.** The victim is declared *first* even though it is printed
+ * last: target↔requirement alignment is positional (`TargetValidator`), so an unbounded requirement
+ * has to come last or every requirement after it loses its slice. Declaring the victim first also
+ * pins it to `ContextTarget(0)`/its own bound name regardless of how many creatures the unbounded
+ * slot swallowed. `TargetOther` on the two "you control" requirements keeps the same creature from
+ * being chosen twice and so dealing damage twice.
+ *
+ * Partial legality follows from where each half reads its targets (CR 608.2b, and the printed
+ * rulings): the gather sees only the still-legal targets, so dealers that became illegal drop out and
+ * the rest still deal damage; the victim is referenced by name, so if *it* is illegal the reference
+ * resolves to nothing and no creature deals or is dealt damage.
+ */
+val GracefulTakedown = card("Graceful Takedown") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Any number of target enchanted creatures you control and up to one other target " +
+        "creature you control each deal damage equal to their power to target creature you don't " +
+        "control."
+
+    spell {
+        val victim = target(
+            "target creature you don't control",
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls)
+        )
+        target(
+            "up to one other target creature you control",
+            TargetOther(TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl))
+        )
+        target(
+            "any number of target enchanted creatures you control",
+            TargetOther(
+                TargetCreature(unlimited = true, filter = TargetFilter.CreatureYouControl.enchanted())
+            )
+        )
+
+        effect = Effects.Pipeline {
+            val chosen = gather(CardSource.ChosenTargets)
+            val dealers = filter(chosen, GameObjectFilter.Creature.youControl())
+            run(
+                ForEachInCollectionEffect(
+                    collection = dealers.key,
+                    effect = DealDamageEffect(
+                        amount = DynamicAmount.EntityProperty(
+                            EntityReference.IterationEntity,
+                            EntityNumericProperty.Power
+                        ),
+                        target = victim,
+                        damageSource = EffectTarget.Self
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "The fauns of the Tanglespan are adept at using the precarious environment " +
+            "against larger opponents."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg?1783915083"
+        ruling(
+            "2023-09-01",
+            "If one of the target creatures you control is an illegal target as Graceful Takedown " +
+                "resolves (perhaps because it's no longer enchanted or is no longer on the " +
+                "battlefield), the remaining legal target creatures you control will still deal " +
+                "damage equal to their power."
+        )
+        ruling(
+            "2023-09-01",
+            "If the last target creature is an illegal target as Graceful Takedown resolves, or if " +
+                "all of the target creatures you control are illegal targets, no creature deals or " +
+                "is dealt damage."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HyldaOfTheIcyCrown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/HyldaOfTheIcyCrown.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hylda of the Icy Crown
+ * {2}{W}{U}
+ * Legendary Creature — Human Warlock
+ * 3/4
+ *
+ * Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do,
+ * choose one —
+ * • Create a 4/4 white and blue Elemental creature token.
+ * • Put a +1/+1 counter on each creature you control.
+ * • Scry 2, then draw a card.
+ *
+ * [Triggers.YouTap] carries the *attribution* half — only a tap Hylda's controller caused fires
+ * this, so an opponent tapping their own creature (attacking, crewing, paying a cost) does nothing,
+ * and neither does a spell you control that instructs *them* to tap (Tangle Wire). "Untapped" is
+ * intrinsic: tapping is a transition (CR 603.2f), so an already-tapped creature emits no tap event.
+ *
+ * The payoff is a "When you do" reflexive (CR 603.12): the optional {1} is the action, and the mode
+ * is chosen only once it is paid ([ReflexiveTriggerEffect] over a resolution-time
+ * [ModalEffect.chooseOne] — none of the three modes targets). Per-tap, not once per turn: tapping
+ * two of an opponent's creatures at once triggers it twice, each with its own {1}.
+ */
+val HyldaOfTheIcyCrown = card("Hylda of the Icy Crown") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever you tap an untapped creature an opponent controls, you may pay {1}. " +
+        "When you do, choose one —\n" +
+        "• Create a 4/4 white and blue Elemental creature token.\n" +
+        "• Put a +1/+1 counter on each creature you control.\n" +
+        "• Scry 2, then draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls())
+        effect = ReflexiveTriggerEffect(
+            action = PayManaCostEffect(ManaCost.parse("{1}")),
+            optional = true,
+            reflexiveEffect = ModalEffect.chooseOne(
+                Mode.noTarget(
+                    Effects.CreateToken(
+                        power = 4,
+                        toughness = 4,
+                        colors = setOf(Color.WHITE, Color.BLUE),
+                        creatureTypes = setOf("Elemental"),
+                    ),
+                    "Create a 4/4 white and blue Elemental creature token"
+                ),
+                Mode.noTarget(
+                    Effects.ForEachInGroup(
+                        filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                    ),
+                    "Put a +1/+1 counter on each creature you control"
+                ),
+                Mode.noTarget(
+                    Patterns.Library.scry(2).then(Effects.DrawCards(1)),
+                    "Scry 2, then draw a card"
+                ),
+            ),
+            descriptionOverride = "you may pay {1}. When you do, choose one — create a 4/4 white " +
+                "and blue Elemental creature token; put a +1/+1 counter on each creature you " +
+                "control; or scry 2, then draw a card"
+        )
+        description = "Whenever you tap an untapped creature an opponent controls, you may pay {1}. " +
+            "When you do, choose one — create a 4/4 white and blue Elemental creature token; put a " +
+            "+1/+1 counter on each creature you control; or scry 2, then draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "206"
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg?1783915071"
+        ruling(
+            "2023-09-01",
+            "Hylda of the Icy Crown's ability will trigger only when an effect instructs you to tap " +
+                "an opponent's creature. It won't trigger if a spell or ability you control instructs " +
+                "an opponent to tap a creature they control. For example, if you control Tangle Wire " +
+                "and an opponent taps an untapped creature they control as part of the resolution of " +
+                "Tangle Wire's triggered ability, Hylda's ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IcewroughtSentry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IcewroughtSentry.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Icewrought Sentry
+ * {2}{U}
+ * Creature — Elemental Soldier
+ * 2/3
+ *
+ * Vigilance
+ * Whenever this creature attacks, you may pay {1}{U}. When you do, tap target creature an opponent
+ * controls.
+ * Whenever you tap an untapped creature an opponent controls, this creature gets +2/+1 until end of
+ * turn.
+ *
+ * The attack ability is a "When you do" reflexive (CR 603.12): no target is chosen when the attack
+ * trigger goes on the stack — only once the {1}{U} is actually paid ([ReflexiveTriggerEffect]).
+ *
+ * The pump is [Triggers.YouTap] — tap *attribution*, so only a tap this creature's controller caused
+ * fires it (not an opponent tapping their own creature to attack or crew). Its own reflexive tap is
+ * one, so attacking and paying pumps it before damage; so does any other tapper you control, which
+ * is why the trigger is a separate ability rather than a rider on the reflexive effect. Per-tap, not
+ * once per turn: tapping two of an opponent's creatures at once pumps it twice.
+ */
+val IcewroughtSentry = card("Icewrought Sentry") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "Whenever this creature attacks, you may pay {1}{U}. When you do, tap target creature an " +
+        "opponent controls.\n" +
+        "Whenever you tap an untapped creature an opponent controls, this creature gets +2/+1 until " +
+        "end of turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ReflexiveTriggerEffect(
+            action = PayManaCostEffect(ManaCost.parse("{1}{U}")),
+            optional = true,
+            reflexiveEffect = Effects.Tap(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(
+                TargetCreature(filter = TargetFilter.Creature.opponentControls())
+            )
+        )
+        description = "Whenever this creature attacks, you may pay {1}{U}. When you do, tap target " +
+            "creature an opponent controls."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls())
+        effect = Effects.ModifyStats(2, 1, EffectTarget.Self, Duration.EndOfTurn)
+        description = "Whenever you tap an untapped creature an opponent controls, this creature " +
+            "gets +2/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg?1783915119"
+        ruling(
+            "2023-09-01",
+            "Icewrought Sentry's last ability will trigger only when an effect instructs you to tap " +
+                "an opponent's creature. It won't trigger if a spell or ability you control instructs " +
+                "an opponent to tap a creature they control. For example, if you control Tangle Wire " +
+                "and an opponent taps an untapped creature they control as part of the resolution of " +
+                "Tangle Wire's triggered ability, Icewrought Sentry's ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SharaeOfNumbingDepths.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SharaeOfNumbingDepths.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sharae of Numbing Depths
+ * {2}{W}{U}
+ * Legendary Creature — Merfolk Wizard
+ * 2/3
+ *
+ * When Sharae enters, tap target creature an opponent controls and put a stun counter on it.
+ * Whenever you tap one or more untapped creatures your opponents control, draw a card. This ability
+ * triggers only once each turn.
+ *
+ * The draw is the **batch** form of the tap-attribution trigger — `Triggers.YouTap(…, batch = true)`
+ * (CR 603.2c): tapping several of your opponents' creatures at once (a sweeper tapper, one
+ * resolution that taps two) is one event batch and draws one card, not one per creature. Only taps
+ * *you* caused count toward the batch, so an opponent tapping their own creatures never fires it,
+ * and neither does a spell you control that instructs *them* to tap (Tangle Wire).
+ *
+ * `oncePerTurn` carries the printed "triggers only once each turn" limit on top, which is what
+ * separates this from Hylda of the Icy Crown / Icewrought Sentry / Solitary Sanctuary (per-tap
+ * payoffs with no limit).
+ */
+val SharaeOfNumbingDepths = card("Sharae of Numbing Depths") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Merfolk Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "When Sharae enters, tap target creature an opponent controls and put a stun " +
+        "counter on it. (If a permanent with a stun counter would become untapped, remove one from " +
+        "it instead.)\n" +
+        "Whenever you tap one or more untapped creatures your opponents control, draw a card. This " +
+        "ability triggers only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.Tap(victim) then Effects.AddCounters(Counters.STUN, 1, victim)
+        description = "When Sharae enters, tap target creature an opponent controls and put a stun " +
+            "counter on it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls(), batch = true)
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+        description = "Whenever you tap one or more untapped creatures your opponents control, draw " +
+            "a card. This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg?1783915068"
+        ruling(
+            "2023-09-01",
+            "You may target a creature that is already tapped with Sharae's first ability. If the " +
+                "target creature is already tapped as it resolves, you will still put a stun counter " +
+                "on it."
+        )
+        ruling(
+            "2023-09-01",
+            "Sharae of Numbing Depths's last ability will trigger only when an effect instructs you " +
+                "to tap one or more creatures your opponents control. It won't trigger if a spell or " +
+                "ability you control instructs an opponent to tap a creature they control. For " +
+                "example, if you control Tangle Wire and an opponent taps an untapped creature they " +
+                "control as part of the resolution of Tangle Wire's triggered ability, Sharae's " +
+                "ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SolitarySanctuary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SolitarySanctuary.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Solitary Sanctuary
+ * {2}{W}
+ * Enchantment
+ *
+ * When this enchantment enters, tap target creature an opponent controls and put a stun counter
+ * on it.
+ * Whenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target
+ * creature you control.
+ *
+ * The payoff is [Triggers.YouTap] — tap *attribution*, not a plain "becomes tapped" observer: only
+ * a tap this enchantment's controller caused fires it, so an opponent tapping their own creature
+ * (attacking, crewing, paying a cost) does nothing. "Untapped" is intrinsic to the trigger: tapping
+ * is a transition (CR 603.2f), so an already-tapped creature emits no tap event.
+ *
+ * The entry trigger's own tap is one such tap, so this enchantment triggers its own payoff on the
+ * way in — the two abilities are independent, and the +1/+1 payoff targets separately as it goes on
+ * the stack.
+ */
+val SolitarySanctuary = card("Solitary Sanctuary") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, tap target creature an opponent controls and put a " +
+        "stun counter on it. (If a permanent with a stun counter would become untapped, remove one " +
+        "from it instead.)\n" +
+        "Whenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target " +
+        "creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.Tap(victim) then Effects.AddCounters(Counters.STUN, 1, victim)
+        description = "When this enchantment enters, tap target creature an opponent controls and " +
+            "put a stun counter on it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls())
+        val ally = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, ally)
+        description = "Whenever you tap an untapped creature an opponent controls, put a +1/+1 " +
+            "counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Kasia 'Kafis' Zielińska"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg?1783915126"
+        ruling(
+            "2023-09-01",
+            "You may target a creature that is already tapped with Solitary Sanctuary's first " +
+                "ability. If the target creature is already tapped as it resolves, you will still " +
+                "put a stun counter on it."
+        )
+        ruling(
+            "2023-09-01",
+            "Solitary Sanctuary's last ability will trigger only when an effect instructs you to tap " +
+                "an opponent's creature. It won't trigger if a spell or ability you control instructs " +
+                "an opponent to tap a creature they control. For example, if you control Tangle Wire " +
+                "and an opponent taps an untapped creature they control as part of the resolution of " +
+                "Tangle Wire's triggered ability, Solitary Sanctuary's ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -5713,6 +5713,114 @@
     ]
 }
 
+// Graceful Takedown
+{
+    "name": "Graceful Takedown",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Any number of target enchanted creatures you control and up to one other target creature you control each deal damage equal to their power to target creature you don't control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "gathered0",
+                    "filter": {
+                        "type": "MatchesFilter",
+                        "filter": "creature ctrl:you"
+                    },
+                    "storeMatching": "matching1"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "matching1"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "IterationEntity",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you don't control"
+                        },
+                        "damageSource": "Self"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "target creature you don't control"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "id": "up to one other target creature you control"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "unlimited": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "IsEnchanted"
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "id": "any number of target enchanted creatures you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "The fauns of the Tanglespan are adept at using the precarious environment against larger opponents.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83edf626-ed34-417f-818d-597ecf439167.jpg?1783915083",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If one of the target creatures you control is an illegal target as Graceful Takedown resolves (perhaps because it's no longer enchanted or is no longer on the battlefield), the remaining legal target creatures you control will still deal damage equal to their power."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If the last target creature is an illegal target as Graceful Takedown resolves, or if all of the target creatures you control are illegal targets, no creature deals or is dealt damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Grand Ball Guest
 {
     "name": "Grand Ball Guest",
@@ -6877,6 +6985,112 @@
     ]
 }
 
+// Hylda of the Icy Crown
+{
+    "name": "Hylda of the Icy Crown",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one —\n• Create a 4/4 white and blue Elemental creature token.\n• Put a +1/+1 counter on each creature you control.\n• Scry 2, then draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "creature ctrl:opponent",
+                    "tapper": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "PayManaCost",
+                        "cost": "{1}"
+                    },
+                    "reflexiveEffect": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "CreateToken",
+                                    "power": 4,
+                                    "toughness": 4,
+                                    "colors": [
+                                        "WHITE",
+                                        "BLUE"
+                                    ],
+                                    "creatureTypes": [
+                                        "Elemental"
+                                    ]
+                                }
+                            },
+                            {
+                                "effect": {
+                                    "type": "ForEach",
+                                    "space": {
+                                        "type": "IterationSpace.Group",
+                                        "filter": {
+                                            "baseFilter": "creature ctrl:you"
+                                        }
+                                    },
+                                    "body": {
+                                        "type": "AddCounters",
+                                        "counterType": "+1/+1",
+                                        "count": 1,
+                                        "target": "Self"
+                                    }
+                                },
+                                "description": "Put a +1/+1 counter on each creature you control"
+                            },
+                            {
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "Scry",
+                                            "count": 2
+                                        },
+                                        {
+                                            "type": "DrawCards",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        }
+                                    ]
+                                },
+                                "description": "Scry 2, then draw a card"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "you may pay {1}. When you do, choose one — create a 4/4 white and blue Elemental creature token; put a +1/+1 counter on each creature you control; or scry 2, then draw a card"
+                },
+                "descriptionOverride": "Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do, choose one — create a 4/4 white and blue Elemental creature token; put a +1/+1 counter on each creature you control; or scry 2, then draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "MYTHIC",
+        "artist": "Ekaterina Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae9231fd-053d-4b84-a7a8-86063465bc49.jpg?1783915071",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Hylda of the Icy Crown's ability will trigger only when an effect instructs you to tap an opponent's creature. It won't trigger if a spell or ability you control instructs an opponent to tap a creature they control. For example, if you control Tangle Wire and an opponent taps an untapped creature they control as part of the resolution of Tangle Wire's triggered ability, Hylda's ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Hylda's Crown of Winter
 {
     "name": "Hylda's Crown of Winter",
@@ -7036,6 +7250,89 @@
             {
                 "date": "2023-09-01",
                 "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Icewrought Sentry
+{
+    "name": "Icewrought Sentry",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Elemental Soldier",
+    "oracleText": "Vigilance\nWhenever this creature attacks, you may pay {1}{U}. When you do, tap target creature an opponent controls.\nWhenever you tap an untapped creature an opponent controls, this creature gets +2/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "PayManaCost",
+                        "cost": "{1}{U}"
+                    },
+                    "reflexiveEffect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may pay {1}{U}. When you do, tap target creature an opponent controls."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "creature ctrl:opponent",
+                    "tapper": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you tap an untapped creature an opponent controls, this creature gets +2/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/859419d3-cd15-4362-98b3-a7ff98e29692.jpg?1783915119",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Icewrought Sentry's last ability will trigger only when an effect instructs you to tap an opponent's creature. It won't trigger if a spell or ability you control instructs an opponent to tap a creature they control. For example, if you control Tangle Wire and an opponent taps an untapped creature they control as part of the resolution of Tangle Wire's triggered ability, Icewrought Sentry's ability won't trigger."
             }
         ]
     },
@@ -12098,6 +12395,97 @@
     ]
 }
 
+// Sharae of Numbing Depths
+{
+    "name": "Sharae of Numbing Depths",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Legendary Creature — Merfolk Wizard",
+    "oracleText": "When Sharae enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap one or more untapped creatures your opponents control, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "descriptionOverride": "When Sharae enters, tap target creature an opponent controls and put a stun counter on it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "creature ctrl:opponent",
+                    "batch": true,
+                    "tapper": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you tap one or more untapped creatures your opponents control, draw a card. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "Evyn Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/600bc36a-3ef0-459c-9a93-94ec45b8c3d9.jpg?1783915068",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may target a creature that is already tapped with Sharae's first ability. If the target creature is already tapped as it resolves, you will still put a stun counter on it."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Sharae of Numbing Depths's last ability will trigger only when an effect instructs you to tap one or more creatures your opponents control. It won't trigger if a spell or ability you control instructs an opponent to tap a creature they control. For example, if you control Tangle Wire and an opponent taps an untapped creature they control as part of the resolution of Tangle Wire's triggered ability, Sharae's ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Shatter the Oath
 {
     "name": "Shatter the Oath",
@@ -12564,6 +12952,99 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Solitary Sanctuary
+{
+    "name": "Solitary Sanctuary",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target creature you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "descriptionOverride": "When this enchantment enters, tap target creature an opponent controls and put a stun counter on it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "TapEvent",
+                    "filter": "creature ctrl:opponent",
+                    "tapper": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "Whenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d155693c-def0-4290-b662-ab9932e07fe5.jpg?1783915126",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may target a creature that is already tapped with Solitary Sanctuary's first ability. If the target creature is already tapped as it resolves, you will still put a stun counter on it."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Solitary Sanctuary's last ability will trigger only when an effect instructs you to tap an opponent's creature. It won't trigger if a spell or ability you control instructs an opponent to tap a creature they control. For example, if you control Tangle Wire and an opponent taps an untapped creature they control as part of the resolution of Tangle Wire's triggered ability, Solitary Sanctuary's ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -40,6 +40,14 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // counter on it" (Tinybones, Bauble Burglar) expressible.
     supported("WhenAPlayerDiscardsACard", "trigger: a player discards a card (Triggers.AnyOpponentDiscards / YouDiscard / discards(player, cardFilter)); binds the discarded card as TriggeringEntity")
     supported("WhenAPermanentBecomesTapped", "trigger: this permanent becomes tapped (Triggers.BecomesTapped — Wylie Duke, Atiin Hero)")
+    // "Whenever you tap an untapped creature an opponent controls" — the tap-*attribution* trigger, a
+    // different axis from the passive WhenAPermanentBecomesTapped above: only a tap the trigger's
+    // controller caused fires it (Triggers.YouTap(filter); Hylda of the Icy Crown, Icewrought Sentry,
+    // Solitary Sanctuary). The IR's `IsUntapped` clause is intrinsic to the engine — tapping is a
+    // transition (CR 603.2f), so an already-tapped permanent emits no tap event — and the emitter drops
+    // it rather than recovering a `.untapped()` predicate that would read false at detection time.
+    // You-scope only; the emitter recovers the permanent filter exactly or declines -> SCAFFOLD.
+    supported("WhenAPlayerTapsAPermanent", "trigger: you tap an untapped permanent matching a filter (Triggers.YouTap)")
     supported("WhenACreatureDealsCombatDamageToAPlayer", "trigger: combat damage to player")
     // "Whenever you sacrifice a/another [filter] …" — the batched sacrifice trigger that fires when a
     // matching permanent you control is sacrificed (Triggers.YouSacrificeOneOrMore; the first matching

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.tooling.coverage.call
 import com.wingedsheep.tooling.coverage.compact
 import com.wingedsheep.tooling.coverage.field
 import com.wingedsheep.tooling.coverage.findInteger
+import com.wingedsheep.tooling.coverage.hasTag
 import com.wingedsheep.tooling.coverage.firstArgStringTagged
 import com.wingedsheep.tooling.coverage.jsonContains
 import com.wingedsheep.tooling.coverage.nodesTagged
@@ -2988,6 +2989,28 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         return "Triggers.YouAttackWithFilter($filter)"
     }
 
+    // "Whenever you tap an untapped [filter]" — WhenAPlayerTapsAPermanent(playerScope, permanentFilter),
+    // the tap-*attribution* trigger (Wilds of Eldraine's Hylda of the Icy Crown, Icewrought Sentry,
+    // Solitary Sanctuary, Sharae of Numbing Depths). Distinct from WhenAPermanentBecomesTapped in
+    // TRIGGER_SPEC above, which is the passive SELF "becomes tapped" observer. Maps to
+    // Triggers.YouTap(<filter>); only the You scope has a calibrated form, so any other scope declines
+    // -> SCAFFOLD.
+    //
+    // The IR's `IsUntapped` clause must be *dropped*, not round-tripped: the filter is evaluated when
+    // the trigger is detected, i.e. after the permanent has already become tapped, so a recovered
+    // `.untapped()` predicate would read false and the trigger would never fire. The engine gets the
+    // "untapped" half for free — tapping is a transition (CR 603.2f), so an already-tapped permanent
+    // emits no tap event at all. [withoutIsUntapped] strips exactly that clause and nothing else; if
+    // any `IsUntapped` survives (a shape it doesn't understand), decline rather than misrender.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerTapsAPermanent")) {
+        val argv = trig["args"].asArr ?: return null
+        if (castScope(argv.getOrNull(0) as? JsonObject) != CastScope.YOU) return null
+        val permanents = withoutIsUntapped(argv.getOrNull(1))
+        if (permanents.hasTag("IsUntapped")) return null
+        val filter = gameObjectFilterDsl(permanents) ?: return null
+        return "Triggers.YouTap($filter)"
+    }
+
     // "Whenever you attack" — WhenAPlayerAttacks scoped to a SinglePlayer(You). The batched trigger
     // fires once per combat when you declare one or more attackers. Maps to Triggers.YouAttack
     // (Living History). Only the You scope renders; any other player scope has no calibrated
@@ -3193,6 +3216,23 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
  *  search — a `_Player: You` buried in the spell filter (e.g. WasCastFromAPlayersGraveyard(You))
  *  must not be mistaken for the caster. */
 private enum class CastScope { YOU, ANY, OPPONENT }
+
+/**
+ * Drop the `IsUntapped` clause from an `And(...)` permanent filter, leaving every other clause alone.
+ *
+ * Only used by the "whenever you tap an untapped …" trigger, where the IR spells out a state the
+ * engine already guarantees structurally and recovering it would invert the filter's meaning (see the
+ * `WhenAPlayerTapsAPermanent` branch). Returns the node unchanged when there is nothing to strip, and
+ * collapses a one-clause remainder out of its `And` wrapper.
+ */
+private fun withoutIsUntapped(node: JsonElement?): JsonElement? {
+    val obj = node as? JsonObject ?: return node
+    if (obj.strField("_Permanents") != "And") return node
+    val args = obj["args"].asArr ?: return node
+    val kept = args.filterNot { (it as? JsonObject)?.strField("_Permanents") == "IsUntapped" }
+    if (kept.size == args.size) return node
+    return kept.singleOrNull() ?: JsonObject(obj.toMutableMap().apply { put("args", JsonArray(kept)) })
+}
 
 private fun castScope(players: JsonObject?): CastScope? = when (players?.strField("_Players")) {
     "AnyPlayer" -> CastScope.ANY

--- a/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/YouTapTriggerEmitterTest.kt
+++ b/mtgish-tooling/src/test/kotlin/com/wingedsheep/tooling/coverage/YouTapTriggerEmitterTest.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.tooling.coverage
+
+import com.wingedsheep.tooling.coverage.emitter.Emitter
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Pins the emitter's recovery of `WhenAPlayerTapsAPermanent` — the tap-*attribution* trigger
+ * ("Whenever you tap an untapped creature an opponent controls", Wilds of Eldraine's Hylda of the Icy
+ * Crown / Icewrought Sentry / Solitary Sanctuary / Sharae of Numbing Depths) — onto
+ * `Triggers.YouTap(filter)`.
+ *
+ * Two things are load-bearing and neither is visible in the corpus today (all four printed cards carry
+ * payoffs the emitter still scaffolds on, so only a synthetic fixture exercises the trigger itself):
+ *
+ *  - The IR's explicit `IsUntapped` clause must be **dropped**, not round-tripped. The filter is
+ *    evaluated when the trigger is detected — after the permanent has become tapped — so a recovered
+ *    `.untapped()` predicate would read false and the trigger would never fire. The engine gets that
+ *    half structurally: tapping is a transition (CR 603.2f), so an already-tapped permanent emits no
+ *    tap event.
+ *  - Only the `You` scope has a calibrated form; any other player scope must decline to a SCAFFOLD
+ *    rather than be silently widened into "whenever *anyone* taps".
+ *
+ * Each fixture is a synthetic single-trigger card whose payoff (gain 1 life) renders whole, so the
+ * only thing under test is the trigger. Hermetic: no IR download, no Scryfall cache.
+ */
+class YouTapTriggerEmitterTest : StringSpec({
+
+    val effects = Registry.loadEffectSerialNames()
+    val keywords = Registry.loadKeywords()
+
+    /**
+     * A "whenever [playerScope] taps a permanent matching [an untapped creature an opponent controls],
+     * you gain 1 life" card. [includeIsUntapped] controls whether the filter carries the IR's
+     * `IsUntapped` clause.
+     */
+    fun tapTriggerCard(
+        playersScope: String,
+        playerArg: String?,
+        includeIsUntapped: Boolean,
+    ): JsonObject = buildJsonObject {
+        put("Name", JsonPrimitive("Test You Tap $playersScope${playerArg?.let { " $it" } ?: ""}"))
+        putJsonObject("Typeline") {
+            putJsonArray("Supertypes") {}
+            putJsonArray("Cardtypes") { add(JsonPrimitive("Enchantment")) }
+            putJsonArray("Subtypes") {}
+        }
+        putJsonArray("ManaCost") { addJsonObject { put("_ManaSymbol", JsonPrimitive("ManaCostW")) } }
+        putJsonArray("Rules") {
+            addJsonObject {
+                put("_Rule", JsonPrimitive("TriggerA"))
+                putJsonArray("args") {
+                    addJsonObject {
+                        put("_Trigger", JsonPrimitive("WhenAPlayerTapsAPermanent"))
+                        putJsonArray("args") {
+                            // arg 0: who did the tapping.
+                            addJsonObject {
+                                put("_Players", JsonPrimitive(playersScope))
+                                if (playerArg != null) {
+                                    putJsonObject("args") { put("_Player", JsonPrimitive(playerArg)) }
+                                }
+                            }
+                            // arg 1: which permanents count.
+                            addJsonObject {
+                                put("_Permanents", JsonPrimitive("And"))
+                                putJsonArray("args") {
+                                    if (includeIsUntapped) {
+                                        addJsonObject { put("_Permanents", JsonPrimitive("IsUntapped")) }
+                                    }
+                                    addJsonObject {
+                                        put("_Permanents", JsonPrimitive("IsCardtype"))
+                                        put("args", JsonPrimitive("Creature"))
+                                    }
+                                    addJsonObject {
+                                        put("_Permanents", JsonPrimitive("ControlledByAPlayer"))
+                                        putJsonObject("args") { put("_Players", JsonPrimitive("Opponent")) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    addJsonObject {
+                        put("_Actions", JsonPrimitive("ActionList"))
+                        putJsonArray("args") {
+                            addJsonObject {
+                                put("_Action", JsonPrimitive("GainLife"))
+                                putJsonArray("args") {
+                                    addJsonObject {
+                                        put("_Players", JsonPrimitive("SinglePlayer"))
+                                        putJsonObject("args") { put("_Player", JsonPrimitive("You")) }
+                                    }
+                                    addJsonObject {
+                                        put("_GameNumber", JsonPrimitive("Integer"))
+                                        put("args", JsonPrimitive(1))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun render(playersScope: String, playerArg: String?, includeIsUntapped: Boolean = true) =
+        Emitter.renderCard(
+            tapTriggerCard(playersScope, playerArg, includeIsUntapped), null, effects, keywords
+        )
+
+    "the You scope maps to Triggers.YouTap with the recovered permanent filter" {
+        val r = render("SinglePlayer", "You")
+        r.complete shouldBe true
+        r.text shouldContain "trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls())"
+    }
+
+    "the IR's IsUntapped clause is dropped — it would invert the filter at detection time" {
+        val r = render("SinglePlayer", "You")
+        r.text shouldNotContain "untapped()"
+    }
+
+    "the filter still renders when the IR omits IsUntapped" {
+        val r = render("SinglePlayer", "You", includeIsUntapped = false)
+        r.complete shouldBe true
+        r.text shouldContain "trigger = Triggers.YouTap(GameObjectFilter.Creature.opponentControls())"
+    }
+
+    "a non-You tapper scope declines to a scaffold rather than widening the trigger" {
+        for (scope in listOf("AnyPlayer" to null, "Opponent" to null, "SinglePlayer" to "HostController")) {
+            val r = render(scope.first, scope.second)
+            r.complete shouldBe false
+            r.text shouldNotContain "Triggers.YouTap"
+        }
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -929,12 +929,21 @@ data class PriorityChangedEvent(
 
 /**
  * A permanent was tapped.
+ *
+ * @property tappedById the player who tapped it — the controller of the spell, ability, or cost
+ *   payment that caused the permanent to become tapped. A permanent tapped as a turn-based action
+ *   (declaring it as an attacker) or to pay its own controller's cost is tapped by its controller,
+ *   which is why [com.wingedsheep.engine.core.tap] defaults this to the permanent's controller
+ *   rather than leaving it unattributed. Drives the "whenever **you tap** a creature an opponent
+ *   controls" trigger family ([com.wingedsheep.sdk.scripting.EventPattern.TapEvent.tapper]); null
+ *   only for a permanent with no controller at all.
  */
 @Serializable
 @SerialName("TappedEvent")
 data class TappedEvent(
     val entityId: EntityId,
-    val entityName: String
+    val entityName: String,
+    val tappedById: EntityId? = null
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TapHelpers.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.model.EntityId
@@ -37,16 +38,44 @@ import com.wingedsheep.sdk.model.EntityId
  * not transitioning from untapped to tapped, so those sites set [TappedComponent]
  * directly and emit no event — they are the allowlist in `TapEventEnforcementTest`.
  *
+ * **Attribution.** [TappedEvent.tappedById] records *who tapped it*, which the "whenever you tap a
+ * creature an opponent controls" trigger family reads. It defaults to the permanent's own
+ * controller, which is already correct for every tap a permanent's controller performs on it — a
+ * cost payment (convoke, crew, saddle, a tap symbol in an activation cost), a mana ability, or the
+ * turn-based action of declaring it as an attacker. Only an *effect* that taps a permanent needs to
+ * pass [tappedById] explicitly: there the tapper is the controller of that effect, not of the
+ * permanent, and the two differ exactly when it matters. Pass the player the game instructs to tap,
+ * not the controller of the card that gave the instruction — a spell you control that makes an
+ * opponent tap their own creature is *their* tap (Tangle Wire; Hylda of the Icy Crown ruling).
+ *
+ * The default reads the controller from **projected** state, so a permanent whose control was changed
+ * (Threaten, Mind Control) attributes its cost/attack taps to the player actually wielding it rather
+ * than to its owner. That costs a projection on a state instance that may not have one cached yet —
+ * deliberate, and the same price [untapOrConsumeStun] already pays for its can't-untap check. It is
+ * bounded by how many permanents one action taps (a mana payment, a combat declaration), not by board
+ * size; if it ever shows up in a profile, the fix is to pass [tappedById] at the tapping call sites
+ * — every one of them knows the acting player — not to fall back to base [ControllerComponent],
+ * which would misattribute a stolen creature's taps to its owner.
+ *
+ * @param tappedById the player causing the tap; null (the default) attributes it to the permanent's
+ *   controller.
  * @return the updated state paired with the emitted [TappedEvent], or `state to null`
  *   when the permanent was already tapped or doesn't exist (no mutation performed).
  */
-fun tap(state: GameState, entityId: EntityId): Pair<GameState, TappedEvent?> {
+fun tap(
+    state: GameState,
+    entityId: EntityId,
+    tappedById: EntityId? = null,
+): Pair<GameState, TappedEvent?> {
     val container = state.getEntity(entityId) ?: return state to null
     // CR 603.2f: tapping an already-tapped permanent is not a transition — no event.
     if (container.has<TappedComponent>()) return state to null
     val cardName = container.get<CardComponent>()?.name ?: "Permanent"
+    val tapper = tappedById
+        ?: state.projectedState.getController(entityId)
+        ?: container.get<ControllerComponent>()?.playerId
     val newState = state.updateEntity(entityId) { it.with(TappedComponent) }
-    return newState to TappedEvent(entityId, cardName)
+    return newState to TappedEvent(entityId, cardName, tapper)
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -122,7 +122,12 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                     trigger.requires.all { matcher.matchesAttackPredicate(it, event, attachedEntityId, state) }
             }
             is EventPattern.TapEvent -> {
-                event is TappedEvent && event.entityId == attachedEntityId
+                if (event !is TappedEvent || event.entityId != attachedEntityId) return false
+                // "Whenever you tap …" attribution applies on the ATTACHED path too; relative to
+                // the aura/equipment's controller, as everywhere else here.
+                val tapper = trigger.tapper ?: return true
+                val tappedById = event.tappedById ?: return false
+                matcher.matchesPlayer(tapper, tappedById, auraControllerId)
             }
             // "Whenever equipped creature becomes untapped" (Fishing Pole). UntapEvent carries no
             // filter, so identity with the attached permanent is the whole match.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2148,8 +2148,8 @@ class TriggerDetector(
         triggers: MutableList<PendingTrigger>,
         index: TriggerIndex
     ) {
-        val tappedIds = events.filterIsInstance<TappedEvent>().map { it.entityId }
-        if (tappedIds.isEmpty()) return
+        val tapEvents = events.filterIsInstance<TappedEvent>()
+        if (tapEvents.isEmpty()) return
 
         for (entry in index.getEntitiesForCategory(TriggerCategory.TAPPED)) {
             for (ability in entry.abilities) {
@@ -2157,6 +2157,20 @@ class TriggerDetector(
                 if (trigger !is EventPattern.TapEvent || !trigger.batch) continue
                 // Batch tap triggers are "one or more … become tapped" observers (ANY binding).
                 if (ability.binding != TriggerBinding.ANY) continue
+
+                // "Whenever you tap one or more …" (Sharae of Numbing Depths) — only the taps this
+                // trigger's controller caused count toward the batch. A batch mixing tappers is
+                // therefore narrowed, not discarded, before the filter runs.
+                val tapper = trigger.tapper
+                val tappedIds = if (tapper == null) {
+                    tapEvents.map { it.entityId }
+                } else {
+                    tapEvents.filter { event ->
+                        event.tappedById != null &&
+                            matcher.matchesPlayer(tapper, event.tappedById, entry.controllerId)
+                    }.map { it.entityId }
+                }
+                if (tappedIds.isEmpty()) continue
 
                 val filter = trigger.filter
                 val matched = if (filter == null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -434,6 +434,12 @@ class TriggerMatcher(
                 // detectTapBatchTriggers — never once per event here.
                 if (trigger.batch) return false
                 if (binding == TriggerBinding.SELF && event.entityId != sourceId) return false
+                // "Whenever you tap …" — only a tap this trigger's controller caused counts.
+                val tapper = trigger.tapper
+                if (tapper != null) {
+                    val tappedById = event.tappedById ?: return false
+                    if (!matchesPlayer(tapper, tappedById, controllerId)) return false
+                }
                 val filter = trigger.filter
                 if (filter != null) {
                     val predicateEvaluator = PredicateEvaluator()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapCollectionExecutor.kt
@@ -35,7 +35,8 @@ class TapUntapCollectionExecutor : EffectExecutor<TapUntapCollectionEffect> {
         // and event emission; untapOrConsumeStun also applies stun-counter replacement (CR 122.1d).
         for (entityId in entityIds) {
             if (effect.tap) {
-                val (next, event) = tap(currentState, entityId)
+                // Attribute the tap to this effect's controller (see TapUntapExecutor).
+                val (next, event) = tap(currentState, entityId, tappedById = context.controllerId)
                 currentState = next
                 event?.let(events::add)
             } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/tapping/TapUntapExecutor.kt
@@ -36,7 +36,12 @@ class TapUntapExecutor : EffectExecutor<TapUntapEffect> {
         }
 
         // The tap atom owns the already-tapped no-op guard (CR 603.2f) and the TappedEvent.
-        val (newState, event) = tap(state, targetId)
+        // The tapper is this effect's controller — the player the game instructs to tap, which
+        // "whenever you tap a creature an opponent controls" reads. Inside a per-player loop
+        // (Tangle Wire's "that player taps …") `controllerId` is already rebound to the player
+        // doing the tapping, so their tap is correctly attributed to them and not to the card's
+        // controller.
+        val (newState, event) = tap(state, targetId, tappedById = context.controllerId)
         return EffectResult.success(newState, listOfNotNull(event))
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
@@ -1,9 +1,15 @@
 package com.wingedsheep.engine.core
 
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.scripting.Duration
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -33,6 +39,57 @@ class TapAtomTest : ScenarioTestBase() {
             newState.getEntity(wurm)?.has<TappedComponent>() shouldBe true
             event.shouldBeInstanceOf<TappedEvent>()
             event!!.entityId shouldBe wurm
+        }
+
+        test("tap() attributes the tap to the permanent's controller by default") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Spined Wurm", tapped = false)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (_, event) = tap(game.state, wurm)
+
+            // Every tap a permanent's own controller performs on it — a cost payment, a mana
+            // ability, crew/saddle, declaring it as an attacker — is theirs, so the default has to
+            // be the controller rather than "unattributed". This is what keeps "whenever you tap a
+            // creature an opponent controls" from firing on an opponent's own taps.
+            event?.tappedById shouldBe game.player2Id
+        }
+
+        test("tap() attributes a control-changed permanent to the player now wielding it") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Spined Wurm", tapped = false)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+            game.state = game.state.addFloatingEffect(
+                layer = Layer.CONTROL,
+                modification = SerializableModification.ChangeController(game.player1Id),
+                affectedEntities = setOf(wurm),
+                duration = Duration.EndOfTurn,
+                context = EffectContext(sourceId = wurm, controllerId = game.player1Id),
+            )
+            // Sanity: only the projection flipped; the base component still says player 2.
+            game.state.getEntity(wurm)?.get<ControllerComponent>()?.playerId shouldBe game.player2Id
+
+            val (_, event) = tap(game.state, wurm)
+
+            // A stolen creature tapped for a cost or to attack is tapped by the player who stole it,
+            // not by its owner — so the default reads projected control, not ControllerComponent.
+            event?.tappedById shouldBe game.player1Id
+        }
+
+        test("tap() records an explicit tapper, so an effect's controller owns the tap") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(2, "Spined Wurm", tapped = false)
+                .build()
+            val wurm = game.findPermanent("Spined Wurm")!!
+
+            val (_, event) = tap(game.state, wurm, tappedById = game.player1Id)
+
+            event?.tappedById shouldBe game.player1Id
         }
 
         test("tap() is a no-op with no event on an already-tapped permanent (CR 603.2f)") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GracefulTakedownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GracefulTakedownScenarioTest.kt
@@ -1,0 +1,258 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Graceful Takedown (WOE #171) — {1}{G} Sorcery.
+ *
+ *   Any number of target enchanted creatures you control and up to one other target creature you
+ *   control each deal damage equal to their power to target creature you don't control.
+ *
+ * The card's three target requirements are declared **victim first** (see the card's notes: the
+ * unbounded "any number of" slot has to be last for positional target↔requirement alignment), so the
+ * `targets` list here reads victim, other-creature, then the enchanted creatures.
+ *
+ * What these tests pin: only the creatures *you control* deal damage — the victim, which is also one
+ * of the spell's targets, must not damage itself; the damage is each dealer's own power summed; zero
+ * dealers is a legal cast that does nothing; and the CR 608.2b partial-legality split from the
+ * printed rulings (a dealer that became illegal drops out, an illegal victim cancels everything).
+ */
+class GracefulTakedownScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Cast Graceful Takedown with an explicit, requirement-ordered target list:
+     * `[victim] + [other?] + enchanted`.
+     */
+    private fun TestGame.castTakedown(
+        victim: EntityId,
+        other: EntityId? = null,
+        enchanted: List<EntityId> = emptyList(),
+    ) {
+        val cardId = state.getHand(player1Id).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Graceful Takedown"
+        }
+        val targets = (listOf(victim) + listOfNotNull(other) + enchanted)
+            .map { ChosenTarget.Permanent(it) }
+        execute(CastSpell(player1Id, cardId, targets)).error shouldBe null
+    }
+
+    private fun TestGame.settle() {
+        var guard = 0
+        while (guard++ < 40) {
+            when (state.pendingDecision) {
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                null -> {
+                    if (state.stack.isEmpty()) return
+                    resolveStack()
+                }
+                else -> error("unexpected decision: ${state.pendingDecision}")
+            }
+        }
+        error("decision loop did not settle")
+    }
+
+    private fun TestGame.damageOn(id: EntityId): Int =
+        state.getEntity(id)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.DamageComponent>()
+            ?.amount ?: 0
+
+    init {
+        context("Graceful Takedown") {
+
+            test("two enchanted creatures you control each deal their power to the victim") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3
+                    .withCardOnBattlefield(1, "Pacifism")
+                    .withCardOnBattlefield(1, "Holy Strength")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false) // 6/4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                // Holy Strength makes the Giant a 4/5, so 2 + 4 = 6 damage.
+                game.state.projectedState.getPower(giant) shouldBe 4
+
+                game.castTakedown(victim = wurm, enchanted = listOf(bears, giant))
+                game.settle()
+
+                withClue("6 damage on a 6/4 kills it") {
+                    game.isOnBattlefield("Craw Wurm") shouldBe false
+                    game.isInGraveyard(2, "Craw Wurm") shouldBe true
+                }
+                withClue("the victim is one of the spell's targets but must not damage itself") {
+                    game.damageOn(bears) shouldBe 0
+                    game.damageOn(giant) shouldBe 0
+                }
+            }
+
+            test("the 'up to one other' slot may be an unenchanted creature and also deals damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(1, "Pacifism")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3, bare
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false) // 6/4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castTakedown(victim = wurm, other = giant, enchanted = listOf(bears))
+                game.settle()
+
+                withClue("3 (bare Giant) + 2 (enchanted Bears) = 5 on a 6/4") {
+                    game.isOnBattlefield("Craw Wurm") shouldBe false
+                }
+            }
+
+            test("an unenchanted creature is not a legal choice for the unbounded slot") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Graceful Takedown"
+                }
+
+                // Two bare creatures: the first fills the "up to one other" slot, the second lands in
+                // the enchanted slot and has no Aura — so the whole cast is rejected.
+                val result = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(wurm, giant, bears).map { ChosenTarget.Permanent(it) }
+                    )
+                )
+                withClue("only one non-enchanted creature you control may be targeted") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("targeting no creatures of your own is a legal cast that deals no damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castTakedown(victim = wurm)
+                game.settle()
+
+                withClue("no dealers, no damage — and the spell still resolved") {
+                    game.damageOn(wurm) shouldBe 0
+                    game.isOnBattlefield("Craw Wurm") shouldBe true
+                    game.isInGraveyard(1, "Graceful Takedown") shouldBe true
+                }
+            }
+
+            test("a dealer that became an illegal target drops out; the rest still deal damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3
+                    .withCardOnBattlefield(1, "Pacifism")
+                    .withCardOnBattlefield(1, "Holy Strength")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false) // 6/4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+
+                game.castTakedown(victim = wurm, enchanted = listOf(bears, giant))
+                // The 4/5 Giant leaves before resolution — an illegal target (CR 608.2b).
+                game.state = game.state.moveToZone(
+                    giant,
+                    ZoneKey(game.player1Id, Zone.BATTLEFIELD),
+                    ZoneKey(game.player1Id, Zone.GRAVEYARD),
+                )
+                game.settle()
+
+                withClue("only the Bears' 2 damage lands, so the 6/4 survives with 2 marked") {
+                    game.isOnBattlefield("Craw Wurm") shouldBe true
+                    game.damageOn(wurm) shouldBe 2
+                }
+            }
+
+            test("an illegal victim means no creature deals or is dealt damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Graceful Takedown")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Pacifism")
+                    .withCardAttachedTo(1, "Pacifism", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val wurm = game.findPermanent("Craw Wurm")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castTakedown(victim = wurm, enchanted = listOf(bears))
+                game.state = game.state.moveToZone(
+                    wurm,
+                    ZoneKey(game.player2Id, Zone.BATTLEFIELD),
+                    ZoneKey(game.player2Id, Zone.GRAVEYARD),
+                )
+                game.settle()
+
+                withClue("the dealer is still legal, but with no victim nothing is dealt damage") {
+                    game.damageOn(bears) shouldBe 0
+                    game.damageOn(giant) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldaOfTheIcyCrownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HyldaOfTheIcyCrownScenarioTest.kt
@@ -1,0 +1,188 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Hylda of the Icy Crown (WOE #206) — {2}{W}{U} Legendary Creature 3/4.
+ *
+ *   Whenever you tap an untapped creature an opponent controls, you may pay {1}. When you do,
+ *   choose one —
+ *   • Create a 4/4 white and blue Elemental creature token.
+ *   • Put a +1/+1 counter on each creature you control.
+ *   • Scry 2, then draw a card.
+ *
+ * The tap trigger is fed by Hylda's Crown of Winter (a {T} tapper you control). Each mode is
+ * exercised once, plus the two ways the payoff can be skipped: declining the {1}, and a tap that
+ * isn't yours.
+ */
+class HyldaOfTheIcyCrownScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioBuilder.hyldaBoard(): ScenarioBuilder = this
+        .withPlayers("Player1", "Player2")
+        .withCardOnBattlefield(1, "Hylda of the Icy Crown", summoningSickness = false)
+        .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+        .withLandsOnBattlefield(1, "Island", 2)
+        .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+    /** Tap the opponent's Hill Giant with the Crown, then run the trigger picking [mode]. */
+    private fun TestGame.tapWithCrownAndChoose(mode: Int?, pay: Boolean = true) {
+        val crown = findPermanent("Hylda's Crown of Winter")!!
+        val giant = findPermanent("Hill Giant")!!
+        execute(
+            ActivateAbility(
+                playerId = player1Id,
+                sourceId = crown,
+                abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Permanent(giant)),
+            )
+        ).error shouldBe null
+
+        var guard = 0
+        while (guard++ < 40) {
+            when (val decision = state.pendingDecision) {
+                is YesNoDecision -> answerYesNo(pay)
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                is ChooseOptionDecision -> submitDecision(
+                    OptionChosenResponse(
+                        decision.id,
+                        mode ?: error("a mode was offered but the test expected none")
+                    )
+                )
+                // Scry: put nothing on the bottom, keep the looked-at cards in order.
+                is SelectCardsDecision -> skipSelection()
+                is ReorderLibraryDecision -> keepLibraryOrder()
+                null -> {
+                    if (state.stack.isEmpty()) return
+                    resolveStack()
+                }
+                else -> error("unexpected decision: $decision")
+            }
+        }
+        error("decision loop did not settle")
+    }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Hylda of the Icy Crown") {
+
+            test("mode 1 creates a 4/4 white and blue Elemental token") {
+                val game = scenario().hyldaBoard().build()
+
+                game.tapWithCrownAndChoose(mode = 0)
+
+                val token = game.findPermanent("Elemental Token")
+                withClue("the token was created") { (token != null) shouldBe true }
+                game.state.projectedState.getPower(token!!) shouldBe 4
+                game.state.projectedState.getToughness(token) shouldBe 4
+                withClue("the opposing creature really is tapped") {
+                    game.state.getEntity(game.findPermanent("Hill Giant")!!)
+                        ?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("mode 2 puts a +1/+1 counter on each creature you control") {
+                val game = scenario().hyldaBoard()
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .build()
+
+                val hylda = game.findPermanent("Hylda of the Icy Crown")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.tapWithCrownAndChoose(mode = 1)
+
+                withClue("every creature you control gets one counter") {
+                    game.plusOneCounters(hylda) shouldBe 1
+                    game.plusOneCounters(bears) shouldBe 1
+                }
+                withClue("the opponent's creature gets nothing") {
+                    game.plusOneCounters(giant) shouldBe 0
+                }
+            }
+
+            test("mode 3 scries 2 and draws a card") {
+                val game = scenario().hyldaBoard()
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(1, "Bog Imp")
+                    .withCardInLibrary(1, "Wind Drake")
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val libraryBefore = game.librarySize(1)
+
+                game.tapWithCrownAndChoose(mode = 2)
+
+                withClue("scry keeps the cards in the library; only the draw moves one") {
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                }
+            }
+
+            test("declining the {1} skips the mode choice entirely") {
+                val game = scenario().hyldaBoard().build()
+
+                game.tapWithCrownAndChoose(mode = null, pay = false)
+
+                withClue("the tap happened but nothing was paid, so no mode resolved") {
+                    game.state.getEntity(game.findPermanent("Hill Giant")!!)
+                        ?.has<TappedComponent>() shouldBe true
+                    game.findPermanent("Elemental Token") shouldBe null
+                    game.plusOneCounters(game.findPermanent("Hylda of the Icy Crown")!!) shouldBe 0
+                }
+            }
+
+            test("an opponent tapping their own creature never offers the payment") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hylda of the Icy Crown", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player2Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("no decision at all — the trigger never fired") {
+                    game.state.pendingDecision shouldBe null
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+                    game.findPermanent("Elemental Token") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IcewroughtSentryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IcewroughtSentryScenarioTest.kt
@@ -1,0 +1,198 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Icewrought Sentry (WOE #55) — {2}{U} Creature — Elemental Soldier 2/3.
+ *
+ *   Vigilance
+ *   Whenever this creature attacks, you may pay {1}{U}. When you do, tap target creature an
+ *   opponent controls.
+ *   Whenever you tap an untapped creature an opponent controls, this creature gets +2/+1 until end
+ *   of turn.
+ *
+ * Two abilities that chain into each other: the reflexive tap is itself "a tap you made", so paying
+ * for it also pumps the Sentry. The pump is per-tap and not restricted to its own tap — any tapper
+ * you control feeds it — and it must not fire off the opponent's own taps.
+ */
+class IcewroughtSentryScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.power(id: EntityId): Int =
+        state.projectedState.getPower(id) ?: error("no projected power for $id")
+
+    private fun TestGame.toughness(id: EntityId): Int =
+        state.projectedState.getToughness(id) ?: error("no projected toughness for $id")
+
+    private fun TestGame.isTapped(id: EntityId): Boolean =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    /** Answer decisions until the stack is empty, paying every optional cost and picking [target]. */
+    private fun TestGame.drainPaying(target: EntityId?) {
+        var guard = 0
+        while (guard++ < 40) {
+            when (state.pendingDecision) {
+                is YesNoDecision -> answerYesNo(true)
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                is ChooseTargetsDecision -> selectTargets(listOfNotNull(target))
+                null -> {
+                    if (state.stack.isEmpty()) return
+                    resolveStack()
+                }
+                else -> error("unexpected decision: ${state.pendingDecision}")
+            }
+        }
+        error("decision loop did not settle")
+    }
+
+    init {
+        context("Icewrought Sentry") {
+
+            test("paying the attack trigger taps an opposing creature and pumps the Sentry to 4/4") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Icewrought Sentry", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentry = game.findPermanent("Icewrought Sentry")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Icewrought Sentry" to 2)).error shouldBe null
+                game.drainPaying(giant)
+
+                withClue("the reflexive tap resolved") {
+                    game.isTapped(giant) shouldBe true
+                }
+                withClue("vigilance means attacking didn't tap the Sentry itself") {
+                    game.isTapped(sentry) shouldBe false
+                }
+                withClue("its own reflexive tap is a tap *you* made, so the Sentry pumps: 2/3 -> 4/4") {
+                    game.power(sentry) shouldBe 4
+                    game.toughness(sentry) shouldBe 4
+                }
+            }
+
+            test("declining the payment taps nothing and leaves the Sentry a 2/3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Icewrought Sentry", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentry = game.findPermanent("Icewrought Sentry")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Icewrought Sentry" to 2)).error shouldBe null
+
+                var guard = 0
+                var declined = false
+                while (guard++ < 20 && !declined) {
+                    when (game.state.pendingDecision) {
+                        is YesNoDecision -> {
+                            game.answerYesNo(false); declined = true
+                        }
+                        null -> game.resolveStack()
+                        else -> error("unexpected decision: ${game.state.pendingDecision}")
+                    }
+                }
+                withClue("the optional payment was genuinely offered") { declined shouldBe true }
+
+                withClue("no tap happened, so no pump") {
+                    game.isTapped(giant) shouldBe false
+                    game.power(sentry) shouldBe 2
+                    game.toughness(sentry) shouldBe 3
+                }
+            }
+
+            test("two separate taps of opposing creatures pump it twice — it is not once per turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Icewrought Sentry", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentry = game.findPermanent("Icewrought Sentry")!!
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val tapAbility = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id
+
+                // The Crown's {T} is part of its cost, so untap it between activations.
+                for (victimName in listOf("Hill Giant", "Grizzly Bears")) {
+                    val victim = game.findPermanent(victimName)!!
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = crown,
+                            abilityId = tapAbility,
+                            targets = listOf(ChosenTarget.Permanent(victim)),
+                        )
+                    ).error shouldBe null
+                    game.drainPaying(null)
+                    game.state = game.state.updateEntity(crown) { it.without<TappedComponent>() }
+                }
+
+                withClue("two taps, two pumps: 2/3 -> 6/5") {
+                    game.power(sentry) shouldBe 6
+                    game.toughness(sentry) shouldBe 5
+                }
+            }
+
+            test("an opponent tapping their own creature does not pump it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Icewrought Sentry", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sentry = game.findPermanent("Icewrought Sentry")!!
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player2Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                    )
+                ).error shouldBe null
+                game.drainPaying(null)
+
+                withClue("their tap of their own creature is not a tap you made") {
+                    game.isTapped(giant) shouldBe true
+                    game.power(sentry) shouldBe 2
+                    game.toughness(sentry) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharaeOfNumbingDepthsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SharaeOfNumbingDepthsScenarioTest.kt
@@ -1,0 +1,183 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sharae of Numbing Depths (WOE #213) — {2}{W}{U} Legendary Creature 2/3.
+ *
+ *   When Sharae enters, tap target creature an opponent controls and put a stun counter on it.
+ *   Whenever you tap one or more untapped creatures your opponents control, draw a card. This
+ *   ability triggers only once each turn.
+ *
+ * The draw ability differs from its per-tap siblings on two axes, and each gets a test: it is a
+ * **batch** trigger (CR 603.2c — tapping two of their creatures at once draws one card, not two) and
+ * it is limited to **once each turn** (two separate taps in one turn still draw one). Attribution is
+ * shared with the rest of the cluster: an opponent tapping their own creatures never fires it.
+ */
+class SharaeOfNumbingDepthsScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.drain(targets: List<EntityId> = emptyList()) {
+        var asked = 0
+        var guard = 0
+        while (guard++ < 40) {
+            when (state.pendingDecision) {
+                is ChooseTargetsDecision -> {
+                    val pick = targets.getOrNull(asked)
+                        ?: error("unexpected extra ChooseTargetsDecision (#${asked + 1})")
+                    asked++
+                    selectTargets(listOf(pick))
+                }
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                null -> {
+                    if (state.stack.isEmpty()) return
+                    resolveStack()
+                }
+                else -> error("unexpected decision: ${state.pendingDecision}")
+            }
+        }
+        error("decision loop did not settle")
+    }
+
+    private fun TestGame.crownTap(activator: Int, victim: EntityId) {
+        val crown = findPermanent("Hylda's Crown of Winter")!!
+        execute(
+            ActivateAbility(
+                playerId = if (activator == 1) player1Id else player2Id,
+                sourceId = crown,
+                abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                    .activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+            )
+        ).error shouldBe null
+        drain()
+        // The Crown's own {T} is part of the cost; free it up for a second activation.
+        state = state.updateEntity(crown) { it.without<TappedComponent>() }
+    }
+
+    init {
+        context("Sharae of Numbing Depths") {
+
+            test("the entry trigger taps an opposing creature, stuns it, and that tap draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sharae of Numbing Depths")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Sharae of Numbing Depths").error shouldBe null
+                game.drain(listOf(giant))
+
+                withClue("tapped with a stun counter") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(giant)?.get<CountersComponent>()
+                        ?.getCount(CounterType.STUN) shouldBe 1
+                }
+                withClue("Sharae left your hand and one card was drawn off her own entry tap") {
+                    game.handSize(1) shouldBe handBefore - 1 + 1
+                }
+            }
+
+            test("tapping two of their creatures at once draws one card, not two (CR 603.2c)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sharae of Numbing Depths", summoningSickness = false)
+                    .withCardInHand(1, "Deluge")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(1, "Bog Imp")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                // Deluge taps every creature without flying — both of theirs, in one batch.
+                game.castSpell(1, "Deluge").error shouldBe null
+                game.drain()
+
+                withClue("both opposing creatures got tapped by your spell") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("one batch → one card (Deluge left the hand, so net zero)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 1
+                }
+            }
+
+            test("two separate taps in one turn still draw only one card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sharae of Numbing Depths", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardInLibrary(1, "Bog Imp")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.crownTap(1, game.findPermanent("Hill Giant")!!)
+                game.crownTap(1, game.findPermanent("Grizzly Bears")!!)
+
+                withClue("both taps happened") {
+                    game.state.getEntity(game.findPermanent("Hill Giant")!!)
+                        ?.has<TappedComponent>() shouldBe true
+                    game.state.getEntity(game.findPermanent("Grizzly Bears")!!)
+                        ?.has<TappedComponent>() shouldBe true
+                }
+                withClue("'triggers only once each turn' caps the draw at one") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("an opponent tapping their own creature draws nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sharae of Numbing Depths", summoningSickness = false)
+                    .withCardInLibrary(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.crownTap(2, giant)
+
+                withClue("their tap of their own creature is not a tap you made") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SolitarySanctuaryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SolitarySanctuaryScenarioTest.kt
@@ -1,0 +1,234 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Solitary Sanctuary (WOE #30) — {2}{W} Enchantment.
+ *
+ *   When this enchantment enters, tap target creature an opponent controls and put a stun counter
+ *   on it.
+ *   Whenever you tap an untapped creature an opponent controls, put a +1/+1 counter on target
+ *   creature you control.
+ *
+ * The point of interest is the second ability's **attribution**: it is not "whenever a creature an
+ * opponent controls becomes tapped". These tests pin all four quadrants of (who tapped) × (whose
+ * creature), plus the "untapped" transition rule (CR 603.2f):
+ *
+ *  - you tap an opponent's creature → fires (both via this card's own entry trigger and via a
+ *    separate tapper you control),
+ *  - the opponent taps their *own* creature → does not fire,
+ *  - you tap your *own* creature → does not fire (filter),
+ *  - you "tap" an already-tapped creature of theirs → does not fire (no transition, no event).
+ */
+class SolitarySanctuaryScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Answer the engine's decisions until the stack is empty, feeding [targets] to each
+     * `ChooseTargetsDecision` in the order they are asked and auto-paying mana. Returns the number
+     * of target decisions that were answered — which is how many times a targeting trigger fired.
+     */
+    private fun TestGame.drain(targets: List<EntityId> = emptyList()): Int {
+        var asked = 0
+        var guard = 0
+        while (guard++ < 40) {
+            when (state.pendingDecision) {
+                is ChooseTargetsDecision -> {
+                    val pick = targets.getOrNull(asked)
+                        ?: error("unexpected extra ChooseTargetsDecision (#${asked + 1})")
+                    asked++
+                    selectTargets(listOf(pick))
+                }
+                is SelectManaSourcesDecision -> submitManaSourcesAutoPay()
+                null -> {
+                    if (state.stack.isEmpty()) return asked
+                    resolveStack()
+                }
+                else -> error("unexpected decision: ${state.pendingDecision}")
+            }
+        }
+        error("decision loop did not settle")
+    }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun TestGame.isTapped(id: EntityId): Boolean =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    init {
+        context("Solitary Sanctuary") {
+
+            test("the entry trigger taps and stuns, and that tap is a tap you made — so the payoff fires") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Solitary Sanctuary")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Solitary Sanctuary").error shouldBe null
+                // Entry trigger targets the Hill Giant; its tap then triggers the payoff, which
+                // targets the Bears.
+                val asked = game.drain(listOf(giant, bears))
+
+                withClue("both the entry trigger and the payoff asked for a target") {
+                    asked shouldBe 2
+                }
+                withClue("the opposing creature is tapped with a stun counter") {
+                    game.isTapped(giant) shouldBe true
+                    game.state.getEntity(giant)?.get<CountersComponent>()
+                        ?.getCount(CounterType.STUN) shouldBe 1
+                }
+                withClue("the enchantment's own entry tap is a tap *you* made, so it pays off") {
+                    game.plusOneCounters(bears) shouldBe 1
+                }
+            }
+
+            test("a separate tapper you control also fires the payoff") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Solitary Sanctuary")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                    )
+                ).error shouldBe null
+
+                game.drain(listOf(bears)) shouldBe 1
+                withClue("your Crown tapped their creature, so the Sanctuary pays off") {
+                    game.isTapped(giant) shouldBe true
+                    game.plusOneCounters(bears) shouldBe 1
+                }
+            }
+
+            test("an opponent tapping their own creature does not fire the payoff") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Solitary Sanctuary")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // The opponent owns the tapper *and* the creature being tapped.
+                    .withCardOnBattlefield(2, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player2Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                    )
+                ).error shouldBe null
+
+                withClue("the tapped creature is still 'a creature an opponent controls' from your side, but *they* tapped it") {
+                    game.drain() shouldBe 0
+                    game.isTapped(giant) shouldBe true
+                    game.plusOneCounters(bears) shouldBe 0
+                }
+            }
+
+            test("tapping your own creature does not fire the payoff") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Solitary Sanctuary")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Air Elemental", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val elemental = game.findPermanent("Air Elemental")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(elemental)),
+                    )
+                ).error shouldBe null
+
+                withClue("you tapped it, but it isn't a creature an opponent controls") {
+                    game.drain() shouldBe 0
+                    game.isTapped(elemental) shouldBe true
+                    game.plusOneCounters(bears) shouldBe 0
+                }
+            }
+
+            test("targeting an already-tapped creature of theirs does not fire the payoff (CR 603.2f)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Solitary Sanctuary")
+                    .withCardOnBattlefield(1, "Hylda's Crown of Winter")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crown = game.findPermanent("Hylda's Crown of Winter")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crown,
+                        abilityId = cardRegistry.getCard("Hylda's Crown of Winter")!!
+                            .activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(giant)),
+                    )
+                ).error shouldBe null
+
+                withClue("an already-tapped permanent never *becomes* tapped, so there is no tap to pay off") {
+                    game.drain() shouldBe 0
+                    game.plusOneCounters(bears) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two cards that were scoped in and dropped as "needs engine work". One did; the other turned out to compose.

## `Triggers.YouTap` — tap attribution (real engine work)

`Solitary Sanctuary` / `Icewrought Sentry` / `Hylda of the Icy Crown` / `Sharae of Numbing Depths`
all want *"whenever you tap an untapped creature an opponent controls"*. The new axis is
**attribution**, not a filter — the trigger fires only on a tap *its controller caused*.

- **`TappedEvent.tappedById`** records who tapped it. The `tap()` atom defaults it to the permanent's
  **projected** controller — correct for every cost payment, mana ability, crew/saddle and the
  turn-based attack tap, and for a stolen creature (Threaten) it names the player wielding it rather
  than its owner. The two tap *effect* executors override it with the effect's `controllerId`.
- That's what makes the **Tangle Wire** ruling fall out for free: a per-player loop has already
  rebound `controllerId`, so a spell you control that instructs an *opponent* to tap their own
  creature is **their** tap and does not fire a `You` pattern.
- **"Untapped" needs no axis.** Tapping is a transition (CR 603.2f), so an already-tapped permanent
  emits no tap event at all.
- `EventPattern.TapEvent.tapper` + `Triggers.YouTap(filter, batch)`, honored on the per-event path
  (`TriggerMatcher`), the batch path (`detectTapBatchTriggers`, which narrows a mixed-tapper batch
  *before* applying the filter — CR 603.2c), and the ATTACHED path.

### Perf note
The default reads projected control, which costs a projection on a state instance that may not have
one cached. Deliberate, and the price `untapOrConsumeStun` already pays for its can't-untap check;
bounded by how many permanents one action taps, not by board size. If it ever shows in a profile the
fix is to pass `tappedById` at the tapping call sites — every one knows the acting player — **not**
to fall back to base `ControllerComponent`, which would misattribute a stolen creature's taps.

## Graceful Takedown — no new engine vocabulary needed

"Iterate one slice of the spell's targets" already composes:
`GatherCards(ChosenTargets)` → `FilterCollection(MatchesFilter)` → `ForEachInCollection`, with each
dealer as its own `damageSource` so lifelink/deathtouch see the creature, not the sorcery.

The real obstacle wasn't `IterationSpace` — it was **target↔requirement alignment**. Targets are
matched to requirements positionally, so an unbounded requirement must be **last** or every
requirement after it loses its slice; in printed order the card was uncastable. Declaring the victim
first fixes it and pins its slot index no matter how many creatures the unbounded slot swallowed.

Two supporting SDK fixes it needed:
- `TargetOther` now delegates `minCount` / `unlimited` / `chooser` to its base requirement — it was
  silently collapsing `TargetOther(unlimited = true)` into one *mandatory* target.
- `TargetFilter` gains the `enchanted()` chainer.

## mtgish

`WhenAPlayerTapsAPermanent` is bridged and rendered as `Triggers.YouTap(...)`. The IR's explicit
`IsUntapped` clause is **dropped**, not round-tripped: the filter runs at detection time, when the
permanent is already tapped, so a recovered `.untapped()` would read false and the trigger would
never fire. Non-`You` tapper scopes decline → SCAFFOLD.

All four printed cards still scaffold on *unrelated* constructs (`MayCost`, modal-trigger, targeted
counter payoff), so the trigger recovery is pinned by a synthetic-fixture test instead.

## Tests

24 new tests, all green; `just build` clean.

- `TapAtomTest` — attribution default, control-changed permanent, explicit override.
- One scenario file per card. The tap cluster covers all four (who tapped) × (whose creature)
  quadrants plus the no-transition case; Sharae covers batch-vs-per-tap *and* once-each-turn;
  Graceful Takedown covers the damage math, the victim not damaging itself, a zero-dealer cast, and
  both halves of the printed CR 608.2b partial-legality split.

## Note for the reviewer

The first commit of this work briefly landed on `land-suggestion-scale-with-picks` (another agent
created that branch mid-session). This branch is rebased onto `main` and contains only my commit, but
**`land-suggestion-scale-with-picks` still has it as its tip** — moving that pointer back was blocked
by a permission check. To clean up: `git branch -f land-suggestion-scale-with-picks 3c62c72477`
(that only moves their branch back to their own web-client commit; nothing of theirs is discarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
