### PR TITLE
Add Basri and Bloodghast to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6162,6 +6162,9 @@ answer it and would silently return `false`.
   plain "greater than your starting life total" reading. Elenda, Saint of Dusk gates her two stat tiers on
   `LifeAboveStartingBy(1)` and `LifeAboveStartingBy(10)`.
 - `APlayerLifeAtMost(n)` — *some* player in the game has ≤N life (existential over `state.turnOrder`; distinct from `LifeAtMost`, which is `Player.You`). Used by enters-tapped-unless lands like Razortrap Gorge.
+- `AnOpponentLifeAtMost(n)` — at least one opponent of the ability's controller has ≤N life. Unlike
+  `APlayerLifeAtMost`, the controller's own life total never satisfies it; this is the conditional
+  static-ability gate for Bloodghast's haste.
 - `YouLostLife` — you lost life this turn.
 - `OpponentLostLife` — an opponent lost life this turn.
 - `PlayerLostLifeThisTurn(player)` — a specific player lost life this turn. Use when the wording

--- a/manual-scenarios/cards/b/bloodghast-landfall-haste.json
+++ b/manual-scenarios/cards/b/bloodghast-landfall-haste.json
@@ -1,0 +1,26 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Swamp"],
+    "battlefield": [],
+    "graveyard": ["Bloodghast"],
+    "library": ["Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 10,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -582,6 +582,10 @@ object Conditions {
     fun APlayerLifeAtMost(threshold: Int): ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.APlayerLifeAtMost(threshold)
 
+    /** If at least one opponent has [threshold] or less life. */
+    fun AnOpponentLifeAtMost(threshold: Int): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.AnOpponentLifeAtMost(threshold)
+
     /**
      * If your life total is N or more.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -289,6 +289,13 @@ data class APlayerLifeAtMost(val threshold: Int) : Condition {
     override val description: String = "a player has $threshold or less life"
 }
 
+/** Condition: at least one opponent of the ability's controller has [threshold] or less life. */
+@SerialName("AnOpponentLifeAtMost")
+@Serializable
+data class AnOpponentLifeAtMost(val threshold: Int) : Condition {
+    override val description: String = "an opponent has $threshold or less life"
+}
+
 @SerialName("Exists")
 @Serializable
 data class Exists(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BasriTomorrowsChampion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BasriTomorrowsChampion.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/** Basri, Tomorrow's Champion — Aetherdrift #3. */
+val BasriTomorrowsChampion = card("Basri, Tomorrow's Champion") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink. " +
+        "(An exerted creature won't untap during your next untap step.)\n" +
+        "Cycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, Cats you control gain hexproof and indestructible until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap, Costs.Exert)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Cat"),
+            keywords = setOf(Keyword.LIFELINK),
+            imageUri = "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg?1783907681",
+        )
+        description = "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink."
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val cats = GroupFilter(GameObjectFilter.Creature.withSubtype("Cat").youControl())
+        effect = Effects.Composite(
+            Patterns.Group.grantKeywordToAll(Keyword.HEXPROOF, cats),
+            Patterns.Group.grantKeywordToAll(Keyword.INDESTRUCTIBLE, cats),
+        )
+        description = "When you cycle this card, Cats you control gain hexproof and indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg?1783907922"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BloodghastReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BloodghastReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Bloodghast reprint in Aetherdrift; canonical definition lives in Zendikar. */
+val BloodghastReprint = Printing(
+    oracleId = "e97f9c2b-b41e-4f36-9245-77c0ac125647",
+    name = "Bloodghast",
+    setCode = "DFT",
+    collectorNumber = "77",
+    scryfallId = "fdceefe6-f083-4955-b53a-8e6f8aeb2083",
+    artist = "Francisco Badilla",
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fdceefe6-f083-4955-b53a-8e6f8aeb2083.jpg?1783907898",
+    releaseDate = "2025-02-14",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/Bloodghast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/Bloodghast.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** Bloodghast — Zendikar #83. Canonical definition for later reprints. */
+val Bloodghast = card("Bloodghast") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "This creature can't block.\n" +
+        "This creature has haste as long as an opponent has 10 or less life.\n" +
+        "Landfall — Whenever a land you control enters, you may return this card from your graveyard to the battlefield."
+
+    staticAbility { ability = CantBlock() }
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, GroupFilter.source()),
+            condition = Conditions.AnOpponentLifeAtMost(10),
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Land.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        triggerZone = Zone.GRAVEYARD
+        effect = MayEffect(
+            Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
+        )
+        description = "Landfall — Whenever a land you control enters, you may return this card from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg?1783942155"
+        ruling(
+            "2009-10-01",
+            "Bloodghast's landfall ability triggers only if it's already in your graveyard at the time a land enters under your control.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -996,6 +996,110 @@
     ]
 }
 
