### PR TITLE
Remove the Seats setting from the wizard and the lobby

### DIFF
--- a/e2e-scenarios/helpers/homeScreen.ts
+++ b/e2e-scenarios/helpers/homeScreen.ts
@@ -28,8 +28,6 @@ export interface WizardChoice {
   roster: Roster
   cards: Cards
   shape?: Shape
-  /** Seat count, when the shape offers a choice. */
-  seats?: number
 }
 
 /** Wait for the landing screen to be interactive (step 1 rendered). */
@@ -56,10 +54,7 @@ export async function createLobby(page: Page, choice: WizardChoice): Promise<str
     if (await tile.isVisible({ timeout: 2000 }).catch(() => false)) await tile.click()
   }
 
-  if (choice.seats !== undefined) {
-    await page.getByTestId(`wizard-seats-${choice.seats}`).click()
-  }
-
+  // No seat step: the lobby opens at the cap its shape allows and people join until it is full.
   await page.getByTestId('wizard-create').click()
   await expect(page.getByText('Invite Code')).toBeVisible({ timeout: 10000 })
   const lobbyId = await page.getByTestId('invite-code').textContent() ?? ''

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -561,6 +561,30 @@ class LobbyHandler(
         return "$names $verb — add at least one regular set to play with"
     }
 
