### PR TITLE
Add Full Throttle to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4131,6 +4131,11 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
     - `NEXT_TURN` — stricter "on your next turn"-style timing: the current turn never qualifies
       regardless of step. Pair with `fireOnPlayer = PlayerRef(Player.You)` to land on the
       controller's upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
+  - `repeatAtEachMatchingStep = true` keeps a step-based delayed trigger resident after it fires,
+    repeating at every matching step until `expiry` removes it. The default is `false`, preserving
+    the one-shot "at the beginning of the next ..." shape. Pair with
+    `expiry = DelayedTriggerExpiry.EndOfTurn` for "at the beginning of each [step] this turn"
+    (Full Throttle uses `step = BEGIN_COMBAT`).
 - **Event-based delayed triggers** — pass `trigger = <TriggerSpec>` (instead of `step`) and the
   delayed ability fires whenever a matching *event* occurs, staying resident until `expiry`
   (`DelayedTriggerExpiry.EndOfTurn`) removes it. Supported events include `DealsDamageEvent`,

--- a/manual-scenarios/cards/f/full-throttle.json
+++ b/manual-scenarios/cards/f/full-throttle.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Full Throttle"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Hill Giant", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -720,6 +720,12 @@ data class CreateDelayedTriggerEffect(
      */
     val fireOnce: Boolean = false,
     /**
+     * For step-based delayed triggers: keep the trigger resident after it fires so it repeats at
+     * every matching step until [expiry]. The default preserves the ordinary one-shot "at the
+     * beginning of the next ..." shape.
+     */
+    val repeatAtEachMatchingStep: Boolean = false,
+    /**
      * The earliest turn this step-based delayed trigger may fire. See
      * [DelayedTriggerTiming]. Orthogonal to [fireOnPlayer], which gates *whose* turn the
      * trigger fires on (not *which* turn is the earliest eligible one).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FullThrottle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FullThrottle.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Full Throttle — Aetherdrift #127
+ * {4}{R}{R} · Sorcery
+ *
+ * The additional combats are gated on being in either player's main phase: the spell's ruling says
+ * the untap trigger is still installed when it resolves outside a main phase, but no combats are
+ * added. The repeating delayed trigger expires at cleanup and untaps only surviving permanents that
+ * attacked earlier in the turn.
+ */
+val FullThrottle = card("Full Throttle") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "After this main phase, there are two additional combat phases.\n" +
+        "At the beginning of each combat this turn, untap all creatures that attacked this turn."
+
+    spell {
+        effect = Effects.Composite(
+            ConditionalEffect(
+                condition = Conditions.IsInPhase(
+                    Phase.PRECOMBAT_MAIN,
+                    Phase.POSTCOMBAT_MAIN,
+                    yoursOnly = false,
+                ),
+                effect = Effects.Composite(Effects.AddCombatPhase, Effects.AddCombatPhase),
+            ),
+            CreateDelayedTriggerEffect(
+                step = Step.BEGIN_COMBAT,
+                effect = Patterns.Group.untapGroup(
+                    GroupFilter(GameObjectFilter.Creature.attackedThisTurn())
+                ),
+                repeatAtEachMatchingStep = true,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Benjamin Ee"
+        flavorText = "\"You wanted a fight. Now you've got two.\"\n—Chandra Nalaar"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg?1783907882"
+
+        ruling(
+            "2025-02-07",
+            "There is no main phase between the two additional combat phases. If you cast this " +
+                "during your second main phase, you will go directly to the end step after the two " +
+                "additional combat phases are complete."
+        )
+        ruling(
+            "2025-02-07",
+            "If you somehow cast this spell when it's not a main phase, the second ability still " +
+                "takes effect, but there are no additional combat phases this turn. If you cast it " +
+                "during an opponent's main phase, there are two additional combat phases, but that " +
+                "opponent gets to attack during those combat phases, not you."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -5039,6 +5039,88 @@
     ]
 }
 
+// Full Throttle
+{
+    "name": "Full Throttle",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "After this main phase, there are two additional combat phases.\nAt the beginning of each combat this turn, untap all creatures that attacked this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "IsInPhase",
+                            "phases": [
+                                "PRECOMBAT_MAIN",
+                                "POSTCOMBAT_MAIN"
+                            ],
+                            "yoursOnly": false
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            "AddCombatPhase",
+                            "AddCombatPhase"
+                        ]
+                    }
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "step": "BEGIN_COMBAT",
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        "AttackedThisTurn"
+                                    ]
+                                }
+                            }
+                        },
+                        "body": {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        }
+                    },
+                    "repeatAtEachMatchingStep": true
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Benjamin Ee",
+        "flavorText": "\"You wanted a fight. Now you've got two.\"\n—Chandra Nalaar",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d91f7cad-89e8-45cb-a78e-b35b0ee64783.jpg?1783907882",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "There is no main phase between the two additional combat phases. If you cast this during your second main phase, you will go directly to the end step after the two additional combat phases are complete."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If you somehow cast this spell when it's not a main phase, the second ability still takes effect, but there are no additional combat phases this turn. If you cast it during an opponent's main phase, there are two additional combat phases, but that opponent gets to attack during those combat phases, not you."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Gallant Strike
 {
     "name": "Gallant Strike",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -925,8 +925,9 @@ class CleanupPhaseManager(
             )
         }
 
