### PR TITLE
Add Daretti and Mendicant Core to Aetherdrift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,6 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
-      - name: Upload generated card snapshot
-        if: failure() && matrix.name == 'content'
-        uses: actions/upload-artifact@v7
-        with:
-          name: generated-dft-card-snapshot
-          path: mtg-sets/build/snapshots-actual/snapshots/cards/DFT.json
-
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
 
+      - name: Upload generated card snapshot
+        if: failure() && matrix.name == 'content'
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-dft-card-snapshot
+          path: mtg-sets/build/snapshots-actual/DFT.json
+
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all
   # others before this job reports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: generated-dft-card-snapshot
-          path: mtg-sets/build/snapshots-actual/DFT.json
+          path: mtg-sets/build/snapshots-actual/snapshots/cards/DFT.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DarettiRocketeerEngineer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DarettiRocketeerEngineer.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Daretti, Rocketeer Engineer — Aetherdrift #120.
+ *
+ * The graveyard card is targeted when either trigger goes on the stack. The artifact sacrifice is
+ * an optional resolution-time cost, so declining it (or being unable to pay it) leaves the target
+ * in the graveyard.
+ */
+val DarettiRocketeerEngineer = card("Daretti, Rocketeer Engineer") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Goblin Artificer"
+    oracleText = "Daretti's power is equal to the greatest mana value among artifacts you control.\n" +
+        "Whenever Daretti enters or attacks, choose target artifact card in your graveyard. You may " +
+        "sacrifice an artifact. If you do, return the chosen card to the battlefield."
+    toughness = 5
+
+    dynamicPower(
+        DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).maxManaValue()
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val artifactCard = target(
+            "target artifact card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = GatedEffect(
+            gate = Gate.MayPay(SacrificeEffect(GameObjectFilter.Artifact)),
+            then = Effects.Move(artifactCard, Zone.BATTLEFIELD)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val artifactCard = target(
+            "target artifact card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = GatedEffect(
+            gate = Gate.MayPay(SacrificeEffect(GameObjectFilter.Artifact)),
+            then = Effects.Move(artifactCard, Zone.BATTLEFIELD)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg?1783907885"
+        ruling("2025-02-07", "If an artifact on the battlefield has {X} in its mana cost, X is 0 when determining its mana value.")
+        ruling("2025-02-07", "You choose the target card in your graveyard as Daretti's second ability is put on the stack, but you don't choose whether to sacrifice an artifact or which one to sacrifice until the ability resolves.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MendicantCoreGuidelight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MendicantCoreGuidelight.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EffectTarget
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Mendicant Core, Guidelight — Aetherdrift #213. */
+val MendicantCoreGuidelight = card("Mendicant Core, Guidelight") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Artifact Creature — Robot"
+    oracleText = "Mendicant Core's power is equal to the number of artifacts you control.\n" +
+        "Start your engines! (If you have no speed, it starts at 1. It increases once on each of " +
+        "your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Max speed — Whenever you cast an artifact spell, you may pay {1}. If you do, copy it. " +
+        "(The copy becomes a token.)"
+    toughness = 3
+
+    dynamicPower(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact))
+    startYourEngines()
+    maxSpeed {
+        triggeredAbility {
+            trigger = Triggers.youCastSpell(GameObjectFilter.Artifact)
+            effect = MayPayManaEffect(
+                cost = ManaCost.parse("{1}"),
+                effect = Effects.CopyTargetSpell(EffectTarget.TriggeringEntity)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "213"
+        artist = "Zezhou Chen"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg?1783907856"
+        ruling("2025-02-07", "A resolving copy of a permanent spell becomes a token, so the token isn't created. Effects that care about a token being created won't interact with a token that enters the battlefield from Mendicant Core's last ability.")
+        ruling("2025-02-07", "The copy remembers any decisions that were made for the original spell as it was cast, including values chosen for X in its mana cost and whether any alternative or additional costs were chosen.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MendicantCoreGuidelight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MendicantCoreGuidelight.kt
@@ -7,10 +7,10 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.maxSpeed
 import com.wingedsheep.sdk.dsl.startYourEngines
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.EffectTarget
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
 import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /** Mendicant Core, Guidelight — Aetherdrift #213. */

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -3348,6 +3348,113 @@
     ]
 }
 
+// Daretti, Rocketeer Engineer
+{
+    "name": "Daretti, Rocketeer Engineer",
+    "manaCost": "{4}{R}",
+    "typeLine": "Legendary Creature — Goblin Artificer",
+    "oracleText": "Daretti's power is equal to the greatest mana value among artifacts you control.\nWhenever Daretti enters or attacks, choose target artifact card in your graveyard. You may sacrifice an artifact. If you do, return the chosen card to the battlefield.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact",
+                "aggregation": "MAX",
+                "property": "MANA_VALUE"
+            }
+        },
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact card in your graveyard"
+                        },
+                        "destination": "Battlefield"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target artifact card in your graveyard"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact card in your graveyard"
+                        },
+                        "destination": "Battlefield"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target artifact card in your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be626e2f-1075-4497-bd5b-bd805777afd3.jpg?1783907885",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an artifact on the battlefield has {X} in its mana cost, X is 0 when determining its mana value."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "You choose the target card in your graveyard as Daretti's second ability is put on the stack, but you don't choose whether to sacrifice an artifact or which one to sacrifice until the ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Daring Mechanic
 {
     "name": "Daring Mechanic",
@@ -9151,6 +9258,89 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b199ce2-0ea0-47e5-a36c-36373be53fec.jpg"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Mendicant Core, Guidelight
+{
+    "name": "Mendicant Core, Guidelight",
+    "manaCost": "{W}{U}",
+    "typeLine": "Legendary Artifact Creature — Robot",
+    "oracleText": "Mendicant Core's power is equal to the number of artifacts you control.\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nMax speed — Whenever you cast an artifact spell, you may pay {1}. If you do, copy it. (The copy becomes a token.)",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "Speed",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Max speed — you casts a artifact spell, you may pay {1}. If you do, copy target spell."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "RARE",
+        "artist": "Zezhou Chen",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f434b103-490f-424e-a0a1-efb1b931c8e6.jpg?1783907856",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "A resolving copy of a permanent spell becomes a token, so the token isn't created. Effects that care about a token being created won't interact with a token that enters the battlefield from Mendicant Core's last ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "The copy remembers any decisions that were made for the original spell as it was cast, including values chosen for X in its mana cost and whether any alternative or additional costs were chosen."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLUE"
     ]
 }


### PR DESCRIPTION
## Summary
- implement Daretti, Rocketeer Engineer with dynamic power and its enter/attack artifact recursion trigger
- implement Mendicant Core, Guidelight with dynamic power, start your engines, and max-speed artifact spell copying
- include authoritative Aetherdrift metadata and mechanically relevant Scryfall rulings

## Verification
- `just check-card-printing "Daretti, Rocketeer Engineer"`
- `just check-card-printing "Mendicant Core, Guidelight"`
- exact Scryfall image URLs return HTTP 200
- `git diff --check`
- Gradle tests intentionally delegated to PR CI because local AI training is running