### PR TITLE
Add Agatha and The End to Wilds of Eldraine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  snapshot-refresh:
-    if: github.head_ref == 'codex/woe-cards-handful-aug01-12'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
-      - name: Refresh card snapshots
-        run: ./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
-      - name: Upload refreshed snapshots
-        uses: actions/upload-artifact@v7
-        with:
-          name: refreshed-card-snapshots
-          path: |
-            mtg-sets/src/test/resources/snapshots/cards/ATQ.json
-            mtg-sets/src/test/resources/snapshots/cards/WOE.json
-            mtg-sets/src/test/resources/snapshots/cards/TMT.json
-
   # Backend tests run as parallel jobs, one per module group, instead of a single monolithic
   # `./gradlew build`. The old single job serialized the two largest suites (game-server + rules-engine)
   # to the end on one runner; splitting them onto separate runners makes wall-clock ≈ the slowest group

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  snapshot-refresh:
+    if: github.head_ref == 'codex/woe-cards-handful-aug01-12'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Refresh card snapshots
+        run: ./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
+      - name: Upload refreshed snapshots
+        uses: actions/upload-artifact@v7
+        with:
+          name: refreshed-card-snapshots
+          path: |
+            mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+            mtg-sets/src/test/resources/snapshots/cards/WOE.json
+            mtg-sets/src/test/resources/snapshots/cards/TMT.json
+
   # Backend tests run as parallel jobs, one per module group, instead of a single monolithic
   # `./gradlew build`. The old single job serialized the two largest suites (game-server + rules-engine)
   # to the end on one runner; splitting them onto separate runners makes wall-clock ≈ the slowest group

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4975,13 +4975,16 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   `CreateTokenCopyOfTargetEffect.addedStaticAbilities`), the equip-cost reader unions
   `grantedStaticAbilities` with printed statics.
 - `ReduceActivatedAbilityCost(filter, amount, manaFloor = 0)` — the activated abilities of permanents
-  matching `filter` cost `{amount}` generic mana less to activate, with the mana in each cost floored
+  matching `filter` cost the dynamic `amount` of generic mana less to activate, with the mana in each
+  cost floored
   at `manaFloor` *total* mana (generic + colored). The activated-ability sibling of `ReduceEquipCost`,
   generalized over a `GroupFilter`: `GroupFilter.attachedCreature()` keys it to an Aura's enchanted
   permanent (Power Artifact: "Enchanted artifact's activated abilities cost {2} less to activate. This
   effect can't reduce the mana in that cost to less than one mana." → `ReduceActivatedAbilityCost(
-  GroupFilter.attachedCreature(), amount = 2, manaFloor = 1)`); `GroupFilter.source()` for "this
-  permanent's abilities"; a battlefield filter for a group lord. Generic-only (colored/hybrid pips
+  GroupFilter.attachedCreature(), amount = DynamicAmount.Fixed(2), manaFloor = 1)`);
+  `GroupFilter.source()` for "this permanent's abilities"; a battlefield filter for a group lord.
+  `DynamicAmounts.sourcePower()` models Agatha of the Vile Cauldron's reduction by her current
+  projected power. Generic-only (colored/hybrid pips
   untouched, CR 118.7); with `manaFloor = 1` a `{1}` ability stays `{1}`, `{3}`→`{1}`, `{2}{U}`→`{U}`.
   `manaFloor = 0` (default) floors at `{0}`. Reductions stack additively; the most restrictive
   (largest) `manaFloor` wins. Consulted by `CastPermissionUtils.applyActivatedAbilityCostReduction`

