### PR TITLE
SPM: Mister Negative, Carnage, Behold the Sinister SixSpider-Verse (+ life-exchange / different-names / legend-rule primitives)

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 175 / 188
+**Implemented:** 176 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -145,7 +145,7 @@
 - [x] Spider-Slayer, Hatred Honed
 - [x] Spider-Suit
 - [x] Spider-UK
-- [ ] Spider-Verse
+- [x] Spider-Verse
 - [x] Spider-Woman, Stunning Savior
 - [x] Spiders-Man, Heroic Horde
 - [x] Spinneret and Spiderling

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 178 / 188
+**Implemented:** 179 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -71,7 +71,7 @@
 - [x] Mechanical Mobster
 - [x] Merciless Enforcers
 - [x] Miles Morales // Ultimate Spider-Man
-- [ ] Mister Negative
+- [x] Mister Negative
 - [x] Mob Lookout
 - [x] Molten Man, Inferno Incarnate
 - [x] Morbius the Living Vampire

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 176 / 188
+**Implemented:** 177 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -13,7 +13,7 @@
 - [x] Aunt May
 - [x] Bagel and Schmear
 - [x] Beetle, Legacy Criminal
-- [ ] Behold the Sinister Six!
+- [x] Behold the Sinister Six!
 - [x] Biorganic Carapace
 - [ ] Black Cat, Cunning Thief
 - [ ] Carnage, Crimson Chaos

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 177 / 188
+**Implemented:** 178 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -16,7 +16,7 @@
 - [x] Behold the Sinister Six!
 - [x] Biorganic Carapace
 - [ ] Black Cat, Cunning Thief
-- [ ] Carnage, Crimson Chaos
+- [x] Carnage, Crimson Chaos
 - [x] Chameleon, Master of Disguise
 - [x] Cheering Crowd
 - [x] City Pigeon

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -415,7 +415,15 @@ Blocked cards:
 - **With Great Power . . .** [24] — `{3}{W}` Aura; "+2/+2 per attached Aura/Equipment" (fine) + "all damage that would be dealt to you is dealt to enchanted creature instead" (the redirect is the blocker).
 </details>
 
-## "The legend rule doesn't apply to [filter]" exemption
+## "The legend rule doesn't apply to [filter]" exemption — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-keywords-statics`. Added `LegendRuleDoesNotApplyTo(filter)` StaticAbility
+(scan-based) + a consult hook in `LegendRuleCheck.check` (`isExemptFromLegendRule` — excludes matching
+permanents from the duplicate grouping; the check now takes a `CardRegistry`). Card: **Spider-Verse** [93]
+(the copy-spell-from-non-hand clause uses `youCastSpell(CastFromZoneOtherThan(HAND))` + `oncePerTurn` +
+`CopyTargetSpell(addedTokenKeywords = HASTE)`, wrapped in `MayEffect`).
+
+<details><summary>Original analysis</summary>
 
 > The "legend rule" doesn't apply to **Spiders you control**.
 
@@ -429,6 +437,7 @@ fully expressible via `youCastSpell(CastFromZoneOtherThan(HAND))` + `oncePerTurn
 
 Blocked cards:
 - **Spider-Verse** [93] — `{3}{R}{R}` Enchantment; the legend-rule exemption for Spiders is the blocker (the copy-spell-from-non-hand clause is fine).
+</details>
 
 ## Play cards exiled **face down** from an opponent's library (controller may look + cast)
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -207,7 +207,16 @@ for lifelink/triggers) + a way to feed the controller's life-lost delta into `Dr
 Blocked cards:
 - **Mister Negative** [135] — `{5}{W}{B}` Vigilance/lifelink; "you may exchange life totals with target opponent. If you lost life this way, draw that many cards." (Vigilance + lifelink are fine; the ETB exchange is blocked.)
 
-## "Different names" multi-target distinctness constraint
+## "Different names" multi-target distinctness constraint — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-target-constraints`. Added a `differentNames: Boolean` field to
+`TargetObject`, enforced cross-target by `TargetValidator` (authoritative) and `DecisionValidators`
+(interactive, via a new `TargetRequirementInfo.differentNames` propagated at the target-decision build
+sites) — grouping chosen targets by projected name (battlefield) / base card name (other zones). Card:
+**Behold the Sinister Six!** [51] (`TargetObject(count = 6, optional = true, differentNames = true)` +
+`ForEachTargetEffect(PutOntoBattlefield)`).
+
+<details><summary>Original analysis</summary>
 
 > Return up to six **target creature cards with different names** from your graveyard to the
 > battlefield.
@@ -222,6 +231,7 @@ reference + `CardLinter`).
 
 Blocked cards:
 - **Behold the Sinister Six!** [51] — `{6}{B}` Sorcery; "Return up to six target creature cards with different names from your graveyard to the battlefield." Dropping the constraint would wrongly allow six copies of the same-named creature, so it is not approximated.
+</details>
 
 ## Color-filtered permanent "don't lose unspent [color] mana" static — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -92,10 +92,10 @@ Implemented cards (9): **Swarm, Being of Bees** [69] · **Spider-Islanders** [91
 **Rocket-Powered Goblin Glider** [172] (ETB attach gated on `WasCastFromGraveyard`).
 
 Still blocked (not on Mayhem itself):
-- **Carnage, Crimson Chaos** [125] — `{2}{B}{R}` Trample + Mayhem `{B}{R}` work; the ETB "reanimate a creature card
-  with mv ≤ 3, **it gains 'attacks each combat if able' and 'when it deals combat damage to a player, sacrifice it'**"
-  needs a persistent **grant-abilities-to-a-reanimated-target** effect (no clean facade to durably grant a
-  must-attack static + a combat-damage sacrifice trigger to a chosen target). Deferred rather than approximated.
+- **Carnage, Crimson Chaos** [125] — ✅ **IMPLEMENTED** on branch `spm-grant-reanimate`. The persistent
+  grant-abilities-to-a-reanimated-target was expressible after all: `GrantStaticAbilityEffect(MustAttack())`
+  + `GrantTriggeredAbilityEffect(TriggeredAbility.create(DealsCombatDamageToPlayer → SacrificeSelfEffect))`,
+  both `Duration.Permanent`, keyed to the reanimated `Effects.Move(...fromZone = GRAVEYARD)` target.
 - **Oscorp Industries** [182] — ✅ **IMPLEMENTED** on branch `spm-land-plays`. The no-cost 702.187c form is a
   land-play from graveyard: `PlayLandEnumerator` now offers a discarded-this-turn Mayhem land as a `PlayLand`
   action and `PlayLandHandler` allows it (both gated on `MayhemGrants.effectiveMayhem`, via `mayhem("")`). Its

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -190,7 +190,16 @@ event filters (e.g. `DealsDamageEvent.sourceFilter`), + verify the delayed match
 Blocked cards:
 - **The Clone Saga** [28] — `{3}{U}` Enchantment — Saga; chapters I (Surveil 3) and II (copy your next creature spell, non-legendary — both expressible today) are fine, but chapter III ("choose a card name … whenever a creature with the chosen name deals combat damage, draw") is blocked
 
-## Exchange life totals with a player (CR 701.12c) + "life you lost this way" draw amount
+## Exchange life totals with a player (CR 701.12c) + "life you lost this way" draw amount — ✅ IMPLEMENTED
+
+**Implemented** on branch `spm-life-exchange`. Added `ExchangeLifeTotalsEffect(target, drawEqualToLifeLost)`
++ `ExchangeLifeTotalsExecutor` — reads both totals before any change (simultaneous swap, CR 701.12c),
+emits gain/loss `LifeChangedEvent`s for both players (for lifelink/triggers), marks life gained/lost, and —
+because the draw amount is the controller's life-loss delta that no `DynamicAmount` exposes — draws that
+many cards itself (via `DrawCardPrimitive`, `cardRegistry` threaded through `LifeExecutors`). Card:
+**Mister Negative** [135] (`MayEffect(Effects.ExchangeLifeTotals(drawEqualToLifeLost = true))`).
+
+<details><summary>Original analysis</summary>
 
 > You may **exchange life totals** with target opponent. If you lost life this way, draw that
 > many cards.
