### PR TITLE
Add Goddric and Ingenious Prodigy to Wilds of Eldraine

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GoddricCloakedReveler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/GoddricCloakedReveler.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.TransformPermanent
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goddric, Cloaked Reveler
+ * {1}{R}{R}
+ * Legendary Creature — Human Noble
+ * 3/3
+ *
+ * Haste
+ * Celebration — As long as two or more nonland permanents entered under your control this turn,
+ * Goddric is a Dragon with base power and toughness 4/4, flying, and
+ * "{R}: Dragons you control get +1/+0 until end of turn." He loses all other creature types.
+ *
+ * All four continuous changes share one Celebration gate. The subtype replacement is Layer 4,
+ * flying and the granted activated ability are Layer 6, and the base P/T change is Layer 7b. The
+ * granted ability snapshots the Dragons present when it resolves through ForEachInGroup.
+ */
+val GoddricCloakedReveler = card("Goddric, Cloaked Reveler") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Noble"
+    oracleText = "Haste\nCelebration — As long as two or more nonland permanents entered the " +
+        "battlefield under your control this turn, Goddric is a Dragon with base power and " +
+        "toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\" " +
+        "(It loses all other creature types.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.HASTE)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            condition = Conditions.Celebration,
+            ability = CompositeStaticAbility(
+                listOf(
+                    TransformPermanent(setSubtypes = setOf("Dragon"), filter = Filters.Self),
+                    SetBasePowerToughnessStatic(4, 4, Filters.Self),
+                    GrantKeyword(Keyword.FLYING, Filters.Self),
+                    GrantActivatedAbility(
+                        ability = ActivatedAbility(
+                            id = AbilityId.generate(),
+                            cost = Costs.Mana("{R}"),
+                            effect = Effects.ForEachInGroup(
+                                GroupFilter(GameObjectFilter.Creature.withSubtype("Dragon").youControl()),
+                                Effects.ModifyStats(1, 0, EffectTarget.Self),
+                            ),
+                            descriptionOverride = "{R}: Dragons you control get +1/+0 until end of turn.",
+                        ),
+                        filter = Filters.Self,
+                    ),
+                )
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "132"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg?1783915094"
+
+        ruling(
+            "2023-09-01",
+            "If an effect causes Goddric to lose all abilities during a turn in which it has " +
+                "already become a Dragon, he's still a Dragon creature with base power and " +
+                "toughness 4/4."
+        )
+        ruling(
+            "2023-09-01",
+            "Goddric's activated ability affects only Dragons you control at the time it resolves. " +
+                "Any Dragons that come under your control later in the turn won't be affected."
+        )
+        ruling(
+            "2023-09-01",
+            "Celebration abilities only care if two or more nonland permanents entered the " +
+                "battlefield under your control in a turn. They won't get more powerful if more " +
+                "than two permanents entered the battlefield under your control in a turn."
+        )
+        ruling(
+            "2023-09-01",
+            "The permanents that entered the battlefield don't need to remain on the battlefield " +
+                "or under your control. Celebration abilities are checking for past events, not " +
+                "the current game state."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IngeniousProdigy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/IngeniousProdigy.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Ingenious Prodigy
+ * {X}{U}
+ * Creature — Human Wizard
+ * 0/1
+ *
+ * Skulk
+ * This creature enters with X +1/+1 counters on it.
+ * At the beginning of your upkeep, if this creature has one or more +1/+1 counters on it, you may
+ * remove a +1/+1 counter from it. If you do, draw a card.
+ *
+ * Skulk is expressed by its rules text rather than a keyword badge: projected blocker power is
+ * compared with the Prodigy's projected power. The upkeep clause is an intervening-if condition,
+ * checked both when it would trigger and again on resolution. The optional effect keeps removing
+ * the counter and drawing the card in one yes/no branch.
+ */
+val IngeniousProdigy = card("Ingenious Prodigy") {
+    manaCost = "{X}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "Skulk (This creature can't be blocked by creatures with greater power.)\n" +
+        "This creature enters with X +1/+1 counters on it.\n" +
+        "At the beginning of your upkeep, if this creature has one or more +1/+1 counters on it, " +
+        "you may remove a +1/+1 counter from it. If you do, draw a card."
+    power = 0
+    toughness = 1
+
+    staticAbility {
+        ability = CantBeBlockedBy(
+            GameObjectFilter.Creature.powerGreaterThanEntity(EntityReference.Source)
+        )
+    }
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = DynamicAmount.CastX,
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.SourceHasCounter(CounterTypeFilter.PlusOnePlusOne)
+        effect = MayEffect(
+            Effects.Composite(
+                RemoveCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                Effects.DrawCards(1),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg?1783915119"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -6189,6 +6189,139 @@
     ]
 }
 
+// Goddric, Cloaked Reveler
+{
+    "name": "Goddric, Cloaked Reveler",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Haste\nCelebration — As long as two or more nonland permanents entered the battlefield under your control this turn, Goddric is a Dragon with base power and toughness 4/4, flying, and \"{R}: Dragons you control get +1/+0 until end of turn.\" (It loses all other creature types.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CompositeStaticAbility",
+                    "abilities": [
+                        {
+                            "type": "TransformPermanent",
+                            "setSubtypes": [
+                                "Dragon"
+                            ],
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "SetBasePowerToughnessStatic",
+                            "power": 4,
+                            "toughness": 4,
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "GrantActivatedAbility",
+                            "ability": {
+                                "id": "ability_1",
+                                "cost": {
+                                    "type": "CostAtomWrapper",
+                                    "atom": {
+                                        "type": "AtomMana",
+                                        "cost": "{R}"
+                                    }
+                                },
+                                "effect": {
+                                    "type": "ForEach",
+                                    "space": {
+                                        "type": "IterationSpace.Group",
+                                        "filter": {
+                                            "baseFilter": "creature Dragon ctrl:you"
+                                        }
+                                    },
+                                    "body": {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "target": "Self"
+                                    }
+                                },
+                                "descriptionOverride": "{R}: Dragons you control get +1/+0 until end of turn."
+                            },
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        }
+                    ]
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "NONLAND_PERMANENTS_ENTERED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe93ef82-51de-40ad-9b52-8f3fd11c144f.jpg?1783915094",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If an effect causes Goddric to lose all abilities during a turn in which it has already become a Dragon, he's still a Dragon creature with base power and toughness 4/4."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Goddric's activated ability affects only Dragons you control at the time it resolves. Any Dragons that come under your control later in the turn won't be affected."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Celebration abilities only care if two or more nonland permanents entered the battlefield under your control in a turn. They won't get more powerful if more than two permanents entered the battlefield under your control in a turn."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "The permanents that entered the battlefield don't need to remain on the battlefield or under your control. Celebration abilities are checking for past events, not the current game state."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Grabby Giant
 {
     "name": "Grabby Giant",
@@ -7989,6 +8122,93 @@
                 }
             }
         }
+    ]
+}
+
+// Ingenious Prodigy
+{
+    "name": "Ingenious Prodigy",
+    "manaCost": "{X}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Skulk (This creature can't be blocked by creatures with greater power.)\nThis creature enters with X +1/+1 counters on it.\nAt the beginning of your upkeep, if this creature has one or more +1/+1 counters on it, you may remove a +1/+1 counter from it. If you do, draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "RemoveCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "PLUS_ONE_PLUS_ONE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerGreaterThanEntity",
+                            "reference": "Source"
+                        }
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "CastX"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf224968-b676-40dd-83c1-a9ee2ceba574.jpg?1783915119"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoddricCloakedRevelerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoddricCloakedRevelerScenarioTest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class GoddricCloakedRevelerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the second nonland entry turns Goddric into a 4/4 flying Dragon") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Goddric, Cloaked Reveler")
+                .withCardsInHand(1, "Ornithopter", 2)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val goddric = game.findPermanent("Goddric, Cloaked Reveler")!!
+            game.state.projectedState.getPower(goddric) shouldBe 3
+
+            game.castSpell(1, "Ornithopter").error shouldBe null
+            game.resolveStack()
+            game.state.projectedState.getPower(goddric) shouldBe 3
+
+            game.castSpell(1, "Ornithopter").error shouldBe null
+            game.resolveStack()
+
+            game.state.projectedState.getPower(goddric) shouldBe 4
+            game.state.projectedState.getToughness(goddric) shouldBe 4
+            game.state.projectedState.getSubtypes(goddric) shouldBe setOf("Dragon")
+            game.state.projectedState.hasKeyword(goddric, Keyword.FLYING) shouldBe true
+            game.state.projectedState.hasKeyword(goddric, Keyword.HASTE) shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IngeniousProdigyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IngeniousProdigyScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class IngeniousProdigyScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("enters with X +1/+1 counters") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Ingenious Prodigy")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castXSpell(1, "Ingenious Prodigy", xValue = 2).error shouldBe null
+            game.resolveStack()
+
+            val prodigy = game.findPermanent("Ingenious Prodigy")!!
+            fun counterCount(): Int = game.state.getEntity(prodigy)
+                ?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+            counterCount() shouldBe 2
+        }
+
+        test("may remove a +1/+1 counter at upkeep to draw") {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Ingenious Prodigy")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+            repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+            val game = builder.build()
+
+            val prodigy = game.findPermanent("Ingenious Prodigy")!!
+            game.state = game.state.updateEntity(prodigy) {
+                it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+            }
+
+            fun counterCount(): Int = game.state.getEntity(prodigy)
+                ?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.resolveStack()
+            game.answerYesNo(true)
+            game.resolveStack()
+
+            counterCount() shouldBe 1
+            game.handSize(1) shouldBe 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Goddric, Cloaked Reveler with layer-correct Celebration transformation and granted Dragon pump ability
- implement Ingenious Prodigy with skulk, X counters, and its optional upkeep draw
- add one focused rules-engine scenario test per card and update the WOE snapshot

The remaining unimplemented WOE cards are more complex. Imodane was deliberately excluded because the current damage-trigger context does not retain a resolving spell’s target count after it leaves the stack; implementing it faithfully requires an engine feature rather than a card-only approximation.

## Verification
- `just test-class IngeniousProdigyScenarioTest`
- `just test-class GoddricCloakedRevelerScenarioTest`
- `just check-card-printing "Ingenious Prodigy"`
- `just check-card-printing "Goddric, Cloaked Reveler"`
- exact Scryfall image URLs return HTTP 200
- `just build`
- `git diff --check`