### PR TITLE
Fix projected creature choices on entry

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -262,9 +262,8 @@ object PermanentEntryReplacements {
             ChoiceType.CREATURE_ON_BATTLEFIELD -> {
                 val creatures = state.getBattlefield().filter { eid ->
                     if (eid == entityId) return@filter false
-                    val container = state.getEntity(eid) ?: return@filter false
-                    val card = container.get<CardComponent>() ?: return@filter false
-                    state.projectedState.getController(eid) == controllerId && card.typeLine.isCreature
+                    state.projectedState.getController(eid) == controllerId &&
+                        state.projectedState.isCreature(eid)
                 }
                 if (creatures.isEmpty()) return null
                 val id = "choose-creature-enters-${entityId.value}"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3412,10 +3412,9 @@ class StackResolver(
 
             ChoiceType.CREATURE_ON_BATTLEFIELD -> {
                 val battlefieldCreatures = state.getBattlefield().filter { entityId ->
-                    val container = state.getEntity(entityId) ?: return@filter false
-                    val card = container.get<CardComponent>() ?: return@filter false
-                    val controller = container.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()?.playerId ?: return@filter false
-                    controller == controllerId && card.typeLine.isCreature && entityId != spellId
+                    entityId != spellId &&
+                        state.projectedState.getController(entityId) == controllerId &&
+                        state.projectedState.isCreature(entityId)
                 }
                 if (battlefieldCreatures.isEmpty()) return null // No creatures — enter without choice
                 val decisionId = "choose-creature-enters-${spellId.value}"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessBodyguardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessBodyguardScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Dauntless Bodyguard (DOM #14).
+ *
+ * As Dauntless Bodyguard enters the battlefield, choose another creature you control.
+ */
+class DauntlessBodyguardScenarioTest : ScenarioTestBase() {
+
+    private val animateAbilityId by lazy {
+        cardRegistry.requireCard("Tough Cookie").activatedAbilities[0].id
+    }
+
+    init {
+        test("an animated noncreature permanent can be chosen as Bodyguard enters") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Tough Cookie", summoningSickness = false)
+                .withCardOnBattlefield(1, "Food")
+                .withCardInHand(1, "Dauntless Bodyguard")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withLandsOnBattlefield(1, "Plains", 1)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cookie = game.findPermanent("Tough Cookie")!!
+            val food = game.findPermanent("Food")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = cookie,
+                    abilityId = animateAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(food))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+            game.state.projectedState.isCreature(food) shouldBe true
+
+            game.castSpell(1, "Dauntless Bodyguard").error shouldBe null
+            game.resolveStack()
+
+            val choice = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+            choice.options shouldContain food
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- use projected creature characteristics and controller information when an as-enters replacement asks for another creature you control
- fix both cast-permanent and direct-entry paths
- add a Dauntless Bodyguard scenario covering a Food animated by Tough Cookie

## Bug

The entry-choice filters read printed type lines, so a noncreature permanent animated by a continuous effect was omitted even though it was currently a creature. The regression scenario failed against the original implementation because the animated Food was missing from Dauntless Bodyguard’s choices.

## Verification

- `just test-class DauntlessBodyguardScenarioTest`
- `just test-rules`