@@ -206,6 +215,7 @@ for lifelink/triggers) + a way to feed the controller's life-lost delta into `Dr
 
 Blocked cards:
 - **Mister Negative** [135] — `{5}{W}{B}` Vigilance/lifelink; "you may exchange life totals with target opponent. If you lost life this way, draw that many cards." (Vigilance + lifelink are fine; the ETB exchange is blocked.)
+</details>
 
 ## "Different names" multi-target distinctness constraint — ✅ IMPLEMENTED
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2600,6 +2600,12 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   TargetFilter(GameObjectFilter.Creature.ownedByTriggeringPlayer(), zone = Zone.GRAVEYARD),
   totalManaValueAtMost = DynamicAmount.XValue)` — **Fire Lord Sozin** (back face of The Rise of Sozin),
   reanimating post-payment via a `MayPayXForEffect(ReflexiveTriggerEffect(...))`.
+- `differentNames = false` — on `TargetObject`; when `true` and more than one target is chosen, no two
+  chosen targets may share a **name** ("**up to six target creature cards with different names**" —
+  Behold the Sinister Six!). Enforced cross-target by `TargetValidator` (authoritative) and, on the
+  interactive target decision, `DecisionValidators` (via `TargetRequirementInfo.differentNames`),
+  grouping by projected name (battlefield) / base card name (other zones). E.g.
+  `TargetObject(count = 6, optional = true, filter = TargetFilter.CreatureInYourGraveyard, differentNames = true)`.
 - `chooser = TargetChooser.Controller` — **who selects this requirement's target(s)**. Set to
   `TargetChooser.Opponent` for "**… of an opponent's choice**" wording (Cuombajj Witches). The chosen
   target is still a real target of *your* spell/ability — announced together with your own targets,

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -633,9 +633,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `SetLifeTotal(amount, target)` — set target's life total to N.
 - `ExchangeLifeAndPower(target)` — swap target's power with controller's life total.
 - `ExchangeLifeTotals(target, drawEqualToLifeLost)` — swap the controller's life total with `target`
-  player's (CR 701.12c, simultaneous; emits gain/loss events for lifelink/triggers). With
-  `drawEqualToLifeLost = true`, the controller then draws a card for each point of life they **lost** in
-  the swap (Mister Negative). Wrap the whole thing in `MayEffect` for "you may exchange".
+  player's (CR 701.12c): each player gains/loses the life needed to reach the other's former total,
+  applied through the shared gain/lose-life primitives so gain prevention/replacements and loss
+  modification apply and gain/loss triggers fire. With `drawEqualToLifeLost = true`, the controller
+  then draws a card for each point of life they **actually lost** in the swap (Mister Negative). Wrap
+  the whole thing in `MayEffect` for "you may exchange".
 - `LoseHalfLife(roundUp, target, lifePlayer?)` — lose half of life total (round up/down).
 - `LockLifeGain(target?, duration?)` — "target player can't gain life" for `duration` (default
   `Duration.Permanent` = rest of the game; `EndOfTurn` / `UntilYourNextTurn` also honored). A one-shot

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4780,6 +4780,9 @@ staticAbility {
   *replaces* other colours with red, this simply keeps that one colour and lets every other colour empty.
   Merged into the `retain` set at `CleanupPhaseManager.emptyManaPools` (control-aware). The static twin of
   the turn-scoped one-shot `RetainUnspentMana(vararg colors)` effect (The Last Agni Kai).
+- `LegendRuleDoesNotApplyTo(filter)` — "The 'legend rule' doesn't apply to [filter] you control"
+  (Spider-Verse — Spiders). Scan-based: `LegendRuleCheck` excludes permanents you control matching
+  `filter` from the same-name duplicate grouping, so you may keep multiple copies (CR 704.5j).
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -632,6 +632,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   is worded "equal to the life lost this way".
 - `SetLifeTotal(amount, target)` — set target's life total to N.
 - `ExchangeLifeAndPower(target)` — swap target's power with controller's life total.
+- `ExchangeLifeTotals(target, drawEqualToLifeLost)` — swap the controller's life total with `target`
+  player's (CR 701.12c, simultaneous; emits gain/loss events for lifelink/triggers). With
+  `drawEqualToLifeLost = true`, the controller then draws a card for each point of life they **lost** in
+  the swap (Mister Negative). Wrap the whole thing in `MayEffect` for "you may exchange".
 - `LoseHalfLife(roundUp, target, lifePlayer?)` — lose half of life total (round up/down).
 - `LockLifeGain(target?, duration?)` — "target player can't gain life" for `duration` (default
   `Duration.Permanent` = rest of the game; `EndOfTurn` / `UntilYourNextTurn` also honored). A one-shot

--- a/manual-scenarios/sets/spm/spm-life-exchange.json
+++ b/manual-scenarios/sets/spm/spm-life-exchange.json
@@ -1,0 +1,73 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Spider-Ham, Peter Porker",
+      "Spider-Verse",
+      "Behold the Sinister Six!",
+      "Carnage, Crimson Chaos",
+      "Mister Negative"
+    ],
+    "battlefield": [
+      {"name": "Spider-Ham, Peter Porker"},
+      {"name": "Jalum Tome"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [
+      "Grizzly Bears",
+      "Gorilla Warrior",
+      "Gorilla Warrior",
+      "Canyon Wildcat",
+      "Coral Eel",
+      "Bog Imp",
+      "Raging Goblin"
+    ],
+    "library": ["Island", "Island", "Island", "Island", "Island", "Island", "Island", "Island", "Mountain", "Swamp", "Plains", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Swamp", "Mountain", "Island", "Plains", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -451,6 +451,16 @@ object Effects {
         ExchangeLifeAndPowerEffect(target)
 
     /**
+     * Exchange the controller's life total with [target] player's (CR 701.12c). When
+     * [drawEqualToLifeLost] is true, the controller then draws a card for each point of life they
+     * lost in the exchange (Mister Negative).
+     */
+    fun ExchangeLifeTotals(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        drawEqualToLifeLost: Boolean = false
+    ): Effect = com.wingedsheep.sdk.scripting.effects.ExchangeLifeTotalsEffect(target, drawEqualToLifeLost)
+
+    /**
      * Lose half your life, rounded up.
      * Composes as LoseLifeEffect with Divide(LifeTotal, 2).
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -815,6 +815,20 @@ data class RetainUnspentColoredMana(val color: Color) : StaticAbility {
 }
 
 /**
+ * The "legend rule" (CR 704.5j) doesn't apply to permanents matching [filter] that the controller
+ * of this permanent controls (Spider-Verse: "The 'legend rule' doesn't apply to Spiders you
+ * control"). Such permanents are excluded from the legend-rule duplicate grouping in
+ * `LegendRuleCheck`, so the controller may keep multiple same-named copies.
+ */
+@SerialName("LegendRuleDoesNotApplyTo")
+@Serializable
+data class LegendRuleDoesNotApplyTo(
+    val filter: GameObjectFilter
+) : StaticAbility {
+    override val description: String = "The \"legend rule\" doesn't apply to ${filter.description} you control"
+}
+
+/**
  * Removes the maximum hand size limit for the controller.
  * Used for cards like Thought Vessel and Reliquary Tower: "You have no maximum hand size."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
@@ -185,3 +185,26 @@ data class ExchangeLifeAndPowerEffect(
 ) : Effect {
     override val description: String = "Exchange your life total with ${target.description}'s power"
 }
+
+/**
+ * Exchange the controller's life total with [target] player's (CR 701.12c — a simultaneous swap:
+ * each becomes the other's former total). Emits gain/loss `LifeChangedEvent`s for both players so
+ * lifelink / life-change triggers see them, and marks life gained/lost this turn.
+ *
+ * When [drawEqualToLifeLost] is true, the controller then draws a card for each point of life they
+ * **lost** in the exchange (their former total minus their new total, when positive) — Mister
+ * Negative's "If you lost life this way, draw that many cards." Modelled as one self-contained
+ * effect because the draw amount is the controller's life-loss delta, which no `DynamicAmount`
+ * otherwise exposes.
+ */
+@SerialName("ExchangeLifeTotals")
+@Serializable
+data class ExchangeLifeTotalsEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0),
+    val drawEqualToLifeLost: Boolean = false
+) : Effect {
+    override val description: String = buildString {
+        append("Exchange life totals with ${target.description}")
+        if (drawEqualToLifeLost) append(". If you lost life this way, draw that many cards")
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
@@ -187,9 +187,10 @@ data class ExchangeLifeAndPowerEffect(
 }
 
 /**
- * Exchange the controller's life total with [target] player's (CR 701.12c — a simultaneous swap:
- * each becomes the other's former total). Emits gain/loss `LifeChangedEvent`s for both players so
- * lifelink / life-change triggers see them, and marks life gained/lost this turn.
+ * Exchange the controller's life total with [target] player's (CR 701.12c): each player gains or
+ * loses the life needed to reach the other's former total. Applied through the shared gain/lose-life
+ * primitives, so life-gain prevention/replacements and life-loss modification apply, and both
+ * players' `LifeChangedEvent`s fire for "whenever you gain/lose life" triggers.
  *
  * When [drawEqualToLifeLost] is true, the controller then draws a card for each point of life they
  * **lost** in the exchange (their former total minus their new total, when positive) — Mister

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -395,7 +395,15 @@ data class TargetObject(
      * mana value N or less" shape. `null` (the default) imposes no aggregate cap. Distinct from
      * `dynamicMaxCount`, which caps the *count* of targets, not their summed mana value.
      */
-    val totalManaValueAtMost: DynamicAmount? = null
+    val totalManaValueAtMost: DynamicAmount? = null,
+    /**
+     * When true and more than one target is chosen for this requirement, every chosen target must
+     * have a **different name** from the others — "up to six target creature cards with different
+     * names" (Behold the Sinister Six!). Enforced cross-target by `TargetValidator` (authoritative)
+     * and the interactive `DecisionValidators`, grouping by each target's *projected* card name; a
+     * no-op for single-target requirements. Defaults to false.
+     */
+    val differentNames: Boolean = false
 ) : TargetRequirement {
     override val description: String = run {
         val base = if (id != null) {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/BeholdTheSinisterSix.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/BeholdTheSinisterSix.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Behold the Sinister Six! — Marvel's Spider-Man #51
+ * {6}{B} · Sorcery
+ *
+ * Return up to six target creature cards with different names from your graveyard to the
+ * battlefield.
+ *
+ * Uses the new `TargetObject.differentNames` cross-target constraint (enforced by `TargetValidator`
+ * / `DecisionValidators`), so the six chosen cards can't include duplicates of the same name.
+ */
+val BeholdTheSinisterSix = card("Behold the Sinister Six!") {
+    manaCost = "{6}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return up to six target creature cards with different names from your graveyard " +
+        "to the battlefield."
+
+    spell {
+        target = TargetObject(
+            count = 6,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard,
+            differentNames = true,
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.PutOntoBattlefield(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Nathaniel Himawan"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1919bfec-1906-4178-ad32-d4589842e563.jpg?1783905348"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CarnageCrimsonChaos.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CarnageCrimsonChaos.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.mayhem
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.MustAttack
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantStaticAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Carnage, Crimson Chaos — Marvel's Spider-Man #125
+ * {2}{B}{R} · Legendary Creature — Symbiote Villain · 4/3
+ *
+ * Trample
+ * When Carnage enters, return target creature card with mana value 3 or less from your graveyard
+ * to the battlefield. It gains "This creature attacks each combat if able" and "When this creature
+ * deals combat damage to a player, sacrifice it."
+ * Mayhem {B}{R}
+ *
+ * The two granted abilities use `GrantStaticAbilityEffect(MustAttack())` and
+ * `GrantTriggeredAbilityEffect(... SacrificeSelfEffect)` with `Duration.Permanent`, keyed to the
+ * reanimated creature.
+ */
+val CarnageCrimsonChaos = card("Carnage, Crimson Chaos") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Symbiote Villain"
+    power = 4
+    toughness = 3
+    oracleText = "Trample\n" +
+        "When Carnage enters, return target creature card with mana value 3 or less from your " +
+        "graveyard to the battlefield. It gains \"This creature attacks each combat if able\" and " +
+        "\"When this creature deals combat damage to a player, sacrifice it.\"\n" +
+        "Mayhem {B}{R} (You may cast this card from your graveyard for {B}{R} if you discarded it " +
+        "this turn. Timing rules still apply.)"
+
+    keywords(Keyword.TRAMPLE)
+    mayhem("{B}{R}")
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "target creature card",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3))
+        )
+        effect = Effects.Composite(
+            Effects.Move(creature, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
+            GrantStaticAbilityEffect(MustAttack(), creature, Duration.Permanent),
+            GrantTriggeredAbilityEffect(
+                ability = TriggeredAbility.create(
+                    trigger = Triggers.DealsCombatDamageToPlayer.event,
+                    binding = Triggers.DealsCombatDamageToPlayer.binding,
+                    effect = SacrificeSelfEffect
+                ),
+                target = creature,
+                duration = Duration.Permanent
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Lordigan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/930befba-6068-493e-baa2-e9371cd99e93.jpg?1783905319"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/MisterNegative.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/MisterNegative.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Mister Negative — Marvel's Spider-Man #135
+ * {5}{W}{B} · Legendary Creature — Human Villain · 5/5
+ *
+ * Vigilance, lifelink
+ * Darkforce Inversion — When Mister Negative enters, you may exchange life totals with target
+ * opponent. If you lost life this way, draw that many cards.
+ *
+ * The exchange uses the new `Effects.ExchangeLifeTotals(drawEqualToLifeLost = true)` (CR 701.12c).
+ */
+val MisterNegative = card("Mister Negative") {
+    manaCost = "{5}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Villain"
+    power = 5
+    toughness = 5
+    oracleText = "Vigilance, lifelink\n" +
+        "Darkforce Inversion — When Mister Negative enters, you may exchange life totals with " +
+        "target opponent. If you lost life this way, draw that many cards."
+
+    keywords(Keyword.VIGILANCE, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = MayEffect(
+            effect = Effects.ExchangeLifeTotals(target = opponent, drawEqualToLifeLost = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "135"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c9cb13d-55ff-4e26-aa49-755f8bcebc11.jpg?1783905315"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderVerse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderVerse.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LegendRuleDoesNotApplyTo
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spider-Verse — Marvel's Spider-Man #93
+ * {3}{R}{R} · Enchantment
+ *
+ * The "legend rule" doesn't apply to Spiders you control.
+ * Whenever you cast a spell from anywhere other than your hand, you may copy it. If you do, you
+ * may choose new targets for the copy. If the copy is a permanent spell, it gains haste. Do this
+ * only once each turn.
+ *
+ * The legend-rule exemption uses the new `LegendRuleDoesNotApplyTo(filter)` static.
+ */
+val SpiderVerse = card("Spider-Verse") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "The \"legend rule\" doesn't apply to Spiders you control.\n" +
+        "Whenever you cast a spell from anywhere other than your hand, you may copy it. If you do, " +
+        "you may choose new targets for the copy. If the copy is a permanent spell, it gains haste. " +
+        "Do this only once each turn."
+
+    // The "legend rule" doesn't apply to Spiders you control.
+    staticAbility {
+        ability = LegendRuleDoesNotApplyTo(GameObjectFilter.Creature.withAnySubtype("Spider"))
+    }
+
+    // Whenever you cast a spell from a non-hand zone, you may copy it (once each turn); a permanent
+    // copy gains haste.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            requires = setOf(SpellCastPredicate.CastFromZoneOtherThan(Zone.HAND))
+        )
+        oncePerTurn = true
+        effect = MayEffect(
+            effect = Effects.CopyTargetSpell(
+                target = EffectTarget.TriggeringEntity,
+                addedTokenKeywords = setOf(Keyword.HASTE)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "93"
+        artist = "Alexander Gering"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8779eb2-1210-430d-8d42-3077053441ee.jpg?1783905331"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -806,6 +806,97 @@
     ]
 }
 
+// Carnage, Crimson Chaos
+{
+    "name": "Carnage, Crimson Chaos",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Legendary Creature — Symbiote Villain",
+    "oracleText": "Trample\nWhen Carnage enters, return target creature card with mana value 3 or less from your graveyard to the battlefield. It gains \"This creature attacks each combat if able\" and \"When this creature deals combat damage to a player, sacrifice it.\"\nMayhem {B}{R} (You may cast this card from your graveyard for {B}{R} if you discarded it this turn. Timing rules still apply.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE",
+        "MAYHEM"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Mayhem",
+            "cost": "{B}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "GrantStaticAbility",
+                            "ability": "MustAttack",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "GrantTriggeredAbility",
+                            "ability": {
+                                "id": "ability_2",
+                                "trigger": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat",
+                                    "recipient": "AnyPlayer"
+                                },
+                                "effect": "SacrificeSelf"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "RARE",
+        "artist": "Lordigan",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/930befba-6068-493e-baa2-e9371cd99e93.jpg?1783905319"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Chameleon, Master of Disguise
 {
     "name": "Chameleon, Master of Disguise",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -4918,6 +4918,59 @@
     ]
 }
 
+// Mister Negative
+{
+    "name": "Mister Negative",
+    "manaCost": "{5}{W}{B}",
+    "typeLine": "Legendary Creature — Human Villain",
+    "oracleText": "Vigilance, lifelink\nDarkforce Inversion — When Mister Negative enters, you may exchange life totals with target opponent. If you lost life this way, draw that many cards.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExchangeLifeTotals",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target opponent"
+                        },
+                        "drawEqualToLifeLost": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "MYTHIC",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c9cb13d-55ff-4e26-aa49-755f8bcebc11.jpg?1783905315"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Mob Lookout
 {
     "name": "Mob Lookout",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -655,6 +655,49 @@
     ]
 }
 
+// Behold the Sinister Six!
+{
+    "name": "Behold the Sinister Six!",
+    "manaCost": "{6}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to six target creature cards with different names from your graveyard to the battlefield.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Battlefield"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 6,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "differentNames": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Nathaniel Himawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1919bfec-1906-4178-ad32-d4589842e563.jpg?1783905348"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Biorganic Carapace
 {
     "name": "Biorganic Carapace",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -9811,6 +9811,58 @@
     ]
 }
 
+// Spider-Verse
+{
+    "name": "Spider-Verse",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "The \"legend rule\" doesn't apply to Spiders you control.\nWhenever you cast a spell from anywhere other than your hand, you may copy it. If you do, you may choose new targets for the copy. If the copy is a permanent spell, it gains haste. Do this only once each turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellCastFromZoneOtherThan",
+                            "zone": "Hand"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity",
+                        "addedTokenKeywords": [
+                            "HASTE"
+                        ]
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "LegendRuleDoesNotApplyTo",
+                "filter": "creature Spider"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "MYTHIC",
+        "artist": "Alexander Gering",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8779eb2-1210-430d-8d42-3077053441ee.jpg?1783905331"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Spider-Woman, Stunning Savior
 {
     "name": "Spider-Woman, Stunning Savior",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -129,7 +129,13 @@ data class TargetRequirementInfo(
      * [DecisionValidators.validateTargets] rejects a selection whose summed `manaValue` exceeds it.
      * `null` imposes no aggregate cap.
      */
-    val totalManaValueAtMost: Int? = null
+    val totalManaValueAtMost: Int? = null,
+    /**
+     * When true, no two chosen targets for this requirement may share a name — "target creature
+     * cards with different names" (Behold the Sinister Six!). Enforced against each selected
+     * target's name in [DecisionValidators.validateTargets].
+     */
+    val differentNames: Boolean = false
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -643,7 +643,8 @@ class TriggerProcessor(
                 minTargets = effectiveMinTargets,
                 maxTargets = maxTargets,
                 sameOwner = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.sameOwner == true,
-                totalManaValueAtMost = resolveTotalManaValueAtMost(state, trigger, req)
+                totalManaValueAtMost = resolveTotalManaValueAtMost(state, trigger, req),
+                differentNames = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.differentNames == true
             )
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -224,6 +224,16 @@ object DecisionValidators {
                         return "Targets for requirement $reqIndex exceed total mana value $manaCap"
                     }
                 }
+                // "... with different names" — no two chosen targets may share a name (Behold the
+                // Sinister Six!). TargetValidator is authoritative; this rejects it interactively too.
+                if (req.differentNames && selectedIds.size > 1 && state != null) {
+                    val names = selectedIds.map { id ->
+                        state.projectedState.getName(id) ?: state.getEntity(id)?.get<CardComponent>()?.name
+                    }
+                    if (names.size != names.toSet().size) {
+                        return "Targets for requirement $reqIndex must have different names"
+                    }
+                }
             }
         }
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EffectExecutorRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EffectExecutorRegistry.kt
@@ -67,7 +67,7 @@ class EffectExecutorRegistry(
 
     init {
         // Register all effect executors by module
-        registerModule(LifeExecutors(amountEvaluator))
+        registerModule(LifeExecutors(amountEvaluator, cardRegistry))
         registerModule(DamageExecutors(amountEvaluator, decisionHandler))
         // Wire the recursion (for ModifyExplore's Composite delegation) before registering, so the
         // ref is read lazily at explore time (order is not load-bearing — see libraryExecutors).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeTotalsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeTotalsExecutor.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.handlers.effects.life
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.core.LifeChangedEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.drawing.DrawCardPrimitive
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.scripting.effects.ExchangeLifeTotalsEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ExchangeLifeTotalsEffect] — swaps the controller's life total with the target
+ * player's (CR 701.12c, simultaneous: each becomes the other's former total). Emits gain/loss
+ * [LifeChangedEvent]s for both players and marks life gained/lost this turn. When
+ * [ExchangeLifeTotalsEffect.drawEqualToLifeLost], the controller then draws a card for each point of
+ * life they lost (Mister Negative).
+ */
+class ExchangeLifeTotalsExecutor(
+    private val cardRegistry: com.wingedsheep.engine.registry.CardRegistry
+) : EffectExecutor<ExchangeLifeTotalsEffect> {
+
+    private val drawPrimitive = DrawCardPrimitive(cardRegistry)
+
+    override val effectType: KClass<ExchangeLifeTotalsEffect> = ExchangeLifeTotalsEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ExchangeLifeTotalsEffect,
+        context: EffectContext
+    ): EffectResult {
+        val controllerId = context.controllerId
+        val targetId = context.resolveTarget(effect.target, state) ?: return EffectResult.success(state)
+        if (controllerId == targetId) return EffectResult.success(state)
+        if (state.getEntity(controllerId)?.get<LifeTotalComponent>() == null) return EffectResult.success(state)
+        if (state.getEntity(targetId)?.get<LifeTotalComponent>() == null) return EffectResult.success(state)
+
+        // Read both totals before any change (simultaneous swap).
+        val myLife = state.lifeTotal(controllerId)
+        val theirLife = state.lifeTotal(targetId)
+        if (myLife == theirLife) return EffectResult.success(state) // no-op swap
+
+        val events = mutableListOf<EngineGameEvent>()
+        var newState = state
+        newState = newState.withLifeTotal(controllerId, theirLife)
+        newState = newState.withLifeTotal(targetId, myLife)
+
+        events.add(
+            LifeChangedEvent(
+                controllerId, myLife, theirLife,
+                if (theirLife > myLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
+            )
+        )
+        events.add(
+            LifeChangedEvent(
+                targetId, theirLife, myLife,
+                if (myLife > theirLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
+            )
+        )
+        if (theirLife > myLife) newState = DamageUtils.markLifeGainedThisTurn(newState, controllerId, theirLife - myLife)
+        if (theirLife < myLife) newState = DamageUtils.markLifeLostThisTurn(newState, controllerId)
+        if (myLife > theirLife) newState = DamageUtils.markLifeGainedThisTurn(newState, targetId, myLife - theirLife)
+        if (myLife < theirLife) newState = DamageUtils.markLifeLostThisTurn(newState, targetId)
+
+        // "If you lost life this way, draw that many cards."
+        if (effect.drawEqualToLifeLost && myLife > theirLife) {
+            repeat(myLife - theirLife) {
+                val result = drawPrimitive.drawOne(newState, controllerId)
+                newState = result.state
+                events.addAll(result.events)
+                if (result.failed) return@repeat
+            }
+        }
+
+        return EffectResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeTotalsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/ExchangeLifeTotalsExecutor.kt
@@ -3,22 +3,29 @@ package com.wingedsheep.engine.handlers.effects.life
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.core.LifeChangeReason
-import com.wingedsheep.engine.core.LifeChangedEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.drawing.DrawCardPrimitive
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ExchangeLifeTotalsEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for [ExchangeLifeTotalsEffect] — swaps the controller's life total with the target
- * player's (CR 701.12c, simultaneous: each becomes the other's former total). Emits gain/loss
- * [LifeChangedEvent]s for both players and marks life gained/lost this turn. When
- * [ExchangeLifeTotalsEffect.drawEqualToLifeLost], the controller then draws a card for each point of
- * life they lost (Mister Negative).
+ * Executor for [ExchangeLifeTotalsEffect] — each player gains or loses the amount of life needed to
+ * equal the other's previous total (CR 701.12c). Both deltas are computed from the pre-exchange
+ * snapshot, then applied through [DamageUtils.gainLife] / [DamageUtils.loseLife] so that life-gain
+ * prevention (CR 119.5 — a player who can't gain life keeps their total), life-gain replacements
+ * (CR 614 — Alhammarret's Archive), and life-loss modification (CR 119.3 — Bloodletter of Aclazotz)
+ * all apply, and both players' [com.wingedsheep.engine.core.LifeChangedEvent]s fire for
+ * gain/loss triggers.
+ *
+ * When [ExchangeLifeTotalsEffect.drawEqualToLifeLost], the controller then draws a card for each
+ * point of life they *actually* lost — measured from the post-exchange state, so a life-loss
+ * modifier is reflected and a can't-lose-life controller draws nothing (Mister Negative: "If you
+ * lost life this way, draw that many cards.").
  */
 class ExchangeLifeTotalsExecutor(
     private val cardRegistry: com.wingedsheep.engine.registry.CardRegistry
@@ -39,43 +46,56 @@ class ExchangeLifeTotalsExecutor(
         if (state.getEntity(controllerId)?.get<LifeTotalComponent>() == null) return EffectResult.success(state)
         if (state.getEntity(targetId)?.get<LifeTotalComponent>() == null) return EffectResult.success(state)
 
-        // Read both totals before any change (simultaneous swap).
+        // Read both totals before any change; both deltas are computed from this snapshot, so the
+        // two sides apply as one simultaneous swap regardless of order (CR 701.12c).
         val myLife = state.lifeTotal(controllerId)
         val theirLife = state.lifeTotal(targetId)
         if (myLife == theirLife) return EffectResult.success(state) // no-op swap
 
         val events = mutableListOf<EngineGameEvent>()
         var newState = state
-        newState = newState.withLifeTotal(controllerId, theirLife)
-        newState = newState.withLifeTotal(targetId, myLife)
+        // The controller moves toward the target's former total; the target toward the controller's.
+        newState = moveToTotal(newState, controllerId, from = myLife, to = theirLife, events)
+        newState = moveToTotal(newState, targetId, from = theirLife, to = myLife, events)
 
-        events.add(
-            LifeChangedEvent(
-                controllerId, myLife, theirLife,
-                if (theirLife > myLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
-            )
-        )
-        events.add(
-            LifeChangedEvent(
-                targetId, theirLife, myLife,
-                if (myLife > theirLife) LifeChangeReason.LIFE_GAIN else LifeChangeReason.LIFE_LOSS
-            )
-        )
-        if (theirLife > myLife) newState = DamageUtils.markLifeGainedThisTurn(newState, controllerId, theirLife - myLife)
-        if (theirLife < myLife) newState = DamageUtils.markLifeLostThisTurn(newState, controllerId)
-        if (myLife > theirLife) newState = DamageUtils.markLifeGainedThisTurn(newState, targetId, myLife - theirLife)
-        if (myLife < theirLife) newState = DamageUtils.markLifeLostThisTurn(newState, targetId)
-
-        // "If you lost life this way, draw that many cards."
-        if (effect.drawEqualToLifeLost && myLife > theirLife) {
-            repeat(myLife - theirLife) {
+        // "If you lost life this way, draw that many cards." Measure the controller's actual life
+        // loss post-exchange so any life-loss modifier is reflected.
+        if (effect.drawEqualToLifeLost) {
+            var remaining = myLife - newState.lifeTotal(controllerId)
+            while (remaining > 0) {
                 val result = drawPrimitive.drawOne(newState, controllerId)
                 newState = result.state
                 events.addAll(result.events)
-                if (result.failed) return@repeat
+                if (result.failed) break // empty library: the failed draw already lost the game
+                remaining--
             }
         }
 
         return EffectResult.success(newState, events)
+    }
+
+    /**
+     * Bring [playerId] from [from] to [to] by gaining or losing the difference through the shared
+     * life primitives (so prevention / replacement / modification all apply). Appends the emitted
+     * [com.wingedsheep.engine.core.LifeChangedEvent], if any, to [events].
+     */
+    private fun moveToTotal(
+        state: GameState,
+        playerId: EntityId,
+        from: Int,
+        to: Int,
+        events: MutableList<EngineGameEvent>
+    ): GameState {
+        val (newState, event) = when {
+            to > from -> DamageUtils.gainLife(state, playerId, to - from)
+            to < from -> DamageUtils.loseLife(
+                state, playerId, from - to,
+                reason = LifeChangeReason.LIFE_LOSS,
+                applyLifeLossModification = true,
+            )
+            else -> state to null
+        }
+        if (event != null) events.add(event)
+        return newState
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifeExecutors.kt
@@ -8,11 +8,13 @@ import com.wingedsheep.engine.handlers.effects.ExecutorModule
  * Module providing all life-related effect executors.
  */
 class LifeExecutors(
-    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator(),
+    private val cardRegistry: com.wingedsheep.engine.registry.CardRegistry
 ) : ExecutorModule {
     override fun executors(): List<EffectExecutor<*>> = listOf(
         DrainLifeExecutor(amountEvaluator),
         ExchangeLifeAndPowerExecutor(),
+        ExchangeLifeTotalsExecutor(cardRegistry),
         GainLifeExecutor(amountEvaluator),
         LoseLifeExecutor(amountEvaluator),
         OwnerGainsLifeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -29,6 +29,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AttackTax
 import com.wingedsheep.sdk.scripting.AttackerCountLimit
 import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
+import com.wingedsheep.sdk.scripting.MustAttack
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.PredicateContext
@@ -623,6 +624,21 @@ internal class AttackPhaseManager(
     }
 
     /**
+     * Whether [attackerId] is required to attack this combat by a "must attack" static — either the
+     * projected one (printed `MustAttack`: Valley Dasher, Grand Melee) or an entity-scoped
+     * `MustAttack` granted at runtime and stored in [GameState.grantedStaticAbilities] (Carnage's
+     * reanimated target: "attacks each combat if able"). Granted statics never reach projection, so
+     * they must be consulted here at the point of use, alongside the projected value.
+     */
+    private fun mustAttackThisCombat(state: GameState, attackerId: EntityId): Boolean {
+        if (state.projectedState.mustAttack(attackerId)) return true
+        return state.grantedStaticAbilities.any {
+            it.entityId == attackerId && it.ability is MustAttack &&
+                (it.ability as MustAttack).filter.scope is Scope.Self
+        }
+    }
+
+    /**
      * Validate projected "must attack" requirements (e.g., from Grand Melee).
      */
     private fun validateProjectedMustAttackRequirements(
@@ -631,10 +647,9 @@ internal class AttackPhaseManager(
         attackers: Map<EntityId, EntityId>
     ): String? {
         val validAttackers = getValidAttackers(state, attackingPlayer)
-        val projected = state.projectedState
 
         for (attackerId in validAttackers) {
-            if (!projected.mustAttack(attackerId)) continue
+            if (!mustAttackThisCombat(state, attackerId)) continue
 
             if (attackerId !in attackers.keys) {
                 val cardName = state.getEntity(attackerId)?.get<CardComponent>()?.name ?: "Creature"
@@ -670,7 +685,6 @@ internal class AttackPhaseManager(
      */
     fun getMandatoryAttackers(state: GameState, attackingPlayer: EntityId): List<EntityId> {
         val validAttackers = getValidAttackers(state, attackingPlayer)
-        val projected = state.projectedState
         val mandatory = mutableSetOf<EntityId>()
 
         // 1. MustAttackPlayerComponent (Taunt effect) — all valid attackers must attack
@@ -687,9 +701,10 @@ internal class AttackPhaseManager(
             }
         }
 
-        // 3. Projected mustAttack (static ability like Valley Dasher, Grand Melee)
+        // 3. Projected mustAttack (static ability like Valley Dasher, Grand Melee) or a granted
+        // entity-scoped MustAttack (Carnage's reanimated target), which never reaches projection.
         for (attackerId in validAttackers) {
-            if (projected.mustAttack(attackerId)) {
+            if (mustAttackThisCombat(state, attackerId)) {
                 mandatory.add(attackerId)
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -915,6 +915,7 @@ class StaticAbilityHandler(
             is PreventManaPoolEmptying,
             is ConvertEmptyingManaToRed,
             is RetainUnspentColoredMana,
+            is com.wingedsheep.sdk.scripting.LegendRuleDoesNotApplyTo,
             is UntapDuringOtherUntapSteps,
             is UntapFilteredDuringOtherUntapSteps,
             is UntapSelfDuringOtherUntapSteps,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/LegendRuleCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/LegendRuleCheck.kt
@@ -4,23 +4,55 @@ import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.LegendRuleContinuation
 import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.LegendRuleDoesNotApplyTo
 
 /**
  * 704.5j - Legend rule: If a player controls two or more legendary permanents
  * with the same name, that player chooses one and puts the rest into graveyard.
  */
 class LegendRuleCheck(
-    private val decisionHandler: DecisionHandler
+    private val decisionHandler: DecisionHandler,
+    private val cardRegistry: CardRegistry
 ) : StateBasedActionCheck {
     override val name = "704.5j Legend Rule"
     override val order = SbaOrder.LEGEND_RULE
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * Whether [entityId] (controlled by [playerId]) is exempt from the legend rule because
+     * [playerId] controls a permanent with a [LegendRuleDoesNotApplyTo] static whose filter it
+     * matches (Spider-Verse: "The 'legend rule' doesn't apply to Spiders you control").
+     */
+    private fun isExemptFromLegendRule(
+        state: GameState,
+        projected: ProjectedState,
+        playerId: EntityId,
+        entityId: EntityId
+    ): Boolean {
+        val ctx = PredicateContext(controllerId = playerId)
+        for (permId in state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD))) {
+            val cardDef = state.getEntity(permId)?.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is LegendRuleDoesNotApplyTo &&
+                    predicateEvaluator.matches(state, projected, entityId, ability.filter, ctx)
+                ) return true
+            }
+        }
+        return false
+    }
 
     override fun check(state: GameState): ExecutionResult {
         val projected = state.projectedState
@@ -34,7 +66,9 @@ class LegendRuleCheck(
                 val container = state.getEntity(entityId) ?: continue
                 val cardComponent = container.get<CardComponent>() ?: continue
 
-                if (projected.isLegendary(entityId)) {
+                if (projected.isLegendary(entityId) &&
+                    !isExemptFromLegendRule(state, projected, playerId, entityId)
+                ) {
                     // Use the current (projected) name, not just the printed one: a Layer-3
                     // SetName continuous effect (e.g. Witness Protection, "named Legitimate
                     // Businessperson") can make two otherwise-distinct legendary permanents

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/LegendRuleCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/LegendRuleCheck.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.LegendRuleDoesNotApplyTo
 
 /**
@@ -31,27 +32,42 @@ class LegendRuleCheck(
     private val predicateEvaluator = PredicateEvaluator()
 
     /**
-     * Whether [entityId] (controlled by [playerId]) is exempt from the legend rule because
-     * [playerId] controls a permanent with a [LegendRuleDoesNotApplyTo] static whose filter it
-     * matches (Spider-Verse: "The 'legend rule' doesn't apply to Spiders you control").
+     * The filters of every [LegendRuleDoesNotApplyTo] static among [permanents] (a single player's
+     * battlefield). Collected once per player so the per-legendary exemption test doesn't re-scan
+     * the battlefield (Spider-Verse: "The 'legend rule' doesn't apply to Spiders you control").
+     */
+    private fun collectExemptionFilters(
+        state: GameState,
+        permanents: List<EntityId>
+    ): List<GameObjectFilter> {
+        val filters = mutableListOf<GameObjectFilter>()
+        for (permId in permanents) {
+            val cardDef = state.getEntity(permId)?.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                if (ability is LegendRuleDoesNotApplyTo) filters.add(ability.filter)
+            }
+        }
+        return filters
+    }
+
+    /**
+     * Whether [entityId] (controlled by [playerId]) is exempt from the legend rule because it
+     * matches one of [exemptionFilters] — the "legend rule doesn't apply to [filter] you control"
+     * statics that player controls. Short-circuits when there are none (the common case).
      */
     private fun isExemptFromLegendRule(
         state: GameState,
         projected: ProjectedState,
         playerId: EntityId,
-        entityId: EntityId
+        entityId: EntityId,
+        exemptionFilters: List<GameObjectFilter>
     ): Boolean {
+        if (exemptionFilters.isEmpty()) return false
         val ctx = PredicateContext(controllerId = playerId)
-        for (permId in state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD))) {
-            val cardDef = state.getEntity(permId)?.get<CardComponent>()
-                ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
-            for (ability in cardDef.script.staticAbilities) {
-                if (ability is LegendRuleDoesNotApplyTo &&
-                    predicateEvaluator.matches(state, projected, entityId, ability.filter, ctx)
-                ) return true
-            }
+        return exemptionFilters.any { filter ->
+            predicateEvaluator.matches(state, projected, entityId, filter, ctx)
         }
-        return false
     }
 
     override fun check(state: GameState): ExecutionResult {
@@ -60,6 +76,9 @@ class LegendRuleCheck(
             val battlefieldZone = ZoneKey(playerId, Zone.BATTLEFIELD)
             val permanents = state.getZone(battlefieldZone)
 
+            // Collect this player's legend-rule exemptions once, not per legendary permanent.
+            val exemptionFilters = collectExemptionFilters(state, permanents)
+
             val legendaryByName = mutableMapOf<String, MutableList<EntityId>>()
 
             for (entityId in permanents) {
@@ -67,7 +86,7 @@ class LegendRuleCheck(
                 val cardComponent = container.get<CardComponent>() ?: continue
 
                 if (projected.isLegendary(entityId) &&
-                    !isExemptFromLegendRule(state, projected, playerId, entityId)
+                    !isExemptFromLegendRule(state, projected, playerId, entityId, exemptionFilters)
                 ) {
                     // Use the current (projected) name, not just the printed one: a Layer-3
                     // SetName continuous effect (e.g. Witness Protection, "named Legitimate

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
@@ -14,7 +14,7 @@ class PermanentSbaModule(
         EndedDurationExpiryCheck(),
         AttachedCopyExpiryCheck(),
         PlaneswalkerLoyaltyCheck(),
-        LegendRuleCheck(decisionHandler),
+        LegendRuleCheck(decisionHandler, cardRegistry),
         CounterAnnihilationCheck(),
         UnattachedAurasCheck(cardRegistry),
         SagaSacrificeCheck(cardRegistry),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -215,6 +215,23 @@ class TargetValidator {
                     return "Targets must have total mana value $cap or less"
                 }
             }
+
+            // "... with different names" — no two chosen targets for this requirement may share a
+            // name (Behold the Sinister Six!: "up to six target creature cards with different
+            // names"). CR 601.2c. Grouped by projected name on the battlefield, base card name in
+            // other zones (graveyard cards aren't projected).
+            if (requirement is TargetObject && requirement.differentNames && targetsForReq.size > 1) {
+                val names = targetsForReq.map { target ->
+                    val id = (target as? ChosenTarget.Permanent)?.entityId
+                        ?: (target as? ChosenTarget.Card)?.cardId
+                    id?.let {
+                        state.projectedState.getName(it) ?: state.getEntity(it)?.get<CardComponent>()?.name
+                    }
+                }
+                if (names.size != names.toSet().size) {
+                    return "Targets must have different names"
+                }
+            }
         }
 
         return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeholdTheSinisterSixScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeholdTheSinisterSixScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Behold the Sinister Six! (SPM) — "Return up to six target creature cards with different names
+ * from your graveyard to the battlefield." Pins the new `TargetObject.differentNames` cross-target
+ * constraint (`TargetValidator` / `DecisionValidators`).
+ */
+class BeholdTheSinisterSixScenarioTest : FunSpec({
+
+    val spiderA = card("Behold Test Spider A") {
+        manaCost = "{1}"
+        typeLine = "Creature — Spider"
+        power = 1
+        toughness = 1
+    }
+    val spiderB = card("Behold Test Spider B") {
+        manaCost = "{1}"
+        typeLine = "Creature — Spider"
+        power = 1
+        toughness = 1
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(spiderA, spiderB))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("different-named creature cards all return to the battlefield") {
+        val (driver, you) = newGame()
+        val a = driver.putCardInGraveyard(you, "Behold Test Spider A")
+        val b = driver.putCardInGraveyard(you, "Behold Test Spider B")
+        driver.giveMana(you, Color.BLACK, 7)
+        val behold = driver.putCardInHand(you, "Behold the Sinister Six!")
+
+        val result = driver.castSpellWithTargets(
+            you, behold,
+            listOf(ChosenTarget.Card(a, you, Zone.GRAVEYARD), ChosenTarget.Card(b, you, Zone.GRAVEYARD))
+        )
+        result.error shouldBe null
+        resolveStack(driver)
+
+        driver.state.getBattlefield().contains(a) shouldBe true
+        driver.state.getBattlefield().contains(b) shouldBe true
+    }
+
+    test("two same-named creature cards can't both be targeted (different names required)") {
+        val (driver, you) = newGame()
+        val a1 = driver.putCardInGraveyard(you, "Behold Test Spider A")
+        val a2 = driver.putCardInGraveyard(you, "Behold Test Spider A")
+        driver.giveMana(you, Color.BLACK, 7)
+        val behold = driver.putCardInHand(you, "Behold the Sinister Six!")
+
+        val result = driver.castSpellWithTargets(
+            you, behold,
+            listOf(ChosenTarget.Card(a1, you, Zone.GRAVEYARD), ChosenTarget.Card(a2, you, Zone.GRAVEYARD))
+        )
+        result.error shouldNotBe null // rejected: same name
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnageCrimsonChaosScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnageCrimsonChaosScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Carnage, Crimson Chaos (SPM) — ETB reanimates a mv≤3 creature card and grants it "attacks each
+ * combat if able" + "when it deals combat damage to a player, sacrifice it". Pins the
+ * grant-abilities-to-a-reanimated-target composition (`GrantStaticAbilityEffect(MustAttack())` +
+ * `GrantTriggeredAbilityEffect(... SacrificeSelfEffect)` with `Duration.Permanent`).
+ */
+class CarnageCrimsonChaosScenarioTest : FunSpec({
+
+    val smallCreature = card("Carnage Test Grunt") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Zombie"
+        power = 2
+        toughness = 2
+    }
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(smallCreature))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("reanimates the target, which must attack and is sacrificed after dealing combat damage") {
+        val (driver, you, opponent) = newGame()
+        val grunt = driver.putCardInGraveyard(you, "Carnage Test Grunt") // mv 2
+
+        // Cast Carnage; its ETB reanimates the grunt.
+        driver.giveMana(you, Color.BLACK, 3)
+        driver.giveMana(you, Color.RED, 1)
+        val carnage = driver.putCardInHand(you, "Carnage, Crimson Chaos")
+        driver.castSpell(you, carnage)
+        resolveStack(driver)
+
+        // ETB target: choose the grunt in the graveyard.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(you, listOf(grunt))
+        resolveStack(driver)
+
+        driver.state.getBattlefield().contains(grunt) shouldBe true // reanimated
+        driver.removeSummoningSickness(grunt) // so it can attack this turn
+
+        // The grunt attacks; it deals combat damage and is then sacrificed (granted trigger).
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(grunt), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The grunt dealt 2 to the opponent, then sacrificed itself.
+        driver.getLifeTotal(opponent) shouldBe 18
+        driver.state.getBattlefield().contains(grunt) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnageCrimsonChaosScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarnageCrimsonChaosScenarioTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Carnage, Crimson Chaos (SPM) — ETB reanimates a mv≤3 creature card and grants it "attacks each
@@ -60,8 +61,13 @@ class CarnageCrimsonChaosScenarioTest : FunSpec({
         driver.state.getBattlefield().contains(grunt) shouldBe true // reanimated
         driver.removeSummoningSickness(grunt) // so it can attack this turn
 
-        // The grunt attacks; it deals combat damage and is then sacrificed (granted trigger).
+        // The granted "attacks each combat if able" is enforced: declaring no attackers is illegal
+        // while the grunt can attack. (Regression: granted MustAttack lives in
+        // grantedStaticAbilities, not projection, so the point-of-use check must consult it.)
         driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, emptyList(), defendingPlayer = opponent).error shouldNotBe null
+
+        // The grunt attacks; it deals combat damage and is then sacrificed (granted trigger).
         driver.declareAttackers(you, listOf(grunt), defendingPlayer = opponent).error shouldBe null
         driver.passPriorityUntil(Step.COMBAT_DAMAGE)
         resolveStack(driver)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MisterNegativeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MisterNegativeScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mister Negative (SPM) — "you may exchange life totals with target opponent. If you lost life this
+ * way, draw that many cards." Pins the new `Effects.ExchangeLifeTotals(drawEqualToLifeLost = true)`
+ * (CR 701.12c simultaneous swap + draw = life lost).
+ */
+class MisterNegativeScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("higher-life controller swaps totals and draws cards equal to life lost") {
+        val (driver, you, opponent) = newGame()
+        driver.setLifeTotal(you, 12)
+        driver.setLifeTotal(opponent, 5)
+
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 5)
+        val mn = driver.putCardInHand(you, "Mister Negative")
+        driver.castSpell(you, mn)
+        resolveStack(driver) // MN resolves; ETB auto-targets the sole opponent, then pauses on "may"
+
+        val handBefore = driver.getHandSize(you)
+        driver.pendingDecision as YesNoDecision
+        driver.submitYesNo(you, true) // yes, exchange
+        resolveStack(driver)
+
+        driver.getLifeTotal(you) shouldBe 5        // was 12, now the opponent's former 5
+        driver.getLifeTotal(opponent) shouldBe 12  // was 5, now the controller's former 12
+        driver.getHandSize(you) shouldBe handBefore + 7 // lost 7 life → drew 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderVerseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderVerseScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spider-Verse (SPM) — "The 'legend rule' doesn't apply to Spiders you control." Pins the new
+ * `LegendRuleDoesNotApplyTo(filter)` static + its consult hook in `LegendRuleCheck`. The second
+ * Spider is *cast* so the legend-rule state-based action genuinely fires as it resolves.
+ */
+class SpiderVerseScenarioTest : FunSpec({
+
+    val legendarySpider = card("Test Legendary Spider") {
+        manaCost = "{1}{G}"
+        typeLine = "Legendary Creature — Spider"
+        power = 1
+        toughness = 1
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(legendarySpider))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("with Spider-Verse out, casting a second same-named legendary Spider keeps both") {
+        val (driver, you) = newGame()
+        driver.putPermanentOnBattlefield(you, "Spider-Verse")
+        val s1 = driver.putCreatureOnBattlefield(you, "Test Legendary Spider")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val s2card = driver.putCardInHand(you, "Test Legendary Spider")
+        driver.castSpell(you, s2card)
+        resolveStack(driver)
+
+        driver.state.getBattlefield().contains(s1) shouldBe true
+        driver.state.getBattlefield().count {
+            driver.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Test Legendary Spider"
+        } shouldBe 2
+        (driver.pendingDecision == null) shouldBe true // no legend-rule choice — exempt
+    }
+
+    test("without Spider-Verse, casting a second same-named legendary Spider triggers the legend rule") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Test Legendary Spider")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val s2card = driver.putCardInHand(you, "Test Legendary Spider")
+        driver.castSpell(you, s2card)
+        resolveStack(driver)
+
+        // Legend rule applies: either it paused for a choice, or only one copy remains.
+        val remaining = driver.state.getBattlefield().count {
+            driver.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Test Legendary Spider"
+        }
+        (driver.pendingDecision != null || remaining <= 1) shouldBe true
+    }
+})


### PR DESCRIPTION
## SPM batch: four cards + three new SDK primitives (life-exchange, different-names targeting, legend-rule exemption)

Implements four Marvel's Spider-Man cards, each pulling in a small reusable primitive, plus a
grant-based composition that needed no new type. Also addresses a review pass and one gameplay bug
found in playtesting.

### Cards

| # | Card | Mechanic |
|---|------|----------|
| 51 | **Behold the Sinister Six!** | `TargetObject.differentNames` — "up to six target creature cards with different names" |
| 93 | **Spider-Verse** | `LegendRuleDoesNotApplyTo(filter)` static — "the legend rule doesn't apply to Spiders you control" |
| 125 | **Carnage, Crimson Chaos** | reanimate + grant "attacks each combat if able" & "when it deals combat damage, sacrifice it" (composed from existing `GrantStaticAbilityEffect` / `GrantTriggeredAbilityEffect`) |
| 135 | **Mister Negative** | `Effects.ExchangeLifeTotals(drawEqualToLifeLost = true)` — CR 701.12c exchange + draw = life lost |

### New SDK primitives

- **`ExchangeLifeTotals(target, drawEqualToLifeLost)`** (CR 701.12c). Applies the swap through the
  shared `gainLife`/`loseLife` primitives, so gain prevention (CR 119.5/119.7), gain replacements
  (CR 614) and loss modification (CR 119.3) all apply and both players' `LifeChangedEvent`s fire.
  The draw amount is the controller's *actual* post-exchange life loss.
- **`TargetObject.differentNames`** — cross-target distinctness, enforced by `TargetValidator`
  (authoritative) and `DecisionValidators` (interactive), grouping by projected name (battlefield) /
  base card name (other zones).
- **`LegendRuleDoesNotApplyTo(filter)`** static — consulted by `LegendRuleCheck`, which excludes
  matching permanents you control from the same-name duplicate grouping (CR 704.5j).

Carnage needed **no** new type: the reanimate-and-grant is `Effects.Move(...)` +
`GrantStaticAbilityEffect(MustAttack())` + `GrantTriggeredAbilityEffect(... SacrificeSelfEffect)` at
`Duration.Permanent`, keyed to the reanimated target — matching the existing Eddie Brock / Prison
Break pattern.

### Review fixes + playtest bug (commit `98e1569cd`)

Addresses the branch review:
- ExchangeLifeTotals now routes through `gainLife`/`loseLife` (respects prevention / replacement /
  loss modification, sets `firstThisTurn`) instead of setting life totals directly; the draw loop
  stops on an empty library.
- `LegendRuleCheck` collects exemption filters once per player instead of rescanning the battlefield
  per legendary permanent.
- Dropped incorrect "lifelink" wording from docs/KDoc (exchanging life totals is not damage).

**Gameplay bug:** an entity-scoped `MustAttack` granted via `GrantStaticAbilityEffect` (Carnage's
reanimated target) is stored in `grantedStaticAbilities`, which the projection layer never reads — so
`projected.mustAttack` stayed false and the creature was never forced to attack. Now consulted at
both point-of-use sites in `AttackPhaseManager` (declare-attackers validation and
`getMandatoryAttackers`), and the Carnage scenario test now asserts an empty attacker declaration is
rejected.

### Tests

One scenario test per card (`rules-engine` `scenarios/`), plus the strengthened Carnage must-attack
assertion. Verified green against `main` post-rebase, alongside the existing must-attack suite
(Valley Dasher, Grand Melee, Taunt, Walking Desecration) and the legend-rule suite as regression
guards. Docs (`card-sdk-language-reference.md`) and the SPM card snapshot are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
