### PR TITLE
Add Beseech the Mirror and Gadwick's First Duel

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BeseechTheMirror.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BeseechTheMirror.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.bargain
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Beseech the Mirror
+ * {1}{B}{B}{B}
+ * Sorcery
+ *
+ * Bargain
+ * Search your library for a card, exile it face down, then shuffle. If this spell was
+ * bargained, you may cast the exiled card for free if its mana value is 4 or less. Put it
+ * into your hand if it wasn't cast this way.
+ */
+val BeseechTheMirror = card("Beseech the Mirror") {
+    manaCost = "{1}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\n" +
+        "Search your library for a card, exile it face down, then shuffle. If this spell was " +
+        "bargained, you may cast the exiled card without paying its mana cost if that spell's " +
+        "mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way."
+
+    bargain()
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.LIBRARY, Player.You),
+                storeAs = "beseechLibrary"
+            ),
+            SelectFromCollectionEffect(
+                from = "beseechLibrary",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "beseechFound",
+                prompt = "Search your library for a card"
+            ),
+            MoveCollectionEffect(
+                from = "beseechFound",
+                destination = CardDestination.ToZone(Zone.EXILE),
+                faceDown = FaceDownMode.HIDDEN,
+                storeMovedAs = "beseechExiled"
+            ),
+            ShuffleLibraryEffect(),
+            ConditionalEffect(
+                condition = Conditions.WasBargained,
+                effect = Effects.Composite(
+                    FilterCollectionEffect(
+                        from = "beseechExiled",
+                        filter = CollectionFilter.ManaValueAtMost(DynamicAmount.Fixed(4)),
+                        storeMatching = "beseechCastable"
+                    ),
+                    ConditionalOnCollectionEffect(
+                        collection = "beseechCastable",
+                        ifNotEmpty = MayEffect(
+                            Effects.CastFromCollectionWithoutPayingCost("beseechCastable")
+                        )
+                    )
+                )
+            ),
+            FilterCollectionEffect(
+                from = "beseechExiled",
+                filter = CollectionFilter.InZone(Zone.EXILE),
+                storeMatching = "beseechUncast"
+            ),
+            MoveCollectionEffect(
+                from = "beseechUncast",
+                destination = CardDestination.ToZone(Zone.HAND)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "82"
+        artist = "Cynthia Sheppard"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg?1783915111"
+
+        ruling("2023-09-01", "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost.")
+        ruling("2023-09-01", "If you copy a bargained spell, the copy is also bargained.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GadwicksFirstDuel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GadwicksFirstDuel.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Gadwick's First Duel
+ * {1}{U}
+ * Enchantment — Saga
+ *
+ * I — Create a Cursed Role token attached to up to one target creature.
+ * II — Scry 2.
+ * III — Copy the next instant or sorcery spell with mana value 3 or less you cast this turn.
+ */
+val GadwicksFirstDuel = card("Gadwick's First Duel") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Create a Cursed Role token attached to up to one target creature. (If you control " +
+        "another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)\n" +
+        "II — Scry 2.\n" +
+        "III — When you next cast an instant or sorcery spell with mana value 3 or less this turn, " +
+        "copy that spell. You may choose new targets for the copy."
+
+    sagaChapter(1) {
+        val creature = target(
+            "up to one target creature",
+            TargetCreature(optional = true, filter = TargetFilter.Creature)
+        )
+        effect = Effects.CreateRoleToken("Cursed Role", creature)
+    }
+
+    sagaChapter(2) {
+        effect = Effects.Scry(2)
+    }
+
+    sagaChapter(3) {
+        effect = Effects.CopyNextSpellCast(
+            copies = 1,
+            spellFilter = GameObjectFilter.InstantOrSorcery.manaValueAtMost(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg?1783915120"
+
+        ruling("2023-09-01", "If you don't choose a target for the first chapter ability, the Cursed Role token won't be created.")
+        ruling("2023-09-01", "The copy is created on the stack, so it isn't cast.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1312,6 +1312,146 @@
     ]
 }
 
+// Beseech the Mirror
+{
+    "name": "Beseech the Mirror",
+    "manaCost": "{1}{B}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nSearch your library for a card, exile it face down, then shuffle. If this spell was bargained, you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less. Put the exiled card into your hand if it wasn't cast this way.",
+    "keywords": [
+        "BARGAIN"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact|enchantment|token"
+                }
+            },
+            "displayPrefix": "Bargain",
+            "keyword": "BARGAIN",
+            "declaredSlot": "BARGAINED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library"
+                    },
+                    "storeAs": "beseechLibrary"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "beseechLibrary",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "beseechFound",
+                    "prompt": "Search your library for a card"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "beseechFound",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    },
+                    "faceDown": "HIDDEN",
+                    "storeMovedAs": "beseechExiled"
+                },
+                "ShuffleLibrary",
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "BARGAINED"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "FilterCollection",
+                                "from": "beseechExiled",
+                                "filter": {
+                                    "type": "ManaValueAtMost",
+                                    "max": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                },
+                                "storeMatching": "beseechCastable"
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "beseechCastable",
+                                "ifNotEmpty": {
+                                    "type": "Gated",
+                                    "gate": "Gate.MayDecide",
+                                    "then": {
+                                        "type": "CastFromCollectionWithoutPayingCost",
+                                        "from": "beseechCastable"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "beseechExiled",
+                    "filter": {
+                        "type": "InZone",
+                        "zone": "Exile"
+                    },
+                    "storeMatching": "beseechUncast"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "beseechUncast",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "MYTHIC",
+        "artist": "Cynthia Sheppard",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18c59776-e1f1-4197-a128-db1d603f56b7.jpg?1783915111",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "You may sacrifice only one artifact, enchantment, or token to pay a spell's bargain cost."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you copy a bargained spell, the copy is also bargained."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Besotted Knight
 {
     "name": "Besotted Knight",
@@ -5443,6 +5583,84 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Gadwick's First Duel
+{
+    "name": "Gadwick's First Duel",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Create a Cursed Role token attached to up to one target creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature is 1/1.)\nII — Scry 2.\nIII — When you next cast an instant or sorcery spell with mana value 3 or less this turn, copy that spell. You may choose new targets for the copy.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Cursed Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "CopyNextSpellCast",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "ManaValueAtMost",
+                                "max": 3
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af07c47f-8b4e-43cb-b469-2efb82aa5590.jpg?1783915120",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If you don't choose a target for the first chapter ability, the Cursed Role token won't be created."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "The copy is created on the stack, so it isn't cast."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
## Summary

- add Beseech the Mirror using bargain plus the existing library-search, hidden-exile, conditional free-cast, and fallback-to-hand pipeline
- add Gadwick's First Duel using existing Saga, Cursed Role, Scry, and filtered next-spell-copy primitives
- refresh the WOE card snapshot; only these two cards were added

The remaining WOE backlog is the complex tail. I intentionally kept this batch to two rules-faithful cards rather than pulling in cards that require new engine vocabulary.

## Verification

- just check-card-printing "Beseech the Mirror"
- just check-card-printing "Gadwick's First Duel"
- both Scryfall image URLs return HTTP 200
- just build
- git diff --check