### PR TITLE
Show the lobby's settings by default, and say what a collapsed group holds

### DIFF
--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -104,12 +104,7 @@ export function LobbyScreen() {
         GROUP_IDS.map((id) => [id, situationalOptions(id, view, lobbyState)]),
       ) as Record<GroupId, readonly string[]>)
     : null
-  const { isGroupOpen, toggleGroup, revealedIn } = useGroupOpenState(
-    view?.blockGroup ?? null,
-    // A lobby a setup built already has its sets; a fresh one is about to need them.
-    intent !== undefined,
-    situational,
-  )
+  const { isGroupOpen, toggleGroup, revealedIn } = useGroupOpenState(view?.blockGroup ?? null, situational)
 
   /**
    * Start the game, remembering what it was first.
@@ -329,10 +324,11 @@ export function LobbyScreen() {
           )}
         </div>
 
-        {/* Settings sit below the players and the deck picker, not above them.
-            Below the fold is where a *configured* lobby wants them: with the groups collapsed the
-            whole panel is around 320px, it is host-only, and it is set once. What you keep coming
-            back to while waiting is who has arrived and whether the teams are even. */}
+        {/* Settings sit below the players and the deck picker, not above them. What you keep coming
+            back to while waiting is who has arrived and whether the teams are even; the settings are
+            host-only and set once. Below the fold is also what makes opening the groups by default
+            affordable — the panel is long again (see `useGroupOpenState`), and it grows downward into
+            `.lobbyOverlay`'s scroll rather than pushing the roster off screen. */}
         {showSettings && (
           <div className={styles.settingsPanel}>
             {GROUP_IDS.map((id) => {
@@ -586,32 +582,39 @@ function VisibilityRow({
 }
 
 /**
- * Which settings groups are open, derived rather than hand-tuned.
+ * Which settings groups are open. **Open is the default**; collapsing is the host's own doing.
  *
- * Four rules, in order:
+ * The panel used to open with everything but Cards collapsed, on the theory that a *configured*
+ * lobby doesn't need its knobs on screen. What that actually produced was a host who never learned
+ * the Free-for-All attack rule, the private/public switch or the AI-assistance toggle existed —
+ * naming them in the collapsed header helped, but a name is still not the control. A group only ever
+ * renders rows that apply to this lobby's shape (that filtering is in `TournamentLobbySettings` and
+ * in the `push` conditions in `LobbyScreen`), so "open by default" and "open when relevant" are the
+ * same rule: what's on screen is exactly what this lobby can be asked about.
  *
- * 1. **The group holding the reason Start is disabled is open.** Not a courtesy — it is what keeps
- *    collapsing compatible with the project's disabled-with-reason rule: nothing you need to act on
- *    can be hidden. It reads `view.blockGroup`, which comes from the same `startBlockReason` that
- *    writes the Start button's tooltip.
- * 2. **A group that just gained an option opens itself**, and says which one. Switching the Table
- *    axis to Free-for-All *creates* the attack rule; switching to Two-Headed Giant creates the team
- *    setup. Landing that new decision inside a box the host has never expanded is how it stays
- *    unfound — and the host is looking at the axis strip they just clicked, which is exactly where
- *    the group that opens is. Only genuine appearances count (see {@link situationalOptions}); a
- *    value changing inside an option that was already there does not re-open anything.
- * 3. **Cards is open on a lobby that wasn't launched from a setup**, because a fresh lobby's next
- *    move is almost always choosing sets. A lobby a setup built already has them.
- * 4. Otherwise closed — and whatever the host opened or closed by hand wins over all of it, kept in
- *    localStorage so it survives the recreate that switching an axis can cause.
+ * The cost is height — a booster draft with Commander rules and two sets is the case the collapse
+ * was introduced for, and it is long again. That is the trade this screen is choosing: `.lobbyOverlay`
+ * scrolls, and a host who wants the short version collapses the groups they're done with, which
+ * persists.
  *
- * Rule 2 writes into the same overrides the host's own clicks use, rather than sitting beside them
- * as a third source of truth: a group opened this way is a group the host can simply close again,
- * and it stays closed.
+ * Three rules, in order:
+ *
+ * 1. **The group holding the reason Start is disabled is open**, whatever the host last did to it.
+ *    It reads `view.blockGroup`, which comes from the same `startBlockReason` that writes the Start
+ *    button's tooltip.
+ * 2. **A group the host collapsed stays collapsed** — kept in localStorage so it survives the
+ *    recreate that switching an axis can cause. This is the only source of a closed group now.
+ * 3. **Except when a collapsed group gains an option**, which re-opens it and says which one.
+ *    Switching the Table axis to Free-for-All *creates* the attack rule; switching to Two-Headed
+ *    Giant creates the team setup. A host who collapsed Table an hour ago did not thereby decline a
+ *    decision that didn't exist yet. Only genuine appearances count (see {@link situationalOptions}),
+ *    and only into a group that is actually closed — over an open one there is nothing to announce.
+ *
+ * Rule 3 writes into the same overrides rule 2 reads, rather than sitting beside them as a third
+ * source of truth: a group opened this way is a group the host can simply close again.
  */
 function useGroupOpenState(
   blockGroup: GroupId | null,
-  fromSetup: boolean,
   /** Null until the lobby state has arrived — see the effect. */
   situational: Record<GroupId, readonly string[]> | null,
 ) {
@@ -625,6 +628,10 @@ function useGroupOpenState(
   })
   const [revealed, setRevealed] = useState<Partial<Record<GroupId, readonly string[]>>>({})
   const previous = useRef<Record<GroupId, readonly string[]> | null>(null)
+  // The effect below runs on a `signature` change, so its closure over `overrides` can be a render
+  // behind. It needs today's answer to "did the host put this group away?".
+  const overridesRef = useRef(overrides)
+  overridesRef.current = overrides
 
   // Depend on the *contents*, not the object: `situational` is rebuilt every render because the view
   // it derives from is.
@@ -632,8 +639,8 @@ function useGroupOpenState(
     ? GROUP_IDS.map((id) => `${id}:${situational[id].join(',')}`).join('|')
     : null
   useEffect(() => {
-    // Nothing to compare against yet. Tracking the empty pre-state would make the lobby's *first*
-    // state message look like five groups' worth of options appearing at once, and open all of them.
+    // Nothing to compare against yet. Tracking the empty pre-state would count the lobby's *first*
+    // state message as five groups' worth of options appearing at once.
     if (!situational) return
     const before = previous.current
     previous.current = situational
@@ -642,6 +649,12 @@ function useGroupOpenState(
 
     const gained: Partial<Record<GroupId, readonly string[]>> = {}
     for (const id of GROUP_IDS) {
+      // Only a group the host has collapsed. An open group needs no rescuing — the control is
+      // already on screen, and announcing `New:` over it is noise. It is also the only way to stay
+      // quiet on a *fresh* lobby: the wizard's shape lands as a settings update just after the lobby
+      // opens, so a Free-for-All lobby really does go 1v1 → Free-for-All on its first two messages,
+      // and the attack rule really does "appear". Nobody collapsed anything yet, so nobody is told.
+      if (overridesRef.current[id] !== false) continue
       const added = situational[id].filter((option) => !before[id].includes(option))
       if (added.length > 0) gained[id] = added
     }
@@ -655,9 +668,7 @@ function useGroupOpenState(
 
   const isGroupOpen = (id: GroupId): boolean => {
     if (blockGroup === id) return true
-    const override = overrides[id]
-    if (override !== undefined) return override
-    return id === 'CARDS' && !fromSetup
+    return overrides[id] ?? true
   }
 
   const toggleGroup = (id: GroupId) => {

--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -46,6 +46,7 @@ import {
   groupLabel,
   groupSummary,
   groupTopicId,
+  situationalOptions,
   type GroupId,
 } from './settingsGroups'
 import { LobbyAxisSummary } from './LobbyAxisSummary'
@@ -96,10 +97,18 @@ export function LobbyScreen() {
 
   const commands = useLobbyCommands(view, setDeckTab)
   const capture = useCaptureRecipe(view, lobbyState, quickLobby, deckTab, savedDeckName)
-  const { isGroupOpen, toggleGroup } = useGroupOpenState(
+  // Which shape-dependent options each group is currently holding — read twice: named in the
+  // collapsed header, and diffed by `useGroupOpenState` to open a group the moment one appears.
+  const situational = view
+    ? (Object.fromEntries(
+        GROUP_IDS.map((id) => [id, situationalOptions(id, view, lobbyState)]),
+      ) as Record<GroupId, readonly string[]>)
+    : null
+  const { isGroupOpen, toggleGroup, revealedIn } = useGroupOpenState(
     view?.blockGroup ?? null,
     // A lobby a setup built already has its sets; a fresh one is about to need them.
     intent !== undefined,
+    situational,
   )
 
   /**
@@ -387,6 +396,8 @@ export function LobbyScreen() {
                   summary={groupSummary(id, view, lobbyState)}
                   axisStrip={axisStrip}
                   blocking={view.blockGroup === id ? view.primaryAction?.reason : undefined}
+                  situational={situational?.[id] ?? EMPTY_OPTIONS}
+                  revealed={revealedIn(id)}
                   open={isGroupOpen(id)}
                   onToggle={() => toggleGroup(id)}
                   testId={id.toLowerCase()}
@@ -577,18 +588,33 @@ function VisibilityRow({
 /**
  * Which settings groups are open, derived rather than hand-tuned.
  *
- * Three rules, in order:
+ * Four rules, in order:
  *
  * 1. **The group holding the reason Start is disabled is open.** Not a courtesy — it is what keeps
  *    collapsing compatible with the project's disabled-with-reason rule: nothing you need to act on
  *    can be hidden. It reads `view.blockGroup`, which comes from the same `startBlockReason` that
  *    writes the Start button's tooltip.
- * 2. **Cards is open on a lobby that wasn't launched from a setup**, because a fresh lobby's next
+ * 2. **A group that just gained an option opens itself**, and says which one. Switching the Table
+ *    axis to Free-for-All *creates* the attack rule; switching to Two-Headed Giant creates the team
+ *    setup. Landing that new decision inside a box the host has never expanded is how it stays
+ *    unfound — and the host is looking at the axis strip they just clicked, which is exactly where
+ *    the group that opens is. Only genuine appearances count (see {@link situationalOptions}); a
+ *    value changing inside an option that was already there does not re-open anything.
+ * 3. **Cards is open on a lobby that wasn't launched from a setup**, because a fresh lobby's next
  *    move is almost always choosing sets. A lobby a setup built already has them.
- * 3. Otherwise closed — and whatever the host opened or closed by hand wins over all of it, kept in
+ * 4. Otherwise closed — and whatever the host opened or closed by hand wins over all of it, kept in
  *    localStorage so it survives the recreate that switching an axis can cause.
+ *
+ * Rule 2 writes into the same overrides the host's own clicks use, rather than sitting beside them
+ * as a third source of truth: a group opened this way is a group the host can simply close again,
+ * and it stays closed.
  */
-function useGroupOpenState(blockGroup: GroupId | null, fromSetup: boolean) {
+function useGroupOpenState(
+  blockGroup: GroupId | null,
+  fromSetup: boolean,
+  /** Null until the lobby state has arrived — see the effect. */
+  situational: Record<GroupId, readonly string[]> | null,
+) {
   const [overrides, setOverrides] = useState<Partial<Record<GroupId, boolean>>>(() => {
     try {
       const raw = localStorage.getItem(GROUP_OPEN_KEY)
@@ -597,6 +623,35 @@ function useGroupOpenState(blockGroup: GroupId | null, fromSetup: boolean) {
       return {}
     }
   })
+  const [revealed, setRevealed] = useState<Partial<Record<GroupId, readonly string[]>>>({})
+  const previous = useRef<Record<GroupId, readonly string[]> | null>(null)
+
+  // Depend on the *contents*, not the object: `situational` is rebuilt every render because the view
+  // it derives from is.
+  const signature = situational
+    ? GROUP_IDS.map((id) => `${id}:${situational[id].join(',')}`).join('|')
+    : null
+  useEffect(() => {
+    // Nothing to compare against yet. Tracking the empty pre-state would make the lobby's *first*
+    // state message look like five groups' worth of options appearing at once, and open all of them.
+    if (!situational) return
+    const before = previous.current
+    previous.current = situational
+    // First state for this lobby: everything present arrived with it, so nothing "appeared".
+    if (!before) return
+
+    const gained: Partial<Record<GroupId, readonly string[]>> = {}
+    for (const id of GROUP_IDS) {
+      const added = situational[id].filter((option) => !before[id].includes(option))
+      if (added.length > 0) gained[id] = added
+    }
+    const ids = Object.keys(gained) as GroupId[]
+    if (ids.length === 0) return
+
+    setRevealed(gained)
+    setOverrides((prev) => persistOverrides({ ...prev, ...Object.fromEntries(ids.map((id) => [id, true])) }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature])
 
   const isGroupOpen = (id: GroupId): boolean => {
     if (blockGroup === id) return true
@@ -606,19 +661,24 @@ function useGroupOpenState(blockGroup: GroupId | null, fromSetup: boolean) {
   }
 
   const toggleGroup = (id: GroupId) => {
-    setOverrides((prev) => {
-      const next = { ...prev, [id]: !isGroupOpen(id) }
-      try {
-        localStorage.setItem(GROUP_OPEN_KEY, JSON.stringify(next))
-      } catch {
-        // Private browsing / full quota. Remembering the panel's shape is a nicety.
-      }
-      return next
-    })
+    // The "New:" note answered "why did this open?". Acting on the group is the answer being read.
+    setRevealed((prev) => (prev[id] ? { ...prev, [id]: undefined } : prev))
+    setOverrides((prev) => persistOverrides({ ...prev, [id]: !isGroupOpen(id) }))
   }
 
-  return { isGroupOpen, toggleGroup }
+  return { isGroupOpen, toggleGroup, revealedIn: (id: GroupId) => revealed[id] ?? EMPTY_OPTIONS }
 }
+
+function persistOverrides(next: Partial<Record<GroupId, boolean>>): Partial<Record<GroupId, boolean>> {
+  try {
+    localStorage.setItem(GROUP_OPEN_KEY, JSON.stringify(next))
+  } catch {
+    // Private browsing / full quota. Remembering the panel's shape is a nicety.
+  }
+  return next
+}
+
+const EMPTY_OPTIONS: readonly string[] = []
 
 const GROUP_OPEN_KEY = 'argentum-lobby-groups'
 

--- a/web-client/src/components/lobby/SettingsGroup.tsx
+++ b/web-client/src/components/lobby/SettingsGroup.tsx
@@ -16,6 +16,17 @@
  * The summary line is not decoration. A collapsed group has to answer "what is this set to?" without
  * being opened, or the host has to open all five to find the one that is wrong.
  *
+ * **The summary line is also the toggle.** It used to sit beside a bare `⌄` glyph in
+ * `--text-disabled`, 28px wide and unlabelled, and the two together read as a status readout with a
+ * decoration next to it — which is how a host ends up never finding the attack rule or the
+ * public/private switch. So the whole line is one button with a hit target the width of the header,
+ * a hover state, and the word `Edit`/`Hide` beside the chevron. Nothing about *what* collapses
+ * changed; what changed is that the panel now says it collapses.
+ *
+ * On top of that the header names the options a host cannot guess are inside — `+ Attack rule`,
+ * `+ Private / public` — from {@link situationalOptions}. Only the shape-dependent ones: listing
+ * every row would be a second summary line, and the summary already names the values.
+ *
  * Not a scroll container, deliberately: `.lobbyOverlay` is the only one on this screen, which is the
  * lesson recorded in `GameUI.module.css` after an earlier settings panel with its own `max-height`
  * produced three competing scrollbars.
@@ -30,6 +41,8 @@ export function SettingsGroup({
   summary,
   axisStrip,
   blocking,
+  situational = [],
+  revealed = [],
   open,
   onToggle,
   testId,
@@ -44,6 +57,10 @@ export function SettingsGroup({
   axisStrip?: ReactNode
   /** This group holds the reason Start is disabled. */
   blocking?: string | undefined
+  /** Options in here that only exist in this lobby's shape — named while collapsed. */
+  situational?: readonly string[]
+  /** Of those, the ones that appeared just now, which is also why the group opened itself. */
+  revealed?: readonly string[]
   open: boolean
   onToggle: () => void
   testId: string
@@ -51,6 +68,24 @@ export function SettingsGroup({
   children?: ReactNode
 }) {
   const hasBody = Boolean(children)
+
+  const summaryLine = (
+    <>
+      <span className={styles.settingsGroupSummary}>{summary}</span>
+      {blocking && (
+        <span className={styles.settingsGroupBlockingNote} title={blocking}>! {blocking}</span>
+      )}
+      {/* One chip each rather than a `·`-joined run: the summary beside them is `·`-joined too, and
+          "private · AI assist off + Private / public · AI assistance" reads as one list of five
+          things. Once open the controls speak for themselves and the chips go away. */}
+      {hasBody && !open && situational.map((option) => (
+        <span key={option} className={styles.settingsGroupSituational}>+ {option}</span>
+      ))}
+      {open && revealed.length > 0 && (
+        <span className={styles.settingsGroupRevealed}>New: {revealed.join(' · ')}</span>
+      )}
+    </>
+  )
 
   return (
     <div
@@ -65,25 +100,24 @@ export function SettingsGroup({
         </div>
         <div className={styles.settingsGroupMain}>
           {axisStrip}
-          <div className={styles.settingsGroupSummaryRow}>
-            <span className={styles.settingsGroupSummary}>{summary}</span>
-            {blocking && (
-              <span className={styles.settingsGroupBlockingNote} title={blocking}>! {blocking}</span>
-            )}
-          </div>
+          {hasBody ? (
+            <button
+              type="button"
+              className={styles.settingsGroupToggle}
+              onClick={onToggle}
+              aria-expanded={open}
+              aria-label={`${open ? 'Hide' : 'Show'} ${label} settings`}
+              data-testid={`settings-group-toggle-${testId}`}
+            >
+              {summaryLine}
+              <span className={styles.settingsGroupMore}>
+                {open ? 'Hide ⌃' : 'Edit ⌄'}
+              </span>
+            </button>
+          ) : (
+            <div className={styles.settingsGroupSummaryRow}>{summaryLine}</div>
+          )}
         </div>
-        {hasBody && (
-          <button
-            type="button"
-            className={styles.settingsGroupChevron}
-            onClick={onToggle}
-            aria-expanded={open}
-            aria-label={`${open ? 'Hide' : 'Show'} ${label} settings`}
-            data-testid={`settings-group-toggle-${testId}`}
-          >
-            {open ? '⌃' : '⌄'}
-          </button>
-        )}
       </div>
       {hasBody && open && <div className={styles.settingsGroupBody}>{children}</div>}
     </div>

--- a/web-client/src/components/lobby/SettingsGroup.tsx
+++ b/web-client/src/components/lobby/SettingsGroup.tsx
@@ -1,29 +1,31 @@
 /**
- * One collapsible settings group: an axis strip that never hides, over refinements that do.
+ * One settings group: a header that never hides, over refinements that can be put away.
  *
  * ```
  * Cards ?  ( Bring a deck | Random | Momir | Sealed | Draft ⇄ )
- *          ECL + BLB · 6 packs · 45s                        ⌄
+ *          ECL + BLB · 6 packs · 45s                 Hide ⌃
  * ```
+ *
+ * **Open is the default** — the collapsing here is a host's "I'm done with this one", not the state
+ * the panel arrives in. See `useGroupOpenState` for why that flipped.
  *
  * The header carries the axis's own buttons rather than putting them behind the chevron, and that is
  * the whole design. Phase 4's marquee payoff was that someone who entered through "vs AI" can switch
  * the Table to Free-for-All without backing out to the home screen; burying the axis strip would
  * half-undo it, and would also be the version of this that *does* violate the disabled-with-reason
- * rule. What collapses is the sub-rows — deck legality, sets, pack counts, timers — plus the
- * multi-line captions that make each of those rows cost 75–90px.
+ * rule. What a host can collapse is the sub-rows — deck legality, sets, pack counts, timers — plus
+ * the multi-line captions that make each of those rows cost 75–90px.
  *
  * The summary line is not decoration. A collapsed group has to answer "what is this set to?" without
- * being opened, or the host has to open all five to find the one that is wrong.
+ * being opened, or the host has to re-open all five to find the one that is wrong.
  *
  * **The summary line is also the toggle.** It used to sit beside a bare `⌄` glyph in
  * `--text-disabled`, 28px wide and unlabelled, and the two together read as a status readout with a
- * decoration next to it — which is how a host ends up never finding the attack rule or the
- * public/private switch. So the whole line is one button with a hit target the width of the header,
- * a hover state, and the word `Edit`/`Hide` beside the chevron. Nothing about *what* collapses
- * changed; what changed is that the panel now says it collapses.
+ * decoration next to it — nothing on the row looked pressable, which is half of how a host ends up
+ * never finding the attack rule or the public/private switch. So the whole line is one button with a
+ * hit target the width of the header, a hover state, and the word `Edit`/`Hide` beside the chevron.
  *
- * On top of that the header names the options a host cannot guess are inside — `+ Attack rule`,
+ * A collapsed group also names the options a host cannot guess are inside — `+ Attack rule`,
  * `+ Private / public` — from {@link situationalOptions}. Only the shape-dependent ones: listing
  * every row would be a second summary line, and the summary already names the values.
  *

--- a/web-client/src/components/lobby/settingsGroups.ts
+++ b/web-client/src/components/lobby/settingsGroups.ts
@@ -21,19 +21,24 @@
  * deck are facts about *this room*, not about the game being played, and they are the rows a saved
  * setup is least likely to be about.
  *
- * ## The collapse does not hide anything you could act on
+ * ## Grouped, but not hidden
+ *
+ * The groups **open by default** — see `useGroupOpenState`. They were briefly collapsed by default,
+ * and the result was a host who never found the Free-for-All attack rule or the private/public
+ * switch, which is the whole reason grouping had to earn its keep some other way. It still does: the
+ * five headers are what turns twenty rows into five answers you can scan, and collapsing the ones
+ * you're done with is one click.
  *
  * The project's standing rule is *disabled-with-reason over hiding* — every greyed option is a
- * tracked server gap, and rendering it teaches the shape of the system. That rule is about **values
- * within a control**, and it is untouched here: each group header carries its axis's full button
- * strip, so every value stays one click away with its reason and its `⇄` intact. What collapses is
- * the *refinements* below it, and each header states their live values.
+ * tracked server gap, and rendering it teaches the shape of the system. Nothing here bends it: each
+ * group header carries its axis's full button strip, every value keeps its reason and its `⇄`, and
+ * the refinements below are on screen unless the host put them away.
  *
- * Two guards keep the two from drifting apart:
+ * Two guards, still:
  *
- * - a group holding the reason Start is disabled **opens itself** and shows a `!` — see
- *   {@link blockingGroupFor}, which reads the same `startBlockReason` that writes the button's
- *   tooltip rather than a second hand-maintained mapping;
+ * - a group holding the reason Start is disabled is open and shows a `!` even if the host collapsed
+ *   it — see {@link blockingGroupFor}, which reads the same `startBlockReason` that writes the
+ *   button's tooltip rather than a second hand-maintained mapping;
  * - a group is never a scroll container. `.lobbyOverlay` remains the single one, which is the lesson
  *   written into `GameUI.module.css` after an earlier attempt at a scrolling settings panel produced
  *   three competing scrollbars.
@@ -141,30 +146,26 @@ export function groupSummary(id: GroupId, view: UnifiedLobbyView, lobbyState: Lo
 }
 
 /**
- * The options inside this group that only exist in *some* lobby shapes — named, so the host can be
- * told they are there.
+ * The options inside this group that only exist in *some* lobby shapes.
  *
  * The attack rule appears when the table goes Free-for-All, teams when it goes 2HG, ranked when the
- * bracket qualifies, the AI seat's deck when the opponent is a bot. Each is already gated correctly;
- * the problem is that the gate opens *inside a collapsed group*, so a host who has never expanded
- * "Table" has no way to learn that choosing Free-for-All just handed them a decision. A summary line
- * reading "attack any" doesn't fix that — it reads as a fact about the game, not as a control.
+ * bracket qualifies, the AI seat's deck when the opponent is a bot. Since the groups open by default
+ * these are normally just *on screen*, which is the point. This list is for the two cases where they
+ * aren't:
  *
- * Two things consume this list:
- *
- * - the collapsed header names them (`+ Attack rule`), so they are discoverable on a lobby that was
- *   restored from a saved setup or reloaded, where nothing "became" relevant during this session;
- * - {@link useGroupOpenState} diffs it across renders and **opens the group** the moment one
- *   appears, which is the case the header hint can't cover — the host is looking at the axis strip
- *   they just clicked, not at the group three rows down.
+ * - a group the host collapsed **re-opens** when one of them appears, and says which — see
+ *   {@link useGroupOpenState}. Collapsing Table an hour ago wasn't a decision to decline a control
+ *   that didn't exist yet.
+ * - a group the host is keeping collapsed still **names them in its header** (`+ Attack rule`), so
+ *   the fact that there is a decision in there survives being put away.
  *
  * Yes, these conditions are stated a second time here (the first is the `&&` in front of each row).
  * That is the same trade `groupSummary` above already makes, and for the same reason: nothing else
  * knows what a *collapsed* group contains. Keep the two in step — a row whose gate changes changes
  * here too.
  *
- * Cards is deliberately empty: it is the group that opens by default, its rows are unconditional for
- * any non-premade pool, and its summary already names every value it holds.
+ * Cards is deliberately empty: its rows are unconditional for any non-premade pool, so a collapsed
+ * Cards is never withholding a surprise, and its summary already names every value it holds.
  */
 export function situationalOptions(
   id: GroupId,

--- a/web-client/src/components/lobby/settingsGroups.ts
+++ b/web-client/src/components/lobby/settingsGroups.ts
@@ -140,6 +140,67 @@ export function groupSummary(id: GroupId, view: UnifiedLobbyView, lobbyState: Lo
   return parts.join(' · ')
 }
 
+/**
+ * The options inside this group that only exist in *some* lobby shapes — named, so the host can be
+ * told they are there.
+ *
+ * The attack rule appears when the table goes Free-for-All, teams when it goes 2HG, ranked when the
+ * bracket qualifies, the AI seat's deck when the opponent is a bot. Each is already gated correctly;
+ * the problem is that the gate opens *inside a collapsed group*, so a host who has never expanded
+ * "Table" has no way to learn that choosing Free-for-All just handed them a decision. A summary line
+ * reading "attack any" doesn't fix that — it reads as a fact about the game, not as a control.
+ *
+ * Two things consume this list:
+ *
+ * - the collapsed header names them (`+ Attack rule`), so they are discoverable on a lobby that was
+ *   restored from a saved setup or reloaded, where nothing "became" relevant during this session;
+ * - {@link useGroupOpenState} diffs it across renders and **opens the group** the moment one
+ *   appears, which is the case the header hint can't cover — the host is looking at the axis strip
+ *   they just clicked, not at the group three rows down.
+ *
+ * Yes, these conditions are stated a second time here (the first is the `&&` in front of each row).
+ * That is the same trade `groupSummary` above already makes, and for the same reason: nothing else
+ * knows what a *collapsed* group contains. Keep the two in step — a row whose gate changes changes
+ * here too.
+ *
+ * Cards is deliberately empty: it is the group that opens by default, its rows are unconditional for
+ * any non-premade pool, and its summary already names every value it holds.
+ */
+export function situationalOptions(
+  id: GroupId,
+  view: UnifiedLobbyView,
+  lobbyState: LobbyState | null,
+): readonly string[] {
+  const s = lobbyState?.settings
+  const out: string[] = []
+
+  switch (id) {
+    case 'CARDS':
+      break
+    case 'RULES':
+      if (s && view.axes.rules === 'COMMANDER' && s.format !== 'PREMADE_DECKS') out.push('Deck rules')
+      break
+    case 'TABLE':
+      if (view.teams.mode !== 'NONE') out.push('Teams')
+      if (s?.gameMode === 'FREE_FOR_ALL') out.push('Attack rule')
+      break
+    case 'EVENT':
+      if (s && view.axes.event === 'ROUND_ROBIN') out.push('Games per matchup')
+      if (view.ranked.available) out.push('Ranked')
+      break
+    case 'LOBBY':
+      if (view.invitable) out.push('Private / public')
+      // A quick lobby with nobody to invite is the vs-AI one — see `UnifiedLobbyView.invitable`.
+      // Momir hands every seat the same 60 basics, so its AI seat has no deck to pick.
+      if (view.kind === 'QUICK' && !view.invitable && view.axes.cards.kind !== 'MOMIR') {
+        out.push('AI opponent deck')
+      }
+      if (s) out.push('AI assistance')
+      break
+  }
+  return out
+}
+
 function attackLabel(mode: LobbyState['settings']['attackMode'] | undefined): string {
   switch (mode ?? 'MULTIPLE') {
     case 'LEFT': return 'attack left'

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1139,13 +1139,71 @@
   min-width: 0;
 }
 
-.settingsGroupSummaryRow {
+.settingsGroupSummaryRow,
+.settingsGroupToggle {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--space-2);
   max-width: 100%;
+}
+
+/* The summary line *is* the collapse control, not a caption beside one.
+   It replaced a 28px `⌄` in `--text-disabled` sitting off to the right of a grey status line —
+   between them there was nothing on a collapsed group that looked pressable, which is how a host
+   ends up never finding the attack rule or the private/public switch. So: full-width hit target, a
+   hover state, and the word `Edit`/`Hide` next to the chevron. `text-align: right` keeps it aligned
+   with the axis strip above it, since the header's main column is right-aligned. */
+.settingsGroupToggle {
+  margin: 0;
+  padding: 3px 6px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-md);
+  color: inherit;
+  font: inherit;
+  text-align: right;
+  cursor: pointer;
+}
+
+.settingsGroupToggle:hover {
+  background: var(--bg-panel-hover);
+}
+
+.settingsGroupToggle:hover .settingsGroupMore {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.settingsGroupToggle:focus-visible {
+  outline: 1px solid var(--border-strong);
+  outline-offset: 1px;
+}
+
+.settingsGroupMore {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-xs, 0.75rem);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+/* What's inside that the host can't guess is inside — "+ Attack rule". Accent-coloured because it
+   is the one part of a collapsed header that is an invitation rather than a readout. */
+.settingsGroupSituational {
+  font-size: var(--font-xs, 0.75rem);
+  color: var(--color-accent);
+  text-align: right;
+}
+
+/* Why this group just opened by itself. */
+.settingsGroupRevealed {
+  font-size: var(--font-xs, 0.75rem);
+  color: var(--color-accent);
+  text-align: right;
 }
 
 .settingsGroupSummary {
@@ -1158,22 +1216,6 @@
   font-size: var(--font-xs, 0.75rem);
   color: var(--warning, #fbbf24);
   text-align: right;
-}
-
-.settingsGroupChevron {
-  flex-shrink: 0;
-  align-self: center;
-  width: 28px;
-  padding: 4px 0;
-  background: none;
-  border: none;
-  color: var(--text-disabled);
-  font-size: var(--font-md);
-  cursor: pointer;
-}
-
-.settingsGroupChevron:hover {
-  color: var(--text-secondary);
 }
 
 .settingsGroupBody {


### PR DESCRIPTION
The lobby's additional options were effectively hidden. The settings panel opened with everything but
Cards collapsed, behind one affordance — a 28px `⌄` in `--text-disabled`, off to the right of a grey
summary line — and between them there was nothing that read as pressable. The casualties were the
options that only exist in *some* lobby shapes: the Free-for-All attack rule, private/public, AI
assistance, the AI seat's deck.

## What changed

**1. The groups open by default.** Collapsing is now the host's own "I'm done with this one", and it
still persists in localStorage. A group only ever renders rows that apply to this lobby's shape —
that filtering is the `&&` in front of each row in `TournamentLobbySettings` and the `push` conditions
in `LobbyScreen` — so *open by default* and *open when relevant* are the same rule: what's on screen
is exactly what this lobby can be asked about.

The cost is the height the collapse was introduced to fix: a booster draft with Commander rules and
two sets is long again. `.lobbyOverlay` scrolls and the panel sits below the roster, so it grows
downward rather than pushing the players off screen, and a host who wants the short version collapses
the groups they're done with. `fromSetup` is gone with this — it existed to keep Cards closed on a
setup-built lobby, which no longer has a closed state to opt into.

**2. The summary line is the toggle.** Full-width hit target, hover state, and the word `Edit`/`Hide`
beside the chevron, so a group that *has* been collapsed looks like a control rather than a readout
with a decoration next to it. `settings-group-toggle-<id>` and `data-open` are unchanged, so
`openSettingsGroup()` in `e2e-scenarios/helpers/homeScreen.ts` still drives it.

**3. A collapsed group says what it's holding**, from the new `situationalOptions` in
`settingsGroups.ts`: `+ Attack rule`, `+ Teams`, `+ Private / public`, `+ AI assistance`,
`+ AI opponent deck`, `+ Ranked`, `+ Games per matchup`, `+ Deck rules`. One chip each rather than a
`·`-joined run — the value summary beside them is `·`-joined too, and
`private · AI assist off + Private / public · AI assistance` reads as one list of five things.

**4. A collapsed group that gains an option re-opens** and says `New: Attack rule`. Collapsing Table
an hour ago was not a decision to decline a control that didn't exist yet. It writes into the same
localStorage overrides the host's own clicks use rather than sitting beside them as a third source of
truth, so it's a group the host can simply close again. Scoped to groups that are actually
closed — over an open one there's nothing to announce, and it was firing on *fresh* lobbies: the
wizard's shape lands as a settings update just after the lobby opens, so a Free-for-All lobby
genuinely goes 1v1 → Free-for-All across its first two messages and the attack rule genuinely
"appears".

`situationalOptions` restates each row's gate a second time, which the file's own doc comment warns
about. That's the same trade `groupSummary` above it already makes, and for the same reason: nothing
else knows what a *collapsed* group contains. The comment says so, and says to keep them in step.

## Screenshots

All shots are of this branch — no before/after pair, since capturing the old state means a second
full stack run against reverted files. `justfile` in my working tree was already modified before this
work and is not in the diff.

A fresh Free-for-All draft lobby, zero clicks: every group open, the Attack rule / Visibility / AI
assistance rows all on screen, and no spurious `New:`.

![default open](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-settings-discoverability-screenshots/30-default-open.png)

The same lobby after the host collapses **Table** by hand — `+ Attack rule` keeps the fact that
there's a decision in there, and `Edit ⌄` says it can be got at:

![host collapsed](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-settings-discoverability-screenshots/31-host-collapsed.png)

Switching that collapsed Table to Two-Headed Giant re-opens it with `New: Teams`, coexisting with the
`!` start-block reason:

![reopened](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-settings-discoverability-screenshots/32-reopened.png)

A quick vs-AI lobby — open by default too, with the AI opponent's deck row on screen:

![vs ai](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-settings-discoverability-screenshots/33-vs-ai-open.png)

Hover on a collapsed group's toggle — the whole summary line is the hit target and the pill brightens:

![hover](https://raw.githubusercontent.com/wingedsheep/argentum-engine/lobby-settings-discoverability-screenshots/02-hover.png)

The `lobby-settings-discoverability-screenshots` branch is throwaway — images only, no code, safe to
delete once this merges.

## Verification

- `npm run typecheck`, `npm run build`, `npm run test` (363 tests, 30 files) — all pass.
- Driven in the real app (game server + vite, Playwright via system Chrome). `data-open` asserted
  rather than eyeballed at each step: fresh lobby `{cards,rules,table,event,lobby} = all true`; after
  collapsing Table by hand, `table=false` and nothing else changed; after switching that collapsed
  Table to 2HG, `table=true` again.
- No spec other than the helper itself calls `openSettingsGroup`, and the helper's contract is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
