### PR TITLE
Add Canyon Vaulter and Reckless Velocitaur

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3845,6 +3845,12 @@ Triggers.youCastSpell(
   `firstThisTurn` flag, which is true only when the permanent wasn't already saddled when the ability
   resolved (re-saddling in the same turn reports false, since `SaddledComponent` persists until
   cleanup). Use an `ANY` binding + `filter` for "whenever a [filter] becomes saddled".
+- `CrewsOrSaddles` — SELF-bound "whenever this creature saddles a Mount or crews a Vehicle". Crew
+  and Saddle action handlers emit one `CrewOrSaddleContributionEvent` for each creature tapped to
+  pay the activation cost. The contributing creature is used for SELF matching; the Mount or Vehicle
+  it contributed to is exposed as `EffectTarget.TriggeringEntity`. Because the contribution happens
+  while the cost is paid, its trigger is put above the Crew or Saddle ability and resolves first. Add
+  `triggerCondition = Conditions.IsYourMainPhase` for the Aetherdrift Pilot wording.
 - `becomesAttached(attachmentFilter = Any, attachmentController = Any, attachedToFilter = Any, binding = SELF)`
   — "whenever an Aura/Equipment becomes attached to a permanent" (CR 603.2e). Fires from
   `PermanentAttachedEvent`, emitted at every attach site (aura ETB onto its enchant target, equip

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3845,12 +3845,16 @@ Triggers.youCastSpell(
   `firstThisTurn` flag, which is true only when the permanent wasn't already saddled when the ability
   resolved (re-saddling in the same turn reports false, since `SaddledComponent` persists until
   cleanup). Use an `ANY` binding + `filter` for "whenever a [filter] becomes saddled".
-- `CrewsOrSaddles` — SELF-bound "whenever this creature saddles a Mount or crews a Vehicle". Crew
-  and Saddle action handlers emit one `CrewOrSaddleContributionEvent` for each creature tapped to
-  pay the activation cost. The contributing creature is used for SELF matching; the Mount or Vehicle
-  it contributed to is exposed as `EffectTarget.TriggeringEntity`. Because the contribution happens
-  while the cost is paid, its trigger is put above the Crew or Saddle ability and resolves first. Add
-  `triggerCondition = Conditions.IsYourMainPhase` for the Aetherdrift Pilot wording.
+- `Crews` / `Saddles` — SELF-bound atomic triggers for "whenever this creature crews a Vehicle" and
+  "whenever this creature saddles a Mount". Crew and Saddle action handlers emit one contribution
+  event for each creature tapped to pay the activation cost. The contributing creature is used for
+  SELF matching; the Mount or Vehicle it contributed to is exposed as `EffectTarget.TriggeringEntity`.
+  Because the contribution happens while the cost is paid, its trigger is put above the Crew or Saddle
+  ability and resolves first.
+- `or(first, second, vararg others)` — composes two or more trigger atoms with the same binding into a
+  single disjunctive trigger. Nested disjunctions are flattened. Example: the Aetherdrift Pilot wording
+  uses `Triggers.or(Triggers.Saddles, Triggers.Crews)` plus
+  `triggerCondition = Conditions.IsYourMainPhase`.
 - `becomesAttached(attachmentFilter = Any, attachmentController = Any, attachedToFilter = Any, binding = SELF)`
   — "whenever an Aura/Equipment becomes attached to a permanent" (CR 603.2e). Fires from
   `PermanentAttachedEvent`, emitted at every attach site (aura ETB onto its enchant target, equip

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1157,6 +1157,15 @@ object Triggers {
     )
 
     /**
+     * Whenever this creature saddles a Mount or crews a Vehicle. The contributed-to permanent is
+     * available to the effect as `EffectTarget.TriggeringEntity`.
+     */
+    val CrewsOrSaddles: TriggerSpec = TriggerSpec(
+        event = CrewsOrSaddlesEvent,
+        binding = TriggerBinding.SELF
+    )
+
+    /**
      * Whenever you activate an ability whose chosen targets satisfy [targetMatch] — e.g.
      * [AbilityTargetMatch.CreatureOrPlayer] for Ertha Jo, Frontier Mentor's
      * "Whenever you activate an ability that targets a creature or player". A non-targeting

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -34,6 +34,21 @@ import com.wingedsheep.sdk.scripting.references.Player
  */
 object Triggers {
 
+    /** Combines trigger atoms that use the same binding into one disjunctive trigger. */
+    fun or(first: TriggerSpec, second: TriggerSpec, vararg others: TriggerSpec): TriggerSpec {
+        val triggers = listOf(first, second) + others
+        require(triggers.all { it.binding == first.binding }) {
+            "Triggers.or requires every trigger to use the same binding"
+        }
+        return TriggerSpec(
+            event = AnyOf(triggers.flatMap {
+                val event = it.event
+                if (event is AnyOf) event.events else listOf(event)
+            }),
+            binding = first.binding
+        )
+    }
+
     // =========================================================================
     // Zone Change Triggers
     // =========================================================================
@@ -1157,11 +1172,17 @@ object Triggers {
     )
 
     /**
-     * Whenever this creature saddles a Mount or crews a Vehicle. The contributed-to permanent is
-     * available to the effect as `EffectTarget.TriggeringEntity`.
+     * Whenever this creature crews a Vehicle. The Vehicle is available to the effect as
+     * `EffectTarget.TriggeringEntity`.
      */
-    val CrewsOrSaddles: TriggerSpec = TriggerSpec(
-        event = CrewsOrSaddlesEvent,
+    val Crews: TriggerSpec = TriggerSpec(
+        event = CrewsEvent,
+        binding = TriggerBinding.SELF
+    )
+
+    /** Whenever this creature saddles a Mount. */
+    val Saddles: TriggerSpec = TriggerSpec(
+        event = SaddlesEvent,
         binding = TriggerBinding.SELF
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -61,6 +61,22 @@ enum class ExploreReveal { ANY, LAND, NONLAND }
 sealed interface EventPattern : TextReplaceable<EventPattern> {
     val description: String
 
+    /** Matches when any constituent event pattern matches. */
+    @SerialName("AnyOfEvents")
+    @Serializable
+    data class AnyOf(val events: List<EventPattern>) : EventPattern {
+        init {
+            require(events.size >= 2) { "AnyOf requires at least two event patterns" }
+        }
+
+        override val description: String = events.joinToString(" or ") { it.description }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val replaced = events.map { it.applyTextReplacement(replacer) }
+            return if (replaced == events) this else copy(events = replaced)
+        }
+    }
+
     // =========================================================================
     // Damage Events (Replacement Effect)
     // =========================================================================
@@ -1835,16 +1851,18 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         }
     }
 
-    /**
-     * Whenever this creature saddles a Mount or crews a Vehicle.
-     *
-     * The source is the creature tapped as part of the Crew or Saddle activation cost. The
-     * permanent it helped crew or saddle is exposed as `EffectTarget.TriggeringEntity`.
-     */
-    @SerialName("CrewsOrSaddlesEvent")
+    /** Whenever this creature crews a Vehicle. */
+    @SerialName("CrewsEvent")
     @Serializable
-    data object CrewsOrSaddlesEvent : EventPattern {
-        override val description: String = "this creature saddles a Mount or crews a Vehicle"
+    data object CrewsEvent : EventPattern {
+        override val description: String = "this creature crews a Vehicle"
+    }
+
+    /** Whenever this creature saddles a Mount. */
+    @SerialName("SaddlesEvent")
+    @Serializable
+    data object SaddlesEvent : EventPattern {
+        override val description: String = "this creature saddles a Mount"
     }
 
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1835,6 +1835,18 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         }
     }
 
+    /**
+     * Whenever this creature saddles a Mount or crews a Vehicle.
+     *
+     * The source is the creature tapped as part of the Crew or Saddle activation cost. The
+     * permanent it helped crew or saddle is exposed as `EffectTarget.TriggeringEntity`.
+     */
+    @SerialName("CrewsOrSaddlesEvent")
+    @Serializable
+    data object CrewsOrSaddlesEvent : EventPattern {
+        override val description: String = "this creature saddles a Mount or crews a Vehicle"
+    }
+
     // =========================================================================
     // Batched Zone Change Events (Triggers)
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CanyonVaulter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CanyonVaulter.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** Canyon Vaulter — Aetherdrift #8. */
+val CanyonVaulter = card("Canyon Vaulter") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Pilot"
+    power = 3
+    toughness = 1
+    oracleText = "Whenever this creature saddles a Mount or crews a Vehicle during your main " +
+        "phase, that Mount or Vehicle gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.CrewsOrSaddles
+        triggerCondition = Conditions.IsYourMainPhase
+        effect = Effects.GrantKeyword(
+            Keyword.FLYING,
+            target = EffectTarget.TriggeringEntity
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "David Astruga"
+        flavorText = "Some seek thrills in watching the show. Some seek thrills in being the show."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg?1783907921"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CanyonVaulter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CanyonVaulter.kt
@@ -19,7 +19,7 @@ val CanyonVaulter = card("Canyon Vaulter") {
         "phase, that Mount or Vehicle gains flying until end of turn."
 
     triggeredAbility {
-        trigger = Triggers.CrewsOrSaddles
+        trigger = Triggers.or(Triggers.Saddles, Triggers.Crews)
         triggerCondition = Conditions.IsYourMainPhase
         effect = Effects.GrantKeyword(
             Keyword.FLYING,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RecklessVelocitaur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RecklessVelocitaur.kt
@@ -19,7 +19,7 @@ val RecklessVelocitaur = card("Reckless Velocitaur") {
         "phase, that Mount or Vehicle gets +2/+0 and gains trample until end of turn."
 
     triggeredAbility {
-        trigger = Triggers.CrewsOrSaddles
+        trigger = Triggers.or(Triggers.Saddles, Triggers.Crews)
         triggerCondition = Conditions.IsYourMainPhase
         effect = Effects.Composite(
             Effects.ModifyStats(2, 0, EffectTarget.TriggeringEntity),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RecklessVelocitaur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RecklessVelocitaur.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** Reckless Velocitaur — Aetherdrift #144. */
+val RecklessVelocitaur = card("Reckless Velocitaur") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Pilot"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature saddles a Mount or crews a Vehicle during your main " +
+        "phase, that Mount or Vehicle gets +2/+0 and gains trample until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.CrewsOrSaddles
+        triggerCondition = Conditions.IsYourMainPhase
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, EffectTarget.TriggeringEntity),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.TriggeringEntity)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "144"
+        artist = "Inkognit"
+        flavorText = "Repairs are tomorrow's problems."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg?1783907877"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2309,7 +2309,13 @@
         "triggeredAbilities": [
             {
                 "id": "ability_1",
-                "trigger": "CrewsOrSaddlesEvent",
+                "trigger": {
+                    "type": "AnyOfEvents",
+                    "events": [
+                        "SaddlesEvent",
+                        "CrewsEvent"
+                    ]
+                },
                 "effect": {
                     "type": "GrantKeyword",
                     "keyword": "FLYING",
@@ -10991,7 +10997,13 @@
         "triggeredAbilities": [
             {
                 "id": "ability_1",
-                "trigger": "CrewsOrSaddlesEvent",
+                "trigger": {
+                    "type": "AnyOfEvents",
+                    "events": [
+                        "SaddlesEvent",
+                        "CrewsEvent"
+                    ]
+                },
                 "effect": {
                     "type": "Composite",
                     "effects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2295,6 +2295,48 @@
     "colorIdentityOverride": []
 }
 
+// Canyon Vaulter
+{
+    "name": "Canyon Vaulter",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Pilot",
+    "oracleText": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gains flying until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CrewsOrSaddlesEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "TriggeringEntity"
+                },
+                "triggerCondition": {
+                    "type": "IsInPhase",
+                    "phases": [
+                        "PRECOMBAT_MAIN",
+                        "POSTCOMBAT_MAIN"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "David Astruga",
+        "flavorText": "Some seek thrills in watching the show. Some seek thrills in being the show.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc0b15da-a45c-42f5-aafc-20ad9e38bf24.jpg?1783907921"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Caradora, Heart of Alacria
 {
     "name": "Caradora, Heart of Alacria",
@@ -10933,6 +10975,65 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1783907847"
     },
     "colorIdentityOverride": []
+}
+
+// Reckless Velocitaur
+{
+    "name": "Reckless Velocitaur",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Minotaur Pilot",
+    "oracleText": "Whenever this creature saddles a Mount or crews a Vehicle during your main phase, that Mount or Vehicle gets +2/+0 and gains trample until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CrewsOrSaddlesEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "TriggeringEntity"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "TriggeringEntity"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "IsInPhase",
+                    "phases": [
+                        "PRECOMBAT_MAIN",
+                        "POSTCOMBAT_MAIN"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "UNCOMMON",
+        "artist": "Inkognit",
+        "flavorText": "Repairs are tomorrow's problems.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8edd18be-3861-4510-ba6d-38ccba60bb5b.jpg?1783907877"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Reef Roads

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -216,8 +216,8 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // permanent as EffectTarget.TriggeringEntity. Capability-only: mtgish drops Aetherdrift's
     // "during your main phase" rider from these trigger nodes, so the emitter must keep them at
     // SCAFFOLD rather than produce an over-broad AUTO draft.
-    supported("WhenACreatureSaddlesAMount", "trigger: this creature saddles a Mount (Triggers.CrewsOrSaddles)")
-    supported("WhenACreatureCrewsAVehicle", "trigger: this creature crews a Vehicle (Triggers.CrewsOrSaddles)")
+    supported("WhenACreatureSaddlesAMount", "trigger: this creature saddles a Mount (Triggers.Saddles)")
+    supported("WhenACreatureCrewsAVehicle", "trigger: this creature crews a Vehicle (Triggers.Crews)")
     // Graveyard-arrival filters, both backed by the one PutIntoGraveyardThisTurnComponent stamp:
     // "…that was put there this turn" (Abyssal Harvester) reads the stamp, the battlefield-only
     // variant (Samwise the Stouthearted, Lobelia Sackville-Baggins) also requires its

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -211,6 +211,13 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // (Giant Beaver) -> GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn().
     supported("SaddledPermanentThisTurn", "filter: a creature that saddled this permanent this turn (crewedOrSaddledSourceThisTurn)")
     supported("CrewedPermanentThisTurn", "filter: a creature that crewed this permanent this turn (crewedOrSaddledSourceThisTurn)")
+    // Pilot payoff: "whenever this creature saddles a Mount or crews a Vehicle". The engine emits
+    // one contributor event per creature tapped for either activation cost and binds the destination
+    // permanent as EffectTarget.TriggeringEntity. Capability-only: mtgish drops Aetherdrift's
+    // "during your main phase" rider from these trigger nodes, so the emitter must keep them at
+    // SCAFFOLD rather than produce an over-broad AUTO draft.
+    supported("WhenACreatureSaddlesAMount", "trigger: this creature saddles a Mount (Triggers.CrewsOrSaddles)")
+    supported("WhenACreatureCrewsAVehicle", "trigger: this creature crews a Vehicle (Triggers.CrewsOrSaddles)")
     // Graveyard-arrival filters, both backed by the one PutIntoGraveyardThisTurnComponent stamp:
     // "…that was put there this turn" (Abyssal Harvester) reads the stamp, the battlefield-only
     // variant (Samwise the Stouthearted, Lobelia Sackville-Baggins) also requires its

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1613,6 +1613,20 @@ data class CardCycledEvent(
     val cardName: String
 ) : GameEvent
 
+/**
+ * A creature was tapped as a contributor to a Crew or Saddle activation cost.
+ *
+ * One event is emitted per contributing creature. [permanentId] is the Vehicle or Mount that the
+ * creature crewed or saddled and becomes the triggering entity for the resolving payoff.
+ */
+@Serializable
+@SerialName("CrewOrSaddleContributionEvent")
+data class CrewOrSaddleContributionEvent(
+    val contributorId: EntityId,
+    val permanentId: EntityId,
+    val controllerId: EntityId
+) : GameEvent
+
 // =============================================================================
 // Plot Events
 // =============================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1624,8 +1624,12 @@ data class CardCycledEvent(
 data class CrewOrSaddleContributionEvent(
     val contributorId: EntityId,
     val permanentId: EntityId,
-    val controllerId: EntityId
+    val controllerId: EntityId,
+    val kind: CrewOrSaddleKind
 ) : GameEvent
+
+@Serializable
+enum class CrewOrSaddleKind { CREW, SADDLE }
 
 // =============================================================================
 // Plot Events

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -109,6 +109,7 @@ val engineSerializersModule = SerializersModule {
         subclass(AbilityCounteredEvent::class)
         subclass(BecomesTargetEvent::class)
         subclass(CardCycledEvent::class)
+        subclass(CrewOrSaddleContributionEvent::class)
         subclass(CardPlottedEvent::class)
         subclass(CardsRevealedEvent::class)
         subclass(ClassLevelChangedEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -280,6 +280,10 @@ data class TriggerContext(
                     triggeringPlayerId = event.playerId
                 )
                 is CardCycledEvent -> TriggerContext(triggeringPlayerId = event.playerId)
+                is com.wingedsheep.engine.core.CrewOrSaddleContributionEvent -> TriggerContext(
+                    triggeringEntityId = event.permanentId,
+                    triggeringPlayerId = event.controllerId
+                )
                 is AttackersDeclaredEvent -> TriggerContext()
                 is BlockersDeclaredEvent -> TriggerContext()
                 is TappedEvent -> TriggerContext(triggeringEntityId = event.entityId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.core.GiftGivenEvent
 import com.wingedsheep.engine.core.CardRevealedFromDrawEvent
 import com.wingedsheep.engine.core.CardsDrawnEvent
 import com.wingedsheep.engine.core.CountersAddedEvent
+import com.wingedsheep.engine.core.CrewOrSaddleContributionEvent
 import com.wingedsheep.engine.core.ControlChangedEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
 import com.wingedsheep.engine.core.LifeChangeReason
@@ -84,6 +85,7 @@ enum class TriggerCategory {
     MANIFESTED_DREAD,
     SEARCH_LIBRARY,
     BECAME_SADDLED,
+    CREW_OR_SADDLE_CONTRIBUTION,
     BECOMES_ATTACHED,
     SAGA_CHAPTER_RESOLVED,
     PLAYER_LOST,
@@ -273,6 +275,7 @@ class TriggerIndex(
                 is SdkGameEvent.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
                 is SdkGameEvent.SearchLibraryEvent -> SEARCH_LIBRARY_LIST
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
+                is SdkGameEvent.CrewsOrSaddlesEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
                 is SdkGameEvent.PlayerLostGameEvent -> PLAYER_LOST_LIST
@@ -322,6 +325,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
             is com.wingedsheep.engine.core.LibrarySearchedEvent -> SEARCH_LIBRARY_LIST
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
+            is CrewOrSaddleContributionEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
             is com.wingedsheep.engine.core.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
             is com.wingedsheep.engine.core.PlayerLostEvent -> PLAYER_LOST_LIST
@@ -364,6 +368,8 @@ class TriggerIndex(
         private val MANIFESTED_DREAD_LIST = listOf(TriggerCategory.MANIFESTED_DREAD)
         private val SEARCH_LIBRARY_LIST = listOf(TriggerCategory.SEARCH_LIBRARY)
         private val BECAME_SADDLED_LIST = listOf(TriggerCategory.BECAME_SADDLED)
+        private val CREW_OR_SADDLE_CONTRIBUTION_LIST =
+            listOf(TriggerCategory.CREW_OR_SADDLE_CONTRIBUTION)
         private val BECOMES_ATTACHED_LIST = listOf(TriggerCategory.BECOMES_ATTACHED)
         private val SAGA_CHAPTER_RESOLVED_LIST = listOf(TriggerCategory.SAGA_CHAPTER_RESOLVED)
         private val PLAYER_LOST_LIST = listOf(TriggerCategory.PLAYER_LOST)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -206,6 +206,9 @@ class TriggerIndex(
             ) return emptyList()
 
             return when (trigger) {
+                is SdkGameEvent.AnyOf -> trigger.events
+                    .flatMap { triggerToCategories(it, binding) }
+                    .distinct()
                 is SdkGameEvent.ZoneChangeEvent -> listOf(TriggerCategory.ZONE_CHANGE)
                 // "Whenever you create a token" matches token-creation ZoneChangeEvents (fromZone ==
                 // null), so it indexes under the same category as those events (TriggerMatcher.
@@ -275,7 +278,8 @@ class TriggerIndex(
                 is SdkGameEvent.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
                 is SdkGameEvent.SearchLibraryEvent -> SEARCH_LIBRARY_LIST
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
-                is SdkGameEvent.CrewsOrSaddlesEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
+                is SdkGameEvent.CrewsEvent,
+                is SdkGameEvent.SaddlesEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
                 is SdkGameEvent.PlayerLostGameEvent -> PLAYER_LOST_LIST

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -356,6 +356,10 @@ class TriggerMatcher(
                     )
                 } else true
             }
+            is EventPattern.CrewsOrSaddlesEvent ->
+                event is com.wingedsheep.engine.core.CrewOrSaddleContributionEvent &&
+                    binding == TriggerBinding.SELF &&
+                    event.contributorId == sourceId
             is EventPattern.BecomesAttachedEvent -> {
                 if (event !is com.wingedsheep.engine.core.PermanentAttachedEvent) return false
                 // SELF binding = "whenever THIS Equipment/Aura becomes attached" (the attachment

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -60,6 +60,9 @@ class TriggerMatcher(
         ) return false
 
         return when (trigger) {
+            is EventPattern.AnyOf -> trigger.events.any {
+                matchesTrigger(it, binding, event, sourceId, controllerId, state)
+            }
             is EventPattern.ZoneChangeEvent -> matchesZoneChangeTrigger(trigger, binding, event, sourceId, controllerId, state)
             is EventPattern.DrawEvent -> {
                 event is CardsDrawnEvent && matchesPlayer(trigger.player, event.playerId, controllerId)
@@ -356,8 +359,14 @@ class TriggerMatcher(
                     )
                 } else true
             }
-            is EventPattern.CrewsOrSaddlesEvent ->
+            is EventPattern.CrewsEvent ->
                 event is com.wingedsheep.engine.core.CrewOrSaddleContributionEvent &&
+                    event.kind == com.wingedsheep.engine.core.CrewOrSaddleKind.CREW &&
+                    binding == TriggerBinding.SELF &&
+                    event.contributorId == sourceId
+            is EventPattern.SaddlesEvent ->
+                event is com.wingedsheep.engine.core.CrewOrSaddleContributionEvent &&
+                    event.kind == com.wingedsheep.engine.core.CrewOrSaddleKind.SADDLE &&
                     binding == TriggerBinding.SELF &&
                     event.contributorId == sourceId
             is EventPattern.BecomesAttachedEvent -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.actions.ability
 
 import com.wingedsheep.engine.core.CrewVehicle
 import com.wingedsheep.engine.core.CrewOrSaddleContributionEvent
+import com.wingedsheep.engine.core.CrewOrSaddleKind
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.tap
@@ -153,7 +154,8 @@ class CrewVehicleHandler(
                     CrewOrSaddleContributionEvent(
                         contributorId = creatureId,
                         permanentId = action.vehicleId,
-                        controllerId = action.playerId
+                        controllerId = action.playerId,
+                        kind = CrewOrSaddleKind.CREW
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CrewVehicleHandler.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.actions.ability
 
 import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.CrewOrSaddleContributionEvent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.tap
@@ -146,7 +147,16 @@ class CrewVehicleHandler(
         for (creatureId in action.crewCreatures) {
             val (tappedState, tapEvent) = tap(currentState, creatureId)
             currentState = tappedState
-            tapEvent?.let(events::add)
+            tapEvent?.let {
+                events.add(it)
+                events.add(
+                    CrewOrSaddleContributionEvent(
+                        contributorId = creatureId,
+                        permanentId = action.vehicleId,
+                        controllerId = action.playerId
+                    )
+                )
+            }
         }
 
         // Record the crew so Vehicle payoffs can read "creatures that crewed it this turn"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.actions.ability
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.CrewOrSaddleContributionEvent
+import com.wingedsheep.engine.core.CrewOrSaddleKind
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.SaddleMount
 import com.wingedsheep.engine.core.tap
@@ -140,7 +141,8 @@ class SaddleMountHandler(
                     CrewOrSaddleContributionEvent(
                         contributorId = creatureId,
                         permanentId = action.mountId,
-                        controllerId = action.playerId
+                        controllerId = action.playerId,
+                        kind = CrewOrSaddleKind.SADDLE
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/SaddleMountHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.actions.ability
 
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.CrewOrSaddleContributionEvent
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.SaddleMount
 import com.wingedsheep.engine.core.tap
@@ -133,7 +134,16 @@ class SaddleMountHandler(
         for (creatureId in action.saddleCreatures) {
             val (tappedState, tapEvent) = tap(currentState, creatureId)
             currentState = tappedState
-            tapEvent?.let(events::add)
+            tapEvent?.let {
+                events.add(it)
+                events.add(
+                    CrewOrSaddleContributionEvent(
+                        contributorId = creatureId,
+                        permanentId = action.mountId,
+                        controllerId = action.playerId
+                    )
+                )
+            }
         }
 
         // Record the saddlers so Mount payoffs can read "creatures that saddled it this turn".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1199,6 +1199,10 @@ is PermanentsSacrificedEvent -> {
                 isYours = event.playerId == viewingPlayerId
             )
 
+            // Internal trigger signal. The tap, activated ability, and resulting continuous effect
+            // already provide the player-visible narration and state change.
+            is CrewOrSaddleContributionEvent -> null
+
             is CardPlottedEvent -> ClientEvent.CardPlotted(
                 playerId = event.playerId,
                 cardName = event.cardName,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanyonVaulterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanyonVaulterScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.ScenarioTestBase.TestGame
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class CanyonVaulterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Canyon Vaulter") {
+            test("crewing a Vehicle during your main phase grants that Vehicle flying") {
+                val game = canyonGame(Step.PRECOMBAT_MAIN)
+                val vaulter = game.findPermanent("Canyon Vaulter")!!
+                val ferry = game.findPermanent("Spotcycle Scouter")!!
+
+                val crew = game.execute(CrewVehicle(game.player1Id, ferry, listOf(vaulter)))
+                withClue("crew should succeed: ${crew.error}") { crew.error shouldBe null }
+                game.resolveStack()
+
+                game.state.projectedState.hasKeyword(ferry, Keyword.FLYING) shouldBe true
+            }
+
+            test("crewing outside your main phase does not grant flying") {
+                val game = canyonGame(Step.DECLARE_ATTACKERS)
+                val vaulter = game.findPermanent("Canyon Vaulter")!!
+                val ferry = game.findPermanent("Spotcycle Scouter")!!
+
+                val crew = game.execute(CrewVehicle(game.player1Id, ferry, listOf(vaulter)))
+                withClue("crew should be legal at instant speed: ${crew.error}") {
+                    crew.error shouldBe null
+                }
+                game.resolveStack()
+
+                game.state.projectedState.hasKeyword(ferry, Keyword.FLYING) shouldBe false
+            }
+        }
+    }
+
+    private fun canyonGame(step: Step): TestGame = scenario()
+        .withPlayers("Player", "Opponent")
+        .withCardOnBattlefield(1, "Canyon Vaulter", summoningSickness = false)
+        .withCardOnBattlefield(1, "Spotcycle Scouter")
+        .withActivePlayer(1)
+        .withTurnNumber(3)
+        .inPhase(if (step == Step.PRECOMBAT_MAIN) Phase.PRECOMBAT_MAIN else Phase.COMBAT, step)
+        .build()
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessVelocitaurScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessVelocitaurScenarioTest.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class RecklessVelocitaurScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reckless Velocitaur") {
+            test("saddling a Mount during your main phase buffs that Mount and grants trample") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Reckless Velocitaur", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Alacrian Jaguar", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .withTurnNumber(3)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val velocitaur = game.findPermanent("Reckless Velocitaur")!!
+                val jaguar = game.findPermanent("Alacrian Jaguar")!!
+
+                val saddle = game.execute(SaddleMount(game.player1Id, jaguar, listOf(velocitaur)))
+                withClue("saddle should succeed: ${saddle.error}") { saddle.error shouldBe null }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                projected.getPower(jaguar) shouldBe 6
+                projected.getToughness(jaguar) shouldBe 4
+                projected.hasKeyword(jaguar, Keyword.TRAMPLE) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Canyon Vaulter and Reckless Velocitaur to Aetherdrift
- add atomic `Triggers.Crews` and `Triggers.Saddles` primitives plus generic `Triggers.or(...)` composition
- preserve the contributed-to Mount or Vehicle as `EffectTarget.TriggeringEntity` through a typed Crew/Saddle contribution event
- document the SDK additions and update the DFT snapshot
- add one scenario test file per card, covering both composition branches and the main-phase restriction

## Verification
Before the trigger-composition follow-up, the branch passed:
- `just check-card-printing "Canyon Vaulter"`
- `just check-card-printing "Reckless Velocitaur"`
- focused Canyon Vaulter and Reckless Velocitaur scenarios
- card snapshot and JSON round-trip tests
- `just test` (full suite)

Per request, local builds/tests were skipped for the follow-up composition commit; GitHub Actions is the verification authority for that revision. `git diff --check` passes.