### PR TITLE
Add three Innistrad Remastered cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           JSTACK="${JAVA_HOME}/bin/jstack"
           WATCHDOG_TIMEOUT=$((20 * 60))
 
-          ./gradlew ${{ matrix.tasks }} ${{ matrix.name == 'content' && '-DupdateSnapshots=true' || '' }} &
+          ./gradlew ${{ matrix.tasks }} &
           BUILD_PID=$!
 
           (
@@ -100,16 +100,6 @@ jobs:
           STATUS=$?
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
-
-      - name: Upload generated Innistrad snapshots
-        if: matrix.name == 'content'
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated-innistrad-snapshots
-          path: |
-            mtg-sets/src/test/resources/snapshots/cards/EMN.json
-            mtg-sets/src/test/resources/snapshots/cards/MID.json
-            mtg-sets/src/test/resources/snapshots/cards/VOW.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           JSTACK="${JAVA_HOME}/bin/jstack"
           WATCHDOG_TIMEOUT=$((20 * 60))
 
-          ./gradlew ${{ matrix.tasks }} &
+          ./gradlew ${{ matrix.tasks }} ${{ matrix.name == 'content' && '-DupdateSnapshots=true' || '' }} &
           BUILD_PID=$!
 
           (
@@ -100,6 +100,16 @@ jobs:
           STATUS=$?
           kill "${WATCHDOG_PID}" 2>/dev/null || true
           exit "${STATUS}"
+
+      - name: Upload generated Innistrad snapshots
+        if: matrix.name == 'content'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-innistrad-snapshots
+          path: |
+            mtg-sets/src/test/resources/snapshots/cards/EMN.json
+            mtg-sets/src/test/resources/snapshots/cards/MID.json
+            mtg-sets/src/test/resources/snapshots/cards/VOW.json
 
   # Aggregate gate so branch protection can keep requiring a single "backend" check. It passes only
   # if every test group passed; with fail-fast disabled, a failure in one group still surfaces all

--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 199 / 273
+**Implemented:** 200 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -256,7 +256,7 @@
 - [x] Vilespawn Spider
 - [x] Voice of the Blessed
 - [x] Volatile Arsonist
-- [ ] Voldaren Bloodcaster
+- [x] Voldaren Bloodcaster
 - [x] Voldaren Epicure
 - [x] Voldaren Estate
 - [ ] Voltaic Visionary

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6188,6 +6188,7 @@ answer it and would silently return `false`.
   plain "greater than your starting life total" reading. Elenda, Saint of Dusk gates her two stat tiers on
   `LifeAboveStartingBy(1)` and `LifeAboveStartingBy(10)`.
 - `APlayerLifeAtMost(n)` — *some* player in the game has ≤N life (existential over `state.turnOrder`; distinct from `LifeAtMost`, which is `Player.You`). Used by enters-tapped-unless lands like Razortrap Gorge.
+- `EachPlayerLifeAtMost(n)` — every player in the game has ≤N life (universal over `state.turnOrder`). Used by Cryptolith Fragment's intervening-if upkeep trigger.
 - `AnOpponentLifeAtMost(n)` — at least one opponent of the ability's controller has ≤N life. Unlike
   `APlayerLifeAtMost`, the controller's own life total never satisfies it; this is the conditional
   static-ability gate for Bloodghast's haste.

--- a/manual-scenarios/cards/c/cryptolith-fragment.json
+++ b/manual-scenarios/cards/c/cryptolith-fragment.json
@@ -1,0 +1,27 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 10,
+    "hand": [],
+    "battlefield": [
+      {"name": "Cryptolith Fragment", "tapped": false}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 10,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -582,6 +582,10 @@ object Conditions {
     fun APlayerLifeAtMost(threshold: Int): ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.APlayerLifeAtMost(threshold)
 
+    /** If every player in the game has [threshold] or less life. */
+    fun EachPlayerLifeAtMost(threshold: Int): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.EachPlayerLifeAtMost(threshold)
+
     /** If at least one opponent has [threshold] or less life. */
     fun AnOpponentLifeAtMost(threshold: Int): ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.AnOpponentLifeAtMost(threshold)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -289,6 +289,13 @@ data class APlayerLifeAtMost(val threshold: Int) : Condition {
     override val description: String = "a player has $threshold or less life"
 }
 
+/** Condition: every player in the game has [threshold] or less life. */
+@SerialName("EachPlayerLifeAtMost")
+@Serializable
+data class EachPlayerLifeAtMost(val threshold: Int) : Condition {
+    override val description: String = "each player has $threshold or less life"
+}
+
 /** Condition: at least one opponent of the ability's controller has [threshold] or less life. */
 @SerialName("AnOpponentLifeAtMost")
 @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CryptolithFragment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CryptolithFragment.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+private val CryptolithFragmentFront = card("Cryptolith Fragment") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters tapped.\n" +
+        "{T}: Add one mana of any color. Each player loses 1 life.\n" +
+        "At the beginning of your upkeep, if each player has 10 or less life, transform this artifact."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddManaOfChoice(),
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.Each)),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.EachPlayerLifeAtMost(10)
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1783937432"
+        ruling("2025-01-24", "Cryptolith Fragment's second ability is a mana ability. Players can't respond to it or to the loss of life it causes.")
+        ruling("2025-01-24", "If any player has 11 or more life as your upkeep begins, Cryptolith Fragment's last ability doesn't trigger. If any player has 11 or more life as the ability resolves, the ability has no effect.")
+    }
+}
+
+private val AuroraOfEmrakul = card("Aurora of Emrakul") {
+    manaCost = ""
+    typeLine = "Creature — Eldrazi Reflection"
+    oracleText = "Flying, deathtouch\nWhenever this creature attacks, each opponent loses 3 life."
+    power = 1
+    toughness = 4
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "John Avon"
+        flavorText = "\"I felt compelled to take the twisted stone, and I abandoned my horse's burden to accommodate its weight. Now, its continued glow illuminates my home and warms my mind.\"\n—Garner Kroft, Moorland farmer"
+        imageUri = "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1783937432"
+    }
+}
+
+val CryptolithFragment: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = CryptolithFragmentFront,
+    backFace = AuroraOfEmrakul,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AmbitiousFarmhandReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AmbitiousFarmhandReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in MID. */
+val AmbitiousFarmhandReprint = Printing(
+    oracleId = "b85e7ab2-6f57-4b65-8c16-034b342996f0",
+    name = "Ambitious Farmhand",
+    setCode = "INR",
+    collectorNumber = "8",
+    scryfallId = "36cb9b12-98a3-4770-9ae0-a3b02f057c2e",
+    artist = "Bryan Sola",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36cb9b12-98a3-4770-9ae0-a3b02f057c2e.jpg?1783908192",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/3/6/36cb9b12-98a3-4770-9ae0-a3b02f057c2e.jpg?1783908192",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CryptolithFragmentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CryptolithFragmentReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val CryptolithFragmentReprint = Printing(
+    oracleId = "60c8a1d4-8d0a-4906-bcaf-d3a09d57c452",
+    name = "Cryptolith Fragment",
+    setCode = "INR",
+    collectorNumber = "260",
+    scryfallId = "262b7b55-0b32-4c4f-a2ca-02f0b83fa7a2",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/262b7b55-0b32-4c4f-a2ca-02f0b83fa7a2.jpg?1783908073",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/2/6/262b7b55-0b32-4c4f-a2ca-02f0b83fa7a2.jpg?1783908073",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VoldarenBloodcasterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VoldarenBloodcasterReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in VOW. */
+val VoldarenBloodcasterReprint = Printing(
+    oracleId = "a720f3d3-c2d7-4e50-8cc6-600120380e9c",
+    name = "Voldaren Bloodcaster",
+    setCode = "INR",
+    collectorNumber = "138",
+    scryfallId = "4b4390f4-451f-4575-96e0-dc4dcb45ad8f",
+    artist = "Kim Sokol",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b4390f4-451f-4575-96e0-dc4dcb45ad8f.jpg?1783908133",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/4/b/4b4390f4-451f-4575-96e0-dc4dcb45ad8f.jpg?1783908133",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/AmbitiousFarmhand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/AmbitiousFarmhand.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val AmbitiousFarmhandFront = card("Ambitious Farmhand") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Peasant"
+    oracleText = "When this creature enters, you may search your library for a basic Plains card, " +
+        "reveal it, put it into your hand, then shuffle.\n" +
+        "Coven — {1}{W}{W}: Transform this creature. Activate only if you control three or more " +
+        "creatures with different powers."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand.withSubtype(Subtype.PLAINS),
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}{W}")
+        effect = TransformEffect(EffectTarget.Self)
+        condition = Conditions.CompareAmounts(
+            left = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature,
+                aggregation = Aggregation.DISTINCT_VALUES,
+                property = CardNumericProperty.POWER,
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(3),
+        )
+        timing = TimingRule.SorcerySpeed
+        description = "Coven — {1}{W}{W}: Transform this creature. Activate only if you control " +
+            "three or more creatures with different powers."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1783925674"
+        ruling("2021-09-24", "For three creatures to have different powers from one another, each of their powers needs to be different.")
+    }
+}
+
+private val SeasonedCathar = card("Seasoned Cathar") {
+    manaCost = ""
+    colorIdentity = "W"
+    colorIndicator = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Lifelink"
+    power = 3
+    toughness = 3
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Bryan Sola"
+        flavorText = "\"The cathars have taught me many things, but I will never forget the hard, honest work that first callused my hands.\""
+        imageUri = "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1783925674"
+    }
+}
+
+val AmbitiousFarmhand: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = AmbitiousFarmhandFront,
+    backFace = SeasonedCathar,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/AmbitiousFarmhand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/AmbitiousFarmhand.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
@@ -44,15 +45,19 @@ private val AmbitiousFarmhandFront = card("Ambitious Farmhand") {
     activatedAbility {
         cost = Costs.Mana("{1}{W}{W}")
         effect = TransformEffect(EffectTarget.Self)
-        condition = Conditions.CompareAmounts(
-            left = DynamicAmount.AggregateBattlefield(
-                player = Player.You,
-                filter = GameObjectFilter.Creature,
-                aggregation = Aggregation.DISTINCT_VALUES,
-                property = CardNumericProperty.POWER,
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.CompareAmounts(
+                    left = DynamicAmount.AggregateBattlefield(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature,
+                        aggregation = Aggregation.DISTINCT_VALUES,
+                        property = CardNumericProperty.POWER,
+                    ),
+                    operator = ComparisonOperator.GTE,
+                    right = DynamicAmount.Fixed(3),
+                ),
             ),
-            operator = ComparisonOperator.GTE,
-            right = DynamicAmount.Fixed(3),
         )
         timing = TimingRule.SorcerySpeed
         description = "Coven — {1}{W}{W}: Transform this creature. Activate only if you control " +

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VoldarenBloodcaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VoldarenBloodcaster.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+private val bloodFilter = GameObjectFilter.Artifact.withSubtype("Blood")
+
+private val VoldarenBloodcasterFront = card("Voldaren Bloodcaster") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Wizard"
+    oracleText = "Flying\n" +
+        "Whenever this creature or another nontoken creature you control dies, create a Blood token. " +
+        "(It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you create a Blood token, if you control five or more Blood tokens, transform this creature."
+    power = 2
+    toughness = 1
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateBlood()
+    }
+
+    // A Blood token entering under your control is necessarily one you just created: tokens cannot
+    // move onto the battlefield from another zone. This therefore matches the printed trigger.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = bloodFilter.youControl().token(),
+            binding = TriggerBinding.ANY,
+        )
+        triggerCondition = Conditions.YouControlAtLeast(5, bloodFilter)
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "137"
+        artist = "Kim Sokol"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1783924857"
+        ruling("2025-01-24", "Voldaren Bloodcaster's last ability checks how many Blood tokens you have both as it triggers and as it resolves. If you don't control at least five Blood tokens at both of those times, it won't transform.")
+    }
+}
+
+private val BloodbatSummoner = card("Bloodbat Summoner") {
+    manaCost = ""
+    colorIdentity = "B"
+    colorIndicator = "B"
+    typeLine = "Creature — Vampire Wizard"
+    oracleText = "Flying\nAt the beginning of combat on your turn, up to one target Blood token " +
+        "you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types."
+    power = 3
+    toughness = 3
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val blood = target(
+            "up to one target Blood token you control",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(bloodFilter.youControl()),
+            ),
+        )
+        effect = Effects.BecomeCreature(
+            target = blood,
+            power = 2,
+            toughness = 2,
+            keywords = setOf(Keyword.FLYING, Keyword.HASTE),
+            creatureTypes = setOf("Bat"),
+            addTypes = setOf(CardType.ARTIFACT.name),
+            colors = setOf(Color.BLACK.name),
+            duration = Duration.Permanent,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "137"
+        artist = "Kim Sokol"
+        flavorText = "\"Humans throw rice and release doves at their weddings? How quaint.\""
+        imageUri = "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1783924857"
+        ruling("2025-01-24", "Blood tokens that become Bats with Bloodbat Summoner's ability are still Blood artifact tokens and still have their activated ability.")
+    }
+}
+
+val VoldarenBloodcaster: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = VoldarenBloodcasterFront,
+    backFace = BloodbatSummoner,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -552,6 +552,116 @@
     ]
 }
 
