### PR TITLE
Gate the easter egg deck injector behind a config flag, off in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ GAME_DEV_ENDPOINTS_ENABLED=true
 GAME_ADMIN_PASSWORD=admin
 
 # =============================================================================
+# Easter Eggs
+# =============================================================================
+# Name-based joke cards slipped into a deck (EasterEggDeckInjector). Off in production —
+# the deploy never sets this — so keep it local-only.
+GAME_EASTER_EGGS_ENABLED=true
+
+# =============================================================================
 # Set Configuration
 # =============================================================================
 # Enable incomplete/development sets locally

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -8,7 +8,17 @@ data class GameProperties(
     val sets: SetsProperties = SetsProperties(),
     val admin: AdminProperties = AdminProperties(),
     val ai: AiProperties = AiProperties(),
+    val easterEggs: EasterEggProperties = EasterEggProperties(),
     val debugMode: Boolean = false
+)
+
+/**
+ * Joke cards that [com.wingedsheep.gameserver.deck.EasterEggDeckInjector] sneaks into a deck based on
+ * the player's name. **Off by default** so production stays clean unless someone opts in — the deploy
+ * passes no `GAME_EASTER_EGGS_ENABLED`, so a redeploy can't silently switch them back on.
+ */
+data class EasterEggProperties(
+    val enabled: Boolean = false
 )
 
 data class HandSmootherProperties(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/EasterEggDeckInjector.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/EasterEggDeckInjector.kt
@@ -14,8 +14,12 @@ object EasterEggDeckInjector {
     /**
      * If the player is named "Rick" (case-insensitive) and their deck contains
      * both Forest and Plains, inject Sekshaas, Early Sleeper into the deck.
+     *
+     * A no-op unless [enabled] (`game.easter-eggs.enabled`, off by default) — production runs without
+     * the eggs; local dev opts in via `GAME_EASTER_EGGS_ENABLED=true`.
      */
-    fun maybeInjectEasterEggs(playerName: String, deck: Map<String, Int>): Map<String, Int> {
+    fun maybeInjectEasterEggs(playerName: String, deck: Map<String, Int>, enabled: Boolean): Map<String, Int> {
+        if (!enabled) return deck
         if (!playerName.equals("Rick", ignoreCase = true)) return deck
         if (!deck.containsCard("Forest") || !deck.containsCard("Plains")) return deck
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -133,7 +133,9 @@ class FreeForAllHandler(
                 lobby.getSubmittedDeck(identity.playerId) ?: return false,
                 lobby.basicLands
             )
-            val deckWithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(identity.playerName, baseDeck)
+            val deckWithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(
+                identity.playerName, baseDeck, gameProperties.easterEggs.enabled
+            )
             val commander = if (isCommanderShape) playerState.commander else null
             val deck = if (commander != null) stripCommanderFromCards(deckWithEgg, commander) else deckWithEgg
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -125,7 +125,9 @@ class GamePlayHandler(
         } else {
             message.deckList
         }
-        val deckList = EasterEggDeckInjector.maybeInjectEasterEggs(playerSession.playerName, baseDeck)
+        val deckList = EasterEggDeckInjector.maybeInjectEasterEggs(
+            playerSession.playerName, baseDeck, gameProperties.easterEggs.enabled
+        )
 
         val gameSession = GameSession(
             cardRegistry = cardRegistry,
@@ -272,7 +274,9 @@ class GamePlayHandler(
         } else {
             message.deckList
         }
-        val deckList = EasterEggDeckInjector.maybeInjectEasterEggs(playerSession.playerName, baseDeck)
+        val deckList = EasterEggDeckInjector.maybeInjectEasterEggs(
+            playerSession.playerName, baseDeck, gameProperties.easterEggs.enabled
+        )
 
         // A generated random deck (empty submission) has no sideboard.
         val sideboard = if (message.deckList.isEmpty()) emptyMap() else message.sideboard

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -525,7 +525,9 @@ class LobbyHandler(
             val baseDeck = playerState.submittedDeck
                 ?: throw IllegalStateException("Player $playerId has no submitted deck")
             val deckWithLandArt = BoosterGenerator.withBasicLandArt(baseDeck, sealedSession.basicLands)
-            val deck = EasterEggDeckInjector.maybeInjectEasterEggs(playerState.session.playerName, deckWithLandArt)
+            val deck = EasterEggDeckInjector.maybeInjectEasterEggs(
+                playerState.session.playerName, deckWithLandArt, gameProperties.easterEggs.enabled
+            )
             gameSession.addPlayer(playerState.session, deck, sideboard = playerState.submittedSideboard)
 
             // Store player info for persistence

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -574,6 +574,7 @@ class QuickGameLobbyHandler(
                 EasterEggDeckInjector.maybeInjectEasterEggs(
                     lobbyPlayer.playerName,
                     resolveDeck(lobbyPlayer, randomFallbackSet, lobby.format),
+                    gameProperties.easterEggs.enabled,
                 )
             }
             val playerSession = sessionRegistry

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -435,10 +435,10 @@ class TournamentMatchHandler(
             lobby.basicLands
         )
         val deck1WithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(
-            player1State.identity.playerName, baseDeck1
+            player1State.identity.playerName, baseDeck1, gameProperties.easterEggs.enabled
         )
         val deck2WithEgg = EasterEggDeckInjector.maybeInjectEasterEggs(
-            player2State.identity.playerName, baseDeck2
+            player2State.identity.playerName, baseDeck2, gameProperties.easterEggs.enabled
         )
 
         // Commander-shape lobbies route through the engine's 1v1 Commander rules. Two sources:

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -103,6 +103,11 @@ game:
     # flattens an empty collection to an empty-string property that fails to
     # bind to the Map/Set target. Override them in a profile (see
     # application-local.yml) when you actually need entries.
+  easter-eggs:
+    # Name-based joke cards slipped into a player's deck (EasterEggDeckInjector). Off by default so
+    # production stays clean — the deploy passes no GAME_EASTER_EGGS_ENABLED, so a redeploy can't
+    # switch them back on. Local dev opts in via .env.
+    enabled: ${GAME_EASTER_EGGS_ENABLED:false}
   admin:
     # Password for admin replay feature. Feature is disabled if not set.
     password: ${GAME_ADMIN_PASSWORD:}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/EasterEggDeckInjectorTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/EasterEggDeckInjectorTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.deck
 
+import com.wingedsheep.gameserver.config.GameProperties
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.shouldBe
@@ -14,13 +15,13 @@ class EasterEggDeckInjectorTest : FunSpec({
     test("Rick's Forest + Plains deck gets Sekshaas") {
         val deck = mapOf("Forest" to 8, "Plains" to 8, "Llanowar Elves" to 4)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck) shouldBe deck + (sekshaas to 1)
+        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck, enabled = true) shouldBe deck + (sekshaas to 1)
     }
 
     test("the player name matches case-insensitively") {
         val deck = mapOf("Forest" to 8, "Plains" to 8)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("rICk", deck) shouldContainKey sekshaas
+        EasterEggDeckInjector.maybeInjectEasterEggs("rICk", deck, enabled = true) shouldContainKey sekshaas
     }
 
     // BoosterGenerator.withBasicLandArt rewrites basics to `Name#SetCode-CollectorNumber` before the
@@ -28,24 +29,36 @@ class EasterEggDeckInjectorTest : FunSpec({
     test("basics carrying a printing suffix still count as Forest and Plains") {
         val deck = mapOf("Forest#FDN-278" to 8, "Plains#FDN-272" to 8)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck) shouldContainKey sekshaas
+        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck, enabled = true) shouldContainKey sekshaas
     }
 
     test("a deck missing either colour of basic is left alone") {
         val monoGreen = mapOf("Forest#FDN-278" to 17, "Llanowar Elves" to 4)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", monoGreen) shouldBe monoGreen
+        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", monoGreen, enabled = true) shouldBe monoGreen
     }
 
     test("nobody else gets the easter egg") {
         val deck = mapOf("Forest" to 8, "Plains" to 8)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("Vincent", deck) shouldBe deck
+        EasterEggDeckInjector.maybeInjectEasterEggs("Vincent", deck, enabled = true) shouldBe deck
     }
 
     test("a card whose name merely starts with a basic land name does not count") {
         val deck = mapOf("Forestwalker" to 4, "Plains" to 8)
 
-        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck) shouldBe deck
+        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck, enabled = true) shouldBe deck
+    }
+
+    test("the kill switch leaves an otherwise-qualifying deck alone") {
+        val deck = mapOf("Forest" to 8, "Plains" to 8, "Llanowar Elves" to 4)
+
+        EasterEggDeckInjector.maybeInjectEasterEggs("Rick", deck, enabled = false) shouldBe deck
+    }
+
+    // Production passes no GAME_EASTER_EGGS_ENABLED, so the property default is what keeps the eggs
+    // off there — a default flip would silently re-enable them on the next deploy.
+    test("easter eggs are off unless configuration opts in") {
+        GameProperties().easterEggs.enabled shouldBe false
     }
 })


### PR DESCRIPTION
## Why

`EasterEggDeckInjector` slips name-based joke cards (`Sekshaas, Early Sleeper` for players named Rick) into decks. It ran **unconditionally** in every deck-building path, so it was live in production games.

It had no config gate at all — git history shows `4a31eb85e1` adding it and `a54de49daa` widening it into the quick-game paths, and nothing ever disabling it. Any earlier disable must have been made server-side, which is why a deploy brought it back.

## What

Adds `game.easter-eggs.enabled` (`GAME_EASTER_EGGS_ENABLED`), **defaulting to `false`**.

- `GameProperties` — new `EasterEggProperties(enabled = false)`.
- `EasterEggDeckInjector.maybeInjectEasterEggs` — takes `enabled` and returns the deck untouched when false.
- All 6 call sites (`GamePlayHandler` ×2, `LobbyHandler`, `QuickGameLobbyHandler`, `TournamentMatchHandler` ×2, `FreeForAllHandler`) pass `gameProperties.easterEggs.enabled`. Every one of these handlers already injected `GameProperties`, so no wiring changed.
- `application.yml` — `enabled: ${GAME_EASTER_EGGS_ENABLED:false}`.
- `.env.example` — documents the local opt-in (`.env` is gitignored).

## Notes for review

Two deliberate choices:

- **`enabled` is a required parameter, not defaulted.** A default would let a missed call site compile and silently keep injecting; this way the compiler enumerates them.
- **`docker-compose.yml` is untouched on purpose.** It does not forward `GAME_EASTER_EGGS_ENABLED` to the backend, so production gets the `false` default. Nothing needs setting on the server, and a redeploy can't undo it. A test pins the default to `false`, since that default is the entire mechanism keeping production clean — flipping it should fail the build rather than ship.

## Testing

`just test-server` green. `EasterEggDeckInjectorTest` — 8/8 pass, including a new case for the kill switch and one for the property default.

Production is unaffected until this merges and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)