### PR TITLE
Add Kellan, the Fae-Blooded to Wilds of Eldraine

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KellanTheFaeBlooded.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/KellanTheFaeBlooded.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kellan, the Fae-Blooded // Birthright Boon
+ * {2}{R}
+ * Legendary Creature — Human Faerie
+ * 2/2
+ * Double strike
+ * Other creatures you control get +1/+0 for each Aura and Equipment attached to Kellan.
+ *
+ * Adventure: Birthright Boon — {1}{W}, Sorcery — Adventure
+ * Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle.
+ *
+ * The anthem reads Kellan's live attachment count, so attaching or removing an Aura/Equipment
+ * immediately changes every other creature's projected power. Birthright Boon uses the shared
+ * library-search recipe and the engine's existing Adventure resolution/exile permission.
+ */
+val KellanTheFaeBlooded = card("Kellan, the Fae-Blooded") {
+    manaCost = "{2}{R}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Faerie"
+    oracleText = "Double strike\n" +
+        "Other creatures you control get +1/+0 for each Aura and Equipment attached to Kellan."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.OtherCreaturesYouControl,
+            powerBonus = DynamicAmounts.attachmentsOnSelf(),
+            toughnessBonus = DynamicAmount.Fixed(0),
+        )
+    }
+
+    adventure("Birthright Boon") {
+        manaCost = "{1}{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Search your library for an Aura or Equipment card, reveal it, put it into " +
+            "your hand, then shuffle. (Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any.withAnySubtype("Aura", "Equipment"),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "230"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1783915063"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -7901,6 +7901,99 @@
     ]
 }
 
+// Kellan, the Fae-Blooded
+{
+    "name": "Kellan, the Fae-Blooded",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Human Faerie",
+    "oracleText": "Double strike\nOther creatures you control get +1/+0 for each Aura and Equipment attached to Kellan.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": "AttachmentCount"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "MYTHIC",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec5e2680-8b42-4571-ab45-4936aec51901.jpg?1783915063"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Birthright Boon",
+            "manaCost": "{1}{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Search your library for an Aura or Equipment card, reveal it, put it into your hand, then shuffle. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "Aura|Equipment"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Kindled Heroism
 {
     "name": "Kindled Heroism",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanTheFaeBloodedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanTheFaeBloodedScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario tests for Kellan, the Fae-Blooded // Birthright Boon (WOE #230). */
+class KellanTheFaeBloodedScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("each Aura attached to Kellan gives other creatures +1/+0, but not Kellan") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Kellan, the Fae-Blooded", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardInHand(1, "Holy Strength")
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kellan = game.findPermanent("Kellan, the Fae-Blooded")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Holy Strength", kellan).error shouldBe null
+            game.resolveStack()
+
+            withClue("the attached Aura increases only the other creature's power") {
+                game.state.projectedState.getPower(bears) shouldBe 3
+                // Holy Strength itself gives Kellan +1/+2; Kellan's anthem must not add another +1.
+                game.state.projectedState.getPower(kellan) shouldBe 3
+            }
+        }
+
+        test("Birthright Boon finds either an Aura or Equipment and resolves as an Adventure") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Kellan, the Fae-Blooded")
+                .withCardInLibrary(1, "Holy Strength")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kellan = game.findCardsInHand(1, "Kellan, the Fae-Blooded").single()
+            val aura = game.findCardsInLibrary(1, "Holy Strength").single()
+            game.execute(CastSpell(game.player1Id, kellan, faceIndex = 0)).error shouldBe null
+            game.resolveStack()
+
+            game.selectCards(listOf(aura)).error shouldBe null
+            game.resolveStack()
+
+            withClue("the selected Aura moved to hand") {
+                game.findCardsInHand(1, "Holy Strength").size shouldBe 1
+            }
+            withClue("the resolved Adventure exiled Kellan for later creature casting") {
+                game.isInExile(1, "Kellan, the Fae-Blooded") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Kellan, the Fae-Blooded // Birthright Boon with its Adventure face
- model the live Aura/Equipment attachment-count anthem using existing SDK primitives
- add focused scenarios for the anthem and Adventure library search/exile flow
- update the WOE card snapshot

The batch was intentionally reduced to one card after fidelity probes found the other candidate cards require missing engine support (including source-relative activated-cost filtering and multi-target delayed triggers).

## Verification
- `just test-class KellanTheFaeBloodedScenarioTest`
- `just check-card-printing "Kellan, the Fae-Blooded"`
- `just rebless-cards`
- `just build`