### PR TITLE
Add three Wilds of Eldraine cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BackForSeconds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BackForSeconds.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Back for Seconds
+ * {2}{B}
+ * Sorcery
+ *
+ * Bargain
+ * Return up to two target creature cards from your graveyard to your hand. If this spell was
+ * bargained, you may put one of those cards with mana value 4 or less onto the battlefield
+ * instead of putting it into your hand.
+ *
+ * Targets are chosen while casting, but the optional battlefield choice happens on resolution
+ * after target legality is checked. Moving the chosen eligible card first and then filtering the
+ * original target collection to cards still in the graveyard implements "instead"; the selected
+ * card cannot subsequently be moved to hand by the final step.
+ */
+val BackForSeconds = card("Back for Seconds") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Return up to two target creature cards from your graveyard to your hand. If this spell " +
+        "was bargained, you may put one of those cards with mana value 4 or less onto the " +
+        "battlefield instead of putting it into your hand."
+
+    bargain()
+
+    spell {
+        target = TargetObject(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard,
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.ChosenTargets,
+                storeAs = "backForSecondsTargets",
+            ),
+            ConditionalEffect(
+                condition = Conditions.WasBargained,
+                effect = Effects.Composite(
+                    SelectFromCollectionEffect(
+                        from = "backForSecondsTargets",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                        storeSelected = "backForSecondsReanimated",
+                        filter = GameObjectFilter.Creature.manaValueAtMost(4),
+                        prompt = "Put up to one creature card with mana value 4 or less onto the battlefield",
+                    ),
+                    MoveCollectionEffect(
+                        from = "backForSecondsReanimated",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                        underOwnersControl = true,
+                    ),
+                    FilterCollectionEffect(
+                        from = "backForSecondsTargets",
+                        filter = CollectionFilter.InZone(Zone.GRAVEYARD),
+                        storeMatching = "backForSecondsToHand",
+                    ),
+                    MoveCollectionEffect(
+                        from = "backForSecondsToHand",
+                        destination = CardDestination.ToZone(Zone.HAND),
+                    ),
+                ),
+                elseEffect = MoveCollectionEffect(
+                    from = "backForSecondsTargets",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg?1783915111"
+
+        ruling(
+            "2023-09-01",
+            "If you bargain this spell, you can still choose not to put one of the cards onto the " +
+                "battlefield, even if at least one is eligible.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KorvoldAndTheNobleThief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KorvoldAndTheNobleThief.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Korvold and the Noble Thief
+ * {3}{R}
+ * Enchantment — Saga
+ *
+ * I, II — Create a Treasure token.
+ * III — Exile the top three cards of target opponent's library. You may play those cards this turn.
+ *
+ * The third chapter targets the opponent, not their cards. The cards are gathered from that
+ * player's library only when the chapter resolves, then moved to exile and granted to the Saga's
+ * controller until end of turn. "Play" intentionally includes playing a land, subject to the
+ * normal timing and one-land-per-turn rules.
+ */
+val KorvoldAndTheNobleThief = card("Korvold and the Noble Thief") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice " +
+        "after III.)\n" +
+        "I, II — Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: " +
+        "Add one mana of any color.\")\n" +
+        "III — Exile the top three cards of target opponent's library. You may play those cards " +
+        "this turn."
+
+    sagaChapter(1) {
+        effect = Effects.CreateTreasure()
+    }
+
+    sagaChapter(2) {
+        effect = Effects.CreateTreasure()
+    }
+
+    sagaChapter(3) {
+        target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(
+                    count = DynamicAmount.Fixed(3),
+                    player = Player.TargetOpponent,
+                ),
+                storeAs = "korvoldExiled",
+            ),
+            MoveCollectionEffect(
+                from = "korvoldExiled",
+                destination = CardDestination.ToZone(Zone.EXILE, player = Player.TargetOpponent),
+            ),
+            GrantMayPlayFromExileEffect(
+                from = "korvoldExiled",
+                expiry = MayPlayExpiry.EndOfTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Ben Hill"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg?1783915092"
+
+        ruling(
+            "2023-09-01",
+            "You pay all costs and follow all normal timing rules for a card played this way. For " +
+                "example, if the exiled card is a land card, you may play it only during your main " +
+                "phase while the stack is empty.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RealmScorcherHellkite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/RealmScorcherHellkite.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Realm-Scorcher Hellkite
+ * {4}{R}{R}
+ * Creature — Dragon
+ * 4/6
+ *
+ * Bargain
+ * Flying, haste
+ * When this creature enters, if it was bargained, add four mana in any combination of colors.
+ * {1}{R}: This creature deals 1 damage to any target.
+ *
+ * The bargain condition is an intervening "if": an unbargained Hellkite never puts the mana
+ * ability on the stack. The four mana is distributed pip by pip, so the player may choose a mix
+ * of colors rather than one color for all four.
+ */
+val RealmScorcherHellkite = card("Realm-Scorcher Hellkite") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 6
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this " +
+        "spell.)\n" +
+        "Flying, haste\n" +
+        "When this creature enters, if it was bargained, add four mana in any combination of " +
+        "colors.\n" +
+        "{1}{R}: This creature deals 1 damage to any target."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+    bargain()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasBargained
+        effect = Effects.AddManaInAnyCombination(4)
+        description = "When this creature enters, if it was bargained, add four mana in any " +
+            "combination of colors."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        val target = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, target)
+        description = "This creature deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "145"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg?1783915090"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -774,6 +774,133 @@
     ]
 }
 
+// Back for Seconds
+{
+    "name": "Back for Seconds",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nReturn up to two target creature cards from your graveyard to your hand. If this spell was bargained, you may put one of those cards with mana value 4 or less onto the battlefield instead of putting it into your hand.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "backForSecondsTargets"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "BARGAINED"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "backForSecondsTargets",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "creature mv<=4",
+                                "storeSelected": "backForSecondsReanimated",
+                                "prompt": "Put up to one creature card with mana value 4 or less onto the battlefield"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "backForSecondsReanimated",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "underOwnersControl": true
+                            },
+                            {
+                                "type": "FilterCollection",
+                                "from": "backForSecondsTargets",
+                                "filter": {
+                                    "type": "InZone",
+                                    "zone": "Graveyard"
+                                },
+                                "storeMatching": "backForSecondsToHand"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "backForSecondsToHand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "MoveCollection",
+                        "from": "backForSecondsTargets",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Hand"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Metzger",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/660845b5-96fa-4484-822b-aa0508801306.jpg?1783915111",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you bargain this spell, you can still choose not to put one of the cards onto the battlefield, even if at least one is eligible."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Barrow Naughty
 {
     "name": "Barrow Naughty",
@@ -7885,6 +8012,84 @@
     ]
 }
 
+// Korvold and the Noble Thief
+{
+    "name": "Korvold and the Noble Thief",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II — Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nIII — Exile the top three cards of target opponent's library. You may play those cards this turn.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "player": "TargetOpponent"
+                            },
+                            "storeAs": "korvoldExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "korvoldExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": "TargetOpponent"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "korvoldExiled"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Hill",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a811b2cb-ffc7-4100-ac3e-bc4125842bb2.jpg?1783915092",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You pay all costs and follow all normal timing rules for a card played this way. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lady of Laughter
 {
     "name": "Lady of Laughter",
@@ -10673,6 +10878,107 @@
                 }
             }
         }
+    ]
+}
+
+// Realm-Scorcher Hellkite
+{
+    "name": "Realm-Scorcher Hellkite",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nFlying, haste\nWhen this creature enters, if it was bargained, add four mana in any combination of colors.\n{1}{R}: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE",
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "CastChoiceMade",
+                    "slot": "BARGAINED"
+                },
+                "descriptionOverride": "When this creature enters, if it was bargained, add four mana in any combination of colors."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "This creature deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "MYTHIC",
+        "artist": "Billy Christian",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/845b3c26-05da-4a09-a6c9-4ea4166104a7.jpg?1783915090"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary
- implement Back for Seconds with bargain-aware optional reanimation
- implement Korvold and the Noble Thief with Saga chapters and exile-play permission
- implement Realm-Scorcher Hellkite with bargain mana and activated damage
- refresh the WOE card-definition snapshot

## Verification
- `just check-card-printing` for all three cards
- exact Scryfall image URLs return HTTP 200
- `just rebless-cards` (WOE only; exactly three new card trees)
- `just build`