### PR TITLE
Add Liesa to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LiesaForgottenArchangelReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LiesaForgottenArchangelReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing of Liesa, Forgotten Archangel. */
+val LiesaForgottenArchangelReprint = Printing(
+    oracleId = "efcaadbe-24e3-4dfc-b08c-a910f003d427",
+    name = "Liesa, Forgotten Archangel",
+    setCode = "INR",
+    collectorNumber = "243",
+    artist = "Dmitry Burmak",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/106b6b43-1881-417b-97f5-f5b050eb98fd.jpg?1783908075",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/LiesaForgottenArchangel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/LiesaForgottenArchangel.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Liesa, Forgotten Archangel
+ * {2}{W}{W}{B}
+ * Legendary Creature — Angel
+ * 4/5
+ *
+ * Flying, lifelink
+ * Whenever another nontoken creature you control dies, return that card to its owner's hand at the
+ * beginning of the next end step.
+ * If a creature an opponent controls would die, exile it instead.
+ */
+val LiesaForgottenArchangel = card("Liesa, Forgotten Archangel") {
+    manaCost = "{2}{W}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Angel"
+    power = 4
+    toughness = 5
+    oracleText = "Flying, lifelink\n" +
+        "Whenever another nontoken creature you control dies, return that card to its owner's hand " +
+        "at the beginning of the next end step.\n" +
+        "If a creature an opponent controls would die, exile it instead."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.nontoken().youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = CreateDelayedTriggerEffect(
+            step = Step.END,
+            effect = Effects.Move(
+                EffectTarget.TriggeringEntity,
+                Zone.HAND,
+                fromZone = Zone.GRAVEYARD,
+            ),
+        )
+    }
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.opponentControls(),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD,
+            ),
+        ),
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg?1783925558"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -1302,6 +1302,68 @@
     ]
 }
 
+// Liesa, Forgotten Archangel
+{
+    "name": "Liesa, Forgotten Archangel",
+    "manaCost": "{2}{W}{W}{B}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flying, lifelink\nWhenever another nontoken creature you control dies, return that card to its owner's hand at the beginning of the next end step.\nIf a creature an opponent controls would die, exile it instead.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "END",
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": "TriggeringEntity",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChange",
+                "newDestination": "Exile",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/532fca6b-f788-43f8-b29f-7273e7a48449.jpg?1783925558"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Memory Deluge
 {
     "name": "Memory Deluge",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LiesaForgottenArchangelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LiesaForgottenArchangelScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mid.cards.LiesaForgottenArchangel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LiesaForgottenArchangelScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + LiesaForgottenArchangel)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            skipMulligans = true,
+            startingPlayer = 0,
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun destroy(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val murder = driver.putCardInHand(caster, "Murder")
+        driver.giveMana(caster, Color.BLACK, 3)
+        driver.castSpell(caster, murder, listOf(victim)).isSuccess shouldBe true
+        driver.bothPass()
+    }
+
+    test("another nontoken creature you control returns to its owner's hand at the next end step") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        driver.putCreatureOnBattlefield(player, "Liesa, Forgotten Archangel")
+        val creature = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        destroy(driver, player, creature)
+        driver.bothPass() // resolve Liesa's dies trigger and schedule the delayed return
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(creature) shouldBe true
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(creature) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(creature) shouldBe false
+    }
+
+    test("Liesa does not return herself") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val liesa = driver.putCreatureOnBattlefield(player, "Liesa, Forgotten Archangel")
+        destroy(driver, player, liesa)
+        driver.passPriorityUntil(Step.END)
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(liesa) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(liesa) shouldBe false
+    }
+
+    test("an opponent's creature is exiled instead of dying") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.player2
+
+        driver.putCreatureOnBattlefield(player, "Liesa, Forgotten Archangel")
+        val creature = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        destroy(driver, player, creature)
+
+        driver.state.getZone(ZoneKey(opponent, Zone.EXILE)).contains(creature) shouldBe true
+        driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD)).contains(creature) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- add the canonical MID definition for Liesa, Forgotten Archangel
- add the Innistrad Remastered printing metadata
- cover delayed return, self-exclusion, and opponent-creature exile replacement in a dedicated scenario test

## Scope
The remaining INR backlog has no cards in the tooling’s full-fidelity tier. I reduced this batch to one fully supported card rather than include cards whose central mechanics (meld, madness, emerge, or complete unattached-event handling) are not yet faithfully supported.

## Verification
- `just test-class LiesaForgottenArchangelScenarioTest`
- `just rebless-cards`
- `just check-card-printing "Liesa, Forgotten Archangel"`
- `just build`
- exact canonical and INR Scryfall image URLs return HTTP 200