### PR TITLE
Add two Aetherdrift exhaust cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: generated-dft-snapshot
-          path: mtg-sets/build/snapshots-actual/DFT.json
+          path: mtg-sets/build/snapshots-actual/snapshots/cards/DFT.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
+      - name: Upload generated card snapshot
+        if: failure() && matrix.name == 'content'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-dft-snapshot
+          path: mtg-sets/build/snapshots-actual/DFT.json
+
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,6 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
-      - name: Upload generated card snapshot
-        if: failure() && matrix.name == 'content'
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated-dft-snapshot
-          path: mtg-sets/build/snapshots-actual/snapshots/cards/DFT.json
-
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AfterburnerExpert.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AfterburnerExpert.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Afterburner Expert — Aetherdrift #150
+ * {2}{G} · Creature — Goblin Artificer · 4/2
+ *
+ * Its second ability functions from the graveyard. It triggers as soon as any exhaust ability you
+ * control is activated, so the Expert returns before that exhaust ability resolves.
+ */
+val AfterburnerExpert = card("Afterburner Expert") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Goblin Artificer"
+    power = 4
+    toughness = 2
+    oracleText = "Exhaust — {2}{G}{G}: Put two +1/+1 counters on this creature. " +
+        "(Activate each exhaust ability only once.)\n" +
+        "Whenever you activate an exhaust ability, return this card from your graveyard to the battlefield."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}{G}")
+        isExhaust = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        description = "Exhaust — {2}{G}{G}: Put two +1/+1 counters on this creature."
+    }
+
+    triggeredAbility {
+        triggerZone = Zone.GRAVEYARD
+        trigger = Triggers.YouActivateExhaustAbility
+        effect = Effects.Move(EffectTarget.Self, Zone.BATTLEFIELD)
+        description = "Whenever you activate an exhaust ability, return this card from your " +
+            "graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "April Prime"
+        flavorText = "Speedbump has miraculously survived ninety-nine rocket crashes, and he's " +
+            "aiming for an even hundred."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg?1783907875"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RangersRefueler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RangersRefueler.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rangers' Refueler — Aetherdrift #55
+ * {1}{U} · Artifact — Vehicle · 3/3
+ *
+ * The exhaust ability animates the Vehicle permanently; crew can still animate it until end of turn
+ * before the exhaust ability is used.
+ */
+val RangersRefueler = card("Rangers' Refueler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you activate an exhaust ability, draw a card.\n" +
+        "Exhaust — {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. " +
+        "(Activate each exhaust ability only once.)\n" +
+        "Crew 2"
+
+    triggeredAbility {
+        trigger = Triggers.YouActivateExhaustAbility
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 3,
+                toughness = 3,
+                duration = Duration.Permanent,
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "Exhaust — {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it."
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Samuel Perin"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg?1783907906"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -337,6 +337,84 @@
     "colorIdentityOverride": []
 }
 
+// Afterburner Expert
+{
+    "name": "Afterburner Expert",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Goblin Artificer",
+    "oracleText": "Exhaust — {2}{G}{G}: Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)\nWhenever you activate an exhaust ability, return this card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "requireExhaust": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield"
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "Whenever you activate an exhaust ability, return this card from your graveyard to the battlefield."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {2}{G}{G}: Put two +1/+1 counters on this creature.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "April Prime",
+        "flavorText": "Speedbump has miraculously survived ninety-nine rocket crashes, and he's aiming for an even hundred.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/555e1bfc-6d07-4979-a914-b2bd1fb031f2.jpg?1783907875",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Agonasaur Rex
 {
     "name": "Agonasaur Rex",
@@ -11118,6 +11196,110 @@
     },
     "colorIdentityOverride": [
         "GREEN",
+        "BLUE"
+    ]
+}
+
+// Rangers' Refueler
+{
+    "name": "Rangers' Refueler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever you activate an exhaust ability, draw a card.\nExhaust — {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it. (Activate each exhaust ability only once.)\nCrew 2",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "requireExhaust": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {4}: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "UNCOMMON",
+        "artist": "Samuel Perin",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67d2d713-8acb-4e3d-bd1d-0416fe9b9ef6.jpg?1783907906",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }


### PR DESCRIPTION
## Summary

- Afterburner Expert: composes the existing exhaust marker, counter effect, graveyard-active trigger, and self-move effect.
- Rangers’ Refueler: composes the existing exhaust trigger, card draw, permanent Vehicle animation, counter effect, and crew ability.

The batch was intentionally limited to two cards because the remaining unimplemented Aetherdrift cards need more complex cost modification, activated-ability copying, multi-zone selection, or X-dependent cycling support.

## Verification

- GitHub PR CI passed: frontend, content, engine, server, tools, and aggregate backend checks.
- The DFT golden snapshot was generated remotely and contains changes only for these two cards.
- Scryfall metadata, Oracle text, rulings, earliest-printing placement, and image URLs were checked for both cards.
- Local heavy tests were not run because AI training is active on the development machine.
- No manual web-client playthrough or e2e test was performed; both cards use existing decision/UX paths.