### PR TITLE
Add Aetherdrift Pilot card batch

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5610,6 +5610,13 @@ composite abilities).
   Conditions.SourceIsSaddled` for "whenever this attacks while saddled"). The marker (engine
   `SaddledComponent`) is cleared at end of turn or when the permanent leaves the battlefield, and
   is not a copiable value (CR 702.171b). Mounts that gate on the saddled state use this.
+- `CrewSaddleContribution(characteristic = POWER, modifier = 0)` — changes only the numeric value
+  a creature contributes while paying a Crew or Saddle cost; it does not change that creature's
+  power or toughness. The selected `characteristic` is read from projected state before `modifier`
+  is applied, so counters and continuous effects are honored. Pilot text such as “saddles Mounts
+  and crews Vehicles as though its power were 2 greater” uses `modifier = 2`; “using its toughness
+  rather than its power” uses `characteristic = CrewSaddleCharacteristic.TOUGHNESS`. Printed and
+  token-granted instances use the same handler path.
 - `Modular(n)` — ETB with +1/+1 counters, transfer on death.
 - `Fading(n)` — ETB with N fade counters; removes one each upkeep, sacrifice if can't.
 - `Vanishing(n)` — same idea with time counters.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -12,6 +12,41 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Changes the value a creature contributes when it is tapped to crew a Vehicle or saddle a Mount.
+ *
+ * This does not change the creature's power or toughness. It only changes the number used while
+ * paying a crew or saddle cost. [characteristic] is read from projected state, so counters and
+ * continuous effects are reflected before [modifier] is applied.
+ *
+ * A Pilot that "saddles Mounts and crews Vehicles as though its power were 2 greater" uses
+ * `CrewSaddleContribution(modifier = 2)`. A creature that uses its toughness rather than its power
+ * uses `CrewSaddleContribution(characteristic = CrewSaddleCharacteristic.TOUGHNESS)`.
+ */
+@SerialName("CrewSaddleContribution")
+@Serializable
+data class CrewSaddleContribution(
+    val characteristic: CrewSaddleCharacteristic = CrewSaddleCharacteristic.POWER,
+    val modifier: Int = 0
+) : StaticAbility {
+    override val description: String = when {
+        characteristic == CrewSaddleCharacteristic.TOUGHNESS && modifier == 0 ->
+            "This creature saddles Mounts and crews Vehicles using its toughness rather than its power"
+        characteristic == CrewSaddleCharacteristic.POWER && modifier > 0 ->
+            "This creature saddles Mounts and crews Vehicles as though its power were $modifier greater"
+        else ->
+            "This creature's crew and saddle contribution uses its ${characteristic.name.lowercase()} with a ${modifier.signed()} modifier"
+    }
+
+    private fun Int.signed(): String = if (this >= 0) "+$this" else toString()
+}
+
+@Serializable
+enum class CrewSaddleCharacteristic {
+    POWER,
+    TOUGHNESS
+}
+
+/**
  * You control enchanted permanent.
  * Used for Auras like Annex that steal control of the enchanted permanent.
  */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BackOnTrack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BackOnTrack.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Back on Track — Aetherdrift #76
+ * {4}{B} · Sorcery
+ */
+val BackOnTrack = card("Back on Track") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature or Vehicle card from your graveyard to the battlefield. " +
+        "Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews " +
+        "Vehicles as though its power were 2 greater.\""
+
+    spell {
+        val returned = target(
+            "target creature or Vehicle card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.CreatureOrVehicle.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Move(returned, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD).then(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                creatureTypes = setOf("Pilot"),
+                imageUri = "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                staticAbilities = listOf(CrewSaddleContribution(modifier = 2))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Raoul Vitale"
+        flavorText = "At the Tombs Before Time, the living of Amonkhet made vital alliances with the honored dead."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg?1783907899"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DeathlessPilot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DeathlessPilot.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deathless Pilot — Aetherdrift #82
+ * {1}{B} · Creature — Zombie Pilot · 2/2
+ */
+val DeathlessPilot = card("Deathless Pilot") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Pilot"
+    oracleText = "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\n" +
+        "{3}{B}: Return this card from your graveyard to your hand."
+    power = 2
+    toughness = 2
+
+    staticAbility {
+        ability = CrewSaddleContribution(modifier = 2)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}")
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+        activateFromZone = Zone.GRAVEYARD
+        description = "{3}{B}: Return this card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Justin Cornell"
+        flavorText = "Amonkhet champions become markedly more reckless after dying."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg?1783907896"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DynamiteDiver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DynamiteDiver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+
+/**
+ * Dynamite Diver — Aetherdrift #123
+ * {R} · Creature — Goblin Pilot · 1/1
+ */
+val DynamiteDiver = card("Dynamite Diver") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Pilot"
+    oracleText = "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\n" +
+        "When this creature dies, it deals 1 damage to any target."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = CrewSaddleContribution(modifier = 2)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val damaged = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, damaged)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Pete Venters"
+        flavorText = "\"Launch the explosives! No, you idiot, not like that!\"\n" +
+            "—Redshift, Rocketeer chief"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg?1783907883"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -936,6 +936,66 @@
     "colorIdentityOverride": []
 }
 
+// Back on Track
+{
+    "name": "Back on Track",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature or Vehicle card from your graveyard to the battlefield. Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or Vehicle card in your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Pilot"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                    "staticAbilities": [
+                        {
+                            "type": "CrewSaddleContribution",
+                            "modifier": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|Vehicle own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature or Vehicle card in your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "flavorText": "At the Tombs Before Time, the living of Amonkhet made vital alliances with the honored dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/884c0032-9c62-4028-a55f-6a3da2545654.jpg?1783907899"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Beastrider Vanguard
 {
     "name": "Beastrider Vanguard",
@@ -2917,6 +2977,54 @@
     ]
 }
 
+// Deathless Pilot
+{
+    "name": "Deathless Pilot",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Pilot",
+    "oracleText": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\n{3}{B}: Return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{3}{B}: Return this card from your graveyard to your hand."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CrewSaddleContribution",
+                "modifier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Justin Cornell",
+        "flavorText": "Amonkhet champions become markedly more reckless after dying.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e704fb95-17b7-432a-831c-18abe7d9cc73.jpg?1783907896"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Debris Beetle
 {
     "name": "Debris Beetle",
@@ -3573,6 +3681,60 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Dynamite Diver
+{
+    "name": "Dynamite Diver",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Pilot",
+    "oracleText": "This creature saddles Mounts and crews Vehicles as though its power were 2 greater.\nWhen this creature dies, it deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CrewSaddleContribution",
+                "modifier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Pete Venters",
+        "flavorText": "\"Launch the explosives! No, you idiot, not like that!\"\n—Redshift, Rocketeer chief",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a4f96f6-dd91-4357-ae19-1c35db2c2bcb.jpg?1783907883"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -3,6 +3,14 @@ package com.wingedsheep.tooling.coverage.bridge
 /** Triggered-ability conditions and costs (accepted as [supported] pending a `Triggers.*`/`Costs.*`
  *  facade scan), plus the duration-scoped trigger/replacement creators (composed from primitives). */
 internal fun BridgeBuilder.triggersCostsAndContinuous() {
+    supported(
+        "CrewsVehiclesAsThoughPowerWereGreater",
+        "static ability: projected power plus N contributes to Crew (CrewSaddleContribution)"
+    )
+    supported(
+        "SaddlesMountsAsThoughPowerWereGreater",
+        "static ability: projected power plus N contributes to Saddle (CrewSaddleContribution)"
+    )
     // Triggers — validated by a Triggers.* facade scan in a later phase.
     supported("WhenAPermanentEntersTheBattlefield", "trigger: ETB (Triggers.* scan validates in P1)")
     // Batched ETB — "whenever one or more permanents [matching a filter] enter" fires once per event

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -113,8 +113,24 @@ internal fun EmitCtx.staticBlock(rule: JsonObject): List<Stmt>? {
         return stmts
     }
     val stmts = mutableListOf<Stmt>()
+    var crewSaddleModifier: Int? = null
     for (r in rules) {
         val name = r.strField("_PermanentRule")!!
+        if (name == "CrewsVehiclesAsThoughPowerWereGreater" ||
+            name == "SaddlesMountsAsThoughPowerWereGreater"
+        ) {
+            val modifier = (r["args"] as? JsonObject)
+                ?.takeIf { it.strField("_GameNumber") == "Integer" }
+                ?.get("args")
+                .asInt()
+                ?: run { reasons.add(name); return null }
+            if (crewSaddleModifier == modifier) continue
+            if (crewSaddleModifier != null) {
+                reasons.add("CrewSaddleContribution")
+                return null
+            }
+            crewSaddleModifier = modifier
+        }
         if (name == "CantBeBlocked") {
             stmts.add(Eval(call("flags", arg("AbilityFlag.CANT_BE_BLOCKED")))); continue
         }
@@ -592,6 +608,15 @@ private fun EmitCtx.lordGroupFilterExpr(filterNode: JsonElement?): Dsl? {
 
 internal fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): Dsl? {
     when (ruleName) {
+        "CrewsVehiclesAsThoughPowerWereGreater",
+        "SaddlesMountsAsThoughPowerWereGreater" -> {
+            val modifier = (ruleNode["args"] as? JsonObject)
+                ?.takeIf { it.strField("_GameNumber") == "Integer" }
+                ?.get("args")
+                .asInt()
+            if (modifier == null) return null
+            return call("CrewSaddleContribution", arg("modifier", "$modifier"))
+        }
         "CantBlock" -> return call("CantBlock")
         "CantBeBlockedByMoreThanOne" -> return call("CantBeBlockedByMoreThan", arg("maxBlockers", "1"))
         "CanBlockOnly" -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewSaddleContributionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewSaddleContributionEvaluator.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.handlers.actions.ability
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CrewSaddleCharacteristic
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+
+/**
+ * Reads the value a creature contributes toward a crew or saddle cost.
+ *
+ * Printed and granted instances are both considered: printed abilities cover ordinary cards, while
+ * token text is stored in [GameState.grantedStaticAbilities]. Multiple instances do not stack; each
+ * is an alternative way to determine the contribution, so the controller gets the greatest value.
+ */
+internal object CrewSaddleContributionEvaluator {
+    fun evaluate(
+        state: GameState,
+        projected: ProjectedState,
+        cardRegistry: CardRegistry,
+        creatureId: EntityId
+    ): Int {
+        val printed = state.getEntity(creatureId)
+            ?.get<CardComponent>()
+            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            ?.staticAbilities
+            .orEmpty()
+        val granted = state.grantedStaticAbilities
+            .asSequence()
+            .filter { it.entityId == creatureId }
+            .map { it.ability }
+            .toList()
+        val alternatives = (printed + granted).filterIsInstance<CrewSaddleContribution>()
+
+        val actualPower = projected.getPower(creatureId) ?: 0
+        if (alternatives.isEmpty()) return actualPower
+
+        return alternatives.maxOf { ability ->
+            val base = when (ability.characteristic) {
+                CrewSaddleCharacteristic.POWER -> actualPower
+                CrewSaddleCharacteristic.TOUGHNESS -> projected.getToughness(creatureId) ?: 0
+            }
+            base + ability.modifier
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -114,8 +114,12 @@ class CrewVehicleHandler(
             }
 
             // Summoning sickness does NOT prevent crewing (CR 702.122c)
-            val power = projected.getPower(creatureId) ?: 0
-            totalPower += power
+            totalPower += CrewSaddleContributionEvaluator.evaluate(
+                state = state,
+                projected = projected,
+                cardRegistry = cardRegistry,
+                creatureId = creatureId
+            )
         }
 
         if (totalPower < crewAbility.n) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -104,7 +104,12 @@ class SaddleMountHandler(
                 return "Creature is already tapped: $creatureId"
             }
 
-            totalPower += projected.getPower(creatureId) ?: 0
+            totalPower += CrewSaddleContributionEvaluator.evaluate(
+                state = state,
+                projected = projected,
+                cardRegistry = cardRegistry,
+                creatureId = creatureId
+            )
         }
 
         if (totalPower < saddleAbility.n) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -28,6 +28,7 @@ import com.wingedsheep.sdk.scripting.AddLandTypeByCounter
 import com.wingedsheep.sdk.scripting.CantBeBlocked
 import com.wingedsheep.sdk.scripting.CantAttack
 import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
 import com.wingedsheep.sdk.scripting.CanBlockAdditionalForCreatureGroup
 import com.wingedsheep.sdk.scripting.MustBeBlocked
 import com.wingedsheep.sdk.scripting.MustBlock
@@ -840,6 +841,7 @@ class StaticAbilityHandler(
             is CantBlockCreaturesWithGreaterPower,
             is CantBlockUnless,
             is CantBlockUnlessCoBlocker,
+            is CrewSaddleContribution,
 
             // Combat: damage assignment (CombatDamageManager / CombatDamageUtils / DamageUtils):
             is AssignCombatDamageAsUnblocked,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BackOnTrackScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BackOnTrackScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class BackOnTrackScenarioTest : FunSpec({
+    val crewThreeVehicle = card("Crew Three Test Vehicle") {
+        manaCost = "{3}"
+        typeLine = "Artifact — Vehicle"
+        power = 3
+        toughness = 3
+        keywordAbility(KeywordAbility.crew(3))
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        registerCard(crewThreeVehicle)
+        initMirrorMatch(Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("returns the target and creates a Pilot token whose contribution pays crew three") {
+        val d = driver()
+        val bear = d.putCardInGraveyard(d.player1, "Grizzly Bears")
+        val spell = d.putCardInHand(d.player1, "Back on Track")
+        d.giveMana(d.player1, Color.BLACK, 5)
+
+        d.submitSuccess(
+            CastSpell(
+                playerId = d.player1,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(bear, d.player1, Zone.GRAVEYARD)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        d.bothPass()
+
+        d.state.getZone(ZoneKey(d.player1, Zone.BATTLEFIELD)).contains(bear) shouldBe true
+        val pilot = d.getPermanents(d.player1).single { d.getCardName(it) == "Pilot Token" }
+        val vehicle = d.putPermanentOnBattlefield(d.player1, "Crew Three Test Vehicle")
+        d.submitSuccess(CrewVehicle(d.player1, vehicle, listOf(pilot)))
+        d.isTapped(pilot) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrewSaddleContributionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrewSaddleContributionScenarioTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.CrewSaddleCharacteristic
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level coverage for contribution variants not used by the first three Aetherdrift cards.
+ */
+class CrewSaddleContributionScenarioTest : FunSpec({
+    val toughnessPilot = card("Toughness Pilot") {
+        manaCost = "{2}"
+        typeLine = "Creature — Pilot"
+        power = 1
+        toughness = 4
+        staticAbility {
+            ability = CrewSaddleContribution(
+                characteristic = CrewSaddleCharacteristic.TOUGHNESS
+            )
+        }
+    }
+    val crewFourVehicle = card("Contribution Test Vehicle") {
+        manaCost = "{4}"
+        typeLine = "Artifact — Vehicle"
+        power = 4
+        toughness = 4
+        keywordAbility(KeywordAbility.crew(4))
+    }
+
+    test("a toughness contribution replaces rather than merely floors at power") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(toughnessPilot)
+        d.registerCard(crewFourVehicle)
+        d.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val pilot = d.putCreatureOnBattlefield(d.player1, "Toughness Pilot")
+        val vehicle = d.putPermanentOnBattlefield(d.player1, "Contribution Test Vehicle")
+
+        d.submitSuccess(CrewVehicle(d.player1, vehicle, listOf(pilot)))
+        d.isTapped(pilot) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathlessPilotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathlessPilotScenarioTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DeathlessPilotScenarioTest : FunSpec({
+    val crewFourVehicle = card("Crew Four Test Vehicle") {
+        manaCost = "{4}"
+        typeLine = "Artifact — Vehicle"
+        power = 4
+        toughness = 4
+        keywordAbility(KeywordAbility.crew(4))
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        registerCard(crewFourVehicle)
+        initMirrorMatch(Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("its projected power plus two pays crew") {
+        val d = driver()
+        val pilot = d.putCreatureOnBattlefield(d.player1, "Deathless Pilot")
+        val vehicle = d.putPermanentOnBattlefield(d.player1, "Crew Four Test Vehicle")
+
+        d.submitSuccess(CrewVehicle(d.player1, vehicle, listOf(pilot)))
+        d.isTapped(pilot) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DynamiteDiverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DynamiteDiverScenarioTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class DynamiteDiverScenarioTest : FunSpec({
+    val saddleThreeMount = card("Saddle Three Test Mount") {
+        manaCost = "{3}"
+        typeLine = "Creature — Horse Mount"
+        power = 3
+        toughness = 3
+        keywordAbility(KeywordAbility.saddle(3))
+    }
+
+    fun driver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        registerCard(saddleThreeMount)
+        initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("its projected power plus two pays saddle") {
+        val d = driver()
+        val diver = d.putCreatureOnBattlefield(d.player1, "Dynamite Diver")
+        val mount = d.putCreatureOnBattlefield(d.player1, "Saddle Three Test Mount")
+
+        d.submitSuccess(SaddleMount(d.player1, mount, listOf(diver)))
+        d.isTapped(diver) shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

- implement Back on Track, Deathless Pilot, and Dynamite Diver from Aetherdrift
- add a reusable CrewSaddleContribution static ability using projected characteristics for crew and saddle payments
- teach mtgish coverage/emission about the shared Pilot wording and update the SDK language reference
- add one scenario test per card plus an engine-level toughness-contribution test

## Verification

- just check-card-printing for all three cards
- just coverage-fidelity --emit "Deathless Pilot"
- focused scenario tests for all three cards
- just rebless-cards
- just test
- git diff --check
- exact Scryfall card and token image URLs return HTTP 200