### PR TITLE
Add three Aetherdrift cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CloudspireCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CloudspireCaptain.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Cloudspire Captain — Aetherdrift #9
+ * {2}{W} · Creature — Human Pilot · 2/3
+ */
+val CloudspireCaptain = card("Cloudspire Captain") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Pilot"
+    oracleText = "Mounts and Vehicles you control get +1/+1.\n" +
+        "This creature saddles Mounts and crews Vehicles as though its power were 2 greater."
+    power = 2
+    toughness = 3
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Any.withAnySubtype("Mount", "Vehicle").youControl()
+            )
+        )
+    }
+
+    staticAbility {
+        ability = CrewSaddleContribution(modifier = 2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Manny Edeko"
+        flavorText = "Cloudspire's might comes from its unparalleled coordination."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg?1783907920"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DefendTheRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DefendTheRider.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Defend the Rider — Aetherdrift #157
+ * {G} · Instant
+ */
+val DefendTheRider = card("Defend the Rider") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target permanent you control gains hexproof and indestructible until end of turn.\n" +
+        "• Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews " +
+        "Vehicles as though its power were 2 greater.\""
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Grant hexproof and indestructible") {
+                val permanent = target(
+                    "target permanent you control",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.youControl()))
+                )
+                effect = Effects.GrantKeyword(Keyword.HEXPROOF, permanent, Duration.EndOfTurn)
+                    .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, permanent, Duration.EndOfTurn))
+            }
+            mode("Create a 1/1 Pilot creature token") {
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    creatureTypes = setOf("Pilot"),
+                    imageUri = "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                    staticAbilities = listOf(CrewSaddleContribution(modifier = 2))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Raph Lomotan"
+        flavorText = "Lagorin would not lose another."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg?1783907873"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RoadsideAssistance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RoadsideAssistance.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Roadside Assistance — Aetherdrift #26
+ * {2}{W} · Enchantment — Aura
+ */
+val RoadsideAssistance = card("Roadside Assistance") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature or Vehicle\n" +
+        "When this Aura enters, create a 1/1 colorless Pilot creature token with \"This token " +
+        "saddles Mounts and crews Vehicles as though its power were 2 greater.\"\n" +
+        "Enchanted permanent gets +1/+1 and has lifelink."
+
+    auraTarget = TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrVehicle))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Pilot"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+            staticAbilities = listOf(CrewSaddleContribution(modifier = 2))
+        )
+        description = "When this Aura enters, create a 1/1 colorless Pilot creature token."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "Artur Nakhodkin"
+        flavorText = "No road has to be traveled alone."
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg?1783907914"
+        ruling(
+            "2025-02-07",
+            "Saddling a Mount or crewing a Vehicle doesn’t cause the token’s power to change."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2496,6 +2496,44 @@
     ]
 }
 
+// Cloudspire Captain
+{
+    "name": "Cloudspire Captain",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Pilot",
+    "oracleText": "Mounts and Vehicles you control get +1/+1.\nThis creature saddles Mounts and crews Vehicles as though its power were 2 greater.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "Mount|Vehicle ctrl:you"
+                }
+            },
+            {
+                "type": "CrewSaddleContribution",
+                "modifier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Manny Edeko",
+        "flavorText": "Cloudspire's might comes from its unparalleled coordination.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/3380d87a-c460-409c-8d47-9b2fc5ddd2ea.jpg?1783907920"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cloudspire Skycycle
 {
     "name": "Cloudspire Skycycle",
@@ -3165,6 +3203,83 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "GREEN"
+    ]
+}
+
+// Defend the Rider
+{
+    "name": "Defend the Rider",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Target permanent you control gains hexproof and indestructible until end of turn.\n• Create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target permanent you control"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target permanent you control"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent ctrl:you"
+                            },
+                            "id": "target permanent you control"
+                        }
+                    ],
+                    "description": "Grant hexproof and indestructible"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [],
+                        "creatureTypes": [
+                            "Pilot"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                        "staticAbilities": [
+                            {
+                                "type": "CrewSaddleContribution",
+                                "modifier": 2
+                            }
+                        ]
+                    },
+                    "description": "Create a 1/1 Pilot creature token"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Raph Lomotan",
+        "flavorText": "Lagorin would not lose another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59ed23a2-6153-47b2-ab73-062195cafb74.jpg?1783907873"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }
@@ -11448,6 +11563,75 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Roadside Assistance
+{
+    "name": "Roadside Assistance",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature or Vehicle\nWhen this Aura enters, create a 1/1 colorless Pilot creature token with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"\nEnchanted permanent gets +1/+1 and has lifelink.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Pilot"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                    "staticAbilities": [
+                        {
+                            "type": "CrewSaddleContribution",
+                            "modifier": 2
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this Aura enters, create a 1/1 colorless Pilot creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|Vehicle"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Nakhodkin",
+        "flavorText": "No road has to be traveled alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f2a9154-7b43-4b8d-9d81-d11cfda5d597.jpg?1783907914",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Saddling a Mount or crewing a Vehicle doesn’t cause the token’s power to change."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
## Summary

- add Cloudspire Captain with its Mount/Vehicle anthem and crew/saddle contribution
- add Defend the Rider with both modal choices and the Aetherdrift Pilot token
- add Roadside Assistance with Aura buffs, Pilot creation, and its Scryfall ruling
- refresh the DFT card-definition snapshot

## Verification

- `just build`
- `just check-card-printing` for all three cards
- Scryfall image URLs return HTTP 200
- snapshot diff contains only the three added cards