--- a/manual-scenarios/cards/a/agatha-of-the-vile-cauldron.json
+++ b/manual-scenarios/cards/a/agatha-of-the-vile-cauldron.json
@@ -1,0 +1,47 @@
+{
+  "player1Name": "Agatha",
+  "player2Name": "Adversary",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Agatha of the Vile Cauldron",
+        "counters": {
+          "PLUS_ONE_PLUS_ONE": 2
+        }
+      },
+      {
+        "name": "Toadstool Admirer"
+      },
+      {
+        "name": "Grizzly Bears"
+      },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Mountain" },
+      { "name": "Mountain" }
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Grizzly Bears"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      { "name": "Grizzly Bears" }
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -815,11 +816,12 @@ sealed interface UnlockCostTarget {
  * generalized so one type covers the family:
  *  - **Power Artifact** ("Enchanted artifact's activated abilities cost {2} less to activate. This
  *    effect can't reduce the mana in that cost to less than one mana.") →
- *    `ReduceActivatedAbilityCost(GroupFilter.attachedCreature(), amount = 2, manaFloor = 1)`. The
+ *    `ReduceActivatedAbilityCost(GroupFilter.attachedCreature(), amount = DynamicAmount.Fixed(2), manaFloor = 1)`. The
  *    `attachedCreature()` scope resolves to the enchanted permanent, so the reduction keys to the
  *    artifact this Aura is attached to.
- *  - A future "your creatures' activated abilities cost {1} less" lord →
- *    `ReduceActivatedAbilityCost(GroupFilter(GameObjectFilter.Creature.youControl()), amount = 1)`.
+ *  - A "your creatures' activated abilities cost {X} less, where X is this creature's power" lord →
+ *    `ReduceActivatedAbilityCost(GroupFilter(GameObjectFilter.Creature.youControl()),
+ *    amount = DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power))`.
  *
  * Only the **generic** portion of the ability's mana cost is reduced; colored/hybrid/Phyrexian pips
  * are untouched (CR 118.7). [manaFloor] is the minimum *total* mana the cost may be reduced to: with
@@ -831,19 +833,22 @@ sealed interface UnlockCostTarget {
  * @property filter Which permanents' activated abilities are cheaper (matched via projected state;
  *   use [GroupFilter.attachedCreature] for an Aura's enchanted permanent, [GroupFilter.source] for
  *   "this permanent's abilities", or a battlefield filter for a group).
- * @property amount Generic-mana reduction applied to each matching ability's cost.
+ * @property amount Dynamic generic-mana reduction applied to each matching ability's cost.
  * @property manaFloor Minimum total mana the cost may be reduced to (default 0).
  */
 @SerialName("ReduceActivatedAbilityCost")
 @Serializable
 data class ReduceActivatedAbilityCost(
     val filter: GroupFilter,
-    val amount: Int,
+    val amount: DynamicAmount,
     val manaFloor: Int = 0
 ) : StaticAbility {
     override val description: String = buildString {
         append(filter.description.replaceFirstChar { it.uppercase() })
-        append("'s activated abilities cost {$amount} less to activate")
+        when (amount) {
+            is DynamicAmount.Fixed -> append("'s activated abilities cost {${amount.amount}} less to activate")
+            else -> append("'s activated abilities cost {X} less to activate, where X is ${amount.description}")
+        }
         if (manaFloor > 0) {
             append(". This effect can't reduce the mana in that cost to less than ")
             append(if (manaFloor == 1) "one mana" else "$manaFloor mana")
@@ -852,6 +857,7 @@ data class ReduceActivatedAbilityCost(
 
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
-        return if (newFilter !== filter) copy(filter = newFilter) else this
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newFilter !== filter || newAmount !== amount) copy(filter = newFilter, amount = newAmount) else this
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/PowerArtifact.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/PowerArtifact.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Power Artifact
@@ -33,7 +34,7 @@ val PowerArtifact = card("Power Artifact") {
     staticAbility {
         ability = ReduceActivatedAbilityCost(
             filter = GroupFilter.attachedCreature(),
-            amount = 2,
+            amount = DynamicAmount.Fixed(2),
             manaFloor = 1
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutagenManLivingOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutagenManLivingOoze.kt
@@ -38,7 +38,7 @@ val MutagenManLivingOoze = card("Mutagen Man, Living Ooze") {
                     cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsToken)
                 ).youControl()
             ),
-            amount = 1
+            amount = DynamicAmount.Fixed(1)
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathaOfTheVileCauldron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathaOfTheVileCauldron.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/** Agatha of the Vile Cauldron — Wilds of Eldraine #199. */
+val AgathaOfTheVileCauldron = card("Agatha of the Vile Cauldron") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Warlock"
+    oracleText = "Activated abilities of creatures you control cost {X} less to activate, where X is " +
+        "Agatha's power. This effect can't reduce the mana in that cost to less than one mana.\n" +
+        "{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = ReduceActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+            amount = DynamicAmounts.sourcePower(),
+            manaFloor = 1
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}{G}")
+        effect = Effects.Composite(
+            Patterns.Group.modifyStatsForAll(
+                power = 1,
+                toughness = 1,
+                filter = GroupFilter(GameObjectFilter.Creature.youControl()).other(),
+                duration = Duration.EndOfTurn
+            ),
+            Patterns.Group.grantKeywordToAll(
+                Keyword.TRAMPLE,
+                GroupFilter(GameObjectFilter.Creature.youControl()).other(),
+                Duration.EndOfTurn
+            ),
+            Patterns.Group.grantKeywordToAll(
+                Keyword.HASTE,
+                GroupFilter(GameObjectFilter.Creature.youControl()).other(),
+                Duration.EndOfTurn
+            )
+        )
+        description = "Other creatures you control get +1/+1 and gain trample and haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "199"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg?1783915073"
+        ruling(
+            "2023-09-01",
+            "Agatha of the Vile Cauldron's first ability affects only abilities of creatures you control " +
+                "on the battlefield. The costs of activated abilities of creature cards that work in " +
+                "other zones (such as cycling) won't be reduced."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheEnd.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/TheEnd.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.namedFromVariable
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The End — Wilds of Eldraine #87
+ * {2}{B}{B} · Instant
+ *
+ * The target's controller is snapshotted before the target leaves the battlefield. This matters
+ * when the permanent is controlled by someone other than its owner.
+ */
+val TheEnd = card("The End") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if your life total is 5 or less.\n" +
+        "Exile target creature or planeswalker. Search its controller's graveyard, hand, and library " +
+        "for any number of cards with the same name as that permanent and exile them. That player " +
+        "shuffles, then draws a card for each card exiled from their hand this way."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.LifeAtMost(5))
+        )
+    }
+
+    spell {
+        target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Pipeline {
+            val target = gather(CardSource.ChosenTargets, name = "target")
+            val targetControllers = captureControllers(target, name = "targetControllers")
+            val targetName = storeCardName(target, name = "targetName")
+            move(target, CardDestination.ToZone(Zone.EXILE))
+
+            forEachCaptured(target, target, targetControllers) {
+                val matches = gather(
+                    CardSource.FromMultipleZones(
+                        zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                        player = Player.You,
+                        filter = GameObjectFilter.Any.namedFromVariable(targetName)
+                    ),
+                    name = "matches"
+                )
+                val selected = chooseAnyNumber(
+                    from = matches,
+                    chooser = Chooser.SourceController,
+                    prompt = "Choose any number of matching cards to exile",
+                    showAllCards = true,
+                    alwaysPrompt = true,
+                    name = "selected"
+                )
+                val selectedFromHand = filter(
+                    selected,
+                    CollectionFilter.InZone(Zone.HAND),
+                    name = "selectedFromHand"
+                )
+                exile(selected)
+                run(ShuffleLibraryEffect(target = EffectTarget.Controller))
+                run(
+                    Effects.DrawCards(
+                        DynamicAmount.VariableReference("${selectedFromHand.key}_count"),
+                        EffectTarget.Controller
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "87"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg?1783915109"
+        ruling(
+            "2023-09-01",
+            "If the permanent that's exiled was the back face of a double-faced card, you will not be " +
+                "able to exile any additional cards, because those cards have only their front-face " +
+                "characteristics (including name) in the graveyard, hand, and library."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -2797,7 +2797,10 @@
                     "baseFilter": "permanent",
                     "scope": "AttachedTo"
                 },
-                "amount": 2,
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
                 "manaFloor": 1
             }
         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -6975,7 +6975,10 @@
                 "filter": {
                     "baseFilter": "artifact token ctrl:you"
                 },
-                "amount": 1
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -36,6 +36,120 @@
     ]
 }
 
+// Agatha of the Vile Cauldron
+{
+    "name": "Agatha of the Vile Cauldron",
+    "manaCost": "{R}{G}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Activated abilities of creatures you control cost {X} less to activate, where X is Agatha's power. This effect can't reduce the mana in that cost to less than one mana.\n{4}{R}{G}: Other creatures you control get +1/+1 and gain trample and haste until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you",
+                                    "excludeSelf": true
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Other creatures you control get +1/+1 and gain trample and haste until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "amount": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": "Power"
+                },
+                "manaFloor": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "MYTHIC",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6c48f07-63b7-4a60-8da6-ce77405abf1e.jpg?1783915073",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Agatha of the Vile Cauldron's first ability affects only abilities of creatures you control on the battlefield. The costs of activated abilities of creature cards that work in other zones (such as cycling) won't be reduced."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Agatha's Champion
 {
     "name": "Agatha's Champion",
@@ -16138,6 +16252,154 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// The End
+{
+    "name": "The End",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if your life total is 5 or less.\nExile target creature or planeswalker. Search its controller's graveyard, hand, and library for any number of cards with the same name as that permanent and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "target"
+                },
+                {
+                    "type": "CaptureControllers",
+                    "from": "target",
+                    "storeAs": "targetControllers"
+                },
+                {
+                    "type": "StoreCardName",
+                    "from": "target",
+                    "storeAs": "targetName"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "target",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "ForEachCapturedController",
+                    "collection": "target",
+                    "originalCollection": "target",
+                    "controllerSnapshot": "targetControllers",
+                    "countVariable": "count4",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromMultipleZones",
+                                "zones": [
+                                    "Graveyard",
+                                    "Hand",
+                                    "Library"
+                                ],
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "NameEqualsChosen",
+                                            "variableName": "targetName"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "matches"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "matches",
+                            "selection": "ChooseAnyNumber",
+                            "chooser": "SourceController",
+                            "storeSelected": "selected",
+                            "prompt": "Choose any number of matching cards to exile",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "selected",
+                            "filter": {
+                                "type": "InZone",
+                                "zone": "Hand"
+                            },
+                            "storeMatching": "selectedFromHand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "VariableReference",
+                                "variableName": "selectedFromHand_count"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "LifeTotal",
+                            "player": "You"
+                        },
+                        "operator": "LTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "RARE",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b18402dc-c4ab-417c-92d1-5e4d9cfb840d.jpg?1783915109",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "If the permanent that's exiled was the back face of a double-faced card, you will not be able to exile any additional cards, because those cards have only their front-face characteristics (including name) in the graveyard, hand, and library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.legalactions.utils
 
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.registry.CardRegistry
@@ -751,7 +752,12 @@ class CastPermissionUtils(
             for (ability in cardDef.script.staticAbilities) {
                 val reduce = ability as? com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost ?: continue
                 if (activatedAbilityReductionApplies(state, entityId, reduce.filter, sourceId)) {
-                    totalAmount += reduce.amount
+                    val controllerId = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: continue
+                    totalAmount += DynamicAmountEvaluator().evaluate(
+                        state,
+                        reduce.amount,
+                        EffectContext(sourceId = entityId, controllerId = controllerId)
+                    ).coerceAtLeast(0)
                     floor = maxOf(floor, reduce.manaFloor)
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgathaOfTheVileCauldronScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgathaOfTheVileCauldronScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario coverage for Agatha's dynamic, projected-power activated-ability cost reduction. */
+class AgathaOfTheVileCauldronScenarioTest : ScenarioTestBase() {
+
+    private val cauldronAssistant = card("Cauldron Assistant") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Human Warlock"
+        power = 2
+        toughness = 2
+        activatedAbility {
+            cost = Costs.Mana("{4}")
+            effect = Effects.DrawCards(1)
+            description = "Draw a card."
+        }
+    }
+
+    init {
+        cardRegistry.register(cauldronAssistant)
+
+        fun abilityAffordable(lands: Int, agathaCounters: Int = 0): Boolean {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Agatha of the Vile Cauldron")
+                .withCardOnBattlefield(1, "Cauldron Assistant")
+                .withLandsOnBattlefield(1, "Forest", lands)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            if (agathaCounters > 0) {
+                val agatha = game.findPermanent("Agatha of the Vile Cauldron")!!
+                game.state = game.state.updateEntity(agatha) {
+                    it.with(
+                        CountersComponent(
+                            mapOf(CounterType.PLUS_ONE_PLUS_ONE to agathaCounters)
+                        )
+                    )
+                }
+            }
+
+            val assistant = game.findPermanent("Cauldron Assistant")!!
+            return game.getLegalActions(1).firstOrNull {
+                val action = it.action
+                action is ActivateAbility && action.sourceId == assistant
+            }?.isAffordable == true
+        }
+
+        context("Agatha of the Vile Cauldron") {
+            test("reduces creature activated abilities by her current power") {
+                withClue("base 1 power reduces {4} to {3}") {
+                    abilityAffordable(lands = 3) shouldBe true
+                }
+                withClue("two +1/+1 counters make Agatha 3 power and reduce {4} to {1}") {
+                    abilityAffordable(lands = 1, agathaCounters = 2) shouldBe true
+                }
+            }
+
+            test("cannot reduce the mana in an activated ability below one") {
+                withClue("even a 3-power Agatha leaves the {4} ability costing one mana") {
+                    abilityAffordable(lands = 0, agathaCounters = 2) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add faithful WOE definitions for Agatha of the Vile Cauldron and The End
- generalize activated-ability cost reduction amounts to DynamicAmount so Agatha reads projected power
- add focused Agatha scenario coverage and a manual client scenario
- compose The End from the existing gather/select/move pipeline while preserving the targeted permanent controller

## Verification
- PR CI: backend aggregate passed
- PR CI: content, engine, server, tools, and frontend jobs all passed
- `just check-card-printing "Agatha of the Vile Cauldron"`
- `just check-card-printing "The End"`
- `git diff --check`
- Scryfall image URLs verified HTTP 200

All Gradle build/test work ran in the PR workflow to avoid competing with the local AI training workload. Card snapshots were generated by a temporary PR-only artifact job; that job was removed before the final green run.