### PR TITLE
Add Bruna, the Fading Light to Innistrad Remastered

### DIFF
--- a/manual-scenarios/cards/b/bruna-the-fading-light.json
+++ b/manual-scenarios/cards/b/bruna-the-fading-light.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Bruna Tester",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Bruna, the Fading Light"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [
+      "Glory Seeker",
+      "Serra Angel",
+      "Grizzly Bears"
+    ],
+    "library": [
+      "Plains",
+      "Plains"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BrunaTheFadingLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BrunaTheFadingLight.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Bruna, the Fading Light
+ * {5}{W}{W}
+ * Legendary Creature — Angel Horror
+ * 5/7
+ *
+ * When you cast this spell, you may return target Angel or Human creature card from your
+ * graveyard to the battlefield.
+ * Flying, vigilance
+ * (Melds with Gisela, the Broken Blade.)
+ */
+val BrunaTheFadingLight = card("Bruna, the Fading Light") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Angel Horror"
+    power = 5
+    toughness = 7
+    oracleText = "When you cast this spell, you may return target Angel or Human creature card " +
+        "from your graveyard to the battlefield.\nFlying, vigilance\n" +
+        "(Melds with Gisela, the Broken Blade.)"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        optional = true
+        val creature = target(
+            "target Angel or Human creature card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Creature
+                        .withAnySubtype("Angel", "Human")
+                        .ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.PutOntoBattlefield(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Clint Cearley"
+        flavorText = "She now sees only Emrakul's visions."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg?1783937523"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BrunaTheFadingLightReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BrunaTheFadingLightReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bruna, the Fading Light reprint in Innistrad Remastered. The canonical card definition
+ * lives in Eldritch Moon, its earliest real-expansion printing.
+ */
+val BrunaTheFadingLightReprint = Printing(
+    oracleId = "bce7e45d-b2c5-43aa-91a6-3a3c24f30850",
+    name = "Bruna, the Fading Light",
+    setCode = "INR",
+    collectorNumber = "14",
+    scryfallId = "6fccdb60-5fce-4a6e-a709-b986f9a4b653",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6fccdb60-5fce-4a6e-a709-b986f9a4b653.jpg?1783908189",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -181,6 +181,57 @@
     "hasNoManaCost": true
 }
 
+// Bruna, the Fading Light
+{
+    "name": "Bruna, the Fading Light",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Legendary Creature — Angel Horror",
+    "oracleText": "When you cast this spell, you may return target Angel or Human creature card from your graveyard to the battlefield.\nFlying, vigilance\n(Melds with Gisela, the Broken Blade.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Angel or Human creature card in your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "optional": true,
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Angel|Human own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target Angel or Human creature card in your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Clint Cearley",
+        "flavorText": "She now sees only Emrakul's visions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27907985-b5f6-4098-ab43-15a0c2bf94d5.jpg?1783937523"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cemetery Recruitment
 {
     "name": "Cemetery Recruitment",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrunaTheFadingLightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrunaTheFadingLightScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Bruna, the Fading Light.
+ *
+ * Her reanimation ability triggers on cast, before Bruna resolves, and may target only an Angel
+ * or Human creature card in her controller's graveyard.
+ */
+class BrunaTheFadingLightScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bruna, the Fading Light") {
+
+            test("cast trigger may return an Angel or Human creature card from your graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Bruna, the Fading Light")
+                    .withCardInGraveyard(1, "Glory Seeker")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 7)
+                    .build()
+
+                val cast = game.castSpell(1, "Bruna, the Fading Light")
+                withClue("casting Bruna should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                game.resolveStack()
+                val targetDecision = game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                val human = game.findCardsInGraveyard(1, "Glory Seeker").single()
+                val bear = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                withClue("the Human is legal and the non-Angel, non-Human creature is not") {
+                    targetDecision.legalTargets[0].orEmpty() shouldContain human
+                    targetDecision.legalTargets[0].orEmpty() shouldNotContain bear
+                }
+
+                game.submitDecision(
+                    TargetsResponse(targetDecision.id, mapOf(0 to listOf(human))),
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the cast trigger reanimates the chosen Human before Bruna resolves") {
+                    game.isOnBattlefield("Glory Seeker") shouldBe true
+                    game.isOnBattlefield("Bruna, the Fading Light") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Bruna, the Fading Light in its canonical Eldritch Moon package
- add the Innistrad Remastered printing metadata and art
- add a focused cast-trigger scenario test and a manual client scenario

The remaining unimplemented INR candidates are dominated by cross-cutting mechanics such as madness, emerge, undying, meld, soulbond, or card-specific replacement/permission behavior, so this PR intentionally keeps the batch to one rules-faithful card.

## Verification
- just test-class BrunaTheFadingLightScenarioTest
- just rebless-cards (only Bruna added to EMN snapshot)
- just check-card-printing Bruna, the Fading Light
- just build
- exact EMN and INR Scryfall image URLs return HTTP 200