### PR TITLE
Add Undying support and two Innistrad Remastered cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5325,6 +5325,15 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > card types or subtypes. Author the printed dies-clause + reminder text into `oracleText`. The
 > `Keyword.ENDURING` display keyword carries no combat behavior.
 
+> **Undying** (`Keyword.UNDYING`, CR 702.93). "When this permanent is put into a graveyard from the
+> battlefield, if it had no +1/+1 counters on it, return it to the battlefield under its owner's
+> control with a +1/+1 counter on it." Like Persist, this is a synthesized SELF dies-trigger in
+> `DeathAndLeaveTriggerDetector`, built from `MoveToZoneEffect(Self, BATTLEFIELD)` followed by
+> `AddCountersEffect(PLUS_ONE_PLUS_ONE, 1, Self)`. It reads projected keywords and counters from the
+> `ZoneChangeEvent` last-known snapshot, so printed and granted undying work identically. A token's
+> undying ability triggers, but the token ceases to exist before the trigger resolves and cannot return.
+> Card definitions only need `keywords(Keyword.UNDYING)` plus the full reminder text in `oracleText`.
+
 > **Bargain** (CR 702.166, Wilds of Eldraine). "Bargain (You may sacrifice an artifact, enchantment, or
 > token as you cast this spell.)" — a static ability functioning on the stack that grants one **optional
 > additional cost** (702.166a): sacrificing an artifact, an enchantment, or a token you control. A spell
