### PR TITLE
Add Johann, Apprentice Sorcerer to Wilds of Eldraine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5175,8 +5175,11 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
   `ConditionalStaticAbility` wrapper — the play/cast-from-top readers unwrap the conditional and
   evaluate its gate against the granting permanent, so the permission can be time-restricted (The
   Lunar Whale: `condition = Conditions.SourceAttackedThisTurn` — only after the Whale attacked).
-- `CastSpellTypesFromTopOfLibrary(filter)` — cast only matching spell types from the top; no land
-  play, no full public reveal. (Precognition Field = instants/sorceries)
+- `CastSpellTypesFromTopOfLibrary(filter, maxCastsPerTurn?)` — cast only matching spell types from
+  the top; no land play, no full public reveal. `maxCastsPerTurn` limits each granting permanent's
+  permission independently and resets at cleanup; when that permanent leaves and returns, the new
+  object has a fresh allowance. (Precognition Field = unlimited instants/sorceries; Johann,
+  Apprentice Sorcerer = one instant/sorcery each turn.)
 - `LookAtTopOfLibrary` — *private*: the controller may look at their own top card any time (revealed
   only to them, not opponents). (Lens of Clarity, Vizier of the Menagerie)
 - `PlotFromTopOfLibrary(filter = Nonland)` — the controller may **plot** (CR 718) the top card of

