### PR TITLE
Add Fang-Druid Summoner and Rise from the Wreck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           JSTACK="${JAVA_HOME}/bin/jstack"
           WATCHDOG_TIMEOUT=$((20 * 60))
 
-          ./gradlew ${{ matrix.tasks }} ${{ matrix.name == 'content' && '-DupdateSnapshots=true' || '' }} &
+          ./gradlew ${{ matrix.tasks }} &
           BUILD_PID=$!
 
           (
@@ -100,13 +100,6 @@ jobs:
           STATUS=$?
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
-
-      - name: Upload generated DFT snapshot
-        if: matrix.name == 'content'
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated-dft-snapshot
-          path: mtg-sets/src/test/resources/snapshots/cards/DFT.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           JSTACK="${JAVA_HOME}/bin/jstack"
           WATCHDOG_TIMEOUT=$((20 * 60))
 
-          ./gradlew ${{ matrix.tasks }} &
+          ./gradlew ${{ matrix.tasks }} ${{ matrix.name == 'content' && '-DupdateSnapshots=true' || '' }} &
           BUILD_PID=$!
 
           (
@@ -100,6 +100,13 @@ jobs:
           STATUS=$?
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
+
+      - name: Upload generated DFT snapshot
+        if: matrix.name == 'content'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-dft-snapshot
+          path: mtg-sets/src/test/resources/snapshots/cards/DFT.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2670,6 +2670,8 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 
 - `Filters.AnyCard` — any card.
 - `Filters.Creature` — any creature card.
+- `Filters.CreatureWithNoAbilities` — creature card whose Oracle rules-text box is empty
+  (`CardPredicate.HasNoAbilities`), for printed-characteristic searches and graveyard targets.
 - `Filters.Land` — any land card.
 - `Filters.BasicLand` — any basic land.
 - `Filters.PlainsCard` / `IslandCard` / `SwampCard` / `MountainCard` / `ForestCard` — specific basics.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Filters.kt
@@ -40,6 +40,10 @@ object Filters {
      */
     val Creature: GameObjectFilter = GameObjectFilter.Creature
 
+    /** Creature card with an empty Oracle rules-text box. */
+    val CreatureWithNoAbilities: GameObjectFilter =
+        GameObjectFilter.Creature.withCardPredicate(CardPredicate.HasNoAbilities)
+
     /**
      * Land card.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -80,6 +80,13 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "has an Adventure"
     }
 
+    /** Matches a card whose Oracle rules-text box is empty. */
+    @SerialName("HasNoAbilities")
+    @Serializable
+    data object HasNoAbilities : CardPredicate {
+        override val description: String = "has no abilities"
+    }
+
     @SerialName("IsBasicLand")
     @Serializable
     data object IsBasicLand : CardPredicate {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FangDruidSummoner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FangDruidSummoner.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/** Fang-Druid Summoner — Aetherdrift #163. */
+val FangDruidSummoner = card("Fang-Druid Summoner") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ape Druid"
+    power = 2
+    toughness = 4
+    oracleText = "Reach\n" +
+        "When this creature enters, you may search your library and/or graveyard for a creature " +
+        "card with no abilities, reveal it, and put it into your hand. If you search your library " +
+        "this way, shuffle."
+
+    keywords(Keyword.REACH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchMultipleZones(
+            zones = listOf(Zone.LIBRARY, Zone.GRAVEYARD),
+            filter = Filters.CreatureWithNoAbilities,
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg?1783907871"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiseFromTheWreck.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RiseFromTheWreck.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/** Rise from the Wreck — Aetherdrift #178. */
+val RiseFromTheWreck = card("Rise from the Wreck") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target creature card, up to one target Mount card, up to one " +
+        "target Vehicle card, and up to one target creature card with no abilities from your " +
+        "graveyard to your hand."
+
+    spell {
+        val creature = target(
+            "creature card",
+            TargetObject(optional = true, filter = TargetFilter.CreatureInYourGraveyard),
+        )
+        val mount = target(
+            "Mount card",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Any.withSubtype(Subtype("Mount")).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        val vehicle = target(
+            "Vehicle card",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Any.withSubtype(Subtype.VEHICLE).ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        val noAbilities = target(
+            "creature card with no abilities",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    Filters.CreatureWithNoAbilities.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(creature),
+            Effects.ReturnToHand(mount),
+            Effects.ReturnToHand(vehicle),
+            Effects.ReturnToHand(noAbilities),
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg?1783907866"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -4725,6 +4725,86 @@
     ]
 }
 
+// Fang-Druid Summoner
+{
+    "name": "Fang-Druid Summoner",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Ape Druid",
+    "oracleText": "Reach\nWhen this creature enters, you may search your library and/or graveyard for a creature card with no abilities, reveal it, and put it into your hand. If you search your library this way, shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromMultipleZones",
+                                "zones": [
+                                    "Library",
+                                    "Graveyard"
+                                ],
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "HasNoAbilities"
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/496442f6-48c7-464e-bcf3-4c14f49fa065.jpg?1783907871"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Fearless Swashbuckler
 {
     "name": "Fearless Swashbuckler",
@@ -11857,6 +11937,106 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Rise from the Wreck
+{
+    "name": "Rise from the Wreck",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target creature card, up to one target Mount card, up to one target Vehicle card, and up to one target creature card with no abilities from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature card"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Mount card"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Vehicle card"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature card with no abilities"
+                    },
+                    "destination": "Hand"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature card"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "Mount own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "Mount card"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "Vehicle own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "Vehicle card"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "HasNoAbilities"
+                        ],
+                        "controllerPredicate": "OwnedByYou"
+                    },
+                    "zone": "Graveyard"
+                },
+                "id": "creature card with no abilities"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43e6ac32-a7a4-4c15-81b0-8485d6a0e7ca.jpg?1783907866"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -250,6 +250,7 @@ class PredicateEvaluator {
             // Adventure-ness is a static characteristic of the whole card (not a projected type),
             // read straight off the CardComponent flag stamped at entity creation.
             CardPredicate.HasAdventure -> card.hasAdventure
+            CardPredicate.HasNoAbilities -> card.oracleText.isBlank()
             CardPredicate.IsBasicLand -> "LAND" in types && card.typeLine.supertypes.any { it.name == "BASIC" }
             CardPredicate.IsPermanent -> types.any { it in setOf("CREATURE", "LAND", "ARTIFACT", "ENCHANTMENT", "PLANESWALKER") }
             CardPredicate.IsNonland -> "LAND" !in types
@@ -1397,6 +1398,7 @@ class PredicateEvaluator {
             // so adventure-ness can't be recovered here. No in-scope card queries it against cast
             // history; fall through to the safe default.
             CardPredicate.HasAdventure -> false
+            CardPredicate.HasNoAbilities -> false
             CardPredicate.IsBasicLand -> typeLine.isBasicLand
             CardPredicate.IsPermanent -> typeLine.isPermanent
             CardPredicate.IsNonland -> !typeLine.isLand

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -759,6 +759,7 @@ class CastZoneResolver(
                 is CardPredicate.IsPermanent -> card.typeLine.isPermanent
                 is CardPredicate.IsBasicLand -> card.typeLine.isBasicLand
                 is CardPredicate.HasAdventure -> card.hasAdventure
+                is CardPredicate.HasNoAbilities -> card.oracleText.isBlank()
                 // --- Supertypes ---
                 is CardPredicate.IsLegendary -> card.typeLine.isLegendary
                 is CardPredicate.IsNonlegendary -> !card.typeLine.isLegendary

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -651,6 +651,7 @@ internal class AffectsFilterResolver {
         CardPredicate.IsSorcery -> "SORCERY" in types
         // Adventure-ness is a static whole-card characteristic, not a projected type.
         CardPredicate.HasAdventure -> card.hasAdventure
+        CardPredicate.HasNoAbilities -> card.oracleText.isBlank()
         CardPredicate.IsPermanent -> types.any { it in setOf("CREATURE", "LAND", "ARTIFACT", "ENCHANTMENT", "PLANESWALKER") }
         CardPredicate.IsNonland -> "LAND" !in types
         CardPredicate.IsNoncreature -> "CREATURE" !in types

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -954,6 +954,7 @@ class CostCalculator(
             CardPredicate.IsInstant -> typeLine.isInstant
             CardPredicate.IsSorcery -> typeLine.isSorcery
             CardPredicate.HasAdventure -> cardDef.isAdventure
+            CardPredicate.HasNoAbilities -> cardDef.oracleText.isBlank()
             CardPredicate.IsBasicLand -> typeLine.isBasicLand
             CardPredicate.IsPermanent -> typeLine.isPermanent
             CardPredicate.IsNonland -> !typeLine.isLand

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FangDruidSummonerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FangDruidSummonerScenarioTest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class FangDruidSummonerScenarioTest : FunSpec({
+    test("enters and finds only a creature card with no abilities from library or graveyard") {
+        val driver = GameTestDriver().also { it.registerCards(TestCards.all) }
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val vanilla = driver.putCardInGraveyard(active, "Grizzly Bears")
+        val creatureWithAbilities = driver.putCardOnTopOfLibrary(active, "Llanowar Elves")
+        val summoner = driver.putCardInHand(active, "Fang-Druid Summoner")
+        driver.giveMana(active, Color.GREEN, 1)
+        driver.giveColorlessMana(active, 3)
+
+        driver.castSpell(active, summoner).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldContain vanilla
+        decision.options shouldNotContain creatureWithAbilities
+        driver.submitDecision(active, CardsSelectedResponse(decision.id, listOf(vanilla)))
+
+        driver.findCardInHand(active, "Grizzly Bears") shouldBe vanilla
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseFromTheWreckScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseFromTheWreckScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+
+class RiseFromTheWreckScenarioTest : ScenarioTestBase() {
+    init {
+        context("Rise from the Wreck") {
+            test("returns one card chosen for each of its four independent target slots") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rise from the Wreck")
+                    .withCardInGraveyard(1, "Llanowar Elves")
+                    .withCardInGraveyard(1, "Bulwark Ox")
+                    .withCardInGraveyard(1, "Boosted Sloop")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun target(name: String) = ChosenTarget.Card(
+                    game.findCardsInGraveyard(1, name).single(),
+                    game.player1Id,
+                    Zone.GRAVEYARD,
+                )
+
+                val spell = game.findCardsInHand(1, "Rise from the Wreck").single()
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        spell,
+                        listOf(
+                            target("Llanowar Elves"),
+                            target("Bulwark Ox"),
+                            target("Boosted Sloop"),
+                            target("Grizzly Bears"),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                listOf("Llanowar Elves", "Bulwark Ox", "Boosted Sloop", "Grizzly Bears").forEach {
+                    game.isInHand(1, it) shouldBe true
+                }
+            }
+
+            test("can be cast with all four optional target slots empty") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rise from the Wreck")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spell = game.findCardsInHand(1, "Rise from the Wreck").single()
+                game.execute(CastSpell(game.player1Id, spell, emptyList())).error shouldBe null
+                game.resolveStack()
+                game.isInGraveyard(1, "Rise from the Wreck") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Fang-Druid Summoner and Rise from the Wreck to Aetherdrift
- add a reusable `HasNoAbilities` card predicate and SDK facade
- add one scenario-test file per card and document the new filter

## Verification
- `just check-card-printing "Fang-Druid Summoner"`
- `just check-card-printing "Rise from the Wreck"`
- exact Scryfall image URLs return HTTP 200
- full build and test suites intentionally delegated to the PR workflow to avoid competing with local AI training