### PR TITLE
Add Seize the Storm to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SeizeTheStormReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SeizeTheStormReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Seize the Storm reprint in Innistrad Remastered. */
+val SeizeTheStormReprint = Printing(
+    oracleId = "d3455e93-3a05-42db-945d-c4c85f4ac827",
+    name = "Seize the Storm",
+    setCode = "INR",
+    collectorNumber = "170",
+    scryfallId = "45ec2af6-8397-429f-900f-846a5056f8e0",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45ec2af6-8397-429f-900f-846a5056f8e0.jpg?1783908114",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeizeTheStormReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeizeTheStormReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Seize the Storm reprint in Jumpstart 2022. */
+val SeizeTheStormReprint = Printing(
+    oracleId = "d3455e93-3a05-42db-945d-c4c85f4ac827",
+    name = "Seize the Storm",
+    setCode = "J22",
+    collectorNumber = "598",
+    scryfallId = "024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/024b3bfd-3d2b-4f45-b015-2d94fe2f2bb3.jpg?1783918908",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SeizeTheStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/SeizeTheStorm.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Seize the Storm
+ * {4}{R}
+ * Sorcery
+ *
+ * Creates an Elemental whose characteristic-defining ability continuously counts instant and
+ * sorcery cards in its controller's graveyard plus cards with flashback they own in exile.
+ * Flashback {6}{R}.
+ */
+val SeizeTheStorm = card("Seize the Storm") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a red Elemental creature token with trample and \"This token's power and " +
+        "toughness are each equal to the number of instant and sorcery cards in your graveyard plus " +
+        "the number of cards with flashback you own in exile.\"\n" +
+        "Flashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    val stormCount = DynamicAmount.Add(
+        DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.InstantOrSorcery),
+        DynamicAmount.Count(
+            Player.You,
+            Zone.EXILE,
+            GameObjectFilter.Any.withKeyword(Keyword.FLASHBACK).ownedByYou()
+        )
+    )
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Elemental"),
+            keywords = setOf(Keyword.TRAMPLE),
+            imageUri = "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg?1783925224",
+            staticAbilities = listOf(SetBasePowerToughnessDynamicStatic(stormCount, stormCount))
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{6}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "158"
+        artist = "Deruchenko Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg?1783925591"
+
+        ruling("2021-09-24", "The power and toughness of the Elemental token will change as the number of instant and sorcery cards in your graveyard and the number of cards with flashback you own in exile change.")
+        ruling("2021-09-24", "If you cast Seize the Storm with no instant or sorcery cards in your graveyard and no cards with flashback in exile, the Elemental will survive because Seize the Storm will be in your graveyard or in exile before state-based actions are checked.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -1613,6 +1613,94 @@
     ]
 }
 
+// Seize the Storm
+{
+    "name": "Seize the Storm",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a red Elemental creature token with trample and \"This token's power and toughness are each equal to the number of instant and sorcery cards in your graveyard plus the number of cards with flashback you own in exile.\"\nFlashback {6}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{6}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 0,
+            "toughness": 0,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Elemental"
+            ],
+            "keywords": [
+                "TRAMPLE"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4052aed-981b-41d0-85f0-20c2599811ba.jpg?1783925224",
+            "staticAbilities": [
+                {
+                    "type": "SetBasePowerToughnessDynamicStatic",
+                    "power": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "instant|sorcery"
+                        },
+                        "right": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Exile",
+                            "filter": "kw:flashback own:you"
+                        }
+                    },
+                    "toughness": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "instant|sorcery"
+                        },
+                        "right": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Exile",
+                            "filter": "kw:flashback own:you"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "UNCOMMON",
+        "artist": "Deruchenko Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/532e079f-55b7-4b92-b489-aed4d3becae7.jpg?1783925591",
+        "rulings": [
+            {
+                "date": "2021-09-24",
+                "text": "The power and toughness of the Elemental token will change as the number of instant and sorcery cards in your graveyard and the number of cards with flashback you own in exile change."
+            },
+            {
+                "date": "2021-09-24",
+                "text": "If you cast Seize the Storm with no instant or sorcery cards in your graveyard and no cards with flashback in exile, the Elemental will survive because Seize the Storm will be in your graveyard or in exile before state-based actions are checked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Shipwreck Marsh
 {
     "name": "Shipwreck Marsh",


### PR DESCRIPTION
## Summary
- add the canonical Seize the Storm definition to Innistrad: Midnight Hunt
- model its Elemental token with continuously recomputed power/toughness and exact token art
- add Jumpstart 2022 and Innistrad Remastered printing rows

## Scope
Kept this to one card because the other probed INR candidates require unsupported mechanics (notably Escalate, Madness, Undying, or double-faced-card behavior).

## Verification
- `just build`
- `just check-card-printing "Seize the Storm"`
- all Scryfall card and token image URLs return HTTP 200
- snapshot diff adds only Seize the Storm to MID