-        // 10. Expire event-based delayed triggered abilities with EndOfTurn expiry
-        // (e.g., Long River Lurker's "whenever that creature deals combat damage this turn").
+        // 10. Expire delayed triggered abilities with EndOfTurn expiry. This covers event-based
+        // triggers and repeating step-based triggers such as "at the beginning of each combat this
+        // turn"; ordinary one-shot step triggers are consumed when they fire.
         if (newState.delayedTriggers.isNotEmpty()) {
             val remainingDelayed = newState.delayedTriggers.filter { delayed ->
                 delayed.expiry !is DelayedTriggerExpiry.EndOfTurn

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -56,6 +56,8 @@ data class DelayedTriggeredAbility(
      * every matching event until [expiry] removes it.
      */
     val fireOnce: Boolean = false,
+    /** Whether a step-based delayed trigger remains resident after each matching step. */
+    val repeatAtEachMatchingStep: Boolean = false,
     /** If set, this trigger won't fire before this turn number. Used for "your next end step" effects. */
     val notBeforeTurn: Int? = null,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -478,7 +478,7 @@ class TriggerDetector(
                 )
             )
         }
-        val consumedIds = matching.map { it.id }.toSet()
+        val consumedIds = matching.filterNot { it.repeatAtEachMatchingStep }.map { it.id }.toSet()
         return matcher.sortByApnapOrder(state, triggers) to consumedIds
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -137,8 +137,9 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             trigger = resolvedTrigger,
             watchedEntityId = watchedEntityId,
             watchedRecipientId = watchedRecipientId,
-            expiry = if (effect.trigger != null) effect.expiry else null,
+            expiry = if (effect.trigger != null || effect.repeatAtEachMatchingStep) effect.expiry else null,
             fireOnce = effect.trigger != null && effect.fireOnce,
+            repeatAtEachMatchingStep = effect.trigger == null && effect.repeatAtEachMatchingStep,
             notBeforeTurn = notBeforeTurn,
             targetRequirement = effect.targetRequirement,
             fireOnPlayerId = fireOnPlayerId

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FullThrottleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FullThrottleScenarioTest.kt
@@ -65,6 +65,7 @@ class FullThrottleScenarioTest : FunSpec({
         driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe true
 
         // First additional combat: the delayed trigger untaps the creature at beginning of combat.
+        driver.passPriorityUntil(Step.END_COMBAT)
         driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
         driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe false
         driver.state.delayedTriggers.size shouldBe 1
@@ -74,9 +75,9 @@ class FullThrottleScenarioTest : FunSpec({
         driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe true
 
         // Second additional combat: the same resident delayed trigger fires again.
+        driver.passPriorityUntil(Step.END_COMBAT)
         driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
         driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe false
-        driver.state.delayedTriggers.size shouldBe 1
     }
 
     test("repeating combat trigger expires at end of turn") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FullThrottleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FullThrottleScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.state.components.player.ExtraPhaseKind
+import com.wingedsheep.engine.state.components.player.QueuedPhase
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dft.cards.FullThrottle
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Full Throttle and its repeating beginning-of-combat delayed trigger. */
+class FullThrottleScenarioTest : FunSpec({
+
+    val testDriver = card("Full Throttle Test Driver") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Human Pilot"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FullThrottle, testDriver))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    test("adds two combats and untaps prior attackers at each additional combat") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        val creature = driver.putCreatureOnBattlefield(attacker, "Full Throttle Test Driver")
+        driver.removeSummoningSickness(creature)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(attacker, Color.RED, 6)
+        val fullThrottle = driver.putCardInHand(attacker, "Full Throttle")
+        driver.castSpell(attacker, fullThrottle).isSuccess shouldBe true
+        driver.resolveStack()
+
+        driver.state.getEntity(attacker)?.get<AdditionalPhasesComponent>() shouldBe
+            AdditionalPhasesComponent(
+                listOf(QueuedPhase(ExtraPhaseKind.COMBAT), QueuedPhase(ExtraPhaseKind.COMBAT))
+            )
+        driver.state.delayedTriggers.single().repeatAtEachMatchingStep shouldBe true
+
+        // Natural combat: attack and remain tapped through the rest of this combat.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(creature), defender)
+        driver.resolveStack()
+        driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe true
+
+        // First additional combat: the delayed trigger untaps the creature at beginning of combat.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe false
+        driver.state.delayedTriggers.size shouldBe 1
+
+        driver.declareAttackers(attacker, listOf(creature), defender)
+        driver.resolveStack()
+        driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe true
+
+        // Second additional combat: the same resident delayed trigger fires again.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.getEntity(creature)?.has<TappedComponent>() shouldBe false
+        driver.state.delayedTriggers.size shouldBe 1
+    }
+
+    test("repeating combat trigger expires at end of turn") {
+        val driver = createDriver()
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(caster, Color.RED, 6)
+        driver.castSpell(caster, driver.putCardInHand(caster, "Full Throttle"))
+        driver.resolveStack()
+        driver.state.delayedTriggers.size shouldBe 1
+
+        val startTurn = driver.state.turnNumber
+        var guard = 0
+        while (driver.state.turnNumber == startTurn && guard < 400) {
+            driver.bothPass()
+            guard++
+        }
+
+        driver.state.delayedTriggers.size shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary
- add a rules-faithful Full Throttle card definition for Aetherdrift
- add an opt-in repeating step-based delayed trigger for "at the beginning of each combat this turn"
- add a dedicated scenario test and manual client scenario
- document the delayed-trigger SDK addition

The remaining Aetherdrift backlog is mechanics-heavy, so this batch intentionally contains one card rather than approximating unsupported behavior.

## Verification
- `just check-card-printing "Full Throttle"`
- Scryfall image URL returns HTTP 200
- `git diff --check`
- heavy build and test gates run through this PRs GitHub Actions workflow to avoid competing with local AI training

## Player experience
Cast Full Throttle in a main phase, then attack in the natural combat and both bonus combats. At each beginning-of-combat step, creatures that attacked earlier this turn untap automatically; no new decision UI is required.