@@ -5440,7 +5449,7 @@ Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all basic landwalks (Pla
 `LandwalkRule` checks `typeLine.isLand && !isBasicLand`; Trailblazer's Boots), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Defender, Indestructible, Hexproof, Shroud, Haste,
 Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Harmonize, Mayhem, Evoke, Sneak, Ninjutsu, Web-slinging, Impending, Conspire, Casualty, Miracle, Hideaway, Cascade, Plot,
-Offspring, Persist, Enduring, Ascend, Start your engines!, Max speed, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, Daybound, Nightbound, … (display-only — engine effect lives in handlers or
+Offspring, Persist, Undying, Enduring, Ascend, Start your engines!, Max speed, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, Daybound, Nightbound, … (display-only — engine effect lives in handlers or
 composite abilities).
 
 **Parameterized `KeywordAbility.*`**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -330,6 +330,7 @@ enum class Keyword(val displayName: String) {
     // ── Creature mechanics ────────────────────────────────
     OFFSPRING("Offspring"),
     PERSIST("Persist"),
+    UNDYING("Undying"),
 
     /**
      * Enduring (Duskmourn: House of Horror — the Glimmer "Enduring" cycle).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ButcherGhoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ButcherGhoul.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/** Butcher Ghoul — Avacyn Restored #89. */
+val ButcherGhoul = card("Butcher Ghoul") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText = "Undying (When this creature dies, if it had no +1/+1 counters on it, return it " +
+        "to the battlefield under its owner's control with a +1/+1 counter on it.)"
+    power = 1
+    toughness = 1
+    keywords(Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Christopher Moeller"
+        flavorText = "Without a mind, it doesn't fear death. Without a soul, it doesn't mind killing."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg?1783940705"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButcherGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButcherGhoulReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Butcher Ghoul reprint in DDQ. Canonical CardDefinition lives in its earliest set (AVR). */
+val ButcherGhoulReprint = Printing(
+    oracleId = "28caeed4-c175-469f-8d8e-f45bc0a51a1c",
+    name = "Butcher Ghoul",
+    setCode = "DDQ",
+    collectorNumber = "53",
+    scryfallId = "37117234-76eb-4a94-8230-a0a8c9b92e47",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37117234-76eb-4a94-8230-a0a8c9b92e47.jpg?1783937841",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/YoungWolf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/YoungWolf.kt
@@ -1,0 +1,26 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/** Young Wolf — Dark Ascension #134. */
+val YoungWolf = card("Young Wolf") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "Undying (When this creature dies, if it had no +1/+1 counters on it, return it " +
+        "to the battlefield under its owner's control with a +1/+1 counter on it.)"
+    power = 1
+    toughness = 1
+    keywords(Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Ryan Pancoast"
+        flavorText = "The Ulvenwald makes no allowances for youth. Today's newborn is either " +
+            "tomorrow's hunter or tomorrow's lunch."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg?1783940798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ButcherGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ButcherGhoulReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Butcher Ghoul reprint in INR. Canonical CardDefinition lives in its earliest set (AVR). */
+val ButcherGhoulReprint = Printing(
+    oracleId = "28caeed4-c175-469f-8d8e-f45bc0a51a1c",
+    name = "Butcher Ghoul",
+    setCode = "INR",
+    collectorNumber = "99",
+    scryfallId = "c4ef03c8-2047-4170-9ac4-f26cc14ebf96",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4ef03c8-2047-4170-9ac4-f26cc14ebf96.jpg?1783908147",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/YoungWolfReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/YoungWolfReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Young Wolf reprint in INR. Canonical CardDefinition lives in its earliest set (DKA). */
+val YoungWolfReprint = Printing(
+    oracleId = "8b492764-10b6-4506-be11-22daa9220a91",
+    name = "Young Wolf",
+    setCode = "INR",
+    collectorNumber = "227",
+    scryfallId = "ed2ca825-b029-495f-83fc-54366229d417",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed2ca825-b029-495f-83fc-54366229d417.jpg?1783908083",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YoungWolfReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YoungWolfReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Young Wolf reprint in J22. Canonical CardDefinition lives in its earliest set (DKA). */
+val YoungWolfReprint = Printing(
+    oracleId = "8b492764-10b6-4506-be11-22daa9220a91",
+    name = "Young Wolf",
+    setCode = "J22",
+    collectorNumber = "746",
+    scryfallId = "07dccb5f-dca4-44d1-bbbf-a84dd016fbb1",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/0/7/07dccb5f-dca4-44d1-bbbf-a84dd016fbb1.jpg?1783918826",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -209,6 +209,30 @@
     ]
 }
 
+// Butcher Ghoul
+{
+    "name": "Butcher Ghoul",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "UNDYING"
+    ],
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Christopher Moeller",
+        "flavorText": "Without a mind, it doesn't fear death. Without a soul, it doesn't mind killing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg?1783940705"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cathars' Crusade
 {
     "name": "Cathars' Crusade",

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -938,3 +938,27 @@
         "GREEN"
     ]
 }
+
+// Young Wolf
+{
+    "name": "Young Wolf",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "UNDYING"
+    ],
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Ryan Pancoast",
+        "flavorText": "The Ulvenwald makes no allowances for youth. Today's newborn is either tomorrow's hunter or tomorrow's lunch.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c39aa40-ef5f-40f1-a6dd-fbce91172c50.jpg?1783940798"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -386,6 +386,58 @@ class DeathAndLeaveTriggerDetector(
     }
 
     /**
+     * Detect undying triggers (CR 702.93) when a permanent dies with no +1/+1 counters on it.
+     *
+     * The keyword is read from the event's projected last-known information, so printed and granted
+     * instances follow the same path. The synthesized ability resolves from the graveyard and returns
+     * the card under its owner's control with a +1/+1 counter. Tokens are not suppressed here: undying
+     * still triggers for a token, but the token ceases to exist before that trigger can return it.
+     */
+    fun detectUndyingTriggers(
+        state: GameState,
+        event: ZoneChangeEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) return
+        if ((event.lastKnown?.plusOnePlusOneCounters ?: 0) > 0) return
+        if (Keyword.UNDYING.name !in (event.lastKnown?.keywords ?: emptySet())) return
+
+        val info = resolveDyingEntity(state, event) ?: return
+
+        val undyingAbility = TriggeredAbility.create(
+            trigger = EventPattern.ZoneChangeEvent(
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD
+            ),
+            binding = TriggerBinding.SELF,
+            effect = CompositeEffect(
+                listOf(
+                    MoveToZoneEffect(
+                        target = EffectTarget.Self,
+                        destination = Zone.BATTLEFIELD
+                    ),
+                    AddCountersEffect(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        count = 1,
+                        target = EffectTarget.Self
+                    )
+                )
+            ),
+            descriptionOverride = "Undying — Return ${info.name} to the battlefield with a +1/+1 counter on it"
+        )
+
+        triggers.add(
+            PendingTrigger(
+                ability = undyingAbility,
+                sourceId = event.entityId,
+                sourceName = info.name,
+                controllerId = event.ownerId,
+                triggerContext = TriggerContext.fromEvent(event)
+            )
+        )
+    }
+
+    /**
      * Detect Enduring triggers (Duskmourn Glimmer cycle) when a permanent dies.
      *
      * Enduring: "When this permanent dies, if it was a creature, return it to the battlefield

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1398,6 +1398,8 @@ class TriggerDetector(
             deathAndLeaveDetector.detectDeadAuraAttachmentTriggers(state, index.statics, event, triggers)
             // Handle persist (CR 702.79) — nontoken creature with persist dies with no -1/-1 counter
             deathAndLeaveDetector.detectPersistTriggers(state, event, triggers)
+            // Handle undying (CR 702.93) — permanent with undying dies with no +1/+1 counter
+            deathAndLeaveDetector.detectUndyingTriggers(state, event, triggers)
             // Handle Enduring (Duskmourn Glimmer cycle) — nontoken creature with Enduring dies and
             // returns as an enchantment.
             deathAndLeaveDetector.detectEnduringTriggers(state, event, triggers)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ButcherGhoulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ButcherGhoulScenarioTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.AvacynRestoredSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ButcherGhoulScenarioTest : FunSpec({
+
+    test("a +1/+1 counter present as Butcher Ghoul dies prevents undying from triggering") {
+        val driver = GameTestDriver().apply {
+            registerCards(TestCards.all + AvacynRestoredSet.cards)
+            initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+        }
+        val you = driver.activePlayer!!
+        val ghoul = driver.putCreatureOnBattlefield(you, "Butcher Ghoul")
+        driver.addComponent(
+            ghoul,
+            CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1))
+        )
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(ghoul)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getGraveyard(you).contains(ghoul) shouldBe true
+        driver.state.stack.isEmpty() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YoungWolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YoungWolfScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dka.DarkAscensionSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class YoungWolfScenarioTest : FunSpec({
+
+    fun createDriver() = GameTestDriver().apply {
+        registerCards(TestCards.all + DarkAscensionSet.cards)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun killWithLightningBolt(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId, victim: com.wingedsheep.sdk.model.EntityId) {
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, listOf(victim)).isSuccess shouldBe true
+        driver.bothPass()
+    }
+
+    test("undying returns Young Wolf with a +1/+1 counter and does not trigger on its next death") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val wolf = driver.putCreatureOnBattlefield(you, "Young Wolf")
+
+        killWithLightningBolt(driver, you, wolf)
+        driver.state.getGraveyard(you).contains(wolf) shouldBe true
+        driver.bothPass()
+
+        driver.state.getBattlefield().contains(wolf) shouldBe true
+        plusOneCounters(driver, wolf) shouldBe 1
+
+        killWithLightningBolt(driver, you, wolf)
+
+        driver.state.getGraveyard(you).contains(wolf) shouldBe true
+        driver.state.stack.isEmpty() shouldBe true
+    }
+})

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -226,6 +226,7 @@ export enum Keyword {
   TOXIC = 'TOXIC',
   // Death replacement
   PERSIST = 'PERSIST',
+  UNDYING = 'UNDYING',
   // Dies-and-returns-as-enchantment (Duskmourn Glimmer cycle)
   ENDURING = 'ENDURING',
   // Resolution-time city's blessing grant (Ixalan)
@@ -309,6 +310,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.WITHER]: 'Wither',
   [Keyword.TOXIC]: 'Toxic',
   [Keyword.PERSIST]: 'Persist',
+  [Keyword.UNDYING]: 'Undying',
   [Keyword.ENDURING]: 'Enduring',
   [Keyword.ASCEND]: 'Ascend',
   [Keyword.START_YOUR_ENGINES]: 'Start your engines!',


### PR DESCRIPTION
## Summary
- add rules-faithful Undying support using projected last-known counters and the existing trigger pipeline
- implement Young Wolf in DKA and Butcher Ghoul in AVR, with INR and intervening reprint rows
- expose the keyword in the client and document it in the SDK reference
- add one scenario test file per card

## Verification
- `just test`
- `just test-class YoungWolfScenarioTest`
- `just test-class ButcherGhoulScenarioTest`
- `just rebless-cards`
- `npm run typecheck`
- `just check-card-printing "Young Wolf"`
- `just check-card-printing "Butcher Ghoul"`
- `just coverage-fidelity --emit` reports AUTO for both cards