### PR TITLE
Add Interface Ace to Aetherdrift

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/InterfaceAce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/InterfaceAce.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleCharacteristic
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Interface Ace — Aetherdrift #17
+ * {1}{W} · Artifact Creature — Robot Pilot · 0/4
+ *
+ * The crew/saddle contribution reads projected toughness, so counters and continuous effects are
+ * reflected without changing Interface Ace's actual power. The tap trigger is gated to its
+ * controller's turn and capped independently per turn.
+ */
+val InterfaceAce = card("Interface Ace") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Robot Pilot"
+    oracleText = "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\n" +
+        "Whenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn."
+    power = 0
+    toughness = 4
+
+    staticAbility {
+        ability = CrewSaddleContribution(characteristic = CrewSaddleCharacteristic.TOUGHNESS)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        triggerCondition = Conditions.IsYourTurn
+        oncePerTurn = true
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Wonchun Choi"
+        flavorText = "To the Guidelight Voyagers, a vehicle is just another hardware upgrade."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg?1783907918"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -7109,6 +7109,48 @@
     ]
 }
 
+// Interface Ace
+{
+    "name": "Interface Ace",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Robot Pilot",
+    "oracleText": "This creature saddles Mounts and crews Vehicles using its toughness rather than its power.\nWhenever this creature becomes tapped during your turn, untap it. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TapEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "triggerCondition": "IsYourTurn",
+                "oncePerTurn": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CrewSaddleContribution",
+                "characteristic": "TOUGHNESS"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Wonchun Choi",
+        "flavorText": "To the Guidelight Voyagers, a vehicle is just another hardware upgrade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fcfd487a-a9e6-44e3-80af-bc384316106f.jpg?1783907918"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Intimidation Tactics
 {
     "name": "Intimidation Tactics",


### PR DESCRIPTION
## Summary
- add Interface Ace with toughness-based crew/saddle contribution
- model its controller-turn, once-per-turn untap trigger
- update the DFT card-definition snapshot

The remaining Aetherdrift gaps screened for this batch require broader unsupported mechanics (including exhaust-activation triggers, crew/saddle contributor triggers, cycling X propagation, or abilityless-card filtering), so this PR intentionally contains one fully faithful card rather than approximating a larger batch.

## Verification
- `just rebless-cards`
- `just build`
- `just check-card-printing "Interface Ace"`
- `git diff --check`