### PR TITLE
Add Aetherdrift basic lands

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AetherdriftBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AetherdriftBasicLands.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Aetherdrift Basic Lands
+ *
+ * Aetherdrift contains one basic land of each type (cards 277, 280, 283, 286, and 289).
+ */
+
+val AetherdriftPlains277 = basicLand("Plains") {
+    collectorNumber = "277"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg?1783907835"
+}
+
+val AetherdriftIsland280 = basicLand("Island") {
+    collectorNumber = "280"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg?1783907834"
+}
+
+val AetherdriftSwamp283 = basicLand("Swamp") {
+    collectorNumber = "283"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg?1783907831"
+}
+
+val AetherdriftMountain286 = basicLand("Mountain") {
+    collectorNumber = "286"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg?1783907832"
+}
+
+val AetherdriftForest289 = basicLand("Forest") {
+    collectorNumber = "289"
+    artist = "Samuele Bandini"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg?1783907831"
+}
+
+val AetherdriftBasicLands = listOf(
+    AetherdriftPlains277,
+    AetherdriftIsland280,
+    AetherdriftSwamp283,
+    AetherdriftMountain286,
+    AetherdriftForest289,
+)


### PR DESCRIPTION
## Summary
- add the five Aetherdrift basic lands using the established `basicLand` DSL
- include authoritative collector numbers, artist credits, and exact Scryfall image URLs
- complete every currently AUTOGEN-ready DFT coverage gap

## Verification
- `just coverage-fidelity --emit` for Plains, Island, Swamp, Mountain, and Forest: AUTO
- all five image URLs return HTTP 200
- `just coverage-gaps --set DFT --list AUTOGEN`: 0 AUTOGEN gaps remaining
- `just rebless-cards`: passed; no snapshot change (basic-land variants are outside the per-card golden)
- `just build`: passed

## Known pre-existing gate issue
- `just check-card-printing` is not actionable for basic lands: it reports repository-wide historical basic-land canonical/printing drift, including hundreds of existing rows unrelated to this change.