--- a/manual-scenarios/cards/j/johann-apprentice-sorcerer.json
+++ b/manual-scenarios/cards/j/johann-apprentice-sorcerer.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Johann",
+  "player2Name": "Apprentice",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Johann, Apprentice Sorcerer"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Quick Study", "Water Wings", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -341,10 +341,20 @@ data object PlayFromTopOfLibrary : StaticAbility {
 @SerialName("CastSpellTypesFromTopOfLibrary")
 @Serializable
 data class CastSpellTypesFromTopOfLibrary(
-    val filter: GameObjectFilter
+    val filter: GameObjectFilter,
+    /**
+     * Maximum number of times this specific permanent's permission may be used each turn.
+     * Null means unlimited. Usage belongs to the granting object, so a permanent that leaves
+     * and returns supplies a fresh permission.
+     */
+    val maxCastsPerTurn: Int? = null
 ) : StaticAbility {
     override val description: String =
-        "You may cast ${filter.description} spells from the top of your library."
+        if (maxCastsPerTurn == 1) {
+            "Once each turn, you may cast a ${filter.description} spell from the top of your library."
+        } else {
+            "You may cast ${filter.description} spells from the top of your library."
+        }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/JohannApprenticeSorcerer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/JohannApprenticeSorcerer.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+
+/**
+ * Johann, Apprentice Sorcerer
+ * {2}{U}{R}
+ * Legendary Creature — Human Wizard Sorcerer
+ * 2/5
+ * You may look at the top card of your library any time.
+ * Once each turn, you may cast an instant or sorcery spell from the top of your library.
+ * (You still pay its costs. Timing rules still apply.)
+ */
+val JohannApprenticeSorcerer = card("Johann, Apprentice Sorcerer") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Wizard Sorcerer"
+    oracleText = "You may look at the top card of your library any time.\n" +
+        "Once each turn, you may cast an instant or sorcery spell from the top of your library. " +
+        "(You still pay its costs. Timing rules still apply.)"
+    power = 2
+    toughness = 5
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(
+            filter = GameObjectFilter.InstantOrSorcery,
+            maxCastsPerTurn = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Dmitry Burmak"
+        flavorText = "\"Okay. First I'll calm the elementals. Then I'll put out the fire. " +
+            "Then I'll unflood the basement. Then I'll do the chores myself.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg?1783915071"
+        ruling(
+            "2023-09-01",
+            "If Johann leaves the battlefield and returns, its new casting permission may be used " +
+                "once even if the old object's permission was used that turn."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -7802,6 +7802,45 @@
     ]
 }
 
+// Johann, Apprentice Sorcerer
+{
+    "name": "Johann, Apprentice Sorcerer",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Legendary Creature — Human Wizard Sorcerer",
+    "oracleText": "You may look at the top card of your library any time.\nOnce each turn, you may cast an instant or sorcery spell from the top of your library. (You still pay its costs. Timing rules still apply.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": "instant|sorcery",
+                "maxCastsPerTurn": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"Okay. First I'll calm the elementals. Then I'll put out the fire. Then I'll unflood the basement. Then I'll do the chores myself.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b88a762d-19ed-451d-a3a9-b3e7eea40f67.jpg?1783915071",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If Johann leaves the battlefield and returns, its new casting permission may be used once even if the old object's permission was used that turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Kellan's Lightblades
 {
     "name": "Kellan's Lightblades",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityResolutionCountThisTurnComponent
@@ -888,13 +889,15 @@ class CleanupPhaseManager(
             val removePlayFree = playFree != null && !playFree.permanent
             val removeLinkedExileUsed = container.get<MayCastFromLinkedExileUsedThisTurnComponent>() != null
             val removeFreeCastUsed = container.get<MayCastWithoutPayingCostUsedThisTurnComponent>() != null
+            val removeTopLibraryCastUses = container.get<CastFromTopOfLibraryUsesThisTurnComponent>() != null
             val removeExileEntryTurn = container.get<ExileEntryTurnComponent>() != null
-            if (removePlayFree || removeLinkedExileUsed || removeFreeCastUsed || removeExileEntryTurn) {
+            if (removePlayFree || removeLinkedExileUsed || removeFreeCastUsed || removeTopLibraryCastUses || removeExileEntryTurn) {
                 newState = newState.updateEntity(entityId) { c ->
                     var updated = c
                     if (removePlayFree) updated = updated.without<PlayWithoutPayingCostComponent>()
                     if (removeLinkedExileUsed) updated = updated.without<MayCastFromLinkedExileUsedThisTurnComponent>()
                     if (removeFreeCastUsed) updated = updated.without<MayCastWithoutPayingCostUsedThisTurnComponent>()
+                    if (removeTopLibraryCastUses) updated = updated.without<CastFromTopOfLibraryUsesThisTurnComponent>()
                     if (removeExileEntryTurn) updated = updated.without<ExileEntryTurnComponent>()
                     updated
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -450,6 +450,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CraftedFromExiledComponent::class)
         subclass(MayCastFromLinkedExileUsedThisTurnComponent::class)
         subclass(MayCastWithoutPayingCostUsedThisTurnComponent::class)
+        subclass(CastFromTopOfLibraryUsesThisTurnComponent::class)
         subclass(ReplacementEffectSourceComponent::class)
         subclass(SagaComponent::class)
         subclass(NotedCreatureTypesComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2039,6 +2039,9 @@ class CastSpellHandler(
         // fail, but we still need the entry to enforce once-per-turn marking after a
         // successful cast.
         val linkedExileGranterEntry = zoneResolver.findLinkedExileGranterEntry(currentState, action.playerId, action.cardId)
+        val limitedTopLibraryCastSource = if (action.cardId in currentState.getLibrary(action.playerId)) {
+            zoneResolver.findLimitedTopLibraryCastSourceToConsume(currentState, action.playerId, action.cardId)
+        } else null
 
         // Calculate effective cost (free if PlayWithoutPayingCostComponent is present, or if a
         // MayCastWithoutPayingManaCost battlefield source (e.g. Weftwalking) is the chosen alt).
@@ -3337,6 +3340,20 @@ class CastSpellHandler(
         if (linkedExileGranterEntry?.ability?.oncePerTurn == true) {
             currentCastState = currentCastState.updateEntity(linkedExileGranterEntry.granterId) { c ->
                 c.with(com.wingedsheep.engine.state.components.battlefield.MayCastFromLinkedExileUsedThisTurnComponent)
+            }
+        }
+
+        // The permission belongs to its granting permanent, not to the player. Mark the source
+        // captured before the card left the library; a source that leaves and returns is a new
+        // object with a fresh allowance, and an unlimited matching source consumes nothing.
+        if (limitedTopLibraryCastSource != null) {
+            currentCastState = currentCastState.updateEntity(limitedTopLibraryCastSource) { c ->
+                val tracker = c.get<com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent>()
+                c.with(
+                    com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent(
+                        uses = (tracker?.uses ?: 0) + 1
+                    )
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.ExileEntryTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
 import com.wingedsheep.engine.state.components.battlefield.MayCastFromLinkedExileUsedThisTurnComponent
@@ -557,7 +558,11 @@ class CastZoneResolver(
                     ability.ability
                 } else ability
                 if (unwrapped is CastSpellTypesFromTopOfLibrary) {
-                    if (matchesCardFilter(cardComponent, unwrapped.filter)) return true
+                    val uses = state.getEntity(entityId)
+                        ?.get<CastFromTopOfLibraryUsesThisTurnComponent>()?.uses ?: 0
+                    val maxCasts = unwrapped.maxCastsPerTurn
+                    val hasUse = maxCasts == null || uses < maxCasts
+                    if (hasUse && matchesCardFilter(cardComponent, unwrapped.filter)) return true
                 }
                 if (unwrapped is PlayLandsAndCastFilteredFromTopOfLibrary) {
                     if (matchesCardFilter(cardComponent, unwrapped.spellFilter)) return true
@@ -565,6 +570,46 @@ class CastZoneResolver(
             }
         }
         return false
+    }
+
+    /**
+     * Returns the limited top-of-library permission source that should consume a use for this cast.
+     * An unlimited matching source wins without consuming a limited source. Otherwise each source
+     * has its own allowance, matching the identity of the granting permanent.
+     */
+    fun findLimitedTopLibraryCastSourceToConsume(
+        state: GameState,
+        playerId: EntityId,
+        cardId: EntityId
+    ): EntityId? {
+        val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return null
+        // A card-specific MayPlayPermission (for example, a reveal-then-cast effect whose card
+        // remains in the library) can authorize the cast independently of a battlefield source.
+        if (state.hasMayPlayFor(cardId, playerId, conditionEvaluator, cardRegistry)) return null
+        var limitedSource: EntityId? = null
+        for (entityId in state.getBattlefield(playerId)) {
+            val sourceCard = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(sourceCard.cardDefinitionId) ?: continue
+            for (ability in cardDef.script.staticAbilities) {
+                val unwrapped = if (ability is ConditionalStaticAbility) {
+                    val ctx = EffectContext(sourceId = entityId, controllerId = playerId)
+                    if (!conditionEvaluator.evaluate(state, ability.condition, ctx)) continue
+                    ability.ability
+                } else ability
+                if (unwrapped is PlayFromTopOfLibrary) return null
+                if (unwrapped is PlayLandsAndCastFilteredFromTopOfLibrary &&
+                    matchesCardFilter(cardComponent, unwrapped.spellFilter)
+                ) return null
+                if (unwrapped !is CastSpellTypesFromTopOfLibrary ||
+                    !matchesCardFilter(cardComponent, unwrapped.filter)
+                ) continue
+                val maxCasts = unwrapped.maxCastsPerTurn ?: return null
+                val uses = state.getEntity(entityId)
+                    ?.get<CastFromTopOfLibraryUsesThisTurnComponent>()?.uses ?: 0
+                if (uses < maxCasts && limitedSource == null) limitedSource = entityId
+            }
+        }
+        return limitedSource
     }
 
     private fun hasPlayFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedEverComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CastFromTopOfLibraryUsesThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.GraveyardPlayPermissionUsedComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -434,8 +435,12 @@ class CastPermissionUtils(
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
                 if (ability is CastSpellTypesFromTopOfLibrary) {
+                    val uses = state.getEntity(entityId)
+                        ?.get<CastFromTopOfLibraryUsesThisTurnComponent>()?.uses ?: 0
+                    val maxCasts = ability.maxCastsPerTurn
+                    if (maxCasts != null && uses >= maxCasts) continue
                     if (ability.filter == GameObjectFilter.Any) return GameObjectFilter.Any
-                    filter = ability.filter
+                    filter = filter?.let { it or ability.filter } ?: ability.filter
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -1030,3 +1030,13 @@ data object MayCastFromLinkedExileUsedThisTurnComponent : Component
  */
 @Serializable
 data object MayCastWithoutPayingCostUsedThisTurnComponent : Component
+
+/**
+ * Counts uses of a permanent's limited [com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary]
+ * permission during the current turn. The count is stored on the granting permanent so each object
+ * has its own allowance; leaving and returning creates a fresh object without this component.
+ */
+@Serializable
+data class CastFromTopOfLibraryUsesThisTurnComponent(
+    val uses: Int = 1
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JohannApprenticeSorcererScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JohannApprenticeSorcererScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ons.cards.FutureSight
+import com.wingedsheep.mtg.sets.definitions.woe.cards.JohannApprenticeSorcerer
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class JohannApprenticeSorcererScenarioTest : FunSpec({
+
+    val testInstant = CardDefinition.instant(
+        name = "Johann Test Instant",
+        manaCost = ManaCost.ZERO,
+        oracleText = "You gain 1 life.",
+        script = CardScript.spell(Effects.GainLife(1))
+    )
+    val secondInstant = CardDefinition.instant(
+        name = "Johann Second Test Instant",
+        manaCost = ManaCost.ZERO,
+        oracleText = "You gain 1 life.",
+        script = CardScript.spell(Effects.GainLife(1))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JohannApprenticeSorcerer, FutureSight, testInstant, secondInstant))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.canCastFromLibrary(cardName: String): Boolean = legalActions(activePlayer!!).any {
+        it.actionType == "CastSpell" && it.sourceZone == "LIBRARY" && it.description.contains(cardName)
+    }
+
+    test("casts only one instant or sorcery from the top each turn") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Johann, Apprentice Sorcerer")
+
+        val first = driver.putCardOnTopOfLibrary(you, "Johann Test Instant")
+        driver.canCastFromLibrary("Johann Test Instant") shouldBe true
+        driver.castSpell(you, first).error shouldBe null
+        driver.bothPass()
+
+        val second = driver.putCardOnTopOfLibrary(you, "Johann Second Test Instant")
+        driver.canCastFromLibrary("Johann Second Test Instant") shouldBe false
+        driver.castSpell(you, second).error shouldBe "Card is not in your hand"
+    }
+
+    test("a new Johann object has a fresh permission in the same turn") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val oldJohann = driver.putCreatureOnBattlefield(you, "Johann, Apprentice Sorcerer")
+
+        val first = driver.putCardOnTopOfLibrary(you, "Johann Test Instant")
+        driver.castSpell(you, first).error shouldBe null
+        driver.bothPass()
+
+        driver.replaceState(
+            driver.state
+                .removeFromZone(ZoneKey(you, Zone.BATTLEFIELD), oldJohann)
+                .withoutEntity(oldJohann)
+        )
+        driver.putCreatureOnBattlefield(you, "Johann, Apprentice Sorcerer")
+
+        val second = driver.putCardOnTopOfLibrary(you, "Johann Second Test Instant")
+        driver.canCastFromLibrary("Johann Second Test Instant") shouldBe true
+        driver.castSpell(you, second).error shouldBe null
+    }
+
+    test("an unlimited permission does not consume Johann's limited permission") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Johann, Apprentice Sorcerer")
+        val futureSight = driver.putPermanentOnBattlefield(you, "Future Sight")
+
+        val first = driver.putCardOnTopOfLibrary(you, "Johann Test Instant")
+        driver.castSpell(you, first).error shouldBe null
+        driver.bothPass()
+
+        driver.replaceState(
+            driver.state
+                .removeFromZone(ZoneKey(you, Zone.BATTLEFIELD), futureSight)
+                .withoutEntity(futureSight)
+        )
+        val second = driver.putCardOnTopOfLibrary(you, "Johann Second Test Instant")
+        driver.canCastFromLibrary("Johann Second Test Instant") shouldBe true
+    }
+
+    test("does not allow a creature spell from the top") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Johann, Apprentice Sorcerer")
+        driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        driver.canCastFromLibrary("Grizzly Bears") shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- add Johann, Apprentice Sorcerer with authoritative WOE metadata and rulings
- extend filtered top-of-library casting permissions with per-source, per-turn usage limits
- preserve fresh-object semantics and avoid consuming Johann when an independent unlimited permission authorizes the cast
- add focused engine scenarios, a manual client scenario, SDK docs, and the WOE snapshot

## Verification
- `just test-class JohannApprenticeSorcererScenarioTest`
- `just rebless-cards`
- `just test`
- `just check-card-printing "Johann, Apprentice Sorcerer"`
- Scryfall image URL returns HTTP 200

## Scope
The remaining WOE backlog is mechanic-heavy. This batch was intentionally narrowed to one rules-faithful card rather than approximating the other candidates.