### PR TITLE
Add two Wilds of Eldraine cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  snapshot-refresh:
-    if: github.head_ref == 'codex/woe-handful-aug01-13'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@v6
-      - name: Refresh card snapshots
-        run: ./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
-      - name: Upload refreshed WOE snapshot
-        uses: actions/upload-artifact@v7
-        with:
-          name: refreshed-woe-card-snapshot
-          path: mtg-sets/src/test/resources/snapshots/cards/WOE.json
-
   # Backend tests run as parallel jobs, one per module group, instead of a single monolithic
   # `./gradlew build`. The old single job serialized the two largest suites (game-server + rules-engine)
   # to the end on one runner; splitting them onto separate runners makes wall-clock ≈ the slowest group

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  snapshot-refresh:
+    if: github.head_ref == 'codex/woe-handful-aug01-13'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Refresh card snapshots
+        run: ./gradlew :mtg-sets:test --tests "*CardDefinitionSnapshotTest" -DupdateSnapshots=true
+      - name: Upload refreshed WOE snapshot
+        uses: actions/upload-artifact@v7
+        with:
+          name: refreshed-woe-card-snapshot
+          path: mtg-sets/src/test/resources/snapshots/cards/WOE.json
+
   # Backend tests run as parallel jobs, one per module group, instead of a single monolithic
   # `./gradlew build`. The old single job serialized the two largest suites (game-server + rules-engine)
   # to the end on one runner; splitting them onto separate runners makes wall-clock ≈ the slowest group

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BlossomingTortoise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BlossomingTortoise.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Blossoming Tortoise — Wilds of Eldraine #163. */
+val BlossomingTortoise = card("Blossoming Tortoise") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Turtle"
+    oracleText = "Whenever this creature enters or attacks, mill three cards, then return a land " +
+        "card from your graveyard to the battlefield tapped.\n" +
+        "Activated abilities of lands you control cost {1} less to activate.\n" +
+        "Land creatures you control get +1/+1."
+    power = 3
+    toughness = 3
+
+    val millAndReturnLand: Effect = Effects.Composite(
+        GatherCardsEffect(
+            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3), Player.You),
+            storeAs = "tortoiseMilled",
+        ),
+        MoveCollectionEffect(
+            from = "tortoiseMilled",
+            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+        ),
+        GatherCardsEffect(
+            source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Land),
+            storeAs = "tortoiseLands",
+        ),
+        SelectFromCollectionEffect(
+            from = "tortoiseLands",
+            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+            storeSelected = "tortoiseLandToReturn",
+            showAllCards = true,
+            prompt = "Return a land card from your graveyard to the battlefield tapped",
+            selectedLabel = "Return tapped",
+            remainderLabel = "Leave in graveyard",
+        ),
+        MoveCollectionEffect(
+            from = "tortoiseLandToReturn",
+            destination = CardDestination.ToZone(
+                Zone.BATTLEFIELD,
+                Player.You,
+                ZonePlacement.Tapped,
+            ),
+        ),
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = millAndReturnLand
+        description = "Whenever this creature enters, mill three cards, then return a land card " +
+            "from your graveyard to the battlefield tapped."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = millAndReturnLand
+        description = "Whenever this creature attacks, mill three cards, then return a land card " +
+            "from your graveyard to the battlefield tapped."
+    }
+
+    staticAbility {
+        ability = ReduceActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Land.youControl()),
+            amount = DynamicAmount.Fixed(1),
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature and GameObjectFilter.Land.youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "163"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg?1783915085"
+
+        ruling(
+            "2023-09-01",
+            "Activated abilities contain a colon. Triggered abilities are unaffected by " +
+                "Blossoming Tortoise's cost reduction ability.",
+        )
+        ruling(
+            "2023-09-01",
+            "Blossoming Tortoise's second ability affects only abilities of lands you control " +
+                "on the battlefield, not abilities of land cards in other zones.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SentinelOfLostLore.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SentinelOfLostLore.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/** Sentinel of Lost Lore — Wilds of Eldraine #184. */
+val SentinelOfLostLore = card("Sentinel of Lost Lore") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Knight"
+    oracleText = "When this creature enters, choose one or more —\n" +
+        "• Return target card you own in exile that has an Adventure to your hand.\n" +
+        "• Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n" +
+        "• Exile target player's graveyard."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.withTarget(
+                    effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+                    target = TargetObject(
+                        filter = TargetFilter(Filters.HasAdventure.ownedByYou(), zone = Zone.EXILE),
+                    ),
+                    description = "Return target card you own in exile that has an Adventure to your hand.",
+                ),
+                Mode.withTarget(
+                    effect = Effects.PutOnBottomOfLibrary(EffectTarget.ContextTarget(0)),
+                    target = TargetObject(
+                        filter = TargetFilter(Filters.HasAdventure.ownedByOpponent(), zone = Zone.EXILE),
+                    ),
+                    description = "Put target card you don't own in exile that has an Adventure " +
+                        "on the bottom of its owner's library.",
+                ),
+                Mode.withTarget(
+                    effect = Effects.Composite(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                            storeAs = "sentinelTargetGraveyard",
+                        ),
+                        MoveCollectionEffect(
+                            from = "sentinelTargetGraveyard",
+                            destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                        ),
+                    ),
+                    target = Targets.Player,
+                    description = "Exile target player's graveyard.",
+                ),
+            ),
+            chooseCount = 3,
+            minChooseCount = 1,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "184"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg?1783915078"
+
+        ruling(
+            "2023-09-01",
+            "The first and second modes can target any face-up exiled card that has an Adventure " +
+                "and has an appropriate owner, whether or not it was cast as an Adventure.",
+        )
+        ruling(
+            "2023-09-01",
+            "You must choose at least one mode if possible. The last mode can target a player " +
+                "whose graveyard is empty.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1847,6 +1847,190 @@
     ]
 }
 
