### PR TITLE
Add Virtue of Loyalty to Wilds of Eldraine

### DIFF
--- a/manual-scenarios/cards/v/virtue-of-loyalty.json
+++ b/manual-scenarios/cards/v/virtue-of-loyalty.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Virtue of Loyalty"],
+    "battlefield": [
+      {"name": "Grizzly Bears", "tapped": true},
+      {"name": "Grizzly Bears"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Grizzly Bears"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfLoyalty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfLoyalty.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Virtue of Loyalty // Ardenvale Fealty
+ *
+ * The end-step trigger iterates the same creature group twice. The first pass puts counters on
+ * every creature the controller currently controls; the second untaps those creatures. Ardenvale
+ * Fealty uses the normal Adventure face machinery, so a resolving Adventure is exiled and grants
+ * permission to cast the enchantment face later.
+ */
+val VirtueOfLoyalty = card("Virtue of Loyalty") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your end step, put a +1/+1 counter on each creature you " +
+        "control. Untap those creatures."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter.AllCreaturesYouControl,
+                AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            ),
+            Effects.ForEachInGroup(
+                GroupFilter.AllCreaturesYouControl,
+                TapUntapEffect(EffectTarget.Self, tap = false)
+            )
+        )
+        description = "At the beginning of your end step, put a +1/+1 counter on each creature " +
+            "you control. Untap those creatures."
+    }
+
+    adventure("Ardenvale Fealty") {
+        manaCost = "{1}{W}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Create a 2/2 white Knight creature token with vigilance. (Then exile this " +
+            "card. You may cast the enchantment later from exile.)"
+        spell {
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Knight"),
+                keywords = setOf(Keyword.VIGILANCE),
+                imageUri = "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1783914992"
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "38"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1783915127"
+
+        ruling(
+            "2023-09-01",
+            "If a spell is cast as an Adventure, its controller exiles it instead of putting it " +
+                "into its owner's graveyard as it resolves. For as long as it remains exiled, " +
+                "that player may cast it as a permanent spell."
+        )
+        ruling(
+            "2023-09-01",
+            "You must still follow any timing restrictions and permissions for the permanent " +
+                "spell you cast from exile. Normally, you'll be able to cast it only during your " +
+                "main phase while the stack is empty."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -17513,6 +17513,106 @@
     ]
 }
 
+// Virtue of Loyalty
+{
+    "name": "Virtue of Loyalty",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, put a +1/+1 counter on each creature you control. Untap those creatures."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "MYTHIC",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea7e7daf-7c06-4c74-8bcf-e42c1f611861.jpg?1783915127",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it as a permanent spell."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You must still follow any timing restrictions and permissions for the permanent spell you cast from exile. Normally, you'll be able to cast it only during your main phase while the stack is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Ardenvale Fealty",
+            "manaCost": "{1}{W}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Create a 2/2 white Knight creature token with vigilance. (Then exile this card. You may cast the enchantment later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4035134-a162-4651-86c5-ae006b6e0e20.jpg?1783914992"
+                }
+            }
+        }
+    ]
+}
+
 // Virtue of Persistence
 {
     "name": "Virtue of Persistence",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirtueOfLoyaltyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirtueOfLoyaltyScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.VirtueOfLoyalty
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+class VirtueOfLoyaltyScenarioTest : FunSpec({
+
+    fun driver() = GameTestDriver().also {
+        it.registerCards(TestCards.all)
+        it.registerCard(VirtueOfLoyalty)
+        it.initMirrorMatch(Deck.of("Plains" to 30, "Grizzly Bears" to 30))
+        it.passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("Ardenvale Fealty creates a vigilant Knight and leaves the card on an Adventure") {
+        val driver = driver()
+        val player = driver.activePlayer!!
+        val virtue = driver.putCardInHand(player, "Virtue of Loyalty")
+        driver.giveMana(player, Color.WHITE, 2)
+
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = virtue,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        while (driver.stackSize > 0) driver.bothPass()
+
+        driver.getExile(player) shouldContain virtue
+        val knight = driver.getPermanents(player).single {
+            driver.state.projectedState.hasSubtype(it, "Knight")
+        }
+        driver.state.projectedState.getPower(knight) shouldBe 2
+        driver.state.projectedState.getToughness(knight) shouldBe 2
+        driver.state.projectedState.hasKeyword(knight, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("end-step trigger puts a counter on and untaps each creature you control") {
+        val driver = driver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Virtue of Loyalty")
+        val first = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val second = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.replaceState(driver.state.updateEntity(first) { it.with(TappedComponent) })
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        for (creature in listOf(first, second)) {
+            driver.state.getEntity(creature)?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+            driver.state.getEntity(creature)?.get<TappedComponent>() shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- implement Virtue of Loyalty // Ardenvale Fealty with the existing Adventure and group-effect DSL
- add focused scenario coverage for the vigilant Knight token and the end-step counter/untap trigger
- add a manual client scenario and refresh the WOE card snapshot

The remaining WOE candidates inspected for this batch require engine support to model faithfully (multi-target delayed triggers or source-relative sacrifice costs), so this PR intentionally contains one complete card rather than approximations.

## Verification
- `just test-class VirtueOfLoyaltyScenarioTest`
- `just rebless-cards`
- `just check-card-printing "Virtue of Loyalty"`
- `just build`
- Scryfall card and Knight token image URLs return HTTP 200