### PR TITLE
Let AI seats play chosen Commander decks

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -403,15 +403,16 @@ sealed, or premade), then one N-player game".
 - **`SetLobbyAiDeck { playerId, spec }`** is the per-seat twin of `SetQuickGameAiDeck`: the host picks
   what *one* AI brings, in the same `AiDeckSpec` vocabulary (`auto` / `sets` / `deck`). Held per seat
   on `LobbyPlayerState.aiDeckSpec` and echoed back as `LobbyPlayerInfo.aiDeck` — an `AiDeckSpecView`
-  summary (kind, sets, label, card count), never the decklist itself, since lobby state re-broadcasts
-  on every change. A `deck` list is validated against the lobby's `deckFormat` on arrival, and the
+  summary (kind, sets, label, card count, designated commander), never the decklist itself, since
+  lobby state re-broadcasts on every change. A `deck` spec carries an optional `commander`; the list
+  is validated against the lobby's `deckFormat` on arrival, and the
   seat's deck is re-rolled immediately rather than at game start: the premade start gate wants every
   seat to have submitted, so the deck has to exist while the host is still looking at the lobby.
   Rejected outside `PREMADE_DECKS`, where the AI builds from the pool it was dealt.
-- **The one axis that still refuses an AI is Rules.** No generator the AI deckbuilds with picks a
-  commander, so `handleAddAiToLobby` rejects a lobby running Commander rules and
-  `UpdateLobbySettings` rejects switching a lobby that holds an AI onto them — refused at the change
-  rather than at Start, which would leave a pod that silently declines to begin.
+- **Commander AI requires a chosen deck.** The generated `auto` / `sets` paths still do not pick a
+  commander, so Commander limited pools remain unavailable to AI seats. In `PREMADE_DECKS`, the host
+  may seat an AI and choose a `deck` spec with a designated commander; the server validates the full
+  Commander deck and holds the lobby at its normal deck-submission gate until that choice exists.
 - **Attack rule.** The same two messages also carry an optional `attackMode` (default `MULTIPLE`),
   echoed by `LobbySettings.attackMode`, choosing which opponents creatures may attack in the FFA
   game (CR 802 / 803; CR 806.2b requires exactly one): `MULTIPLE` (any opponent), `LEFT`, or

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -235,6 +235,8 @@ class AiGameManager(
          * Null = the existing behaviour (generate a random sealed deck for [setCode]).
          */
         deckOverride: Map<String, Int>? = null,
+        /** Commander to place in the command zone when [deckOverride] is a commander deck. */
+        commanderCardName: String? = null,
     ): PlayerSession {
         require(isEnabled) { "AI is not enabled. Set game.ai.enabled=true." }
 
@@ -258,7 +260,7 @@ class AiGameManager(
         // sealed deck, using the same set as the human player when one was provided.
         val aiDeck = deckOverride
             ?: if (setCode != null) deckGenerator.generate(setCode) else deckGenerator.generate()
-        gameSession.addPlayer(playerSession, aiDeck)
+        gameSession.addPlayer(playerSession, aiDeck, commanderCardName = commanderCardName)
 
         // Give the AI knowledge of its deck composition
         controller.setDeckList(aiDeck)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -1461,16 +1461,11 @@ class LobbyHandler(
             return
         }
 
-        if (lobby.usesCommanderRules) {
-            // Every other deck source the AI has is a generator, and none of them build a commander
-            // deck: `RandomDeckResolver` declines commander shapes rather than ship an illegal
-            // 100-card approximation, and `buildAiSealedDeck` never picks a commander out of a pool.
-            // A seat with no commander cannot start a Commander game (FreeForAllHandler.maybeStartGame
-            // refuses the pod), so this is refused here, where the host can still read why.
+        if (lobby.usesCommanderRules && lobby.format != TournamentFormat.PREMADE_DECKS) {
             sender.sendError(
                 session,
                 ErrorCode.INVALID_ACTION,
-                "The AI can't build a Commander deck yet — switch the Rules axis off Commander to seat one"
+                "The AI can't build a Commander deck from a limited pool yet — use Bring a deck to choose one for it"
             )
             return
         }
@@ -1581,7 +1576,7 @@ class LobbyHandler(
                 sender.sendError(session, ErrorCode.INVALID_ACTION, "The AI's deck is empty")
                 return
             }
-            val validation = deckValidator.validate(spec.deckList, lobby.deckFormat)
+            val validation = validateAiDeck(spec, lobby.deckFormat, lobby.usesCommanderRules)
             if (!validation.valid) {
                 val reason = validation.errors.firstOrNull()?.message ?: "Deck is not legal"
                 sender.sendError(session, ErrorCode.INVALID_DECK, "AI deck rejected: $reason")
@@ -1616,6 +1611,11 @@ class LobbyHandler(
         if (lobby.format != TournamentFormat.PREMADE_DECKS) return
         val playerState = lobby.players[aiPlayerId] ?: return
         if (playerState.hasSubmittedDeck) return
+        if (lobby.usesCommanderRules &&
+            (playerState.aiDeckSpec as? AiDeckSpec.Fixed)?.commander.isNullOrBlank()
+        ) {
+            return
+        }
 
         val deck = runCatching {
             randomDeckResolver.resolve(playerState.aiDeckSpec, lobby.deckFormat, lobby.setCodes)
@@ -1623,7 +1623,10 @@ class LobbyHandler(
             .onFailure { logger.error("Could not generate a deck for AI seat ${aiPlayerId.value}", it) }
             .getOrNull() ?: return
 
-        when (val result = lobby.submitDeck(aiPlayerId, deck)) {
+        val commander = (playerState.aiDeckSpec as? AiDeckSpec.Fixed)
+            ?.commander
+            ?.takeIf { lobby.usesCommanderRules }
+        when (val result = lobby.submitDeck(aiPlayerId, deck, commander = commander)) {
             is TournamentLobby.DeckSubmissionResult.Success ->
                 logger.info(
                     "AI {} brought a generated {} deck ({} cards) to premade lobby {}",
@@ -1635,6 +1638,22 @@ class LobbyHandler(
             is TournamentLobby.DeckSubmissionResult.Error ->
                 logger.warn("Generated AI deck rejected in lobby ${lobby.lobbyId}: ${result.message}")
         }
+    }
+
+    private fun validateAiDeck(
+        spec: AiDeckSpec.Fixed,
+        format: com.wingedsheep.sdk.core.DeckFormat?,
+        usesCommanderRules: Boolean,
+    ) = if (usesCommanderRules) {
+        deckValidator.validate(
+            com.wingedsheep.sdk.model.Deck(
+                cards = spec.deckList.flatMap { (name, count) -> List(count) { name } },
+                commander = spec.commander?.takeIf { it.isNotBlank() },
+            ),
+            format,
+        )
+    } else {
+        deckValidator.validate(spec.deckList, format)
     }
 
     /**
@@ -2208,10 +2227,11 @@ class LobbyHandler(
             return
         }
 
-        // What an AI seat's generated deck was built for. Compared at the end: these two axes are
-        // the ones that decide what such a deck may contain, so a change to either invalidates it.
+        // What an AI seat's generated deck was built for. Compared at the end: these axes decide
+        // both what may be in the deck and whether it needs a designated commander.
         val formatBefore = lobby.format
         val deckFormatBefore = lobby.deckFormat
+        val rulesBefore = lobby.rules
 
         // Cube settings are a full replacement, like the ban list. Resolve immediately so an
         // unplayable list never becomes lobby state. Empty returns to catalogued-set mode.
@@ -2395,17 +2415,16 @@ class LobbyHandler(
             return
         }
 
-        // Rules × AI seats, the other direction of the check `handleAddAiToLobby` makes: none of the
-        // AI's deck generators produce a commander, so a lobby holding an AI cannot switch its Rules
-        // axis to Commander. Refused here, before anything is written, rather than at Start — where
-        // the pod would simply decline to begin with no way for the host to see why.
+        // Generated limited pools do not designate commanders. A premade lobby is different: the
+        // host can choose a commander deck for every AI seat after switching the rules.
         if (nextRules.usesCommanders && !lobby.usesCommanderRules &&
+            lobby.format != TournamentFormat.PREMADE_DECKS &&
             lobby.players.keys.any { aiGameManager.isAiPlayer(it) }
         ) {
             sender.sendError(
                 session,
                 ErrorCode.INVALID_ACTION,
-                "The AI can't build a Commander deck yet — remove the AI players first"
+                "The AI can't build a Commander deck from a limited pool yet — use Bring a deck instead"
             )
             return
         }
@@ -2544,10 +2563,12 @@ class LobbyHandler(
         // update — or one that landed earlier — forces it back off.
         if (!lobby.rankedEligible) lobby.ranked = false
 
-        // Re-roll AI decks only when this message actually moved one of the two axes that decide
-        // what may be in them — otherwise toggling an unrelated setting would deal the AI a
-        // different deck each time the host touched the lobby.
-        if (lobby.format != formatBefore || lobby.deckFormat != deckFormatBefore) {
+        // Re-roll only when an axis that determines the AI deck changed. Under Commander rules,
+        // ensureAiPremadeDeck deliberately leaves Auto unsubmitted until the host picks a deck.
+        if (lobby.format != formatBefore ||
+            lobby.deckFormat != deckFormatBefore ||
+            lobby.rules != rulesBefore
+        ) {
             resyncAiDecks(lobby)
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -120,7 +120,7 @@ class QuickGameLobbyHandler(
                         sender.sendError(session, ErrorCode.INVALID_ACTION, "The AI's deck is empty")
                         return@withLock
                     }
-                    val result = deckValidator.validate(spec.deckList, current.format)
+                    val result = validateAiDeck(spec, current.format)
                     if (!result.valid) {
                         val reason = result.errors.firstOrNull()?.message ?: "Deck is not legal"
                         sender.sendError(session, ErrorCode.INVALID_ACTION, "AI deck rejected: $reason")
@@ -183,7 +183,7 @@ class QuickGameLobbyHandler(
                 // clear: an illegal list is dropped back to Auto, which always builds something
                 // legal for the new format. The host sees the seat's label change.
                 val aiSpec = current.aiDeckSpec
-                if (aiSpec is AiDeckSpec.Fixed && !deckValidator.validate(aiSpec.deckList, message.format).valid) {
+                if (aiSpec is AiDeckSpec.Fixed && !validateAiDeck(aiSpec, message.format).valid) {
                     logger.info(
                         "Lobby {}: AI deck '{}' is not legal in {}; reverting the AI to Auto",
                         current.lobbyId,
@@ -478,6 +478,17 @@ class QuickGameLobbyHandler(
                 sender.sendError(session, ErrorCode.INVALID_ACTION, "Pick a deck before readying up")
                 return@withLock
             }
+            if (message.ready && current.vsAi && current.usesCommanderRules) {
+                val aiDeck = current.aiDeckSpec as? AiDeckSpec.Fixed
+                if (aiDeck?.commander.isNullOrBlank()) {
+                    sender.sendError(
+                        session,
+                        ErrorCode.INVALID_ACTION,
+                        "Pick a Commander deck for the AI before readying up",
+                    )
+                    return@withLock
+                }
+            }
             player.ready = message.ready
             broadcastState(current)
             if (current.allReady() && !current.started) {
@@ -639,6 +650,9 @@ class QuickGameLobbyHandler(
                 onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
                 onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) },
                 deckOverride = aiDeck,
+                commanderCardName = (lobby.aiDeckSpec as? AiDeckSpec.Fixed)
+                    ?.commander
+                    ?.takeIf { lobby.usesCommanderRules },
             )
         }
 
@@ -806,6 +820,21 @@ class QuickGameLobbyHandler(
         }
         is AiDeckSpec.Sets ->
             if (spec.setCodes.isEmpty()) "Auto (sealed)" else "Built from ${spec.setCodes.joinToString(", ")}"
-        is AiDeckSpec.Fixed -> "${spec.label} (${spec.deckList.values.sum()})"
+        is AiDeckSpec.Fixed -> "${spec.label} (${spec.deckList.values.sum() + if (spec.commander != null) 1 else 0})"
+    }
+
+    private fun validateAiDeck(
+        spec: AiDeckSpec.Fixed,
+        format: com.wingedsheep.sdk.core.DeckFormat?,
+    ) = if (format?.isCommanderShape == true) {
+        deckValidator.validate(
+            com.wingedsheep.sdk.model.Deck(
+                cards = spec.deckList.flatMap { (name, count) -> List(count) { name } },
+                commander = spec.commander?.takeIf { it.isNotBlank() },
+            ),
+            format,
+        )
+    } else {
+        deckValidator.validate(spec.deckList, format)
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
@@ -54,6 +54,8 @@ sealed interface AiDeckSpec {
     data class Fixed(
         val deckList: Map<String, Int>,
         val label: String = "Custom",
+        /** Designated commander for commander-shaped formats; absent for ordinary decks. */
+        val commander: String? = null,
     ) : AiDeckSpec
 }
 
@@ -76,6 +78,8 @@ data class AiDeckSpecView(
     val label: String? = null,
     /** Card count for [AiDeckSpec.Fixed]; 0 otherwise. */
     val cardCount: Int = 0,
+    /** Designated commander for [AiDeckSpec.Fixed]; null otherwise. */
+    val commander: String? = null,
 ) {
     companion object {
         fun of(spec: AiDeckSpec): AiDeckSpecView = when (spec) {
@@ -84,7 +88,8 @@ data class AiDeckSpecView(
             is AiDeckSpec.Fixed -> AiDeckSpecView(
                 kind = "deck",
                 label = spec.label,
-                cardCount = spec.deckList.values.sum(),
+                cardCount = spec.deckList.values.sum() + if (spec.commander != null) 1 else 0,
+                commander = spec.commander,
             )
         }
     }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
@@ -410,7 +410,7 @@ class FreeForAllLobbyTest : FunSpec() {
             }
         }
 
-        test("a Commander lobby refuses AI seats — no generator it builds with picks a commander") {
+        test("a Commander premade lobby seats an AI once the host chooses its commander deck") {
             val host = createClient()
             host.connectAs("Commander Host")
             host.send(ClientMessage.CreateTournamentLobby(
@@ -425,14 +425,28 @@ class FreeForAllLobbyTest : FunSpec() {
             }
 
             host.send(ClientMessage.AddAiToLobby)
-            eventually(5.seconds) {
-                host.messages.filterIsInstance<ServerMessage.Error>()
-                    .any { it.message.contains("Commander") } shouldBe true
+            eventually(10.seconds) {
+                host.latestLobbyUpdate()?.players?.size shouldBe 2
             }
-            host.latestLobbyUpdate()?.players?.size shouldBe 1
+            val ai = host.latestLobbyUpdate()!!.players.first { it.isAi }
+            ai.deckSubmitted shouldBe false
+
+            host.send(ClientMessage.SetLobbyAiDeck(
+                playerId = ai.playerId,
+                spec = com.wingedsheep.gameserver.lobby.AiDeckSpec.Fixed(
+                    deckList = mapOf("Plains" to 99),
+                    label = "Zetalpa",
+                    commander = "Zetalpa, Primal Dawn",
+                ),
+            ))
+            eventually(10.seconds) {
+                host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe true
+            }
+            host.latestLobbyUpdate()?.players?.first { it.isAi }?.aiDeck?.commander shouldBe
+                "Zetalpa, Primal Dawn"
         }
 
-        test("a lobby holding an AI refuses the switch to Commander rules, rather than failing to start") {
+        test("a premade lobby holding an AI can switch to Commander and waits for its commander deck") {
             val host = createClient()
             host.connectAs("Rules Switch Host")
             host.send(ClientMessage.CreateTournamentLobby(
@@ -451,11 +465,9 @@ class FreeForAllLobbyTest : FunSpec() {
 
             host.send(ClientMessage.UpdateLobbySettings(rules = "COMMANDER"))
             eventually(5.seconds) {
-                host.messages.filterIsInstance<ServerMessage.Error>()
-                    .any { it.message.contains("Commander") } shouldBe true
+                host.latestLobbyUpdate()?.settings?.rules shouldBe "COMMANDER"
             }
-            // Refused before anything was written: the lobby is still the one the host had.
-            host.latestLobbyUpdate()?.settings?.rules shouldBe "STANDARD"
+            host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe false
         }
 
         test("a sealed FFA pod of one human and two AI builds its decks, starts, and the AI plays") {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/QuickGameLobbyCommanderAiTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/QuickGameLobbyCommanderAiTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.gameserver
+
+import com.wingedsheep.gameserver.lobby.AiDeckSpec
+import com.wingedsheep.gameserver.protocol.ClientMessage
+import com.wingedsheep.gameserver.protocol.ServerMessage
+import com.wingedsheep.sdk.core.DeckFormat
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class QuickGameLobbyCommanderAiTest : GameServerTestBase() {
+
+    init {
+        test("AI quick lobby starts Commander with a host-supplied commander deck") {
+            val client = createClient()
+            client.connectAs("Commander Host")
+            val library = mapOf("Plains" to 99)
+            val commander = "Zetalpa, Primal Dawn"
+
+            client.send(ClientMessage.CreateQuickGameLobby(vsAi = true, format = DeckFormat.COMMANDER))
+            eventually(5.seconds) {
+                client.messages.any { it is ServerMessage.QuickGameLobbyState } shouldBe true
+            }
+
+            client.send(
+                ClientMessage.SetQuickGameAiDeck(
+                    AiDeckSpec.Fixed(
+                        deckList = library,
+                        label = "Zetalpa",
+                        commander = commander,
+                    )
+                )
+            )
+            client.send(
+                ClientMessage.SubmitQuickGameLobbyDeck(
+                    deckList = library,
+                    commander = commander,
+                )
+            )
+            client.send(ClientMessage.SetQuickGameLobbyReady(true))
+
+            eventually(10.seconds) {
+                client.messages.any { it is ServerMessage.GameCreated } shouldBe true
+            }
+            client.allErrors() shouldBe emptyList()
+        }
+
+        test("commander-shaped AI deck is rejected without a designated commander") {
+            val client = createClient()
+            client.connectAs("Commander Host")
+            client.send(ClientMessage.CreateQuickGameLobby(vsAi = true, format = DeckFormat.COMMANDER))
+            eventually(5.seconds) {
+                client.messages.any { it is ServerMessage.QuickGameLobbyState } shouldBe true
+            }
+
+            client.send(
+                ClientMessage.SetQuickGameAiDeck(
+                    AiDeckSpec.Fixed(deckList = mapOf("Plains" to 100))
+                )
+            )
+
+            eventually(5.seconds) {
+                client.latestError()?.message?.contains("commander", ignoreCase = true) shouldBe true
+            }
+        }
+    }
+}

--- a/web-client/src/components/lobby/AiOpponentPanel.tsx
+++ b/web-client/src/components/lobby/AiOpponentPanel.tsx
@@ -112,7 +112,7 @@ export function AiOpponentRow({
         {source === 'auto' && (
           <div className={styles.variantCaption}>
             {isCommanderShape
-              ? `The AI can't build a ${format === 'COMMANDER' ? 'Commander' : 'Brawl'} deck yet, so it plays a 40-card sealed deck. Use “Pick a deck” to give it a real one.`
+              ? `The AI can't build a ${format === 'COMMANDER' ? 'Commander' : 'Brawl'} deck yet. Use “Pick a deck” and choose one with a designated commander.`
               : format
                 ? `The server builds the AI a 60-card ${format.replace('_', ' ').toLowerCase()}-legal deck.`
                 : 'The server opens eight boosters from your set and auto-builds the AI a 40-card deck.'}
@@ -154,7 +154,7 @@ export function AiOpponentRow({
               {setCodes.length === 0
                 ? 'Pick one or more sets — until you do, the AI falls back to Auto.'
                 : isCommanderShape
-                  ? 'Commander decks aren’t buildable yet, so the AI opens a sealed pool from these sets.'
+                  ? 'Commander decks aren’t buildable from sets yet. Use “Pick a deck” and choose one with a designated commander.'
                   : format
                     ? `Only ${format.replace('_', ' ').toLowerCase()}-legal cards from these sets are used.`
                     : 'Eight boosters are opened across these sets and auto-built into a deck.'}
@@ -225,13 +225,18 @@ export function AiDeckSection({
   // Deduped like the human picker's submission path: DeckPicker re-emits its current deck on every
   // render, and each send costs a lobby broadcast.
   const handleDeckChange = useCallback(
-    (deckList: Record<string, number>) => {
+    (deckList: Record<string, number>, commander?: string | null) => {
       const total = Object.values(deckList).reduce((a, b) => a + b, 0)
       if (total === 0) return
-      const key = Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')
+      const key = `${Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')}|${commander ?? ''}`
       if (key === lastDeckKeyRef.current) return
       lastDeckKeyRef.current = key
-      setAiDeck({ type: 'deck', deckList, label: 'Chosen deck' } satisfies AiDeckSpec)
+      setAiDeck({
+        type: 'deck',
+        deckList,
+        label: 'Chosen deck',
+        commander: commander ?? null,
+      } satisfies AiDeckSpec)
     },
     [setAiDeck],
   )

--- a/web-client/src/components/lobby/LobbyAiDeckModal.tsx
+++ b/web-client/src/components/lobby/LobbyAiDeckModal.tsx
@@ -82,13 +82,21 @@ export function LobbyAiDeckModal({
   // Deduped like the human picker's submission path: DeckPicker re-emits its current deck on every
   // render, and each send costs a re-roll and a lobby broadcast.
   const handleDeckChange = useCallback(
-    (deckList: Record<string, number>) => {
+    (deckList: Record<string, number>, commander?: string | null) => {
       const total = Object.values(deckList).reduce((a, b) => a + b, 0)
       if (total === 0) return
-      const key = Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')
+      const key = `${Object.entries(deckList).sort().map(([n, c]) => `${n}:${c}`).join('|')}|${commander ?? ''}`
       if (key === lastDeckKeyRef.current) return
       lastDeckKeyRef.current = key
-      setLobbyAiDeck(playerId, { type: 'deck', deckList, label: 'Chosen deck' } satisfies AiDeckSpec)
+      setLobbyAiDeck(
+        playerId,
+        {
+          type: 'deck',
+          deckList,
+          label: 'Chosen deck',
+          commander: commander ?? null,
+        } satisfies AiDeckSpec,
+      )
     },
     [playerId, setLobbyAiDeck],
   )

--- a/web-client/src/components/lobby/LobbyAxes.tsx
+++ b/web-client/src/components/lobby/LobbyAxes.tsx
@@ -344,7 +344,7 @@ function shapeBlock(view: UnifiedLobbyView, cards: CardsAxis): string | null {
   const wouldRun: RulesAxis = isCommanderLimited(cards) ? 'COMMANDER' : view.axes.rules
   const conflict = rulesTableBlock(wouldRun, view.axes.table)
   if (conflict !== null) return conflict
-  if (view.players.some((p) => p.isAi)) return commanderAiBlock(wouldRun)
+  if (view.players.some((p) => p.isAi)) return commanderAiBlock(wouldRun, cards)
   return null
 }
 

--- a/web-client/src/components/lobby/axes.ts
+++ b/web-client/src/components/lobby/axes.ts
@@ -248,9 +248,9 @@ export const COMMANDER_NEEDS_ITS_OWN_LIFE_TOTAL =
   'Commander can’t be played as Two-Headed Giant — a 2HG team shares one life total, and Commander gives every player their own 40. Free-for-All and Team vs. Team pods work.'
 
 /**
- * AI seats in a Commander lobby — the one axis that still refuses them.
+ * AI seats in a Commander limited lobby.
  *
- * The AI never brings a deck; it is dealt one by a generator, and no generator picks a commander.
+ * No generated AI deck picks a commander.
  * `LobbyHandler.buildAiSealedDeck` builds a 40-card deck out of a pool without one, and
  * `RandomDeckResolver` declines commander shapes outright rather than ship an illegal 100-card
  * approximation. Keyed on the **Rules** axis rather than on the Commander pack shape, because that
@@ -258,15 +258,14 @@ export const COMMANDER_NEEDS_ITS_OWN_LIFE_TOTAL =
  * for one just as much as a Commander Draft does, and the pack-shape reading could not see it.
  */
 export const COMMANDER_HAS_NO_AI =
-  'The AI can’t build a Commander deck — nothing it deckbuilds with picks a commander, so it would sit down without one. Play Commander with people.'
+  'The AI can’t build a Commander deck from a limited pool yet. Choose Bring a deck and pick a Commander deck for it.'
 
 /**
- * Why an AI can't sit in a lobby running these rules, or null — the client's copy of the server's
- * `handleAddAiToLobby` rejection, read by every surface that offers an AI seat or offers to switch
- * the Rules axis under one. The same one-statement discipline as {@link rulesTableBlock}.
+ * Why an AI can't use this rules/cards combination, or null. A brought deck is allowed because the
+ * host can designate its commander; generated limited pools remain blocked.
  */
-export function commanderAiBlock(rules: RulesAxis): string | null {
-  return rules === 'COMMANDER' ? COMMANDER_HAS_NO_AI : null
+export function commanderAiBlock(rules: RulesAxis, cards: CardsAxis): string | null {
+  return rules === 'COMMANDER' && cards.kind !== 'BRING_A_DECK' ? COMMANDER_HAS_NO_AI : null
 }
 
 /**

--- a/web-client/src/components/lobby/axisChoices.ts
+++ b/web-client/src/components/lobby/axisChoices.ts
@@ -165,10 +165,9 @@ function rulesAvailability(view: UnifiedLobbyView, rules: RulesAxis): ChoiceAvai
   const conflict = rulesTableBlock(rules, view.axes.table)
   if (conflict !== null) return blocked(conflict)
   if (rules === view.axes.rules) return DIRECT
-  // The AI is dealt every deck it plays and no generator picks a commander, so a lobby holding one
-  // cannot switch to Commander rules. Same rejection the server sends; said before the click.
+  // A brought AI deck can designate its commander. Generated limited pools cannot yet do so.
   if (view.players.some((p) => p.isAi)) {
-    const aiBlock = commanderAiBlock(rules)
+    const aiBlock = commanderAiBlock(rules, view.axes.cards)
     if (aiBlock !== null) return blocked(aiBlock)
   }
   // A quick lobby has no Rules field: the server derives it from deck legality (see

--- a/web-client/src/components/lobby/lobbyViewModel.ts
+++ b/web-client/src/components/lobby/lobbyViewModel.ts
@@ -138,6 +138,8 @@ export function fromQuickGameLobby(
   const youReady = you?.ready ?? false
   const needsDeck = !isMomir && (!opts.deckValid || !you?.deckSelected)
   const axes = axesFromQuickGameLobby(lobby, you, opts.deckTab)
+  const needsAiCommander =
+    lobby.vsAi && axes.rules === 'COMMANDER' && !lobby.aiDeck?.commander
 
   const players = lobby.players.map((p): LobbyViewPlayer => ({
     playerId: p.playerId,
@@ -174,8 +176,12 @@ export function fromQuickGameLobby(
       : {
           kind: 'READY',
           label: "I'm ready",
-          disabled: needsDeck,
-          reason: needsDeck ? 'Pick a deck first' : undefined,
+          disabled: needsDeck || needsAiCommander,
+          reason: needsDeck
+            ? 'Pick a deck first'
+            : needsAiCommander
+              ? 'Pick a Commander deck for the AI'
+              : undefined,
         },
     isPublic: lobby.isPublic,
     // AI is a create-time flag on a quick lobby, not a seat the host can add later.
@@ -267,13 +273,10 @@ export function fromTournamentLobby(
       : null,
     blockGroup: blockReason?.group ?? null,
     isPublic: s.isPublic,
-    // Neither the Table nor the Cards axis narrows this any more: an AI takes a pod seat like anyone
-    // else, and a premade lobby deals it a generated deck the way a quick game always has. The one
-    // axis that still refuses — the server's own `handleAddAiToLobby` rejection — is Rules: none of
-    // the AI's deck generators picks a commander, so it would sit down at a Commander table without
-    // one. `LobbyScreen` hides the button; `LobbyAxes` says why from the other direction.
+    // Commander AI is available when the host brings its deck and designates its commander.
+    // Generated limited pools remain blocked because their builders cannot make that choice.
     canAddAi: isWaiting && lobbyState.isHost && opts.aiEnabled
-      && commanderAiBlock(axes.rules) === null && playerCount < maxPlayers,
+      && commanderAiBlock(axes.rules, axes.cards) === null && playerCount < maxPlayers,
     // Ranked is a 1v1-bracket-only concept server-side (`TournamentLobby.rankedEligible`).
     ranked: { available: axes.table === 'ONE_V_ONE', on: s.ranked ?? false },
     teams: tournamentTeams(lobbyState),

--- a/web-client/src/components/lobby/modeMatrix.ts
+++ b/web-client/src/components/lobby/modeMatrix.ts
@@ -316,7 +316,7 @@ export function shapeChoices(roster: Roster, cards: CardsAxis): Choice<ShapeId>[
     // disagree about which table a Commander pool can sit at.
     const reasonFor = (shape: ShapeId): string | undefined =>
       rulesTableBlock(rulesForCards(cards), shapeAxes(shape).table)
-      ?? commanderAiBlock(rulesForCards(cards))
+      ?? commanderAiBlock(rulesForCards(cards), cards)
       ?? undefined
     if (kind === 'BRING_A_DECK') {
       return [
@@ -329,7 +329,7 @@ export function shapeChoices(roster: Roster, cards: CardsAxis): Choice<ShapeId>[
     // shape it declines — the pod and the bracket both play it out.
     return [
       choice('ONE_GAME', LIMITED_ALWAYS_RUNS_AS_A_BRACKET),
-      choice('BRACKET', commanderAiBlock(rulesForCards(cards)) ?? undefined),
+      choice('BRACKET', commanderAiBlock(rulesForCards(cards), cards) ?? undefined),
       ...MULTIPLAYER_SHAPES.map((s) => choice(s, reasonFor(s))),
     ]
   }

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -353,7 +353,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
         'Bracket play is 1v1 only. Every multiplayer table plays exactly one shared game.',
         'A limited pool always runs as a bracket. Sealed and draft build a pool that is meant to be played more than once; with two players and one game per matchup, that is a single game anyway.',
         'Ranked is 1v1 only. Multiplayer tables are always casual.',
-        'The AI cannot play Commander, at any table or from any card source: nothing it deckbuilds with picks a commander, so it would sit down without one.',
+        'The AI cannot build a Commander deck from a limited pool yet. When everyone brings a deck, the host can pick a Commander deck for each AI seat.',
         'Commander rules cannot be played as Two-Headed Giant: a 2HG team shares one life total, and Commander gives every player their own 40. A 1v1 bracket, a Free-for-All pod and Team vs. Team all work.',
         'Momir Basic and a rolled random pool are 1v1 single games only. Neither exists at a multiplayer table or in a bracket.',
       ] },
@@ -383,7 +383,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     summary:
       'The home screen asks who you are playing with, what you are playing with, and how it is played. The answers decide which lobby you get; everything stays changeable once you are in it.',
     body: [
-      { kind: 'p', text: 'Who you are playing with comes first because it rules out the most: a rolled random pool or a Momir game only exists as a 1v1, and the AI cannot play Commander.' },
+      { kind: 'p', text: 'Who you are playing with comes first because it rules out the most: a rolled random pool or a Momir game only exists as a 1v1, and Commander AI needs a deck chosen by the host.' },
       { kind: 'p', text: 'All three questions stay on screen, numbered, with your answer under each. Click an answer to go back and change it; the answers after it are re-checked against the change.' },
       { kind: 'ul', items: [
         'A question with only one possible answer is decided for you and marked “auto”.',
@@ -406,7 +406,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     body: [
       { kind: 'p', text: 'At 1v1 the AI can play any of the card sources — your own deck, a rolled pool, or Momir Basic.' },
       { kind: 'p', text: 'Every table is open too: the lobby opens as a full pod of AI seats, so on your own you can play a Free-for-All pod, take an AI teammate into Two-Headed Giant, run Team vs. Team, or draft a pod and play the bracket out. Add or remove them in the lobby if you want a smaller table.' },
-      { kind: 'p', text: 'The AI never brings a deck of its own: it builds one from the pool it is dealt, and in a lobby where everyone brings a deck the server rolls it one instead. The one thing it cannot deckbuild is Commander — nothing it builds with picks a commander — so a Commander lobby is humans only.' },
+      { kind: 'p', text: 'The AI builds from the pool it is dealt, and in a lobby where everyone brings a deck the server normally rolls it one. Commander is the exception: choose a saved, example, or pasted Commander deck for the AI so its commander can start in the command zone.' },
     ],
     related: ['axis-limits', 'cards-draft', 'event-round-robin'],
   },

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -2823,7 +2823,12 @@ export interface QuickGameLobbyStateMessage {
 export type AiDeckSpec =
   | { readonly type: 'auto' }
   | { readonly type: 'sets'; readonly setCodes: readonly string[] }
-  | { readonly type: 'deck'; readonly deckList: Record<string, number>; readonly label?: string }
+  | {
+      readonly type: 'deck'
+      readonly deckList: Record<string, number>
+      readonly label?: string
+      readonly commander?: string | null
+    }
 
 /**
  * The lobby-broadcast summary of an [AiDeckSpec]. The decklist behind a `deck` choice never rides
@@ -2834,6 +2839,7 @@ export interface AiDeckSpecView {
   readonly setCodes?: readonly string[]
   readonly label?: string | null
   readonly cardCount?: number
+  readonly commander?: string | null
 }
 
 export interface SetQuickGameAiDeckMessage {


### PR DESCRIPTION
## Summary

- carry a designated commander with a host-supplied AI deck and validate the full Commander/Brawl deck shape
- pass the AI commander through game-session initialization so it starts in the command zone
- allow Commander AI in quick games and premade multiplayer lobbies; keep generated Commander limited pools unavailable until their builders can choose a commander
- update lobby availability, ready-state guidance, help text, and data-contract documentation

## Verification

- `just test-server` — 473 tests passed, 4 skipped
- `cd web-client && npm run typecheck`

Progresses #1453. This delivers legal basic AI Commander play with a chosen deck; automatic Commander deck construction and Commander-specific play heuristics remain tracked by the issue.