### PR TITLE
Add three Innistrad Remastered reprints

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DesperateFarmerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DesperateFarmerReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Desperate Farmer reprint in INR. Canonical CardDefinition lives in its earliest set (VOW). */
+val DesperateFarmerReprint = Printing(
+    oracleId = "60d591f6-6d84-45d2-9d78-a2ef07a3e403",
+    name = "Desperate Farmer",
+    setCode = "INR",
+    collectorNumber = "105",
+    scryfallId = "0ec488de-fded-4df9-97ed-ba46cbacfdbf",
+    artist = "Valera Lutfullina",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0ec488de-fded-4df9-97ed-ba46cbacfdbf.jpg?1783908149",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/0/e/0ec488de-fded-4df9-97ed-ba46cbacfdbf.jpg?1783908149",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/RestlessBloodseekerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/RestlessBloodseekerReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Restless Bloodseeker reprint in INR. Canonical CardDefinition lives in its earliest set (VOW). */
+val RestlessBloodseekerReprint = Printing(
+    oracleId = "7aef5d2e-b66d-4822-b563-44d21d008272",
+    name = "Restless Bloodseeker",
+    setCode = "INR",
+    collectorNumber = "128",
+    scryfallId = "68f71dcf-b0eb-43c7-9ea5-5ff7a7f991be",
+    artist = "Justyna Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68f71dcf-b0eb-43c7-9ea5-5ff7a7f991be.jpg?1783908139",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/6/8/68f71dcf-b0eb-43c7-9ea5-5ff7a7f991be.jpg?1783908139",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WeddingAnnouncementReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WeddingAnnouncementReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Wedding Announcement reprint in INR. Canonical CardDefinition lives in its earliest set (VOW). */
+val WeddingAnnouncementReprint = Printing(
+    oracleId = "259ac30c-cc05-4c04-9b23-71283f84b808",
+    name = "Wedding Announcement",
+    setCode = "INR",
+    collectorNumber = "51",
+    scryfallId = "4e6f365d-c5c4-4fd6-94cb-833b89239d73",
+    artist = "Caroline Gariba",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e6f365d-c5c4-4fd6-94cb-833b89239d73.jpg?1783908174",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/4/e/4e6f365d-c5c4-4fd6-94cb-833b89239d73.jpg?1783908174",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)


### PR DESCRIPTION
## Summary
- add Innistrad Remastered printing data for Desperate Farmer
- add Innistrad Remastered printing data for Restless Bloodseeker
- add Innistrad Remastered printing data for Wedding Announcement
- include authoritative front/back Scryfall art for all three transforming cards

The rules implementations remain canonical in Innistrad: Crimson Vow; these INR rows expose the remastered printings without duplicating card scripts.

## Verification
- `just check-card-printing` for all three cards
- all six front/back image URLs return HTTP 200
- `just card-status --set INR --list` (202/290, up from 199/290)
- `git diff --check`
- `just build`