+// Blossoming Tortoise
+{
+    "name": "Blossoming Tortoise",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Turtle",
+    "oracleText": "Whenever this creature enters or attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped.\nActivated abilities of lands you control cost {1} less to activate.\nLand creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "tortoiseMilled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "tortoiseMilled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "land"
+                            },
+                            "storeAs": "tortoiseLands"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "tortoiseLands",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "tortoiseLandToReturn",
+                            "prompt": "Return a land card from your graveyard to the battlefield tapped",
+                            "selectedLabel": "Return tapped",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "tortoiseLandToReturn",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature enters, mill three cards, then return a land card from your graveyard to the battlefield tapped."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "tortoiseMilled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "tortoiseMilled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "land"
+                            },
+                            "storeAs": "tortoiseLands"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "tortoiseLands",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "tortoiseLandToReturn",
+                            "prompt": "Return a land card from your graveyard to the battlefield tapped",
+                            "selectedLabel": "Return tapped",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "tortoiseLandToReturn",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, mill three cards, then return a land card from your graveyard to the battlefield tapped."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                },
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature land ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "MYTHIC",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/7811a45d-6bfb-4c2a-b5a2-cccbd8cff186.jpg?1783915085",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Activated abilities contain a colon. Triggered abilities are unaffected by Blossoming Tortoise's cost reduction ability."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Blossoming Tortoise's second ability affects only abilities of lands you control on the battlefield, not abilities of land cards in other zones."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Boundary Lands Ranger
 {
     "name": "Boundary Lands Ranger",
@@ -13633,6 +13817,141 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Sentinel of Lost Lore
+{
+    "name": "Sentinel of Lost Lore",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Elf Knight",
+    "oracleText": "When this creature enters, choose one or more —\n• Return target card you own in exile that has an Adventure to your hand.\n• Put target card you don't own in exile that has an Adventure on the bottom of its owner's library.\n• Exile target player's graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Hand"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": {
+                                            "cardPredicates": [
+                                                "HasAdventure"
+                                            ],
+                                            "controllerPredicate": "OwnedByYou"
+                                        },
+                                        "zone": "Exile"
+                                    }
+                                }
+                            ],
+                            "description": "Return target card you own in exile that has an Adventure to your hand."
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Library",
+                                "placement": "Bottom"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": {
+                                            "cardPredicates": [
+                                                "HasAdventure"
+                                            ],
+                                            "controllerPredicate": "OwnedByOpponent"
+                                        },
+                                        "zone": "Exile"
+                                    }
+                                }
+                            ],
+                            "description": "Put target card you don't own in exile that has an Adventure on the bottom of its owner's library."
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "storeAs": "sentinelTargetGraveyard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "sentinelTargetGraveyard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "targetRequirements": [
+                                "TargetPlayer"
+                            ],
+                            "description": "Exile target player's graveyard."
+                        }
+                    ],
+                    "chooseCount": 3,
+                    "minChooseCount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "RARE",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f109a5bf-1472-4b87-b3d3-70db0e123693.jpg?1783915078",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "The first and second modes can target any face-up exiled card that has an Adventure and has an appropriate owner, whether or not it was cast as an Adventure."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You must choose at least one mode if possible. The last mode can target a player whose graveyard is empty."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
## Summary
- add Blossoming Tortoise with its mill/land-return trigger, land ability discount, and land-creature anthem
- add Sentinel of Lost Lore with its choose-one-or-more ETB modes and ownership-aware Adventure targets
- include authoritative WOE metadata and mechanically relevant Scryfall rulings

## Verification
- `just check-card-printing "Blossoming Tortoise"`
- `just check-card-printing "Sentinel of Lost Lore"`
- exact Scryfall image URLs return HTTP 200
- full build/test verification delegated to this PR’s GitHub Actions because local AI training is running
- temporary CI job uploads the refreshed WOE card snapshot; it will be removed after the snapshot is committed