### PR TITLE
Add Howlsquad Heavy and Monument to Endurance

### DIFF
--- a/backlog/cube-draft-format.md
+++ b/backlog/cube-draft-format.md
@@ -339,8 +339,9 @@ printing, per the reprint rule (`just check-card-printing "<Card>"`).
 
 **DFT — Aetherdrift (3)**
 - [x] Guidelight Optimizer · Nesting Bot · Marketback Walker *(artifact creatures)*
-- [ ] Howlsquad Heavy · Webstrike Elite *(creatures — Marauding Mako done)*
-- [ ] Monument to Endurance *(artifact — Lumbering Worldwagon, Perilous Snare, Repurposing Bay done)*
+- [x] Howlsquad Heavy *(creature — Marauding Mako done)*
+- [ ] Webstrike Elite *(creature)*
+- [x] Monument to Endurance *(artifact — Lumbering Worldwagon, Perilous Snare, Repurposing Bay done)*
 - [x] Momentum Breaker *(enchantment)*
 
 **SPM — Marvel's Spider-Man (6)**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1395,6 +1395,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   card (listing goader names) — there is no separate game-log event. Used by **Glóin, Dwarf
   Emissary**: `Costs.Composite(Costs.Tap, Costs.Sacrifice(Artifact.withSubtype("Treasure"))):
   Goad(target creature)`.
+- `Effects.MarkMustAttackThisTurn(target = ContextTarget(0))` (`MarkMustAttackThisTurnEffect`) —
+  require one creature to attack this turn if able. The transient marker is enforced by
+  `AttackPhaseManager` and removed during cleanup. It composes with the token pipeline for “that
+  token attacks this combat if able”: create the token, then target
+  `PipelineTarget(CREATED_TOKENS, 0)` with this facade.
 - `Effects.SkipNextTurn(target = Controller, count = Fixed(1))` (`SkipNextTurnEffect`) — target skips their next `count` turns. `count` is a `DynamicAmount`, so it can read a pipeline value (e.g. a coin-flip tally via `DynamicAmount.VariableReference`). Skips accumulate on a `SkipNextTurnComponent(turns)`, decremented one turn per the player's turn-start; a resolved count of 0 is a no-op. Used by Lethal Vapors (one turn) and **Ral Zarek, Guest Lecturer** (skip N turns where N = heads).
 - `Effects.FlipCoins(count, storeHeadsAs = "heads")` (`FlipCoinsEffect`) — flip `count` coins and store the number of heads under `storeHeadsAs` in the pipeline (`storedNumbers`) so a later sub-effect in the same composite can scale off it via `DynamicAmount.VariableReference`. The general "flip N coins, count heads" primitive (CR 705); unlike `FlipCoinEffect` (branch on win/lose) and `FlipTwoCoinsEffect` (branch on combined outcome) it only tallies. Each flip emits a `CoinFlipEvent`. **Ral Zarek, Guest Lecturer**'s ultimate composes `FlipCoins(5, "heads")` then `SkipNextTurn(target, count = VariableReference("heads"))`.
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").

