### PR TITLE
Add Adrenaline Jockey and Rangers' Aetherhive

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3623,6 +3623,10 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   with `Effects.DealDamage(n, EffectTarget.PlayerRef(Player.TriggeringPlayer))` to punish the activator (Flamescroll
   Celebrant). Backed by `EventPattern.AbilityActivatedEvent(player)`.
 - `YouActivateAbility` — you activate an ability that isn't a mana ability (the `Player.You` form of the above).
+- `YouActivateExhaustAbility` — you activate an ability marked `isExhaust`. Backed by
+  `EventPattern.AbilityActivatedEvent(player = Player.You, requireExhaust = true)` and the activation event's
+  `isExhaust` flag. The event is emitted as soon as the exhaust ability is put on the stack, so the triggered
+  ability is stacked above it and resolves first (Adrenaline Jockey, Rangers' Aetherhive).
 - `youActivateAbilityTargeting(targetMatch)` — you activate an ability whose **chosen targets** satisfy
   `targetMatch`. Backed by `EventPattern.AbilityActivatedEvent(player, targetMatch)`: when `targetMatch != null`, the
   activated ability on the stack must have at least one chosen target matching it, so a non-targeting ability (e.g.

--- a/manual-scenarios/cards/a/adrenaline-jockey.json
+++ b/manual-scenarios/cards/a/adrenaline-jockey.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Racer",
+  "player2Name": "Rival",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Adrenaline Jockey"},
+      {"name": "Prowcatcher Specialist", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/r/rangers-aetherhive.json
+++ b/manual-scenarios/cards/r/rangers-aetherhive.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Racer",
+  "player2Name": "Rival",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Rangers' Aetherhive"},
+      {"name": "Prowcatcher Specialist", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1171,6 +1171,12 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
+    /** Whenever you activate an exhaust ability. */
+    val YouActivateExhaustAbility: TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(player = Player.You, requireExhaust = true),
+        binding = TriggerBinding.ANY
+    )
+
     /**
      * Whenever this creature crews a Vehicle. The Vehicle is available to the effect as
      * `EffectTarget.TriggeringEntity`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1742,7 +1742,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         val player: Player = Player.You,
         val targetMatch: com.wingedsheep.sdk.scripting.events.AbilityTargetMatch? = null,
         val sourceFilter: GameObjectFilter? = null,
-        val requireNoTapInCost: Boolean = false
+        val requireNoTapInCost: Boolean = false,
+        val requireExhaust: Boolean = false,
     ) : EventPattern {
         override val description: String = buildString {
             append(player.description)
@@ -1759,6 +1760,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
                     append("targets a ")
                     append(targetMatch.description)
                 }
+                requireExhaust -> append("is an exhaust ability")
                 requireNoTapInCost -> append("doesn't have {T} in its activation cost")
                 else -> append("isn't a mana ability")
             }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AdrenalineJockey.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AdrenalineJockey.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adrenaline Jockey — Aetherdrift #112
+ * {2}{R} · Creature — Minotaur Pilot · 3/3
+ */
+val AdrenalineJockey = card("Adrenaline Jockey") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Pilot"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever a player casts a spell, if it's not their turn, this creature deals 4 " +
+        "damage to them.\nWhenever you activate an exhaust ability, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerCastsSpell
+        triggerCondition = Conditions.Not(Conditions.IsPlayersTurn(Player.TriggeringPlayer))
+        effect = Effects.DealDamage(4, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouActivateExhaustAbility
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Alfonso Santano"
+        flavorText = "\"Either I win or we both lose. Take your pick.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg?1783907888"
+
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns, it becomes a new object, so its exhaust ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "An ability that triggers when you activate an exhaust ability resolves before that exhaust ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RangersAetherhive.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RangersAetherhive.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rangers' Aetherhive — Aetherdrift #217
+ * {1}{G}{U} · Artifact — Vehicle · 3/5
+ */
+val RangersAetherhive = card("Rangers' Aetherhive") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 5
+    oracleText = "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless " +
+        "Thopter artifact creature token with flying.\nCrew 1"
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.YouActivateExhaustAbility
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Thopter"),
+            keywords = setOf(Keyword.FLYING),
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677",
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Josiah \"Jo\" Cameron"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg?1783907854"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -91,6 +91,86 @@
     ]
 }
 
+// Adrenaline Jockey
+{
+    "name": "Adrenaline Jockey",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Pilot",
+    "oracleText": "Whenever a player casts a spell, if it's not their turn, this creature deals 4 damage to them.\nWhenever you activate an exhaust ability, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "IsPlayersTurn",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "requireExhaust": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Alfonso Santano",
+        "flavorText": "\"Either I win or we both lose. Take your pick.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8655373-320d-440d-b700-d03413f743fd.jpg?1783907888",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns, it becomes a new object, so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "An ability that triggers when you activate an exhaust ability resolves before that exhaust ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Aether Syphon
 {
     "name": "Aether Syphon",
@@ -10981,6 +11061,65 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/0/50bae2ba-a6a0-4a6a-96e9-0e0372e55108.jpg?1783907847"
     },
     "colorIdentityOverride": []
+}
+
+// Rangers' Aetherhive
+{
+    "name": "Rangers' Aetherhive",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Vigilance\nWhenever you activate an exhaust ability, create a 1/1 colorless Thopter artifact creature token with flying.\nCrew 1",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "requireExhaust": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/3/d38fc294-ad86-441e-96fe-4ca286a11218.jpg?1783907677",
+                    "artifactToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Josiah \"Jo\" Cameron",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b238d2c-d10f-496d-aa34-5a1536e056b5.jpg?1783907854"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
 }
 
 // Reckless Velocitaur

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -67,6 +67,7 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // the payoff is renderable (else SCAFFOLD).
     supported("AtTheBeginningOfCombatDuringAPlayersTurn", "trigger: beginning of combat on your turn (Triggers.BeginCombat)")
     supported("WhenAPlayerCastsASpell", "trigger: a player casts a spell (Triggers.YouCastSpell / AnyPlayerCastsSpell / OpponentCastsSpell + type filters)")
+    supported("WhenAPlayerActivatesAnAbility", "trigger: you activate an exhaust ability (Triggers.YouActivateExhaustAbility)")
     supported("WhenAPlayerCastsTheirNthSpellInATurn", "trigger: you cast your Nth spell each turn (Triggers.NthSpellCast(N, Player.You) — Rodeo Pyromancers)")
     // Breeches, the Blastmaker stays a DELIBERATE DECLINE — its second-spell payoff (NthSpellCast above)
     // is a `MayCost(sacrifice an artifact)`-gated `FlipACoin_OnWinAndLose` that sets up two reflexive

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3133,6 +3133,18 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
         return castTriggerDsl(scope, category)
     }
 
+    // "Whenever you activate an exhaust ability". Render only the exact You + ExhaustAbility
+    // shape; other activation filters decline rather than widening to every activated ability.
+    if (jsonContains(trig, "_Trigger", "WhenAPlayerActivatesAnAbility")) {
+        val argv = trig["args"].asArr
+        val scope = castScope(argv?.getOrNull(0) as? JsonObject)
+        val abilityFilter = argv?.getOrNull(1) as? JsonObject
+        if (scope == CastScope.YOU && abilityFilter?.strField("_ActivatedAbilities") == "ExhaustAbility") {
+            return "Triggers.YouActivateExhaustAbility"
+        }
+        return null
+    }
+
     // "Whenever you commit a crime" — WhenAPlayerCommitsACrime scoped to SinglePlayer(You). Only the
     // You scope maps to Triggers.YouCommitCrime; any other player scope (AnyPlayer / Opponent) has no
     // matching Triggers.* constant yet, so it declines -> SCAFFOLD. Pairs with the TriggerOnceEachTurn

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -565,7 +565,8 @@ data class AbilityActivatedEvent(
     val controllerId: EntityId,
     val abilityEntityId: EntityId? = null,
     val costsTap: Boolean = false,
-    val isManaAbility: Boolean = false
+    val isManaAbility: Boolean = false,
+    val isExhaust: Boolean = false,
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -140,7 +140,11 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                 if (!matcher.matchesPlayer(trigger.player, event.controllerId, auraControllerId)) return false
                 // Mirror the main matcher's two wordings (see TriggerMatcher.AbilityActivatedEvent):
                 // "without {T} in its activation cost" vs. "isn't a mana ability".
-                if (trigger.requireNoTapInCost) !event.costsTap else !event.isManaAbility
+                when {
+                    trigger.requireExhaust -> event.isExhaust
+                    trigger.requireNoTapInCost -> !event.costsTap
+                    else -> !event.isManaAbility
+                }
             }
             is EventPattern.TurnFaceUpEvent -> {
                 event is TurnFaceUpEvent && event.entityId == attachedEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -263,7 +263,9 @@ class TriggerMatcher(
             is EventPattern.AbilityActivatedEvent -> {
                 if (event !is AbilityActivatedEvent) return false
                 if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
-                if (trigger.requireNoTapInCost) {
+                if (trigger.requireExhaust) {
+                    if (!event.isExhaust) return false
+                } else if (trigger.requireNoTapInCost) {
                     // Antiquities "activates an ability without {T} in its activation cost"
                     // (Haunting Wind / Powerleech / Artifact Possession). Match any activated
                     // ability whose cost lacks {T} — mana abilities without {T} count too.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1733,6 +1733,7 @@ class ActivateAbilityHandler(
             currentState, abilityOnStack, action.targets,
             targetRequirements = effectiveTargetReqs,
             costsTap = hasTapCost(effectiveCost),
+            isExhaust = ability.isExhaust,
             cantBeCopied = ability.cantBeCopied
         )
         currentState = stackResult.newState
@@ -1822,7 +1823,8 @@ class ActivateAbilityHandler(
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(
                     currentState, repeatAbilityOnStack, action.targets,
-                    targetRequirements = effectiveTargetReqs
+                    targetRequirements = effectiveTargetReqs,
+                    isExhaust = ability.isExhaust,
                 )
                 currentState = repeatStackResult.newState
                 events.addAll(repeatStackResult.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -649,6 +649,7 @@ class StackResolver(
         targetRequirements: List<TargetRequirement> = emptyList(),
         emitActivationEvent: Boolean = true,
         costsTap: Boolean = false,
+        isExhaust: Boolean = false,
         cantBeCopied: Boolean = false
     ): ExecutionResult {
         val (abilityId, stateWithId) = state.newEntity()
@@ -681,7 +682,8 @@ class StackResolver(
                     ability.controllerId,
                     abilityEntityId = abilityId,
                     costsTap = costsTap,
-                    isManaAbility = false
+                    isManaAbility = false,
+                    isExhaust = isExhaust,
                 )
             )
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdrenalineJockeyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdrenalineJockeyScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario coverage for Adrenaline Jockey's exhaust-activation trigger. */
+class AdrenalineJockeyScenarioTest : ScenarioTestBase() {
+    private val ordinaryActivator = card("Ordinary Activator") {
+        manaCost = "{1}"
+        typeLine = "Artifact Creature — Construct"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Mana("{0}")
+            effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        }
+    }
+
+    init {
+        cardRegistry.register(ordinaryActivator)
+
+        test("activating an exhaust ability puts a counter on Adrenaline Jockey") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Adrenaline Jockey")
+                .withCardOnBattlefield(1, "Prowcatcher Specialist", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val jockey = game.findPermanent("Adrenaline Jockey")!!
+            val specialist = game.findPermanent("Prowcatcher Specialist")!!
+            val exhaust = cardRegistry.getCard("Prowcatcher Specialist")!!
+                .script.activatedAbilities.single { it.isExhaust }
+
+            val activation = game.execute(ActivateAbility(game.player1Id, specialist, exhaust.id))
+            withClue("the exhaust activation should be legal: ${activation.error}") {
+                activation.error shouldBe null
+            }
+            game.resolveStack()
+
+            val counters = game.state.getEntity(jockey)!!.get<CountersComponent>()!!.counters
+            counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 1
+        }
+
+        test("activating an ordinary ability does not trigger Adrenaline Jockey") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Adrenaline Jockey")
+                .withCardOnBattlefield(1, "Ordinary Activator", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val jockey = game.findPermanent("Adrenaline Jockey")!!
+            val activator = game.findPermanent("Ordinary Activator")!!
+            val ability = cardRegistry.getCard("Ordinary Activator")!!.script.activatedAbilities.single()
+
+            game.execute(ActivateAbility(game.player1Id, activator, ability.id)).error shouldBe null
+            game.resolveStack()
+
+            val counters = game.state.getEntity(jockey)!!.get<CountersComponent>()?.counters.orEmpty()
+            counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RangersAetherhiveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RangersAetherhiveScenarioTest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario coverage for Rangers' Aetherhive's exhaust-activation trigger. */
+class RangersAetherhiveScenarioTest : ScenarioTestBase() {
+    init {
+        test("activating an exhaust ability creates a flying Thopter") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Rangers' Aetherhive")
+                .withCardOnBattlefield(1, "Prowcatcher Specialist", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val specialist = game.findPermanent("Prowcatcher Specialist")!!
+            val exhaust = cardRegistry.getCard("Prowcatcher Specialist")!!
+                .script.activatedAbilities.single { it.isExhaust }
+
+            val activation = game.execute(ActivateAbility(game.player1Id, specialist, exhaust.id))
+            withClue("the exhaust activation should be legal: ${activation.error}") {
+                activation.error shouldBe null
+            }
+            game.resolveStack()
+
+            game.findPermanents("Thopter Token").size shouldBe 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Adrenaline Jockey and Rangers' Aetherhive to Aetherdrift
- add a reusable exhaust-activation trigger carried by AbilityActivatedEvent
- teach mtgish emission about the exact you-activate-an-exhaust-ability shape
- add one scenario test and one manual DevScenario fixture per card

## Verification
- `just check-card-printing "Adrenaline Jockey"`
- `just check-card-printing "Rangers' Aetherhive"`
- `just check-backlog`
- `just rebless-cards` (DFT snapshot adds only these two cards)
- card and token image URLs return HTTP 200
- `git diff --check`

Per request, local test suites were not run because AI training is active locally; PR CI is the test workflow for this change.