### PR TITLE
Add resource-backed AI evaluation weights

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -189,7 +189,7 @@ class AIPlayer(
             val intents = if (profile.useCardIntent) IntentCatalog.of(cardRegistry) else IntentCatalog.NONE
 
             val simulator = GameSimulator(cardRegistry)
-            val evaluator = profile.evaluationWeights.toEvaluator(intents)
+            val evaluator = EvalWeights.resolve(profile.evalWeightsId).toEvaluator(intents)
             val combatAdvisor = CombatAdvisor(simulator, evaluator, cardRegistry, advisorRegistry)
             val responder = DecisionResponder(
                 simulator, evaluator,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -6,69 +6,8 @@ import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
 import com.wingedsheep.ai.engine.budget.BudgetPolicy
 import com.wingedsheep.ai.engine.budget.LegacyBudgetPolicy
 import com.wingedsheep.ai.engine.budget.TieredBudgetPolicy
-import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
-import com.wingedsheep.ai.engine.evaluation.BoardFeature
-import com.wingedsheep.ai.engine.evaluation.BoardPresence
-import com.wingedsheep.ai.engine.evaluation.CardAdvantage
-import com.wingedsheep.ai.engine.evaluation.CompositeBoardEvaluator
-import com.wingedsheep.ai.engine.evaluation.LifeDifferential
-import com.wingedsheep.ai.engine.evaluation.Tempo
-import com.wingedsheep.ai.engine.evaluation.ThreatAssessment
-import com.wingedsheep.ai.engine.knowledge.IntentCatalog
+import com.wingedsheep.ai.engine.evaluation.EvalWeights
 import com.wingedsheep.ai.engine.rollout.RolloutSettings
-
-/**
- * Weights for the five features [CompositeBoardEvaluator] combines.
- *
- * Every number here is a hand-guessed literal — that is the point of naming them: the arena can now
- * pit two weight sets against each other as two agents, and Phase 9 of
- * `backlog/engine-ai-improvement.md` replaces the guesses with a logistic fit.
- *
- * [DEFAULT] reproduces the values that used to be inline in `AIPlayer.defaultEvaluator()`, so
- * changing nothing changes nothing.
- */
-data class EvaluationWeights(
-    /** Life differential. Matters more when life is low — the non-linearity is inside the feature. */
-    val life: Double = 1.0,
-    /** Board presence. Creatures win games, so this is the largest term. */
-    val boardPresence: Double = 1.5,
-    /** Card advantage — a long-term edge. */
-    val cardAdvantage: Double = 1.0,
-    /** Threat assessment. Catches lethal-on-board situations the other features miss. */
-    val threatAssessment: Double = 1.2,
-    /** Tempo (mana development). Matters early, less late. Counts lands only today. */
-    val tempo: Double = 0.6,
-) {
-    /**
-     * Build the evaluator these weights describe.
-     *
-     * [intents] is Phase 6's structural card knowledge; on [IntentCatalog.NONE] (the default)
-     * [BoardPresence] behaves exactly as it did before Phase 6, so an agent that does not opt in
-     * evaluates identically.
-     */
-    fun toEvaluator(intents: IntentCatalog = IntentCatalog.NONE): BoardEvaluator = CompositeBoardEvaluator(
-        listOf(
-            life to LifeDifferential,
-            boardPresence to BoardFeature { state, projected, playerId ->
-                BoardPresence.score(state, projected, playerId, intents)
-            },
-            cardAdvantage to CardAdvantage,
-            threatAssessment to ThreatAssessment,
-            tempo to Tempo,
-        )
-    )
-
-    companion object {
-        val DEFAULT = EvaluationWeights()
-
-        /**
-         * Every weight zero, so the evaluator returns a constant and the Strategist can only
-         * ever pass. Not a playable agent — it exists so the arena can prove it *discriminates*:
-         * a harness that cannot separate this from [AiProfile.LEGACY_V0] is measuring noise.
-         */
-        val BLIND = EvaluationWeights(0.0, 0.0, 0.0, 0.0, 0.0)
-    }
-}
 
 /**
  * A named, reproducible configuration of the engine AI.
@@ -90,8 +29,8 @@ data class AiProfile(
      * singletons, so one profile instance is safe to share across threads and games.
      */
     val advisorModules: List<CardAdvisorModule> = emptyList(),
-    /** Leaf-evaluation weights. See [EvaluationWeights]. */
-    val evaluationWeights: EvaluationWeights = EvaluationWeights.DEFAULT,
+    /** Resource-backed leaf-evaluation vector. Unknown ids use the compiled default safely. */
+    val evalWeightsId: String = EvalWeights.DEFAULT_ID,
     /**
      * Phase 4a: only propose actions the AI can actually take, and skip windows where it has
      * none.

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.ai.engine.evaluation
+
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.ai.engine.knowledge.IntentCatalog
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The five-feature fallback evaluator's coefficients.
+ *
+ * Phase 9 will add a raw-feature evaluator; keeping this vector loadable makes the existing
+ * evaluator a safe fallback and gives the arena a resource-backed A/B seam in the meantime.
+ */
+@Serializable
+data class EvaluationWeights(
+    val life: Double = 1.0,
+    val boardPresence: Double = 1.5,
+    val cardAdvantage: Double = 1.0,
+    val threatAssessment: Double = 1.2,
+    val tempo: Double = 0.6,
+) {
+    fun toEvaluator(intents: IntentCatalog = IntentCatalog.NONE): BoardEvaluator = CompositeBoardEvaluator(
+        listOf(
+            life to LifeDifferential,
+            boardPresence to BoardFeature { state, projected, playerId ->
+                BoardPresence.score(state, projected, playerId, intents)
+            },
+            cardAdvantage to CardAdvantage,
+            threatAssessment to ThreatAssessment,
+            tempo to Tempo,
+        )
+    )
+
+    companion object {
+        /** Compiled fallback: resource loading can never make the production AI unavailable. */
+        val DEFAULT = EvaluationWeights()
+        val BLIND = EvaluationWeights(0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+}
+
+/**
+ * Resource-backed evaluation vectors, keyed by the stable id carried by [AiProfile].
+ *
+ * A bad tuning artifact deliberately fails closed to [EvaluationWeights.DEFAULT]. Evaluation
+ * tuning is an optimization, not a reason for a game server to fail during startup.
+ */
+object EvalWeights {
+    const val DEFAULT_ID = "default"
+    private const val RESOURCE = "ai/eval-weights.json"
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = false
+    }
+
+    private val resourceWeights: Map<String, EvaluationWeights> by lazy {
+        runCatching {
+            val text = EvalWeights::class.java.classLoader
+                .getResourceAsStream(RESOURCE)
+                ?.bufferedReader()
+                ?.use { it.readText() }
+                ?: return@runCatching emptyMap()
+            decodeOrEmpty(text)
+        }.getOrDefault(emptyMap())
+    }
+
+    fun resolve(id: String): EvaluationWeights =
+        resourceWeights[id]?.takeIf(::isFinite) ?: EvaluationWeights.DEFAULT
+
+    /** Stable ids available to tooling such as the arena agent registry. */
+    val ids: Set<String> get() = resourceWeights.keys
+
+    internal fun decode(text: String): Map<String, EvaluationWeights> =
+        json.decodeFromString<Map<String, EvaluationWeights>>(text)
+
+    internal fun decodeOrEmpty(text: String): Map<String, EvaluationWeights> =
+        runCatching { decode(text) }.getOrDefault(emptyMap())
+
+    private fun isFinite(weights: EvaluationWeights): Boolean =
+        weights.life.isFinite() &&
+            weights.boardPresence.isFinite() &&
+            weights.cardAdvantage.isFinite() &&
+            weights.threatAssessment.isFinite() &&
+            weights.tempo.isFinite()
+}

--- a/ai/src/main/resources/ai/eval-weights.json
+++ b/ai/src/main/resources/ai/eval-weights.json
@@ -1,0 +1,16 @@
+{
+  "default": {
+    "life": 1.0,
+    "boardPresence": 1.5,
+    "cardAdvantage": 1.0,
+    "threatAssessment": 1.2,
+    "tempo": 0.6
+  },
+  "blind": {
+    "life": 0.0,
+    "boardPresence": 0.0,
+    "cardAdvantage": 0.0,
+    "threatAssessment": 0.0,
+    "tempo": 0.0
+  }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -2,11 +2,11 @@ package com.wingedsheep.ai.arena
 
 import com.wingedsheep.ai.engine.AIPlayer
 import com.wingedsheep.ai.engine.AiProfile
-import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.ai.engine.advisor.modules.BloomburrowAdvisorModule
 import com.wingedsheep.ai.engine.advisor.modules.OnslaughtAdvisorModule
 import com.wingedsheep.ai.engine.budget.RolloutBudgetPolicy
 import com.wingedsheep.ai.engine.budget.TieredBudgetPolicy
+import com.wingedsheep.ai.engine.evaluation.EvalWeights
 import com.wingedsheep.ai.engine.rollout.RolloutSettings
 import com.wingedsheep.ai.engine.hidden.OpponentModel
 import com.wingedsheep.engine.registry.CardRegistry
@@ -42,7 +42,7 @@ data class ArenaAgent(val name: String, val profile: AiProfile) {
  */
 object ArenaAgents {
 
-    private val all: List<ArenaAgent> = listOf(
+    private val builtIn: List<ArenaAgent> = listOf(
         // The permanent reference opponent. Every version reports against this one.
         ArenaAgent("v0", AiProfile.LEGACY_V0),
         // Whatever `AIPlayer.create(registry, playerId)` builds today.
@@ -64,7 +64,7 @@ object ArenaAgents {
         // that cannot separate this from `v0` is measuring noise, not strength.
         ArenaAgent("v0-blind", AiProfile.LEGACY_V0.copy(
             id = "v0-blind",
-            evaluationWeights = EvaluationWeights.BLIND,
+            evalWeightsId = "blind",
         )),
         // ── Phase 4 ──
         // The meaningful-action filter alone. `just arena v0 v0-meaningful 1000` is the phase's
@@ -119,6 +119,20 @@ object ArenaAgents {
         // Everything Phases 4, 6 and 7 add — what the plan proposes to ship.
         ArenaAgent("v0-phase4-intent-rollout", AiProfile.PHASE4_PHASE6_PHASE7),
     )
+
+    /**
+     * Every resource vector is automatically arena-addressable as `eval-<id>`. A tuning run can
+     * replace the JSON artifact and immediately A/B its candidates without changing Kotlin.
+     */
+    private val all: List<ArenaAgent> = builtIn + EvalWeights.ids.map { weightsId ->
+        ArenaAgent(
+            name = "eval-$weightsId",
+            profile = AiProfile.LEGACY_V0.copy(
+                id = "eval-$weightsId",
+                evalWeightsId = weightsId,
+            ),
+        )
+    }
 
     /** `v0` plus rollouts, with nothing changed but how many playouts a decision may spend. */
     private fun rolloutAgent(playouts: Int): AiProfile = AiProfile.PHASE7.copy(

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaHarnessTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaHarnessTest.kt
@@ -18,6 +18,11 @@ import io.kotest.matchers.shouldBe
  */
 class ArenaHarnessTest : FunSpec({
 
+    test("resource-backed evaluation vectors are arena-addressable without recompiling") {
+        ArenaAgents.resolve("eval-default").profile.evalWeightsId shouldBe "default"
+        ArenaAgents.resolve("eval-blind").profile.evalWeightsId shouldBe "blind"
+    }
+
     // Six games. Enough for the structural claims; small enough to stay in the always-on suite.
     val config = ArenaConfig(
         agentA = ArenaAgents.resolve("v0"),

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeightsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeightsTest.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.ai.engine.evaluation
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class EvalWeightsTest : StringSpec({
+
+    "bundled default reproduces the compiled fallback" {
+        EvalWeights.resolve("default") shouldBe EvaluationWeights.DEFAULT
+    }
+
+    "bundled profiles are selectable without recompiling" {
+        EvalWeights.resolve("blind") shouldBe EvaluationWeights.BLIND
+        EvalWeights.ids shouldBe setOf("default", "blind")
+    }
+
+    "unknown profile safely uses the compiled fallback" {
+        EvalWeights.resolve("does-not-exist") shouldBe EvaluationWeights.DEFAULT
+    }
+
+    "resource shape decodes profile ids to vectors" {
+        EvalWeights.decode(
+            """{"candidate":{"life":2.0,"boardPresence":3.0,"cardAdvantage":4.0,"threatAssessment":5.0,"tempo":6.0}}"""
+        )["candidate"] shouldBe EvaluationWeights(2.0, 3.0, 4.0, 5.0, 6.0)
+    }
+
+    "malformed tuning artifact is ignored" {
+        EvalWeights.decodeOrEmpty("""{"candidate":""") shouldBe emptyMap()
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/MultiplayerEvaluationTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/MultiplayerEvaluationTest.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.ai.engine.evaluation
 
-import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.ai.engine.sidesFor
 import com.wingedsheep.engine.core.GameConfig
 import com.wingedsheep.engine.core.GameInitializer

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/rollout/PlayoutEngineTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/rollout/PlayoutEngineTest.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.ai.engine.rollout
 import com.wingedsheep.ai.engine.AIPlayer
 import com.wingedsheep.ai.engine.AiProfile
 import com.wingedsheep.ai.engine.CombatAdvisor
-import com.wingedsheep.ai.engine.EvaluationWeights
+import com.wingedsheep.ai.engine.evaluation.EvaluationWeights
 import com.wingedsheep.ai.engine.GameSimulator
 import com.wingedsheep.engine.core.ActionProcessor
 import com.wingedsheep.engine.state.GameState

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.ai.puzzles
 
 import com.wingedsheep.ai.engine.AiProfile
-import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.ai.engine.rollout.RolloutSettings
 import com.wingedsheep.engine.support.ScenarioTestBase
 
@@ -50,7 +49,7 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 // Everything the plan proposes to ship.
                 AiProfile.PHASE4_PHASE6_PHASE7,
                 // The discrimination control, same as the arena's: every weight zero.
-                AiProfile.LEGACY_V0.copy(id = "v0-blind", evaluationWeights = EvaluationWeights.BLIND),
+                AiProfile.LEGACY_V0.copy(id = "v0-blind", evalWeightsId = "blind"),
             )
 
             val runs = profiles.map { profile ->

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.ai.puzzles
 
 import com.wingedsheep.ai.engine.AiProfile
-import com.wingedsheep.ai.engine.EvaluationWeights
 import com.wingedsheep.engine.support.ScenarioTestBase
 import io.kotest.assertions.withClue
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
@@ -51,7 +50,7 @@ class PuzzleSuiteTest : ScenarioTestBase() {
         test("a zero-weight agent solves strictly fewer puzzles") {
             val blind = AiProfile.LEGACY_V0.copy(
                 id = "v0-blind",
-                evaluationWeights = EvaluationWeights.BLIND,
+                evalWeightsId = "blind",
             )
             val blindResults = runner.runAll(PuzzleCatalog.all, blind)
             val blindPassed = blindResults.count { it.passed }

--- a/backlog/engine-ai-improvement.md
+++ b/backlog/engine-ai-improvement.md
@@ -3,7 +3,8 @@
 A phased plan to make the in-game engine AI measurably stronger, on a scoreboard we trust, using
 mechanisms that generalize across the whole card catalog rather than per-card special cases.
 
-**Status:** **Phases 0–8 shipped**, plus 3 of Phase 2b's 6 categories (Phase 8 on 2026-07-29) —
+**Status:** **Phases 0–8 shipped**, plus 3 of Phase 2b's 6 categories; **Phase 9 is underway**
+(resource-backed evaluation vectors landed on 2026-07-31) —
 baselines in [`docs/ai/baseline-metrics.md`](../docs/ai/baseline-metrics.md), measurement guide in
 [`docs/ai/measurement.md`](../docs/ai/measurement.md). Four scoreboards now exist: the arena
 (`just arena`), the 66-puzzle suite (`just arena-puzzles`, **60/66 today**), the multiplayer pod
@@ -12,8 +13,8 @@ The primary strength lever is in: the rollout evaluator beats `v0` **56.0%, CI [
 Phase 8 removes exact opponent-hand and library-order knowledge from rollout search. Its paired
 smoke found no detectable dip against the full-information control (49%, CI [43%, 55%]) and retained
 the Phase 7 strength point estimate against `v0` (55%, CI [48%, 62%]); the merge-sized measurement
-remains intentionally separate because rollout arenas are expensive. Next up is **Phase 9,
-Texel-style evaluation tuning**.
+remains intentionally separate because rollout arenas are expensive. Next in Phase 9 is
+**raw-feature collection for Texel-style evaluation tuning**.
 
 **Related:** [`engine-performance.md`](engine-performance.md) — the CPU profile this plan's
 performance phase built on. **Every step in that document is now closed**; Phase 5a was its Step 4
@@ -1354,7 +1355,8 @@ dip quantified in `docs/ai/`.
 Stop guessing the ~25 constants in `BoardFeatures.kt` and the 5 weights in
 `AIPlayer.defaultEvaluator()` (`:179-187`).
 
-**Weights as data.** `ai/src/main/resources/ai/eval-weights.json` (profileId → weight vector) +
+**Weights as data. ✅ DONE 2026-07-31.** `ai/src/main/resources/ai/eval-weights.json`
+(profileId → weight vector) +
 `evaluation/EvalWeights.kt` with **today's values compiled in as the default**, so a missing or
 malformed resource can never break the AI. `AiProfile.evalWeightsId` selects; the arena A/Bs two
 weight sets as two agents, no recompile.


### PR DESCRIPTION
## Summary

- move the existing five evaluator coefficients into a resource-backed catalog with compiled safe defaults
- let `AiProfile` select a vector by stable `evalWeightsId`
- expose resource vectors automatically as `eval-<id>` arena agents, allowing fitted candidates to be A/B tested without recompiling
- fall back safely for missing IDs, malformed artifacts, and non-finite coefficients
- mark the weights-as-data slice of AI improvement Phase 9 complete

## Testing

- `just test-ai`
- `git diff --cached --check`

The frozen V0 baseline and puzzle suite remain green.