+    /**
+     * How many seats a lobby of this shape holds — the cap people join up to.
+     *
+     * Since the client stopped offering a Seats control (nobody is asked for a number; players join
+     * until the lobby is full), the cap has to follow the shape by itself. It used to be *narrowed*
+     * on each switch, which was fine while a host could raise it again: a lobby that dropped to six
+     * for Free-for-All and then went back to a bracket would now be stuck at six forever, with no
+     * control left to fix it. So every shape change re-derives it rather than clamping it.
+     *
+     * Format wins over game mode where both have an opinion, which is the order the create path
+     * below already used: a Winston lobby is two seats whatever table it claims to be.
+     */
+    private fun seatCapFor(format: TournamentFormat, gameMode: LobbyGameMode): Int = when {
+        format == TournamentFormat.WINSTON_DRAFT -> 2
+        format == TournamentFormat.GRID_DRAFT -> 4
+        // Two teams of two.
+        gameMode == LobbyGameMode.TWO_HEADED_GIANT -> 4
+        // Two even teams: 4 (2v2), 6 (3v3) or 8 (4v4) — the even-pod rule is re-checked at start.
+        gameMode == LobbyGameMode.TEAM_VS_TEAM -> 8
+        // FFA pods cap at 6 — the multiplayer UI lays opponent boards out around the table.
+        gameMode == LobbyGameMode.FREE_FOR_ALL -> 6
+        else -> 8
+    }
+
     private fun handleCreateTournamentLobby(session: WebSocketSession, message: ClientMessage.CreateTournamentLobby) {
         val playerSession = sessionRegistry.getPlayerSession(session.id)
         if (playerSession == null) {
@@ -612,17 +636,17 @@ class LobbyHandler(
             LobbyGameMode.TOURNAMENT
         }
 
+        // The client's own wizard sends the shape's cap (it no longer asks anyone for a number), so
+        // this is really only clamping a hand-rolled or older message.
+        val seatCap = seatCapFor(format, gameMode)
         val maxPlayers = when {
-            format == TournamentFormat.WINSTON_DRAFT -> 2
-            format == TournamentFormat.GRID_DRAFT -> message.maxPlayers.coerceIn(2, 4)
-            // Two-Headed Giant is always exactly four seats (two teams of two).
-            gameMode == LobbyGameMode.TWO_HEADED_GIANT -> 4
+            // Exactly four seats, and exactly two — no client number overrides the shape.
+            gameMode == LobbyGameMode.TWO_HEADED_GIANT -> seatCap
+            format == TournamentFormat.WINSTON_DRAFT -> seatCap
             // Team vs. Team is two even teams: 4 (2v2), 6 (3v3), or 8 (4v4). The even-pod rule is
             // re-checked at game start; an odd cap simply never starts a game.
-            gameMode == LobbyGameMode.TEAM_VS_TEAM -> message.maxPlayers.coerceIn(4, 8)
-            // FFA pods cap at 6 — the multiplayer UI lays opponent boards out around the table.
-            gameMode == LobbyGameMode.FREE_FOR_ALL -> message.maxPlayers.coerceIn(2, 6)
-            else -> message.maxPlayers.coerceIn(2, 8)
+            gameMode == LobbyGameMode.TEAM_VS_TEAM -> message.maxPlayers.coerceIn(4, seatCap)
+            else -> message.maxPlayers.coerceIn(2, seatCap)
         }
 
         // Set appropriate default booster count based on format
@@ -2128,11 +2152,7 @@ class LobbyHandler(
                 // Pool Play only exists for cube Sealed; don't leave it set (and shown) on a format
                 // that ignores it.
                 if (newFormat != TournamentFormat.SEALED) lobby.cubePoolPlay = false
-                if (newFormat == TournamentFormat.WINSTON_DRAFT) {
-                    lobby.maxPlayers = 2
-                } else if (newFormat == TournamentFormat.GRID_DRAFT) {
-                    lobby.maxPlayers = minOf(lobby.maxPlayers, 4)
-                }
+                lobby.maxPlayers = seatCapFor(newFormat, lobby.gameMode)
                 // Commander draft / sealed plays best with a broad mix of sets, so when the
                 // host first switches into a commander format we replace the single-set
                 // default with a curated mix (DOM / BLB / ECL / KTK) for variety. Honor any
@@ -2247,32 +2267,24 @@ class LobbyHandler(
                     }
                 }
                 when (newMode) {
-                    LobbyGameMode.TWO_HEADED_GIANT -> {
-                        // Two teams of two — always exactly four seats.
-                        if (lobby.playerCount > 4) {
-                            sender.sendError(session, ErrorCode.INVALID_ACTION, "Two-Headed Giant is exactly four players")
-                            return
-                        }
-                        lobby.maxPlayers = 4
+                    // Two teams of two — always exactly four seats.
+                    LobbyGameMode.TWO_HEADED_GIANT -> if (lobby.playerCount > 4) {
+                        sender.sendError(session, ErrorCode.INVALID_ACTION, "Two-Headed Giant is exactly four players")
+                        return
                     }
-                    LobbyGameMode.TEAM_VS_TEAM -> {
-                        // Two even teams: at most eight players (4v4).
-                        if (lobby.playerCount > 8) {
-                            sender.sendError(session, ErrorCode.INVALID_ACTION, "Team vs. Team supports at most 8 players")
-                            return
-                        }
-                        lobby.maxPlayers = lobby.maxPlayers.coerceIn(4, 8)
+                    // Two even teams: at most eight players (4v4).
+                    LobbyGameMode.TEAM_VS_TEAM -> if (lobby.playerCount > 8) {
+                        sender.sendError(session, ErrorCode.INVALID_ACTION, "Team vs. Team supports at most 8 players")
+                        return
                     }
-                    LobbyGameMode.FREE_FOR_ALL -> {
-                        if (lobby.playerCount > 6) {
-                            sender.sendError(session, ErrorCode.INVALID_ACTION, "Free-for-All supports at most 6 players")
-                            return
-                        }
-                        lobby.maxPlayers = lobby.maxPlayers.coerceIn(2, 6)
+                    LobbyGameMode.FREE_FOR_ALL -> if (lobby.playerCount > 6) {
+                        sender.sendError(session, ErrorCode.INVALID_ACTION, "Free-for-All supports at most 6 players")
+                        return
                     }
                     LobbyGameMode.TOURNAMENT -> Unit
                 }
                 lobby.gameMode = newMode
+                lobby.maxPlayers = seatCapFor(lobby.format, newMode)
             }
         }
 
@@ -2320,17 +2332,19 @@ class LobbyHandler(
                 lobby.boosterDistribution = dist
             }
         }
+        // No client asks for a seat count any more — the lobby holds what its shape allows and people
+        // join until it is full — but an explicit request is still honoured within that cap, so an
+        // older or hand-rolled client isn't silently ignored.
         message.maxPlayers?.let {
             val oldMaxPlayers = lobby.maxPlayers
-            val modeCap = if (lobby.isFreeForAll) 6 else 8
-            when {
-                // Two-Headed Giant is locked at four seats — the host can't change it.
-                lobby.isTwoHeadedGiant -> lobby.maxPlayers = 4
-                // Team vs. Team allows 4/6/8 (two even teams), above the FFA board-layout cap of 6.
-                lobby.isTeamVsTeam -> lobby.maxPlayers = it.coerceIn(4, 8)
-                lobby.format == TournamentFormat.WINSTON_DRAFT -> lobby.maxPlayers = 2
-                lobby.format == TournamentFormat.GRID_DRAFT -> lobby.maxPlayers = it.coerceIn(2, 4)
-                else -> lobby.maxPlayers = it.coerceIn(2, modeCap)
+            val cap = seatCapFor(lobby.format, lobby.gameMode)
+            lobby.maxPlayers = when {
+                // Locked by the shape — the request can't move these.
+                lobby.isTwoHeadedGiant -> cap
+                lobby.format == TournamentFormat.WINSTON_DRAFT -> cap
+                // Team vs. Team is two even teams, so never fewer than four.
+                lobby.isTeamVsTeam -> it.coerceIn(4, cap)
+                else -> it.coerceIn(2, cap)
             }
             // Auto-adjust grid draft booster count when player count changes (always, since it's fixed)
             if (lobby.format == TournamentFormat.GRID_DRAFT && lobby.maxPlayers != oldMaxPlayers) {

--- a/web-client/src/components/lobby/TournamentLobbySettings.tsx
+++ b/web-client/src/components/lobby/TournamentLobbySettings.tsx
@@ -19,7 +19,7 @@ import { CubePanel } from './CubePanel'
 import { SetIcon } from '../ui/SetIcon'
 import { SetPickerModal } from '../ui/SetPickerModal'
 import { SettingsLabel } from '../ui/SettingsLabel'
-import { COMMANDER_PRESETS, cardsSeatCap, effectiveCommanderPreset } from './axes'
+import { COMMANDER_PRESETS, effectiveCommanderPreset } from './axes'
 import type { UnifiedLobbyView } from './lobbyViewModel'
 import styles from '../ui/GameUI.module.css'
 
@@ -31,24 +31,6 @@ import styles from '../ui/GameUI.module.css'
 const RANDOM_SET_CODE = 'RANDOM'
 const isRandomSetCode = (code: string): boolean =>
   code === RANDOM_SET_CODE || code.startsWith(`${RANDOM_SET_CODE}-`)
-
-/**
- * Seat counts this lobby could be set to, from the same seat facts the landing wizard uses.
- *
- * A single option (or none) means the shape decides it: Two-Headed Giant is exactly four, and the
- * two-player sub-shapes cap themselves. Team vs. Team needs an even pod. Never offers fewer seats
- * than the lobby is already holding.
- */
-function seatOptions(view: UnifiedLobbyView): number[] {
-  const cap = Math.min(
-    cardsSeatCap(view.axes.cards),
-    view.axes.table === 'FREE_FOR_ALL' ? 6 : 8,
-  )
-  if (view.axes.table === 'TWO_HEADED_GIANT') return []
-  const floor = Math.max(2, view.players.length)
-  const all = view.axes.table === 'TEAM_VS_TEAM' ? [4, 6, 8] : [2, 3, 4, 5, 6, 7, 8]
-  return all.filter((n) => n <= cap && n >= floor)
-}
 
 export function TournamentLobbySettings({
   view,
@@ -473,30 +455,11 @@ export function TournamentLobbySettings({
         </>
       )}
 
-      {/* How many seats the lobby can hold.
-          A cap, not a quorum — `startBlockReason` counts the players actually present — so the host
-          can leave it wide and start when everyone has arrived. It lives here as well as on the
-          landing wizard precisely so the wizard doesn't have to make anyone predict the number:
-          the server has always accepted `maxPlayers` on `updateLobbySettings`, and until now no
-          client could send it. Shapes with a forced count (Two-Headed Giant is exactly four) and the
-          sub-shapes that cap themselves (Winston, Grid, the Commander pair) are excluded. */}
-      {seatOptions(view).length > 1 && (
-        <div className={styles.settingsRow}>
-          <span
-            className={styles.settingsLabel}
-            title="The most players this lobby will hold. You can start before it is full."
-          >
-            Seats
-          </span>
-          <select
-            value={view.maxPlayers}
-            onChange={(e) => updateLobbySettings({ maxPlayers: Number(e.target.value) })}
-            className={styles.settingsSelect}
-          >
-            {seatOptions(view).map((n) => <option key={n} value={n}>{n}</option>)}
-          </select>
-        </div>
-      )}
+      {/* No Seats row: the lobby holds as many as its shape allows and people join until it is full.
+          The cap was never a quorum — `startBlockReason` counts the players actually present, so the
+          host starts when everyone has arrived — which made it a number to predict and then correct.
+          It follows the shape server-side (`LobbyHandler.seatCapFor`), and the header's `n / max`
+          says where it currently stands. */}
 
       {/* Only a bracket has matchups. */}
       {view.axes.event === 'ROUND_ROBIN' && (

--- a/web-client/src/components/lobby/modeMatrix.test.ts
+++ b/web-client/src/components/lobby/modeMatrix.test.ts
@@ -20,10 +20,9 @@ import {
 import {
   cardsChoices,
   defaultCardsAxis,
-  defaultSeats,
   lobbyKindFor,
   resolveLaunch,
-  seatRule,
+  seatCap,
   shapeAxes,
   shapeChoices,
   ROSTERS,
@@ -32,11 +31,13 @@ import {
 } from './modeMatrix'
 
 /**
- * Every selection the wizard can reach: roster × enabled Cards kind × open shapes × seat counts.
+ * Every selection the wizard can reach: roster × enabled Cards kind × open shapes.
  *
- * Cards is a *kind* at its default sub-shape, because that is all the wizard commits to — which sealed
- * or draft shape it is stays a lobby sub-option, alongside deck legality. The lobby's own reachability
- * for the non-default shapes lives in `axisChoices`/`LobbyAxes.shapeBlock`, not here.
+ * Seats are not part of the space: the lobby opens at the cap its shape allows and people join until
+ * it is full, so a selection no longer carries a count. Cards is a *kind* at its default sub-shape,
+ * because that is all the wizard commits to — which sealed or draft shape it is stays a lobby
+ * sub-option, alongside deck legality. The lobby's own reachability for the non-default shapes lives
+ * in `axisChoices`/`LobbyAxes.shapeBlock`, not here.
  */
 function everySelection(): Selection[] {
   const out: Selection[] = []
@@ -46,10 +47,7 @@ function everySelection(): Selection[] {
       for (const cards of [defaultCardsAxis(cardsChoice.value)]) {
         for (const shapeChoice of shapeChoices(roster, cards)) {
           if (shapeChoice.disabledReason) continue
-          const rule = seatRule(roster, cards, shapeChoice.value)
-          for (const seats of rule.values) {
-            out.push({ roster, cards, shape: shapeChoice.value, seats })
-          }
+          out.push({ roster, cards, shape: shapeChoice.value })
         }
       }
     }
@@ -69,11 +67,20 @@ describe('modeMatrix', () => {
     }
   })
 
-  it('never offers a seat count outside the Cards value’s cap', () => {
+  it('opens every lobby at a cap the server will accept', () => {
     for (const selection of everySelection()) {
-      const cap = selection.shape === 'FREE_FOR_ALL' ? 6 : 8
-      expect(selection.seats, JSON.stringify(selection)).toBeLessThanOrEqual(cap)
-      expect(selection.seats).toBeGreaterThanOrEqual(2)
+      const { roster, cards, shape } = selection
+      const seats = seatCap(roster, cards, shape)
+      const label = JSON.stringify(selection)
+      // `LobbyHandler.seatCapFor` — the board layout caps a Free-for-All at 6, everything else at 8.
+      expect(seats, label).toBeLessThanOrEqual(shape === 'FREE_FOR_ALL' ? 6 : 8)
+      expect(seats, label).toBeGreaterThanOrEqual(2)
+      // Two even teams, and the server refuses a Team vs. Team pod under four.
+      if (shape === 'TEAM_VS_TEAM') {
+        expect(seats % 2, label).toBe(0)
+        expect(seats, label).toBeGreaterThanOrEqual(4)
+      }
+      if (shape === 'TWO_HEADED_GIANT') expect(seats, label).toBe(4)
     }
   })
 
@@ -126,13 +133,7 @@ describe('modeMatrix', () => {
         if (!enabled) continue
         const cards = defaultCardsAxis(kind)
         const shape = shapeChoices(roster, cards).find((c) => !c.disabledReason)!.value
-        const selection: Selection = {
-          roster,
-          cards,
-          shape,
-          seats: defaultSeats(seatRule(roster, cards, shape)),
-        }
-        expect(lobbyKindFor(selection)).toBe('QUICK')
+        expect(lobbyKindFor({ roster, cards, shape })).toBe('QUICK')
       }
     }
   })

--- a/web-client/src/components/lobby/modeMatrix.ts
+++ b/web-client/src/components/lobby/modeMatrix.ts
@@ -327,85 +327,29 @@ export function shapeChoices(roster: Roster, cards: CardsAxis): Choice<ShapeId>[
 /* ── Seats ──────────────────────────────────────────────────────────────── */
 
 /**
- * How many seats the lobby opens with, and whether the player gets to choose.
+ * How many seats the lobby opens with: always the most the selection allows.
  *
- * `values` is the exact allowed list rather than a min/max pair because Team vs. Team needs an even
- * count and Two-Headed Giant needs exactly four — a range with holes in it is a control that lets you
- * pick something the start button then refuses.
+ * Nobody is asked. `maxPlayers` is a cap, not a quorum — `startBlockReason` only ever counts the
+ * players actually present — so a lobby that opens as wide as its shape permits is one people join
+ * until it is full, and the host starts whenever everyone has arrived. Asking up front only ever
+ * meant predicting a number and then having to notice it was wrong.
+ *
+ * The shapes that force a count still force it here: Two-Headed Giant is exactly four, Team vs. Team
+ * needs an even pod, Free-for-All is capped by the board layout, and the two-player sub-shapes cap
+ * themselves through {@link cardsSeatCap}. For a solo pod this is also the number of AI seats that
+ * get filled (`resolveLaunch`), which the lobby can add to and remove from afterwards.
  */
-export interface SeatRule {
-  values: number[]
-  /** Rendered next to the control; empty when there is nothing to choose. */
-  label: string
-  /** True when the count is forced, so the wizard shows it as a fact instead of a control. */
-  fixed: boolean
-  /**
-   * One line under the control. Says whether the number has to be right *now*.
-   *
-   * For a group it does not: `maxPlayers` is a cap, not a quorum — `startBlockReason` only ever
-   * checks how many players are actually present — so the wizard defaults to the maximum and the
-   * host starts whenever everyone has arrived. For a solo pod it decides how many AI seats to fill,
-   * so it is a real choice, but the lobby can still add and remove them afterwards.
-   */
-  caption: string
-}
+export function seatCap(roster: Roster, cards: CardsAxis, shape: ShapeId): number {
+  if (roster === 'FRIEND') return 2
+  if (roster === 'SOLO' && (isQuickOnly(cards.kind) || cards.kind === 'BRING_A_DECK')) return 2
 
-export function seatRule(roster: Roster, cards: CardsAxis, shape: ShapeId): SeatRule {
-  const twoSeats = (caption: string): SeatRule => ({ values: [2], label: '', fixed: true, caption })
-
-  if (roster === 'FRIEND') return twoSeats('Two seats. Share the invite code and they take the other one.')
-  if (roster === 'SOLO' && (isQuickOnly(cards.kind) || cards.kind === 'BRING_A_DECK')) {
-    return twoSeats('You and one AI opponent.')
-  }
   const cap = Math.min(cardsSeatCap(cards), shape === 'FREE_FOR_ALL' ? 6 : 8)
-
-  if (roster === 'SOLO') {
-    // A limited pod against AI drafters. This one really is a choice — it decides how many AI seats
-    // get filled — but the lobby can add and remove them afterwards.
-    const values = range(2, cap)
-    return {
-      values,
-      label: 'Pod size',
-      fixed: values.length === 1,
-      caption: 'You plus AI opponents. Add or remove them in the lobby.',
-    }
-  }
-
-  const openCaption =
-    'A limit, not a requirement — start whenever everyone is in. Changeable in the lobby.'
-
   switch (shape) {
-    case 'TWO_HEADED_GIANT':
-      return { values: [4], label: '', fixed: true, caption: 'Two-Headed Giant is exactly four seats: two teams of two.' }
-    case 'TEAM_VS_TEAM':
-      return {
-        values: [4, 6, 8].filter((n) => n <= cap),
-        label: 'Up to',
-        fixed: false,
-        caption: `Teams need an even pod. ${openCaption}`,
-      }
-    default: {
-      const values = range(3, cap)
-      return { values, label: 'Up to', fixed: values.length === 1, caption: openCaption }
-    }
+    case 'TWO_HEADED_GIANT': return 4
+    // Two even teams, and the server rejects fewer than four.
+    case 'TEAM_VS_TEAM': return Math.max(4, cap - (cap % 2))
+    default: return Math.max(2, cap)
   }
-}
-
-function range(from: number, to: number): number[] {
-  const out: number[] = []
-  for (let n = from; n <= to; n += 1) out.push(n)
-  return out.length > 0 ? out : [from]
-}
-
-/**
- * The seat count a fresh selection starts on: always the **maximum**.
- *
- * For a group that means the lobby opens as wide as it can — the count is a cap and the host starts
- * once everyone has arrived, so a default of "the smallest legal pod" only ever meant the host had
- * to notice and raise it. For a solo pod it means a full table of AI, which is the interesting case.
- */
-export function defaultSeats(rule: SeatRule): number {
-  return rule.values[rule.values.length - 1] ?? 2
 }
 
 /* ── What will actually happen ──────────────────────────────────────────── */
@@ -419,7 +363,8 @@ export function defaultSeats(rule: SeatRule): number {
  * "Sealed" does not say that a deckbuilding phase and a standings table are coming.
  */
 export function flowStages(selection: Selection): string[] {
-  const { cards, shape, seats } = selection
+  const { roster, cards, shape } = selection
+  const seats = seatCap(roster, cards, shape)
   const stages: string[] = []
 
   switch (cards.kind) {
@@ -433,12 +378,15 @@ export function flowStages(selection: Selection): string[] {
   switch (shape) {
     case 'ONE_GAME': stages.push('One game'); break
     case 'BRACKET':
-      stages.push(seats > 2 ? `Everyone plays everyone (${seats} players)` : 'Play the matchup', 'Standings')
+      stages.push(seats > 2 ? 'Everyone plays everyone' : 'Play the matchup', 'Standings')
+      break
+    // Two-Headed Giant is the one table whose count is exact rather than a cap.
+    case 'TWO_HEADED_GIANT':
+      stages.push('One shared game, 4 seats')
       break
     case 'FREE_FOR_ALL':
-    case 'TWO_HEADED_GIANT':
     case 'TEAM_VS_TEAM':
-      stages.push(`One shared game, ${seats} seats`)
+      stages.push(`One shared game, up to ${seats} seats`)
       break
   }
   return stages
@@ -473,7 +421,6 @@ export interface Selection {
   roster: Roster
   cards: CardsAxis
   shape: ShapeId
-  seats: number
 }
 
 /**
@@ -487,7 +434,8 @@ export function lobbyKindFor(selection: Selection): 'QUICK' | 'TOURNAMENT' {
 }
 
 export function resolveLaunch(selection: Selection): LaunchSpec {
-  const { roster, cards, shape, seats } = selection
+  const { roster, cards, shape } = selection
+  const seats = seatCap(roster, cards, shape)
 
   if (lobbyKindFor(selection) === 'QUICK') {
     return {
@@ -510,14 +458,12 @@ export function resolveLaunch(selection: Selection): LaunchSpec {
   }
 }
 
-/** "Just me · Booster Draft · Round-robin bracket · 8 seats" — the recap, and the Play again chip. */
+/** "Just me · Booster Draft · Round-robin bracket" — the recap, and the Play again chip. */
 export function selectionSummary(selection: Selection): string {
-  const parts = [
+  return [
     rosterLabel(selection.roster),
     // `cardsLabel` already folds the sub-shape in ("Commander Sealed", "Winston Draft").
     cardsLabel(selection.cards),
     shapeLabel(selection.shape),
-  ]
-  if (selection.seats > 2) parts.push(`${selection.seats} seats`)
-  return parts.join(' · ')
+  ].join(' · ')
 }

--- a/web-client/src/components/lobby/rulesAxis.test.ts
+++ b/web-client/src/components/lobby/rulesAxis.test.ts
@@ -199,7 +199,7 @@ describe('the wizard and the lobby agree', () => {
     // lobby. The launch spec has to carry it, or the lobby would come back Standard and disagree
     // with the reasoning the wizard just did.
     const selection = (cards: CardsAxis): Selection =>
-      ({ roster: 'GROUP', cards, shape: 'FREE_FOR_ALL', seats: 4 })
+      ({ roster: 'GROUP', cards, shape: 'FREE_FOR_ALL' })
 
     for (const cards of commanderCards) {
       const spec = resolveLaunch(selection(cards))

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -3353,16 +3353,8 @@
   color: var(--text-tertiary);
 }
 
-.wizardSubLabel {
-  font-size: 10px;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
 /*
- * The launch block: what happens, how many seats, and the button.
+ * The launch block: what happens, and the button.
  *
  * These used to share one wrapping flex row with `align-items: flex-end`, which put a six-chip seat
  * picker and its two-line caption beside a large primary button — the caption wrapped under the
@@ -3378,27 +3370,6 @@
   border-radius: var(--radius-lg);
   border: 1px solid rgba(255, 255, 255, 0.07);
   background: rgba(255, 255, 255, 0.025);
-}
-
-.wizardSeats {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1, 4px);
-  min-width: 0;
-}
-
-.wizardSeatsRow {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.wizardSeatsCaption {
-  margin: 0;
-  font-size: 11px;
-  line-height: 1.4;
-  color: var(--text-disabled);
 }
 
 /* What will actually happen, stage by stage: "Open boosters → Build a deck → Standings". The one

--- a/web-client/src/components/ui/PlayWizard.tsx
+++ b/web-client/src/components/ui/PlayWizard.tsx
@@ -25,8 +25,7 @@
  * with the answers in `useState`, which left the landing screen with two back affordances that
  * disagreed: the stepper stepped back a question, the browser's Back left Argentum. Now each answer
  * is a path segment, so `history.back()` *is* "drop the last answer" and every step is linkable.
- * One user action = one `navigate`, which is the invariant that keeps Back honest; a seat narrowing
- * replaces instead, since it refines the current answer rather than adding one.
+ * One user action = one `navigate`, which is the invariant that keeps Back honest.
  *
  * Everything selectable comes from `lobby/modeMatrix.ts`; this file only renders it.
  */
@@ -36,12 +35,10 @@ import { HelpTip } from '@/components/help/HelpTip'
 import {
   cardsChoices,
   defaultCardsAxis,
-  defaultSeats,
   flowStages,
   resolveLaunch,
   rosterChoices,
   rosterLabel,
-  seatRule,
   selectionSummary,
   shapeChoices,
   shapeLabel,
@@ -84,19 +81,16 @@ export function PlayWizard({
 }) {
   const navigate = useNavigate()
   const { pathname, search } = useLocation()
-  const draft = useMemo(() => pathToDraft(pathname, search, aiEnabled), [pathname, search, aiEnabled])
+  const draft = useMemo(() => pathToDraft(pathname, aiEnabled), [pathname, aiEnabled])
   const lastSelection = useMemo(() => loadLastSelection(aiEnabled), [aiEnabled])
 
   /** Answer a step: one history entry, so Back drops exactly this answer. */
   const setDraft = (next: Draft) => navigate(draftToPath(next))
 
-  /** Refine the current answer (seats) without adding a step to walk back through. */
-  const replaceDraft = (next: Draft) => navigate(draftToPath(next), { replace: true })
-
   /**
    * Normalise the address bar onto the canonical path for what is selected — `/play/solo/bring-a-deck`
-   * gains the shape that was auto-resolved for it, `?seats=99` loses a count no rule allows. Replace,
-   * never push, so tidying a URL never becomes an extra Back to press.
+   * gains the shape that was auto-resolved for it, a saved `?seats=4` loses a query that no longer
+   * answers anything. Replace, never push, so tidying a URL never becomes an extra Back to press.
    *
    * **It may only ever complete a path, never shorten one.** Shortening would mean acting on a
    * *reachability* verdict, and reachability depends on `aiEnabled`, which arrives with the connection
@@ -164,19 +158,13 @@ export function PlayWizard({
     const roster = draft.roster
     if (roster === null) return
     const open = shapeChoices(roster, cards).filter((c) => !c.disabledReason)
-    const only = open.length === 1 ? open[0]!.value : null
-    setDraft({
-      roster,
-      cards,
-      shape: only,
-      seats: only === null ? null : defaultSeats(seatRule(roster, cards, only)),
-    })
+    setDraft({ roster, cards, shape: open.length === 1 ? open[0]!.value : null })
   }
 
   const pickShape = (shape: ShapeId) => {
     const { roster, cards } = draft
     if (roster === null || cards === null) return
-    setDraft({ roster, cards, shape, seats: defaultSeats(seatRule(roster, cards, shape)) })
+    setDraft({ roster, cards, shape })
   }
 
   /**
@@ -190,7 +178,7 @@ export function PlayWizard({
     switch (target) {
       case 'roster': return setDraft(EMPTY)
       case 'cards': return setDraft({ ...EMPTY, roster: draft.roster })
-      case 'shape': if (shapeIsAQuestion) setDraft({ ...draft, shape: null, seats: null })
+      case 'shape': if (shapeIsAQuestion) setDraft({ ...draft, shape: null })
     }
   }
 
@@ -205,7 +193,7 @@ export function PlayWizard({
 
   const complete: Selection | null =
     draft.roster !== null && draft.cards !== null && draft.shape !== null
-      ? { roster: draft.roster, cards: draft.cards, shape: draft.shape, seats: draft.seats ?? 2 }
+      ? { roster: draft.roster, cards: draft.cards, shape: draft.shape }
       : null
 
   return (
@@ -277,10 +265,6 @@ export function PlayWizard({
                 </span>
               ))}
             </p>
-            <SeatControl
-              selection={complete}
-              onChange={(seats) => replaceDraft({ ...complete, seats })}
-            />
             <button
               type="button"
               className={styles.primaryButton}
@@ -413,51 +397,6 @@ function WizardStepper({
 }
 
 /**
- * How many seats the lobby opens with — an optional narrowing, not a question to get past.
- *
- * It defaults to the maximum and the caption says so, because for a group the count is a *cap*:
- * `startBlockReason` only ever counts the players actually present, so the host starts when everyone
- * has arrived and nobody has to predict the number up front. `TournamentLobbySettings` has the same
- * control, so it stays changeable afterwards too.
- *
- * Only rendered when there is something to narrow: a pair is always two, Two-Headed Giant is always
- * four. The allowed counts are an explicit list rather than a range because Team vs. Team needs an
- * even number — a slider with holes in it is a control that lets you pick something the start button
- * then refuses.
- */
-function SeatControl({
-  selection,
-  onChange,
-}: {
-  selection: Selection
-  onChange: (seats: number) => void
-}) {
-  const rule = seatRule(selection.roster, selection.cards, selection.shape)
-  if (rule.fixed || rule.values.length <= 1) return null
-  return (
-    <span className={styles.wizardSeats}>
-      <span className={styles.wizardSeatsRow}>
-        <span className={styles.wizardSubLabel}>{rule.label}</span>
-        <div className={styles.settingsButtons}>
-          {rule.values.map((n) => (
-            <button
-              key={n}
-              type="button"
-              className={`${styles.settingsButton} ${n === selection.seats ? styles.settingsButtonActive : ''}`}
-              data-testid={`wizard-seats-${n}`}
-              onClick={() => onChange(n)}
-            >
-              {n}
-            </button>
-          ))}
-        </div>
-      </span>
-      <p className={styles.wizardSeatsCaption}>{rule.caption}</p>
-    </span>
-  )
-}
-
-/**
  * One step's options.
  *
  * Disabled tiles stay visible with their reason on hover, which is the same rule the lobby's axis
@@ -546,14 +485,15 @@ function loadLastSelection(aiEnabled: boolean): Selection | null {
     return null
   }
   if (typeof parsed !== 'object' || parsed === null) return null
-  const { roster, cards, shape, seats } = parsed as Partial<Selection>
-  if (!roster || !cards || !shape || typeof seats !== 'number') return null
+  // A selection stored before the wizard stopped asking for seats carries a `seats` field; it is
+  // simply ignored, which is the same thing a stale `?seats=` link gets.
+  const { roster, cards, shape } = parsed as Partial<Selection>
+  if (!roster || !cards || !shape) return null
   if (roster === 'SOLO' && !aiEnabled) return null
 
   const cardsOk = cardsChoices(roster).some((c) => c.value === cards.kind && !c.disabledReason)
   const shapeOk = shapeChoices(roster, cards).some((c) => c.value === shape && !c.disabledReason)
   if (!cardsOk || !shapeOk) return null
 
-  const rule = seatRule(roster, cards, shape)
-  return { roster, cards, shape, seats: rule.values.includes(seats) ? seats : defaultSeats(rule) }
+  return { roster, cards, shape }
 }

--- a/web-client/src/components/ui/wizardUrl.test.ts
+++ b/web-client/src/components/ui/wizardUrl.test.ts
@@ -1,7 +1,7 @@
 /**
  * The wizard's URL is now its state, so an encoding that loses or mangles an answer is a broken
  * screen rather than a cosmetic bug. This walks the same space `modeMatrix.test.ts` does — every
- * roster × Cards × sub-shape × shape × seat count the wizard can offer — and asserts the round trip.
+ * roster × Cards × shape the wizard can offer — and asserts the round trip.
  */
 import { describe, it, expect } from 'vitest'
 import {
@@ -9,8 +9,6 @@ import {
   SHAPE_IDS,
   cardsChoices,
   defaultCardsAxis,
-  defaultSeats,
-  seatRule,
   shapeChoices,
   type Roster,
   type ShapeId,
@@ -36,32 +34,22 @@ function everySelection(): WizardDraft[] {
   for (const roster of ROSTERS) {
     for (const cards of offeredCards(roster)) {
       for (const shape of shapeChoices(roster, cards).filter((s) => !s.disabledReason)) {
-        const rule = seatRule(roster, cards, shape.value)
-        for (const seats of rule.values) {
-          out.push({ roster, cards, shape: shape.value, seats })
-        }
+        out.push({ roster, cards, shape: shape.value })
       }
     }
   }
   return out
 }
 
-/** `pathToDraft` needs the path and query separately, the way `useLocation` hands them over. */
-function split(path: string): [string, string] {
-  const i = path.indexOf('?')
-  return i === -1 ? [path, ''] : [path.slice(0, i), path.slice(i)]
-}
-
 function roundTrip(draft: WizardDraft): WizardDraft {
-  const [pathname, search] = split(draftToPath(draft))
-  return pathToDraft(pathname, search, true)
+  return pathToDraft(draftToPath(draft), true)
 }
 
 describe('wizard URL round trip', () => {
   const selections = everySelection()
 
   it('covers a non-trivial space', () => {
-    expect(selections.length).toBeGreaterThan(40)
+    expect(selections.length).toBeGreaterThan(20)
   })
 
   it('survives every complete selection', () => {
@@ -95,21 +83,10 @@ describe('wizard URL round trip', () => {
     expect(new Set(paths).size).toBe(paths.length)
   })
 
-  it('keeps the default seat count out of the query', () => {
-    for (const roster of ROSTERS) {
-      for (const cards of offeredCards(roster)) {
-        for (const shape of shapeChoices(roster, cards).filter((s) => !s.disabledReason)) {
-          const rule = seatRule(roster, cards, shape.value)
-          const path = draftToPath({ roster, cards, shape: shape.value, seats: defaultSeats(rule) })
-          expect(path, `${roster}/${cards.kind}/${shape.value}`).not.toContain('?')
-        }
-      }
-    }
-  })
-
-  it('produces readable, lowercase, slash-delimited paths', () => {
+  it('writes a path and nothing else — every answer is a segment', () => {
     for (const path of selections.map(draftToPath)) {
-      expect(path).toMatch(/^\/play(\/[a-z0-9-]+)+(\?seats=\d+)?$/)
+      expect(path).not.toContain('?')
+      expect(path).toMatch(/^\/play(\/[a-z0-9-]+)+$/)
     }
   })
 })
@@ -117,75 +94,60 @@ describe('wizard URL round trip', () => {
 describe('wizard URL decoding is defensive', () => {
   it('ignores paths it does not own', () => {
     for (const path of ['/', '/help', '/deckbuilder', '/tournament/abc', '/playground']) {
-      expect(pathToDraft(path, '', true), path).toEqual(EMPTY_DRAFT)
+      expect(pathToDraft(path, true), path).toEqual(EMPTY_DRAFT)
     }
   })
 
   it('drops an unknown roster entirely', () => {
-    expect(pathToDraft('/play/nobody', '', true)).toEqual(EMPTY_DRAFT)
-    expect(pathToDraft('/play', '', true)).toEqual(EMPTY_DRAFT)
+    expect(pathToDraft('/play/nobody', true)).toEqual(EMPTY_DRAFT)
+    expect(pathToDraft('/play', true)).toEqual(EMPTY_DRAFT)
   })
 
   it('drops a solo selection when the server has no AI', () => {
-    expect(pathToDraft('/play/solo/bring-a-deck', '', false)).toEqual(EMPTY_DRAFT)
-    expect(pathToDraft('/play/solo/bring-a-deck', '', true).roster).toBe('SOLO')
+    expect(pathToDraft('/play/solo/bring-a-deck', false)).toEqual(EMPTY_DRAFT)
+    expect(pathToDraft('/play/solo/bring-a-deck', true).roster).toBe('SOLO')
   })
 
   it('truncates to the roster when the Cards value is unreachable for it', () => {
     // Momir and Random pool exist only on the two-seat lobby that plays one game.
     for (const slug of ['momir', 'random']) {
-      const back = pathToDraft(`/play/group/${slug}`, '', true)
+      const back = pathToDraft(`/play/group/${slug}`, true)
       expect(back, slug).toEqual({ ...EMPTY_DRAFT, roster: 'GROUP' })
     }
   })
 
   it('does not encode the sealed or draft sub-shape', () => {
     // It is a lobby sub-option, like deck legality — the wizard commits to the kind at its default.
-    expect(draftToPath({ roster: 'GROUP', cards: { kind: 'DRAFT', shape: 'WINSTON' }, shape: 'BRACKET', seats: null }))
+    expect(draftToPath({ roster: 'GROUP', cards: { kind: 'DRAFT', shape: 'WINSTON' }, shape: 'BRACKET' }))
       .toBe('/play/group/draft/bracket')
-    expect(pathToDraft('/play/group/draft', '', true).cards).toEqual({ kind: 'DRAFT', shape: 'BOOSTER' })
-    expect(pathToDraft('/play/friend/sealed', '', true).cards).toEqual({ kind: 'SEALED', shape: 'STANDARD' })
+    expect(pathToDraft('/play/group/draft', true).cards).toEqual({ kind: 'DRAFT', shape: 'BOOSTER' })
+    expect(pathToDraft('/play/friend/sealed', true).cards).toEqual({ kind: 'SEALED', shape: 'STANDARD' })
     // A slug that spells one out is simply not a Cards value, so it truncates to the roster.
-    expect(pathToDraft('/play/group/draft-winston', '', true))
+    expect(pathToDraft('/play/group/draft-winston', true))
       .toEqual({ ...EMPTY_DRAFT, roster: 'GROUP' })
   })
 
   it('drops an unknown or unreachable shape but keeps the answers before it', () => {
-    const back = pathToDraft('/play/group/draft/not-a-shape', '', true)
+    const back = pathToDraft('/play/group/draft/not-a-shape', true)
     expect(back.roster).toBe('GROUP')
     expect(back.cards).toEqual({ kind: 'DRAFT', shape: 'BOOSTER' })
     expect(back.shape).toBeNull()
   })
 
   it('auto-resolves a one-answer shape step', () => {
-    const back = pathToDraft('/play/friend/random', '', true)
+    const back = pathToDraft('/play/friend/random', true)
     expect(back.shape).toBe<ShapeId>('ONE_GAME')
-    expect(back.seats).toBe(2)
-  })
-
-  it('falls back to the default seat count for a nonsense one', () => {
-    for (const seats of ['0', '99', 'abc', '']) {
-      const back = pathToDraft('/play/group/draft/bracket', `?seats=${seats}`, true)
-      expect(back.seats, seats).toBe(defaultSeats(seatRule('GROUP', { kind: 'DRAFT', shape: 'BOOSTER' }, 'BRACKET')))
-    }
-  })
-
-  it('honours a seat count the rule allows', () => {
-    const back = pathToDraft('/play/group/draft/bracket', '?seats=4', true)
-    expect(back.seats).toBe(4)
   })
 
   it('tolerates a trailing slash', () => {
-    expect(pathToDraft('/play/group/', '', true)).toEqual({ ...EMPTY_DRAFT, roster: 'GROUP' })
+    expect(pathToDraft('/play/group/', true)).toEqual({ ...EMPTY_DRAFT, roster: 'GROUP' })
   })
 
   it('has a slug for every shape id', () => {
     // A missing case would make the path collide or read `undefined`; the regex catches that here
     // rather than in the address bar.
     for (const shape of SHAPE_IDS) {
-      const path = draftToPath({
-        roster: 'GROUP', cards: { kind: 'BRING_A_DECK', legality: null }, shape, seats: null,
-      })
+      const path = draftToPath({ roster: 'GROUP', cards: { kind: 'BRING_A_DECK', legality: null }, shape })
       expect(path, shape).toMatch(/^\/play\/group\/bring-a-deck\/[a-z-]+$/)
     }
   })

--- a/web-client/src/components/ui/wizardUrl.ts
+++ b/web-client/src/components/ui/wizardUrl.ts
@@ -9,11 +9,10 @@
  * present, exactly as `PlayWizard` already derives it from its draft — so there is still one source
  * of truth, and `history.back()` is by construction "drop the last answer".
  *
- *     /                                  who with?
- *     /play/group                        what with?
- *     /play/group/draft                  how?
- *     /play/group/draft/bracket          ready
- *     /play/group/draft/bracket?seats=4  ready, narrowed
+ *     /                             who with?
+ *     /play/group                   what with?
+ *     /play/group/draft             how?
+ *     /play/group/draft/bracket     ready
  *
  * Two consequences worth naming:
  *
@@ -34,8 +33,6 @@
 import {
   ROSTERS,
   SHAPE_IDS,
-  defaultSeats,
-  seatRule,
   shapeChoices,
   cardsChoices,
   defaultCardsAxis,
@@ -52,10 +49,9 @@ export interface WizardDraft {
   roster: Roster | null
   cards: CardsAxis | null
   shape: ShapeId | null
-  seats: number | null
 }
 
-export const EMPTY_DRAFT: WizardDraft = { roster: null, cards: null, shape: null, seats: null }
+export const EMPTY_DRAFT: WizardDraft = { roster: null, cards: null, shape: null }
 
 /* ── Slugs ──────────────────────────────────────────────────────────────────
  * Hand-written rather than derived from the enum names, because these are URLs: `two-headed-giant`
@@ -97,31 +93,26 @@ function cardsSlug(kind: CardsKind): string {
   }
 }
 
-/** The canonical path (plus query) for a draft. `/` when nothing is answered yet. */
+/** The canonical path for a draft. `/` when nothing is answered yet. */
 export function draftToPath(draft: WizardDraft): string {
   if (draft.roster === null) return '/'
   const parts = [WIZARD_PREFIX, rosterSlug(draft.roster)]
   if (draft.cards !== null) parts.push(cardsSlug(draft.cards.kind))
   if (draft.cards !== null && draft.shape !== null) parts.push(shapeSlug(draft.shape))
-  const path = parts.join('/')
-
-  // Only a *narrowed* seat count is written down. The default is implied, so the common path stays
-  // clean and a link that does carry `?seats=` is saying something the default wouldn't.
-  if (draft.roster !== null && draft.cards !== null && draft.shape !== null && draft.seats !== null) {
-    const rule = seatRule(draft.roster, draft.cards, draft.shape)
-    if (!rule.fixed && draft.seats !== defaultSeats(rule)) return `${path}?seats=${draft.seats}`
-  }
-  return path
+  return parts.join('/')
 }
 
 /**
- * Parse a location into a draft, keeping only the prefix of answers that still holds.
+ * Parse a path into a draft, keeping only the prefix of answers that still holds.
  *
  * Each answer is validated against the one before it, so an unreachable combination truncates rather
  * than throwing: `/play/group/momir` (Momir has no group implementation) yields just the roster, and
  * the player lands on step 2 with Momir visibly disabled and its reason attached.
+ *
+ * The query string carries no answers — a saved `?seats=4` link from when the wizard asked for a
+ * seat count decodes to the same selection as one without it, and normalising drops the query.
  */
-export function pathToDraft(pathname: string, search: string, aiEnabled: boolean): WizardDraft {
+export function pathToDraft(pathname: string, aiEnabled: boolean): WizardDraft {
   const segments = pathname.replace(/\/+$/, '').split('/').filter(Boolean)
   if (segments[0] !== WIZARD_PREFIX.slice(1)) return EMPTY_DRAFT
 
@@ -143,10 +134,7 @@ export function pathToDraft(pathname: string, search: string, aiEnabled: boolean
         : null
   if (shape === null) return { ...EMPTY_DRAFT, roster, cards }
 
-  const rule = seatRule(roster, cards, shape)
-  const asked = Number(new URLSearchParams(search).get('seats'))
-  const seats = rule.values.includes(asked) ? asked : defaultSeats(rule)
-  return { roster, cards, shape, seats }
+  return { roster, cards, shape }
 }
 
 /** A Cards slug, checked against what this roster can actually pick, at its default sub-shape. */

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -391,7 +391,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
         'Each option says whether it is one game or an event with steps — “Play right away” and “One game” versus “Build a deck first” and “Several rounds · standings”. Once everything is answered, the line above the button spells the whole sequence out.',
         'Greyed-out options are combinations nothing implements yet — hover for the reason.',
         'Options that are simply missing would contradict an earlier answer. A group of five is not offered a 1v1 single game.',
-        'The seat count is a limit, not a requirement: start whenever everyone has arrived, and change it in the lobby.',
+        'Nobody is asked how many seats to open. A lobby holds as many as its table allows, people join until it is full, and the host starts whenever everyone has arrived.',
         'The lobby you land in can change all of it, so a wrong turn costs nothing.',
         '“Play again” repeats your last setup in one click.',
       ] },
@@ -406,7 +406,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
       'You and the built-in AI. Nobody else has to show up, and the game starts as soon as you have picked a deck.',
     body: [
       { kind: 'p', text: 'At 1v1 the AI can play any of the card sources — your own deck, a rolled pool, or Momir Basic.' },
-      { kind: 'p', text: 'Sealed and draft go further: the lobby fills with AI seats, so you can draft a full pod on your own and play the bracket out. Pick the pod size on the last step.' },
+      { kind: 'p', text: 'Sealed and draft go further: the lobby opens as a full pod of AI drafters, so you can draft on your own and play the bracket out. Add or remove them in the lobby if you want a smaller pod.' },
       { kind: 'p', text: 'What the AI cannot do yet is take a seat at a multiplayer table, or bring its own deck to a bracket.' },
     ],
     related: ['axis-limits', 'cards-draft', 'event-round-robin'],


### PR DESCRIPTION
Nobody is asked how many seats to open any more: a lobby holds as many as its shape allows, and people join until it is full.

The count was never a quorum — `startBlockReason` only ever counts the players actually present, so the host starts whenever everyone has arrived. Asking for it up front only meant predicting a number and then having to notice it was wrong.

## Client

- `SeatControl` (the "Up to" / "Pod size" chip row and its caption) is gone from the wizard's launch block, and the **Seats** select from `TournamentLobbySettings`. The lobby header's `n / max` still says where it stands.
- `seatRule` + `defaultSeats` collapse into one `seatCap(roster, cards, shape)` — always the maximum, which is what `defaultSeats` already returned, so **no lobby opens narrower than before**. `resolveLaunch` derives `maxPlayers` and a solo pod's AI seats from it.
- `Selection` and `WizardDraft` drop `seats`, so `?seats=` leaves the URL scheme and `pathToDraft` takes just the path. A shared link or a stored "Play again" selection that still carries a seat count decodes to the same selection — the query is ignored, and normalising drops it.
- Copy follow-through: the flow line reads "One shared game, up to 6 seats", the recap chip drops its `· 8 seats` tail, and two help topics are reworded.

## Server

This part was needed, or the cap could get stuck with nothing left to fix it: switching a table to Free-for-All clamped `maxPlayers` to 6, and switching back to a bracket left it at 6.

`LobbyHandler.seatCapFor(format, gameMode)` (Winston 2, Grid 4, 2HG 4, FFA 6, else 8) is now **re-derived** on every format and game-mode change instead of narrowed, and is the ceiling that the create and `updateLobbySettings` paths clamp an explicit `maxPlayers` to — so an older or hand-rolled client isn't silently ignored.

## Behaviour worth naming

A solo limited pod now always opens as a full pod of AI drafters (8 for booster draft). That was already the value the wizard pre-selected, and the lobby's add/remove-AI buttons still adjust it — but there is no longer a way to say "pod of 4" before the lobby exists.

## Verification

- `npm run typecheck` and `npm run build` clean.
- The 42 lobby + wizard vitest cases pass, updated to the seatless space (the URL round trip and the `modeMatrix` ↔ `axisChoices` agreement walk both lose their seat dimension; a new case asserts the cap the server will accept for each shape).
- `just test-server` green.

No screenshot attached — the visible change is the removal of two controls, so an "after" shot is a launch block and a settings list with one row missing. Happy to capture one if it's useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
