### PR TITLE
Add Laboratory Maniac to Innistrad Remastered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
+      - name: Upload card snapshot actuals
+        if: always() && matrix.name == 'content'
+        uses: actions/upload-artifact@v4
+        with:
+          name: card-snapshot-actuals
+          path: mtg-sets/build/snapshots-actual/
+
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,6 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
-      - name: Upload card snapshot actuals
-        if: always() && matrix.name == 'content'
-        uses: actions/upload-artifact@v4
-        with:
-          name: card-snapshot-actuals
-          path: mtg-sets/build/snapshots-actual/
-
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LaboratoryManiacReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LaboratoryManiacReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing of Laboratory Maniac; the canonical definition lives in ISD. */
+val LaboratoryManiacReprint = Printing(
+    oracleId = "aa286dd5-aa19-446d-9003-684d81eb57ca",
+    name = "Laboratory Maniac",
+    setCode = "INR",
+    collectorNumber = "71",
+    artist = "Jason Felix",
+    flavorText = "His mind whirled with grand plans, never thinking of what might happen if he were to succeed.",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a5be94c-08b8-4964-a79d-e22ea6e94be8.jpg?1783908162",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LaboratoryManiacReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/LaboratoryManiacReprint.kt
@@ -10,7 +10,6 @@ val LaboratoryManiacReprint = Printing(
     setCode = "INR",
     collectorNumber = "71",
     artist = "Jason Felix",
-    flavorText = "His mind whirled with grand plans, never thinking of what might happen if he were to succeed.",
     imageUri = "https://cards.scryfall.io/normal/front/7/a/7a5be94c-08b8-4964-a79d-e22ea6e94be8.jpg?1783908162",
     releaseDate = "2025-01-24",
     rarity = Rarity.UNCOMMON,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/LaboratoryManiac.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/LaboratoryManiac.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Exists
+import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Laboratory Maniac
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/2
+ *
+ * If you would draw a card while your library has no cards in it, you win the game instead.
+ */
+val LaboratoryManiac = card("Laboratory Maniac") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "If you would draw a card while your library has no cards in it, you win the game instead."
+
+    replacementEffect(
+        ReplaceDrawWithEffect(
+            replacementEffect = Effects.WinGame(),
+            restrictions = listOf(
+                Exists(
+                    player = Player.You,
+                    zone = Zone.LIBRARY,
+                    negate = true
+                )
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "61"
+        artist = "Jason Felix"
+        flavorText = "His mind whirled with grand plans, never thinking of what might happen if he were to succeed."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg?1783940974"
+
+        ruling(
+            "2021-03-19",
+            "If for some reason you can't win the game, you won't lose for having tried to draw a card " +
+                "from a library with no cards in it. The draw was still replaced."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/LaboratoryManiac.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/LaboratoryManiac.kt
@@ -4,8 +4,8 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Exists
 import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
+import com.wingedsheep.sdk.scripting.conditions.Exists
 import com.wingedsheep.sdk.scripting.references.Player
 
 /**

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2320,9 +2320,7 @@
         "replacementEffects": [
             {
                 "type": "ReplaceDrawWith",
-                "replacementEffect": {
-                    "type": "WinGame"
-                },
+                "replacementEffect": "WinGame",
                 "restrictions": [
                     {
                         "type": "Exists",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2306,6 +2306,52 @@
     ]
 }
 
+// Laboratory Maniac
+{
+    "name": "Laboratory Maniac",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "If you would draw a card while your library has no cards in it, you win the game instead.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "ReplaceDrawWith",
+                "replacementEffect": {
+                    "type": "WinGame"
+                },
+                "restrictions": [
+                    {
+                        "type": "Exists",
+                        "player": "You",
+                        "zone": "Library",
+                        "negate": true
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "RARE",
+        "artist": "Jason Felix",
+        "flavorText": "His mind whirled with grand plans, never thinking of what might happen if he were to succeed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/809205f3-acf5-4244-b360-09ce4ba76795.jpg?1783940974",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "If for some reason you can't win the game, you won't lose for having tried to draw a card from a library with no cards in it. The draw was still replaced."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Lantern Spirit
 {
     "name": "Lantern Spirit",


### PR DESCRIPTION
## Summary
- add Laboratory Maniac as a canonical Innistrad card
- add its Innistrad Remastered printing row
- model the empty-library draw replacement with existing SDK primitives

## Scope
The remaining INR backlog is dominated by cards requiring unsupported mechanics or new source-specific behavior (Madness, Splice, transform variants, soulbond, emerge, or per-source graveyard-cast limits). Per request, this PR keeps the batch smaller rather than approximating those cards.

## Verification
- `just check-card-printing "Laboratory Maniac"`
- `just check-backlog`
- `scripts/card-status --cards INR`
- `git diff --check`
- both exact Scryfall image URLs return HTTP 200
- full build/tests intentionally delegated to PR CI to avoid interfering with the local AI training run