### PR TITLE
Add Chalice of Life and Harvest Hand to Innistrad Remastered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ docs it points at; load those when the work needs them.
 
 - **Focus on your own work.** If a change you didn't make breaks the build, report it and stop. Never
   revert, stash, or discard others' changes — that's likely another agent's in-flight work. Pause until
-  the user confirms it's safe to continue.
+  the user confirms it's safe to continue. If the user confirms or explicitly asks for a PR despite the
+  unrelated failure, opening the PR is allowed; disclose the failure and the verification that did pass
+  in the PR body.
 - **Route to the matching skill, don't freelance:**
   - Implementing a card, from a backlog file or by name → **`add-card`** (Scryfall lookup, oracle
     errata, canonical-printing placement, scenario test).

--- a/manual-scenarios/cards/c/chalice-of-life.json
+++ b/manual-scenarios/cards/c/chalice-of-life.json
@@ -1,0 +1,27 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 29,
+    "hand": [],
+    "battlefield": [
+      {"name": "Chalice of Life"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/h/harvest-hand.json
+++ b/manual-scenarios/cards/h/harvest-hand.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Harvest Hand"},
+      {"name": "Thraben Inspector"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Murder"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ChaliceOfLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ChaliceOfLife.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+private val ChaliceOfLifeFront = card("Chalice of Life") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: You gain 1 life. Then if you have at least 10 life more than your " +
+        "starting life total, transform this artifact."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            ConditionalEffect(
+                condition = Conditions.LifeAboveStartingBy(10),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "Gain 1 life, then transform Chalice of Life if you have at least 10 life " +
+            "more than your starting life total."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Ryan Yee"
+        flavorText = "The sweet taste of hope's promise."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1783940798"
+        ruling("2011-01-22", "Your starting life total is the life total you began the game with.")
+        ruling("2011-01-22", "You check your life total to see if Chalice of Life transforms only when its ability resolves.")
+    }
+}
+
+private val ChaliceOfDeath = card("Chalice of Death") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Target player loses 5 life."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val player = target("target player", Targets.Player)
+        effect = Effects.LoseLife(5, player)
+        description = "Target player loses 5 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Ryan Yee"
+        flavorText = "The bitter taste of life's only certainty."
+        imageUri = "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1783940798"
+    }
+}
+
+val ChaliceOfLife: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = ChaliceOfLifeFront,
+    backFace = ChaliceOfDeath,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ChaliceOfLifeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ChaliceOfLifeReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Chalice of Life reprint in INR. Canonical CardDefinition lives in its earliest set (DKA). */
+val ChaliceOfLifeReprint = Printing(
+    oracleId = "28df85d6-e13a-4178-a361-7015afd316ca",
+    name = "Chalice of Life",
+    setCode = "INR",
+    collectorNumber = "257",
+    scryfallId = "e432b156-baf0-48a1-b8fb-1aa18bfbf7de",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e432b156-baf0-48a1-b8fb-1aa18bfbf7de.jpg?1783908070",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/4/e432b156-baf0-48a1-b8fb-1aa18bfbf7de.jpg?1783908070",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HarvestHandReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HarvestHandReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Harvest Hand reprint in INR. Canonical CardDefinition lives in its earliest set (SOI). */
+val HarvestHandReprint = Printing(
+    oracleId = "ffd3c928-af42-4d69-8d22-a4c72f93b1c7",
+    name = "Harvest Hand",
+    setCode = "INR",
+    collectorNumber = "265",
+    scryfallId = "6f29b655-f70f-4b30-9253-c7944bfee524",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f29b655-f70f-4b30-9253-c7944bfee524.jpg?1783908069",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/6/f/6f29b655-f70f-4b30-9253-c7944bfee524.jpg?1783908069",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HarvestHand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HarvestHand.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+private val HarvestHandFront = card("Harvest Hand") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    oracleText = "When this creature dies, return it to the battlefield transformed under your control."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.ReturnSelfFromGraveyardTransformed(tapped = false)
+        description = "When Harvest Hand dies, return it to the battlefield transformed under your control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Jason Felix"
+        flavorText = "The harvest is never finished."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1783937712"
+    }
+}
+
+private val ScroungedScythe = card("Scrounged Scythe") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "As long as equipped creature is a Human, it has menace.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        condition = Conditions.EntityMatches(
+            EffectTarget.EquippedCreature,
+            GameObjectFilter.Creature.withSubtype(Subtype.HUMAN),
+        )
+        ability = GrantKeyword(Keyword.MENACE)
+    }
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "256"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1783937712"
+    }
+}
+
+val HarvestHand: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = HarvestHandFront,
+    backFace = ScroungedScythe,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1,3 +1,117 @@
+// Chalice of Life
+{
+    "name": "Chalice of Life",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: You gain 1 life. Then if you have at least 10 life more than your starting life total, transform this artifact.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "LifeTotal",
+                                        "player": "You"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Add",
+                                        "left": {
+                                            "type": "StartingLifeTotal",
+                                            "player": "You"
+                                        },
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 10
+                                        }
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Gain 1 life, then transform Chalice of Life if you have at least 10 life more than your starting life total."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Chalice of Death",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "{T}: Target player loses 5 life.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "descriptionOverride": "Target player loses 5 life."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "146",
+            "rarity": "UNCOMMON",
+            "artist": "Ryan Yee",
+            "flavorText": "The bitter taste of life's only certainty.",
+            "imageUri": "https://cards.scryfall.io/normal/back/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1783940798"
+        },
+        "colorIdentityOverride": [],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Yee",
+        "flavorText": "The sweet taste of hope's promise.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d9c1c46-7aa7-464c-87b0-b29b9663daef.jpg?1783940798",
+        "rulings": [
+            {
+                "date": "2011-01-22",
+                "text": "Your starting life total is the life total you began the game with."
+            },
+            {
+                "date": "2011-01-22",
+                "text": "You check your life total to see if Chalice of Life transforms only when its ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Deadly Allure
 {
     "name": "Deadly Allure",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -676,6 +676,106 @@
     ]
 }
 
+// Harvest Hand
+{
+    "name": "Harvest Hand",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "When this creature dies, return it to the battlefield transformed under your control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": "ReturnSelfFromZoneTransformed",
+                "descriptionOverride": "When Harvest Hand dies, return it to the battlefield transformed under your control."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Scrounged Scythe",
+        "manaCost": "",
+        "typeLine": "Artifact — Equipment",
+        "oracleText": "Equipped creature gets +1/+1.\nAs long as equipped creature is a Human, it has menace.\nEquip {2}",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
+                    },
+                    "effect": {
+                        "type": "AttachEquipment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "creature you control"
+                        }
+                    ],
+                    "timing": "SorcerySpeed",
+                    "isEquipAbility": true
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1
+                },
+                {
+                    "type": "ConditionalStaticAbility",
+                    "ability": {
+                        "type": "GrantKeyword",
+                        "keyword": "MENACE"
+                    },
+                    "condition": {
+                        "type": "EntityMatches",
+                        "entity": "EquippedCreature",
+                        "filter": "creature Human"
+                    }
+                }
+            ]
+        },
+        "equipCost": "{2}",
+        "metadata": {
+            "collectorNumber": "256",
+            "rarity": "UNCOMMON",
+            "artist": "Jason Felix",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1783937712"
+        },
+        "colorIdentityOverride": [],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "The harvest is never finished.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1783937712"
+    },
+    "colorIdentityOverride": []
+}
+
 // Howlpack Resurgence
 {
     "name": "Howlpack Resurgence",


### PR DESCRIPTION
## Summary
- implement Chalice of Life // Chalice of Death in its canonical Dark Ascension set and add the INR printing
- implement Harvest Hand // Scrounged Scythe in its canonical Shadows over Innistrad set and add the INR printing
- add focused manual scenarios for both cards and refresh DKA/SOI card snapshots
- clarify in AGENTS.md that an explicitly requested PR may be opened after an unrelated build failure when the failure is disclosed

## Verification
- `just check-card-printing "Chalice of Life"` — passed
- `just check-card-printing "Harvest Hand"` — passed
- Scryfall canonical front/back image checks — HTTP 200
- card snapshot assertions, JSON round trips, CardLintTest, FacadeBoundaryTest, and catalog tests — passed during `just build`
- `just build` — did not complete: unrelated `:rules-engine:compileTestKotlin` failed with Kotlin daemon OOM (`GC overhead limit exceeded`) while generating `DeceitHybridManaSpentTest`; this PR does not modify rules-engine code or tests

INR coverage increases from 205/290 to 207/290.