### PR TITLE
Fix the inline help `?` losing its layout beside a settings label

### DIFF
--- a/web-client/src/components/help/HelpTip.tsx
+++ b/web-client/src/components/help/HelpTip.tsx
@@ -89,7 +89,7 @@ export function HelpTip({
         className={`${styles.tipButton} ${size === 'sm' ? styles.tipButtonSm : ''} ${open ? styles.tipButtonOpen : ''}`}
         onClick={(e) => { e.preventDefault(); e.stopPropagation(); setOpen((v) => !v) }}
       >
-        ?
+        <span className={styles.tipGlyph} aria-hidden="true">?</span>
       </button>
       {open && pos && createPortal(
         <div

--- a/web-client/src/components/help/help.module.css
+++ b/web-client/src/components/help/help.module.css
@@ -6,6 +6,10 @@
 /* =========================================================================
  * HelpTip button + popover
  * ========================================================================= */
+/* A quiet affordance: it annotates a label or sits on top of card art, so at rest it should read as
+   punctuation, not as a second button competing with the control it explains. The disc is tinted
+   *dark* rather than white — a translucent white fill turns muddy over bright artwork (the lobby
+   header sits on set art), while a dark one keeps its edge on every background. */
 .tipButton {
   flex-shrink: 0;
   display: inline-flex;
@@ -15,28 +19,44 @@
   height: 16px;
   padding: 0;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(8, 10, 16, 0.42);
+  color: var(--text-tertiary);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
   line-height: 1;
   cursor: pointer;
+  -webkit-font-smoothing: antialiased;
   transition: color var(--transition-fast), border-color var(--transition-fast),
-    background var(--transition-fast);
+    background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .tipButtonSm {
-  width: 13px;
-  height: 13px;
-  font-size: 9px;
+  width: 14px;
+  height: 14px;
+  font-size: 10px;
+}
+
+/* `?` carries more sidebearing on its right and no descender, so a geometrically centred glyph
+   looks pushed down-left inside the disc. One shared nudge, applied at both sizes. */
+.tipGlyph {
+  display: block;
+  transform: translate(0.5px, -0.5px);
 }
 
 .tipButton:hover,
 .tipButtonOpen {
   color: var(--text-primary);
   border-color: var(--color-accent, #4fc3f7);
-  background: rgba(79, 195, 247, 0.16);
+  background: rgba(79, 195, 247, 0.18);
+}
+
+.tipButton:focus-visible {
+  outline: none;
+  color: var(--text-primary);
+  border-color: var(--color-accent, #4fc3f7);
+  box-shadow: 0 0 0 2px rgba(79, 195, 247, 0.35);
 }
 
 .tipPopover {

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1118,6 +1118,15 @@
   font-size: var(--font-sm);
 }
 
+/* The label plus its inline `?`. Without this the tip is a bare inline-flex button in a text run:
+   no gap, and baseline-aligned rather than centred on the label's cap height, so it reads as a
+   glyph that collided with the word. */
+.settingsLabelWithHelp {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 /* The AI seat's deck picker, a sibling of the settings panel rather than a row inside it — the
    panel scrolls and so does the picker, and one control should not sit under two scroll contexts.
    Two visually identical pickers end up on screen (the AI's and your own), so the header is what


### PR DESCRIPTION
The lobby's `?` affordances looked unpolished — the one beside **Ranked** was glued to the word and sitting low.

That turned out to be a real bug rather than taste: `SettingsLabel` reached for `styles.settingsLabelWithHelp`, a class that was **never defined** in `GameUI.module.css`. The className resolved to `undefined`, so the tip rendered as a bare inline-flex button inside a text run — no gap, and baseline-aligned instead of centred on the label's cap height.

### Before / after

Same lobby row, same viewport (top = before, bottom = after):

![Ranked label before and after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-tip-polish-screenshots/ranked-compare.png)

The full lobby with the fix in place — settings rows and the axis chips above them now read consistently:

![Lobby with the fixed help tips](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-tip-polish-screenshots/lobby-after-v2.png)

### What changed

- **`GameUI.module.css`** — added the missing `.settingsLabelWithHelp` (inline-flex, centred, 6px gap). This is the actual fix.
- **`help.module.css`** — polish on the shared tip button, so every `?` benefits (lobby settings, axis chips, Play wizard cards, opponent rail):
  - disc tinted **dark** rather than translucent white — a white fill goes muddy over the lobby's set art, which is exactly where these sit;
  - 14px with a 10px glyph at weight 600 (was 13/9 at 700), colour `--text-tertiary` — legible instead of a cramped smudge;
  - added a `:focus-visible` ring; it was keyboard-reachable with no visible focus state.
- **`HelpTip.tsx`** — glyph wrapped in a span nudged half a pixel up-and-right. `?` carries more sidebearing on its right and has no descender, so geometric centring reads as down-left inside a circle. Accessible name is unchanged (`aria-label` on the button, glyph `aria-hidden`).

### Verification

Ran the game server + vite and drove the Play wizard into a real 1v1 lobby to capture the shots above; also checked the axis chips and wizard preset cards for regressions. `npm run typecheck` passes.

The `help-tip-polish-screenshots` branch is a throwaway image host, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