+// Cryptolith Fragment
+{
+    "name": "Cryptolith Fragment",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters tapped.\n{T}: Add one mana of any color. Each player loses 1 life.\nAt the beginning of your upkeep, if each player has 10 or less life, transform this artifact.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "EachPlayerLifeAtMost",
+                    "threshold": 10
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "AddManaOfChoice",
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "Each"
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "backFace": {
+        "name": "Aurora of Emrakul",
+        "manaCost": "",
+        "typeLine": "Creature — Eldrazi Reflection",
+        "oracleText": "Flying, deathtouch\nWhenever this creature attacks, each opponent loses 3 life.",
+        "creatureStats": {
+            "power": 1,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING",
+            "DEATHTOUCH"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "193",
+            "rarity": "UNCOMMON",
+            "artist": "John Avon",
+            "flavorText": "\"I felt compelled to take the twisted stone, and I abandoned my horse's burden to accommodate its weight. Now, its continued glow illuminates my home and warms my mind.\"\n—Garner Kroft, Moorland farmer",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1783937432"
+        },
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/078b2103-15ce-456d-b092-352fa7222935.jpg?1783937432",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "Cryptolith Fragment's second ability is a mana ability. Players can't respond to it or to the loss of life it causes."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If any player has 11 or more life as your upkeep begins, Cryptolith Fragment's last ability doesn't trigger. If any player has 11 or more life as the ability resolves, the ability has no effect."
+            }
+        ]
+    }
+}
+
 // Drogskol Shieldmate
 {
     "name": "Drogskol Shieldmate",

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -1,3 +1,141 @@
+// Ambitious Farmhand
+{
+    "name": "Ambitious Farmhand",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Peasant",
+    "oracleText": "When this creature enters, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.\nCoven — {1}{W}{W}: Transform this creature. Activate only if you control three or more creatures with different powers.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland Plains"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "optional": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}{W}"
+                    }
+                },
+                "effect": "Transform",
+                "timing": "SorcerySpeed",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature",
+                                "aggregation": "DISTINCT_VALUES",
+                                "property": "POWER"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Coven — {1}{W}{W}: Transform this creature. Activate only if you control three or more creatures with different powers."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Seasoned Cathar",
+        "manaCost": "",
+        "typeLine": "Creature — Human Knight",
+        "oracleText": "Lifelink",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "LIFELINK"
+        ],
+        "metadata": {
+            "collectorNumber": "2",
+            "rarity": "UNCOMMON",
+            "artist": "Bryan Sola",
+            "flavorText": "\"The cathars have taught me many things, but I will never forget the hard, honest work that first callused my hands.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1783925674"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "WHITE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54d4e7c3-294d-4900-8b70-faafda17cc33.jpg?1783925674",
+        "rulings": [
+            {
+                "date": "2021-09-24",
+                "text": "For three creatures to have different powers from one another, each of their powers needs to be different."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Angelfire Ignition
 {
     "name": "Angelfire Ignition",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -12923,6 +12923,159 @@
     ]
 }
 
+// Voldaren Bloodcaster
+{
+    "name": "Voldaren Bloodcaster",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Wizard",
+    "oracleText": "Flying\nWhenever this creature or another nontoken creature you control dies, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\nWhenever you create a Blood token, if you control five or more Blood tokens, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact Blood token ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact Blood"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Bloodbat Summoner",
+        "manaCost": "",
+        "typeLine": "Creature — Vampire Wizard",
+        "oracleText": "Flying\nAt the beginning of combat on your turn, up to one target Blood token you control becomes a 2/2 black Bat creature with flying and haste in addition to its other types.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "BEGIN_COMBAT"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "BecomeCreature",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "up to one target Blood token you control"
+                        },
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "keywords": [
+                            "FLYING",
+                            "HASTE"
+                        ],
+                        "creatureTypes": [
+                            "Bat"
+                        ],
+                        "addTypes": [
+                            "ARTIFACT"
+                        ],
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "duration": "Permanent"
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "artifact Blood ctrl:you"
+                        },
+                        "id": "up to one target Blood token you control"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "137",
+            "rarity": "RARE",
+            "artist": "Kim Sokol",
+            "flavorText": "\"Humans throw rice and release doves at their weddings? How quaint.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1783924857",
+            "rulings": [
+                {
+                    "date": "2025-01-24",
+                    "text": "Blood tokens that become Bats with Bloodbat Summoner's ability are still Blood artifact tokens and still have their activated ability."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ],
+        "colorIndicator": [
+            "BLACK"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "RARE",
+        "artist": "Kim Sokol",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca5297a5-bcaa-41fd-a397-e44dc4e00ba3.jpg?1783924857",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "Voldaren Bloodcaster's last ability checks how many Blood tokens you have both as it triggers and as it resolves. If you don't control at least five Blood tokens at both of those times, it won't transform."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Voldaren Epicure
 {
     "name": "Voldaren Epicure",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -54,6 +54,7 @@ import com.wingedsheep.sdk.scripting.conditions.YouControlMostOfChosenType
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
 import com.wingedsheep.sdk.scripting.conditions.AnyCondition
 import com.wingedsheep.sdk.scripting.conditions.APlayerLifeAtMost
+import com.wingedsheep.sdk.scripting.conditions.EachPlayerLifeAtMost
 import com.wingedsheep.sdk.scripting.conditions.AnyPlayerDealtCombatDamageThisTurnAtLeast
 import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.NumberMatches
@@ -456,6 +457,10 @@ class ConditionEvaluator(
             // Reads each player's LifeTotalComponent from state.turnOrder.
             is APlayerLifeAtMost -> state.turnOrder.any { playerId ->
                 // CR 810.9a — read the team's shared total; existential so teams don't double-count.
+                state.lifeTotal(playerId) <= condition.threshold
+            }
+
+            is EachPlayerLifeAtMost -> state.turnOrder.all { playerId ->
                 state.lifeTotal(playerId) <= condition.threshold
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptolithFragmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptolithFragmentScenarioTest.kt
@@ -22,7 +22,7 @@ class CryptolithFragmentScenarioTest : FunSpec({
         EachPlayerLifeAtMost(10),
         EffectContext(
             sourceId = null,
-            controllerId = activePlayer,
+            controllerId = activePlayer!!,
             targets = emptyList(),
             xValue = 0,
         ),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptolithFragmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptolithFragmentScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.conditions.EachPlayerLifeAtMost
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Covers Cryptolith Fragment's "if each player has 10 or less life" condition. */
+class CryptolithFragmentScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 20), skipMulligans = true)
+    }
+
+    fun GameTestDriver.conditionIsMet(): Boolean = ConditionEvaluator().evaluate(
+        state,
+        EachPlayerLifeAtMost(10),
+        EffectContext(
+            sourceId = null,
+            controllerId = activePlayer,
+            targets = emptyList(),
+            xValue = 0,
+        ),
+    )
+
+    test("condition is true when every player has 10 or less life") {
+        val driver = createDriver()
+        val active = driver.activePlayer!!
+        driver.setLifeTotal(active, 10)
+        driver.setLifeTotal(driver.getOpponent(active), 7)
+
+        driver.conditionIsMet() shouldBe true
+    }
+
+    test("condition is false when any player has more than 10 life") {
+        val driver = createDriver()
+        val active = driver.activePlayer!!
+        driver.setLifeTotal(active, 10)
+        driver.setLifeTotal(driver.getOpponent(active), 11)
+
+        driver.conditionIsMet() shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
- add Ambitious Farmhand // Seasoned Cathar in MID with its INR reprint
- add Cryptolith Fragment // Aurora of Emrakul in EMN with its INR reprint
- add Voldaren Bloodcaster // Bloodbat Summoner in VOW with its INR reprint
- add the reusable `EachPlayerLifeAtMost` condition, SDK reference documentation, coverage, and a manual Cryptolith scenario

## Verification
- `git diff --check`
- `just check-backlog`
- `just check-card-printing "Ambitious Farmhand"`
- `just check-card-printing "Cryptolith Fragment"`
- `just check-card-printing "Voldaren Bloodcaster"`
- heavy Gradle tests intentionally delegated to this PR's CI because local AI training is in progress