### PR TITLE
Add three Innistrad Remastered meld partners

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GiselaTheBrokenBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GiselaTheBrokenBlade.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gisela, the Broken Blade
+ * {2}{W}{W}
+ * Legendary Creature — Angel Horror
+ * 4/3
+ *
+ * Flying, first strike, lifelink
+ *
+ * Meld is not yet supported by the engine. As with Bruna, the Fading Light and the other
+ * Eldritch Moon meld cards, the printed meld trigger remains in [oracleText] but is not wired.
+ */
+val GiselaTheBrokenBlade = card("Gisela, the Broken Blade") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Angel Horror"
+    oracleText = "Flying, first strike, lifelink\n" +
+        "At the beginning of your end step, if you both own and control Gisela and a creature " +
+        "named Bruna, the Fading Light, exile them, then meld them into Brisela, Voice of Nightmares."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "28"
+        artist = "Clint Cearley"
+        flavorText = "She now hears only Emrakul's murmurs."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg?1783937515"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrafRats.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrafRats.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Graf Rats
+ * {1}{B}
+ * Creature — Rat
+ * 2/1
+ *
+ * Meld is not yet supported by the engine. As with Midnight Scavengers and the other
+ * Eldritch Moon meld cards, the printed meld trigger remains in [oracleText] but is not wired.
+ */
+val GrafRats = card("Graf Rats") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "At the beginning of combat on your turn, if you both own and control this " +
+        "creature and a creature named Midnight Scavengers, exile them, then meld them into " +
+        "Chittering Host."
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg?1783937482"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HanweirBattlements.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HanweirBattlements.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Hanweir Battlements
+ * Land
+ * {T}: Add {C}.
+ * {R}, {T}: Target creature gains haste until end of turn.
+ *
+ * Meld is not yet supported by the engine. As with Hanweir Garrison and the other
+ * Eldritch Moon meld cards, the printed meld ability remains in [oracleText] but is not wired.
+ */
+val HanweirBattlements = card("Hanweir Battlements") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{R}, {T}: Target creature gains haste until end of turn.\n" +
+        "{3}{R}{R}, {T}: If you both own and control this land and a creature named Hanweir " +
+        "Garrison, exile them, then meld them into Hanweir, the Writhing Township."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.HASTE, creature)
+        description = "{R}, {T}: Target creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "Vincent Proce"
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg?1783937421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GiselaTheBrokenBladeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GiselaTheBrokenBladeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing of Gisela, the Broken Blade. The canonical definition lives in EMN. */
+val GiselaTheBrokenBladeReprint = Printing(
+    oracleId = "f3e23d5e-bd88-4e7c-a3fb-db2a8cb05b22",
+    name = "Gisela, the Broken Blade",
+    setCode = "INR",
+    collectorNumber = "24",
+    scryfallId = "04506bad-3856-4184-8dda-941ded60f41a",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04506bad-3856-4184-8dda-941ded60f41a.jpg?1783908181",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrafRatsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrafRatsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing of Graf Rats. The canonical definition lives in EMN. */
+val GrafRatsReprint = Printing(
+    oracleId = "852edc00-9d98-427c-9869-7d0c8c121118",
+    name = "Graf Rats",
+    setCode = "INR",
+    collectorNumber = "113",
+    scryfallId = "f830ede6-ddbf-49b9-80cd-e3dbeccbf208",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f830ede6-ddbf-49b9-80cd-e3dbeccbf208.jpg?1783908142",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirBattlementsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirBattlementsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing of Hanweir Battlements. The canonical definition lives in EMN. */
+val HanweirBattlementsReprint = Printing(
+    oracleId = "0e735ba6-7fd1-4d12-b20c-21525dc1e2b5",
+    name = "Hanweir Battlements",
+    setCode = "INR",
+    collectorNumber = "279",
+    scryfallId = "8c0acb91-edfc-43a5-af77-6614327fce43",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c0acb91-edfc-43a5-af77-6614327fce43.jpg?1783908057",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -759,6 +759,53 @@
     ]
 }
 
+// Gisela, the Broken Blade
+{
+    "name": "Gisela, the Broken Blade",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Creature — Angel Horror",
+    "oracleText": "Flying, first strike, lifelink\nAt the beginning of your end step, if you both own and control Gisela and a creature named Bruna, the Fading Light, exile them, then meld them into Brisela, Voice of Nightmares.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "MYTHIC",
+        "artist": "Clint Cearley",
+        "flavorText": "She now hears only Emrakul's murmurs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c75c035a-7da9-4b36-982d-fca8220b1797.jpg?1783937515"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Graf Rats
+{
+    "name": "Graf Rats",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "At the beginning of combat on your turn, if you both own and control this creature and a creature named Midnight Scavengers, exile them, then meld them into Chittering Host.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3dedaff6-bd69-4fe3-a301-f7ea7c2f2861.jpg?1783937482"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Grapple with the Past
 {
     "name": "Grapple with the Past",
@@ -892,6 +939,74 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Hanweir Battlements
+{
+    "name": "Hanweir Battlements",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{R}, {T}: Target creature gains haste until end of turn.\n{3}{R}{R}, {T}: If you both own and control this land and a creature named Hanweir Garrison, exile them, then meld them into Hanweir, the Writhing Township.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{R}, {T}: Target creature gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "RARE",
+        "artist": "Vincent Proce",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d743ad6-6ca2-409a-9773-581cc195dbf2.jpg?1783937421"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary

- add canonical Eldritch Moon definitions for Gisela, the Broken Blade; Graf Rats; and Hanweir Battlements
- add their Innistrad Remastered printing rows with set-specific Scryfall metadata
- model Gisela’s keywords and Hanweir Battlements’ mana/haste abilities using existing SDK primitives
- preserve the complete Oracle text while explicitly documenting that meld remains unsupported, consistent with the existing EMN meld-card precedent
- update the EMN card snapshot; INR coverage increases from 209/290 to 212/290

## Verification

- `just build`
- `just check-card-printing "Gisela, the Broken Blade"`
- `just check-card-printing "Graf Rats"`
- `just check-card-printing "Hanweir Battlements"`
- `git diff --check`

All passed.