### PR TITLE
Fix double strike + trample spilling regular damage past surviving blockers

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -606,6 +606,10 @@ class TurnManager(
                 if (!hasAttackingCreatures(newState)) {
                     return advanceStep(newState.copy(step = Step.COMBAT_DAMAGE))
                 }
+                // CR 510.1 / 510.4: this step's damage is assigned from scratch. Anything a
+                // first-strike assignment locked in belongs to the step that just ended — a
+                // double striker re-divides among the blockers still blocking it.
+                newState = combatManager.clearDamageAssignmentsForNewDamageStep(newState)
                 val damageResult = combatManager.applyCombatDamage(newState, firstStrike = false)
                 if (!damageResult.isSuccess) return damageResult
                 newState = damageResult.newState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -670,12 +670,13 @@ internal class CombatDamageManager(
                     val manualAssignment = attackerContainer.get<DamageAssignmentComponent>()
                     when {
                         manualAssignment != null && manualAssignment.assignments.isNotEmpty() -> {
-                            // A DamageAssignmentComponent set during the first-strike damage step
-                            // persists into the regular damage step. If first-strike damage killed
-                            // a blocker, that blocker is no longer on the battlefield. Per CR 702.19c,
-                            // an attacker with trample whose blocker has been removed from combat
-                            // assigns the freed-up damage to the defending player/planeswalker.
-                            // Without trample, damage assigned to a removed blocker is lost.
+                            // A chosen assignment can still name a target that has since left the
+                            // battlefield. Per CR 702.19d, an attacker with trample whose blockers
+                            // have been removed from combat assigns the freed-up damage to the
+                            // defending player/planeswalker; without trample it is simply lost.
+                            // (Assignments never cross a combat damage step — CR 510.1 makes each
+                            // step a fresh division, and CombatManager
+                            // .clearDamageAssignmentsForNewDamageStep drops the first-strike one.)
                             val defenderId = attackingComponent.defenderId
                             val hasTrample = projected.hasKeyword(attackerId, Keyword.TRAMPLE)
                             var trampleRedirect = 0
@@ -705,7 +706,7 @@ internal class CombatDamageManager(
                                     }
                                 }
                             } else if (projected.hasKeyword(attackerId, Keyword.TRAMPLE)) {
-                                // CR 702.19c: Blocked attacker with trample and no remaining blockers
+                                // CR 702.19d: Blocked attacker with trample and no remaining blockers
                                 // assigns all damage to the defending player/planeswalker.
                                 assignments.add(CombatDamageAssignment(attackerId, attackingComponent.defenderId, power))
                             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatManager.kt
@@ -85,6 +85,30 @@ class CombatManager(
         damagePhase.applyCombatDamage(state, firstStrike)
 
     /**
+     * Drop the damage assignments chosen in the first-strike combat damage step, so the regular
+     * one assigns from scratch.
+     *
+     * CR 510.1 / 510.4: the second combat damage step is its own assignment — every creature that
+     * still deals damage (double strikers, plus everything that had no first strike) announces a
+     * fresh division. Carrying the first-strike [DamageAssignmentComponent] over is wrong whenever
+     * first-strike damage killed only *some* of the blockers: the amounts aimed at the dead ones
+     * would spill onto the defending player through trample, while the blockers still blocking
+     * were never assigned the lethal damage CR 702.19b requires first.
+     *
+     * Only the assignment is cleared. Damage assignment *order* ([DamageAssignmentOrderComponent],
+     * [AttackerOrderComponent]) is chosen once per combat and stays put.
+     */
+    fun clearDamageAssignmentsForNewDamageStep(state: GameState): GameState {
+        var newState = state
+        for ((entityId, _) in state.findEntitiesWith<DamageAssignmentComponent>()) {
+            newState = newState.updateEntity(entityId) { container ->
+                container.without<DamageAssignmentComponent>()
+            }
+        }
+        return newState
+    }
+
+    /**
      * Re-pause the same combat damage step for the next chooser (CR 510.1c sequencing and the
      * CR 702.22j/k two-actor banding case). Delegates to [CombatDamageManager.repauseCombatResolution].
      */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RegenerationCombatTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RegenerationCombatTest.kt
@@ -276,7 +276,7 @@ class RegenerationCombatTest : FunSpec({
         // 5/5 trample attacks, 3/3 blocks. 3/3 has regen shield.
         // Active player bolts the 3/3 blocker during combat → regeneration triggers
         // 3/3 removed from combat. 5/5 is still "blocked" but has trample.
-        // Per CR 702.19c, trample creature with no remaining blockers assigns all damage to player.
+        // Per CR 702.19d, trample creature with no remaining blockers assigns all damage to player.
         val driver = createDriver()
         driver.initMirrorMatch(
             deck = Deck.of("Mountain" to 20, "Forest" to 20),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrampleAfterFirstStrikeKillTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrampleAfterFirstStrikeKillTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.CombatResolutionDecision
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Keyword
@@ -12,6 +13,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Regression: an attacker with double strike + trample blocked by a creature
@@ -22,7 +24,7 @@ import io.kotest.matchers.shouldNotBe
  * strike step persisted into the regular damage step. With the blocker now
  * dead, [CombatDamageManager.proposeDamageAssignments] re-emitted the same
  * assignment to a target that was no longer on the battlefield, where it
- * was silently dropped. CR 702.19c says trample damage must carry over to
+ * was silently dropped. CR 702.19d says trample damage must carry over to
  * the defending player when the blocker has been removed from combat.
  */
 class TrampleAfterFirstStrikeKillTest : FunSpec({
@@ -42,6 +44,31 @@ class TrampleAfterFirstStrikeKillTest : FunSpec({
         subtypes = setOf(Subtype("Beast")),
         power = 3,
         toughness = 2
+    )
+
+    val DoubleStrikeTrampler3_3 = CardDefinition.creature(
+        name = "Trampling Doubler",
+        manaCost = ManaCost.parse("{2}{R}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 3,
+        toughness = 3,
+        keywords = setOf(Keyword.DOUBLE_STRIKE, Keyword.TRAMPLE)
+    )
+
+    val BigBlocker4_2 = CardDefinition.creature(
+        name = "Slumbering Hound",
+        manaCost = ManaCost.parse("{2}{R}"),
+        subtypes = setOf(Subtype("Hound")),
+        power = 4,
+        toughness = 2
+    )
+
+    val Goblin1_1 = CardDefinition.creature(
+        name = "Goblin Chit",
+        manaCost = ManaCost.parse("{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 1,
+        toughness = 1
     )
 
     test("trample damage carries through after first strike kills the blocker") {
@@ -81,6 +108,74 @@ class TrampleAfterFirstStrikeKillTest : FunSpec({
 
         // Regular damage step: blocker is gone, trample sends 2 to defender.
         driver.assertLifeTotal(opponent, 18)
+    }
+
+    test("surviving blockers still soak the regular damage of a double-strike trampler") {
+        // 3/3 double strike + trample attacks; blocked by a 4/2 and four 1/1 goblins.
+        // First strike step: 2 to the 4/2 (lethal) and 1 to one goblin — both die.
+        // Regular damage step: three 1/1 goblins are still blocking, so CR 702.19b forces
+        // all 3 power to be assigned to them (1 each) before anything can trample over.
+        // The defending player takes nothing.
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DoubleStrikeTrampler3_3, BigBlocker4_2, Goblin1_1))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(activePlayer, "Trampling Doubler")
+        val bigBlocker = driver.putCreatureOnBattlefield(opponent, "Slumbering Hound")
+        val goblins = (1..4).map { driver.putCreatureOnBattlefield(opponent, "Goblin Chit") }
+        driver.removeSummoningSickness(attacker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(activePlayer, listOf(attacker), opponent).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            opponent,
+            mapOf(
+                bigBlocker to listOf(attacker),
+                goblins[0] to listOf(attacker),
+                goblins[1] to listOf(attacker),
+                goblins[2] to listOf(attacker),
+                goblins[3] to listOf(attacker),
+            )
+        ).isSuccess shouldBe true
+
+        // First strike step: kill the 4/2 and one goblin.
+        driver.passPriorityUntil(Step.FIRST_STRIKE_COMBAT_DAMAGE)
+        driver.submitCombatDamage(
+            mapOf(
+                (attacker to bigBlocker) to 2,
+                (attacker to goblins[0]) to 1,
+                (attacker to goblins[1]) to 0,
+                (attacker to goblins[2]) to 0,
+                (attacker to goblins[3]) to 0,
+                (attacker to opponent) to 0,
+            )
+        )
+
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+
+        // The three surviving goblins are still blocking, so the board must re-open on them
+        // rather than reusing the first-strike assignment (whose targets are now dead).
+        val decision = driver.state.pendingDecision
+        decision.shouldBeInstanceOf<CombatResolutionDecision>()
+        val liveEdges = decision.edges.filter { it.sourceId == attacker && !it.isTrampleDrain }
+        liveEdges.map { it.targetId }.toSet() shouldBe setOf(goblins[1], goblins[2], goblins[3])
+        // Only 3 power for three 1-toughness blockers: nothing is left to trample over.
+        val drainEdge = decision.edges.single { it.sourceId == attacker && it.isTrampleDrain }
+        drainEdge.amount shouldBe 0
+
+        driver.confirmCombatDamage()
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Every blocker died; none of the damage reached the defending player.
+        driver.getCreatures(opponent).size shouldBe 0
+        driver.assertLifeTotal(opponent, 20)
     }
 
     test("without trample, double-strike damage to dead blocker is lost (no spillover)") {


### PR DESCRIPTION
## The bug

A 3/3 with double strike and trample attacked into a 4/2 and four 1/1 goblins. First-strike damage was assigned 2 to the 4/2 and 1 to a goblin, killing both. In the regular combat damage step the remaining 3 goblins were still blocking — so all 3 damage should have been soaked by them — but the engine sent all 3 to the defending player instead.

## Cause

`DamageAssignmentComponent` was only cleared at end of combat, so the assignment chosen in the first-strike damage step persisted into the regular one, and `CombatDamageManager.proposeDamageAssignments` reused it verbatim (the combat resolution board was skipped entirely, since a stored assignment means "already decided"). Its targets were now dead, and the trample fallback redirected every one of those amounts to the defending player — without ever assigning the lethal damage CR 702.19b requires to the blockers that were still blocking.

The existing `TrampleAfterFirstStrikeKillTest` cases didn't catch it because they use a single blocker: when *all* blockers die, "redirect the stale assignment" happens to produce the right answer.

## Fix

CR 510.1 / 510.4 make each combat damage step its own assignment — a double striker announces a fresh division among the creatures still blocking it. `CombatManager.clearDamageAssignmentsForNewDamageStep` drops the stored assignments on entry to the regular combat damage step (`TurnManager`, `Step.COMBAT_DAMAGE`), so the board re-opens over the live blockers. It's a one-shot at step entry, so the resumer's re-entry into `applyCombatDamage` still sees the answered assignment.

Damage assignment *order* (CR 509.2) is chosen once per combat and is deliberately left intact, as is every other combat component.

Also corrects two comments citing CR 702.19c for "blocked attacker with no blockers left" — that's 702.19d; 702.19c is trample over planeswalkers.

## Tests

New case in `TrampleAfterFirstStrikeKillTest`: the reported board (3/3 double strike + trample vs 4/2 + four 1/1s), asserting the regular-step board re-opens over exactly the three surviving goblins, the trample drain edge defaults to 0, and the defending player takes nothing. Fails before the fix (no decision at all in the regular step), passes after.

## Verification

- `just test-rules` — 9000 tests, 0 failures
- `just test-server` — green
- `just test-ai` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)