+// Basri, Tomorrow's Champion
+{
+    "name": "Basri, Tomorrow's Champion",
+    "manaCost": "{W}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink. (An exerted creature won't untap during your next untap step.)\nCycling {2}{W} ({2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, Cats you control gain hexproof and indestructible until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Cat ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Cat ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When you cycle this card, Cats you control gain hexproof and indestructible until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostExert"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Cat"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/0/902fba98-92b7-461b-ac6e-29cb2c4e307f.jpg?1783907681"
+                },
+                "descriptionOverride": "{W}, {T}, Exert Basri: Create a 1/1 white Cat creature token with lifelink."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/991270fa-a391-4c2e-bd9a-19151386fb67.jpg?1783907922"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Beastrider Vanguard
 {
     "name": "Beastrider Vanguard",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -246,6 +246,76 @@
     "colorIdentityOverride": []
 }
 
+// Bloodghast
+{
+    "name": "Bloodghast",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Vampire Spirit",
+    "oracleText": "This creature can't block.\nThis creature has haste as long as an opponent has 10 or less life.\nLandfall — Whenever a land you control enters, you may return this card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "Landfall — Whenever a land you control enters, you may return this card from your graveyard to the battlefield."
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock",
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "AnOpponentLifeAtMost",
+                    "threshold": 10
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63870c81-63bf-4a9a-aeb5-74c6eaded9f1.jpg?1783942155",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "Bloodghast's landfall ability triggers only if it's already in your graveyard at the time a land enters under your control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Burst Lightning
 {
     "name": "Burst Lightning",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -459,6 +459,15 @@ class ConditionEvaluator(
                 state.lifeTotal(playerId) <= condition.threshold
             }
 
+            // Existential over the controller's opponents. The controller's own low life total must
+            // not satisfy cards such as Bloodghast; team games use the shared team life total.
+            is com.wingedsheep.sdk.scripting.conditions.AnOpponentLifeAtMost ->
+                ctx.controllerId?.let { controllerId ->
+                    state.getOpponents(controllerId).any { opponentId ->
+                        state.lifeTotal(opponentId) <= condition.threshold
+                    }
+                } ?: false
+
             // Board-derived only — no targets/triggering/kicker — so it works identically in
             // resolution and projection (required for the djinn `ConditionalStaticAbility` gate).
             is ColorIsMostCommon ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnOpponentLifeAtMostConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnOpponentLifeAtMostConditionTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.conditions.AnOpponentLifeAtMost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AnOpponentLifeAtMostConditionTest : FunSpec({
+    fun createDriver() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(Deck.of("Forest" to 20), skipMulligans = true)
+    }
+
+    fun GameTestDriver.evaluate(threshold: Int): Boolean = ConditionEvaluator().evaluate(
+        state,
+        AnOpponentLifeAtMost(threshold),
+        EffectContext(sourceId = null, controllerId = activePlayer!!, targets = emptyList(), xValue = 0),
+    )
+
+    test("only an opponent at or below the threshold satisfies the condition") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.setLifeTotal(controller, 10)
+        driver.setLifeTotal(opponent, 20)
+        driver.evaluate(10) shouldBe false
+
+        driver.setLifeTotal(opponent, 10)
+        driver.evaluate(10) shouldBe true
+    }
+
+    test("the threshold is inclusive") {
+        val driver = createDriver()
+        val opponent = driver.getOpponent(driver.activePlayer!!)
+
+        driver.setLifeTotal(opponent, 11)
+        driver.evaluate(10) shouldBe false
+        driver.setLifeTotal(opponent, 10)
+        driver.evaluate(10) shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary
- add Basri, Tomorrow's Champion with exert, cycling, Cat token creation, and its cycling payoff
- add Bloodghast canonically to Zendikar plus its Aetherdrift printing row
- add a reusable opponent life-threshold condition, focused engine coverage, SDK documentation, snapshots, and a Bloodghast manual scenario

The remaining Aetherdrift backlog is dominated by cards requiring unsupported exhaust triggers, crew/saddle triggers, planeswalker behavior, or other larger mechanics, so this batch intentionally contains two cards.

## Verification
- just test
- just test-class AnOpponentLifeAtMostConditionTest
- just rebless-cards
- just check-card-printing Basri, Tomorrow's Champion
- just check-card-printing Bloodghast
- exact Scryfall card and token image URLs return HTTP 200

## Known unrelated issue
- just check-backlog fails on origin/main because backlog/sets/innistrad-crimson-vow/cards.md declares 272 cards but contains 273 checklist rows; this PR does not touch that file.