--- a/manual-scenarios/cards/h/howlsquad-heavy.json
+++ b/manual-scenarios/cards/h/howlsquad-heavy.json
@@ -1,0 +1,28 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Howlsquad Heavy"},
+      {"name": "Goblin Surveyor"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["BEGIN_COMBAT", "DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/m/monument-to-endurance.json
+++ b/manual-scenarios/cards/m/monument-to-endurance.json
@@ -1,0 +1,30 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Agonasaur Rex"],
+    "battlefield": [
+      {"name": "Monument to Endurance"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -61,6 +61,7 @@ import com.wingedsheep.sdk.scripting.effects.CantAttackGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantAttackEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockEffect
 import com.wingedsheep.sdk.scripting.effects.GoadEffect
+import com.wingedsheep.sdk.scripting.effects.MarkMustAttackThisTurnEffect
 import com.wingedsheep.sdk.scripting.effects.SetSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantActivateLoyaltyAbilitiesEffect
@@ -3608,6 +3609,10 @@ object Effects {
      */
     fun Goad(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
         GoadEffect(target)
+
+    /** Mark a creature as required to attack this turn if able. */
+    fun MarkMustAttackThisTurn(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        MarkMustAttackThisTurnEffect(target)
 
     /**
      * Target creature becomes suspected (CR 701.60): atomic composite of the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Howlsquad Heavy — Aetherdrift #134
+ * {2}{R} · Creature — Goblin Mercenary · 2/3
+ *
+ * Start your engines!
+ * Other Goblins you control have haste.
+ * At the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token
+ * attacks this combat if able.
+ * Max speed — {T}: Add {R} for each Goblin you control.
+ */
+val HowlsquadHeavy = card("Howlsquad Heavy") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Mercenary"
+    power = 2
+    toughness = 3
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Other Goblins you control have haste.\n" +
+        "At the beginning of combat on your turn, create a 1/1 red Goblin creature token. That " +
+        "token attacks this combat if able.\n" +
+        "Max speed — {T}: Add {R} for each Goblin you control."
+
+    startYourEngines()
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.HASTE,
+            GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Goblin"),
+                imageUri = "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg?1783907679",
+            ),
+            Effects.MarkMustAttackThisTurn(EffectTarget.PipelineTarget(CREATED_TOKENS, 0)),
+        )
+    }
+
+    maxSpeed {
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(
+                Color.RED,
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    filter = GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl()
+                ).count(),
+            )
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "134"
+        artist = "Leonardo Santanna"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg?1783907881"
+        ruling(
+            "2025-02-07",
+            "Mana abilities don't use the stack, which means that they can't be responded to. " +
+                "Notably, this means that a player can't respond to this creature's last ability " +
+                "by destroying one of your Goblins."
+        )
+        ruling(
+            "2025-02-07",
+            "“Max speed — [ability]” means “As long as you have max speed, this object has " +
+                "[ability].” If the granted ability functions in a zone other than the battlefield, " +
+                "the max speed ability does too."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MonumentToEndurance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MonumentToEndurance.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Monument to Endurance — Aetherdrift #237
+ * {3} · Artifact
+ *
+ * Whenever you discard a card, choose one that hasn't been chosen this turn —
+ * • Draw a card.
+ * • Create a Treasure token.
+ * • Each opponent loses 3 life.
+ *
+ * The turn-scoped modal primitive records choices per Monument. Once all three modes have been
+ * chosen in a turn, later discard triggers resolve without an effect, matching the card's ruling.
+ */
+val MonumentToEndurance = card("Monument to Endurance") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever you discard a card, choose one that hasn't been chosen this turn —\n" +
+        "• Draw a card.\n" +
+        "• Create a Treasure token.\n" +
+        "• Each opponent loses 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscard
+        effect = ModalEffect.chooseOneNotYetChosenThisTurn(
+            Mode.noTarget(Effects.DrawCards(1), "Draw a card"),
+            Mode.noTarget(Effects.CreateTreasure(1), "Create a Treasure token"),
+            Mode.noTarget(
+                Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent)),
+                "Each opponent loses 3 life",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "Victor Sales"
+        flavorText = "Loss is not the end of the journey."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg?1783907848"
+        ruling(
+            "2025-02-07",
+            "If you discard a card after all three have been chosen in a turn, that instance of " +
+                "the ability is removed from the stack with no effect."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -6576,6 +6576,119 @@
     ]
 }
 
+// Howlsquad Heavy
+{
+    "name": "Howlsquad Heavy",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Mercenary",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nOther Goblins you control have haste.\nAt the beginning of combat on your turn, create a 1/1 red Goblin creature token. That token attacks this combat if able.\nMax speed — {T}: Add {R} for each Goblin you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "RED"
+                            ],
+                            "creatureTypes": [
+                                "Goblin"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/7/0/7072dea6-0d99-47fa-a83d-c8607e6a4bbd.jpg?1783907679"
+                        },
+                        {
+                            "type": "MarkMustAttackThisTurn",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Goblin ctrl:you"
+                    }
+                },
+                "timing": "ManaAbility",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": "Speed",
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ],
+                "isManaAbility": true,
+                "descriptionOverride": "Max speed — {T}: Add {R} for each the number of you control creature Goblins you control"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Goblin ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "RARE",
+        "artist": "Leonardo Santanna",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df582f80-7b9a-4f71-95a9-70548ec7d2d7.jpg?1783907881",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Mana abilities don't use the stack, which means that they can't be responded to. Notably, this means that a player can't respond to this creature's last ability by destroying one of your Goblins."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "“Max speed — [ability]” means “As long as you have max speed, this object has [ability].” If the granted ability functions in a zone other than the battlefield, the max speed ability does too."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hulldrifter
 {
     "name": "Hulldrifter",
@@ -8623,6 +8736,72 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Monument to Endurance
+{
+    "name": "Monument to Endurance",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you discard a card, choose one that hasn't been chosen this turn —\n• Draw a card.\n• Create a Treasure token.\n• Each opponent loses 3 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DiscardEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        }
+                    ],
+                    "excludeModesChosenThisTurn": true,
+                    "countsAsModalSpell": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "RARE",
+        "artist": "Victor Sales",
+        "flavorText": "Loss is not the end of the journey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d21433ba-0a14-42bc-ad0b-a4ef823a3295.jpg?1783907848",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If you discard a card after all three have been chosen in a turn, that instance of the ability is removed from the stack with no effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Muraganda Raceway

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HowlsquadHeavyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HowlsquadHeavyScenarioTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.combat.MustAttackThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class HowlsquadHeavyScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("beginning of combat creates a hasty Goblin that must attack this combat") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Howlsquad Heavy", summoningSickness = false)
+                .withCardOnBattlefield(1, "Goblin Surveyor", summoningSickness = false)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val surveyor = game.findPermanent("Goblin Surveyor")!!
+            val battlefieldBeforeCombat = game.state.getBattlefield().toSet()
+            StateProjector().project(game.state).hasKeyword(surveyor, Keyword.HASTE) shouldBe true
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.resolveStack()
+
+            val token = game.state.getBattlefield().single { it !in battlefieldBeforeCombat }
+            game.state.getEntity(token)?.has<MustAttackThisTurnComponent>() shouldBe true
+            StateProjector().project(game.state).hasKeyword(token, Keyword.HASTE) shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MonumentToEnduranceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MonumentToEnduranceScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class MonumentToEnduranceScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.resolveToModeChoice(): ChooseOptionDecision {
+        var guard = 0
+        while (getPendingDecision() !is ChooseOptionDecision && guard++ < 20) resolveStack()
+        return getPendingDecision().shouldNotBeNull() as ChooseOptionDecision
+    }
+
+    private fun TestGame.choose(decision: ChooseOptionDecision, mode: String) {
+        val index = decision.options.indexOf(mode)
+        check(index >= 0) { "Mode '$mode' not offered; options=${decision.options}" }
+        submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    init {
+        test("discard triggers offer only modes not already chosen this turn") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Monument to Endurance")
+                .withCardInHand(1, "Disciple of Law")
+                .withCardInHand(1, "Disciple of Law")
+                .withLandsOnBattlefield(1, "Plains", 4)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withLifeTotal(2, 20)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.cycleCard(1, "Disciple of Law").error shouldBe null
+            val first = game.resolveToModeChoice()
+            game.choose(first, "Each opponent loses 3 life")
+            game.resolveStack()
+            game.getLifeTotal(2) shouldBe 17
+
+            game.cycleCard(1, "Disciple of Law").error shouldBe null
+            val second = game.resolveToModeChoice()
+            second.options shouldNotContain "Each opponent loses 3 life"
+            game.choose(second, "Create a Treasure token")
+            game.resolveStack()
+
+            game.state.getBattlefield().count { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Treasure"
+            } shouldBe 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Howlsquad Heavy with start-your-engines, Goblin haste, begin-combat token, and max-speed mana ability
- implement Monument to Endurance with turn-scoped modal choice tracking
- add focused scenario tests, manual scenarios, SDK facade documentation, snapshots, and backlog updates

## Scope
Webstrike Elite remains unimplemented because carrying an X cycling payment into its separate cycling trigger and mana-value target constraint deserves a focused mechanic change.

## Verification
- just test
- just check-card-printing "Howlsquad Heavy"
- just check-card-printing "Monument to Endurance"
- Scryfall card and token image URLs return HTTP 200