### PR TITLE
Send an Aura to the graveyard when its enchant restriction stops holding

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -93,6 +93,12 @@ section; do not let SDK additions land without a corresponding doc update.
   `AttachedToComponent` (players are entities too), survives state-based actions while that player is in
   the game, and exposes the player through `Player.EnchantedPlayer` / `EventPattern.LifeGainEvent(EnchantedPlayer)`
   and a `takesDamage(binding = ATTACHED)` "whenever enchanted player is dealt damage" trigger. (Grievous Wound.)
+  The filter is **not** just a cast-time target check: per CR 303.4c it restricts what the Aura may stay
+  attached to, so the engine re-evaluates it against the projected host after every state change and sends
+  the Aura to its owner's graveyard once the host stops matching (CR 704.5m). Write the filter to cover
+  every type the Aura's *own* effects can turn its host into, exactly as the printed card does — Imprisoned
+  in the Moon makes its host a land and so enchants "creature, land, or planeswalker"; an Aura that turns a
+  creature into a land while enchanting only `Targets.Creature` would destroy itself on resolution.
 - `morph: String?` — morph mana cost (cast face-down).
 - `morphCost: PayCost?` — non-mana morph cost.
 - `morphFaceUpEffect: Effect?` — effect that fires when this morph turns face up.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.mechanics.sba.permanent
 
 import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.cleanupReverseAttachmentLink
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
@@ -12,8 +14,12 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentHostLeftComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.GrantProtection
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 
 /**
  * 704.5m - An Aura attached to an illegal object/player or not attached goes to graveyard.
@@ -29,6 +35,14 @@ import com.wingedsheep.sdk.scripting.GrantProtection
  * 704.5p - A battle or creature attached to an object or player becomes unattached but
  *          remains on the battlefield.
  *
+ * Enchant restrictions (CR 303.4c): an Aura's "Enchant …" ability restricts what it can *stay*
+ * attached to, not just what its spell could target — the restriction is checked continuously, so
+ * an Aura whose host stops matching it becomes an illegal attachment and is put into its owner's
+ * graveyard by 704.5m. E.g. Cradle of Safety ("Enchant creature you control") falls off when an
+ * opponent steals the creature, and Pacifism ("Enchant creature") falls off when its host stops
+ * being a creature. The restriction is re-read from the card's `auraTarget` and evaluated against
+ * the *projected* host so layer-4 type/control changes are seen.
+ *
  * Protection (CR 702.16c/d): a permanent with protection from a quality can't be enchanted by
  * Auras (put into their owners' graveyards as a state-based action) or equipped by Equipment
  * (becomes unattached, stays on the battlefield) that have the stated quality. This covers
@@ -41,6 +55,8 @@ class UnattachedAurasCheck(
 ) : StateBasedActionCheck {
     override val name = "704.5m/n/p Unattached Auras"
     override val order = SbaOrder.UNATTACHED_AURAS
+
+    private val predicateEvaluator = PredicateEvaluator()
 
     override fun check(state: GameState): ExecutionResult {
         var newState = state
@@ -143,6 +159,18 @@ class UnattachedAurasCheck(
                         c.without<AttachedToComponent>()
                     }
                 } else if (
+                    isAura && hostFailsEnchantRestriction(state, projected, entityId, cardComponent, attachedTo.targetId)
+                ) {
+                    // CR 303.4c / 704.5m: the host no longer matches this Aura's "Enchant …"
+                    // restriction (control changed hands, the host stopped being a creature, …),
+                    // so the Aura is illegally attached and goes to its owner's graveyard.
+                    val result = SbaZoneMovementHelper.putPermanentInGraveyard(
+                        newState, entityId, cardComponent,
+                        lastKnownAttachedTo = attachedTo.targetId
+                    )
+                    newState = result.newState
+                    events.addAll(result.events)
+                } else if (
                     hostProtectedFromAttachmentColor(projected, entityId, cardComponent, attachedTo.targetId)
                 ) {
                     // CR 702.16c/d: the host has protection from one of this attachment's colors
@@ -167,6 +195,54 @@ class UnattachedAurasCheck(
         }
 
         return ExecutionResult.success(newState, events)
+    }
+
+    /**
+     * True when [hostId] no longer satisfies the Aura's printed "Enchant …" restriction (CR 303.4c).
+     *
+     * Only the requirement's *filter* is re-evaluated — not full targeting legality. An attached
+     * Aura isn't re-targeted, so hexproof/shroud/"can't be the target of" gained after the fact
+     * don't dislodge it (CR 702.11b); protection is the one quality that does, and
+     * [hostProtectedFromAttachmentColor] handles it separately.
+     *
+     * Deliberately fails *open* — an Aura we can't judge (printing not in the registry, an
+     * "enchant player" requirement, a filter scoped to a zone other than the battlefield) is left
+     * attached rather than destroyed, because a wrong verdict here silently removes a card from
+     * the game.
+     */
+    private fun hostFailsEnchantRestriction(
+        state: GameState,
+        projected: ProjectedState,
+        auraId: EntityId,
+        auraCard: CardComponent,
+        hostId: EntityId
+    ): Boolean {
+        val requirement = cardRegistry.getCard(auraCard.cardDefinitionId)?.script?.auraTarget ?: return false
+        val filter = enchantFilter(requirement) ?: return false
+        // "you" in "Enchant creature you control" is the Aura's controller, read from the
+        // projection so a control-changing effect on the Aura itself is honored.
+        val controllerId = projected.getController(auraId) ?: return false
+        val context = PredicateContext(controllerId = controllerId, sourceId = auraId)
+        // A cross-zone union requirement is satisfied by any one clause; only battlefield clauses
+        // can describe a host an Aura is attached to.
+        val battlefieldClauses = filter.clauses().filter { it.zone == Zone.BATTLEFIELD }
+        if (battlefieldClauses.isEmpty()) return false
+        return battlefieldClauses.none {
+            predicateEvaluator.matches(state, projected, hostId, it.baseFilter, context)
+        }
+    }
+
+    /**
+     * The battlefield filter behind an Aura's `auraTarget`, or null when the requirement isn't one
+     * we can re-check against a permanent host (an "enchant player" [TargetRequirement], say).
+     */
+    private fun enchantFilter(
+        requirement: TargetRequirement
+    ): com.wingedsheep.sdk.scripting.filters.unified.TargetFilter? = when (requirement) {
+        is TargetObject -> requirement.filter
+        // "Enchant another …" — the distinctness rule is targeting-only; the filter is the base's.
+        is TargetOther -> enchantFilter(requirement.baseRequirement)
+        else -> null
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -38,10 +38,14 @@ import com.wingedsheep.sdk.scripting.targets.TargetRequirement
  * Enchant restrictions (CR 303.4c): an Aura's "Enchant …" ability restricts what it can *stay*
  * attached to, not just what its spell could target — the restriction is checked continuously, so
  * an Aura whose host stops matching it becomes an illegal attachment and is put into its owner's
- * graveyard by 704.5m. E.g. Cradle of Safety ("Enchant creature you control") falls off when an
- * opponent steals the creature, and Pacifism ("Enchant creature") falls off when its host stops
- * being a creature. The restriction is re-read from the card's `auraTarget` and evaluated against
- * the *projected* host so layer-4 type/control changes are seen.
+ * graveyard by 704.5m. The Cartouche of Solidarity ruling puts it plainly: "If another player gains
+ * control of either the Cartouche or the enchanted creature (but not both), then the Cartouche will
+ * be enchanting an illegal permanent and be put into its owner's graveyard as a state-based action."
+ * The "but not both" is why this compares the Aura's controller against the host's rather than
+ * watching for a control *change* — if one player ends up with both, the attachment is legal again.
+ * A host that stops being a creature at all (Pacifism on a permanent Imprisoned in the Moon turned
+ * into a land) is the same story via the type predicate. The restriction is re-read from the card's
+ * `auraTarget` and evaluated against the *projected* host so layer-4 type/control changes are seen.
  *
  * Protection (CR 702.16c/d): a permanent with protection from a quality can't be enchanted by
  * Auras (put into their owners' graveyards as a state-based action) or equipped by Equipment

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuraEnchantRestrictionStateBasedActionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuraEnchantRestrictionStateBasedActionTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 303.4c/704.5m: an Aura's "enchant" restriction is checked continuously, not only when the
+ * Aura spell resolves. Once the permanent it's attached to stops matching that restriction, the
+ * Aura is "attached to an illegal object" and is put into its owner's graveyard as a state-based
+ * action.
+ *
+ * The case exercised here is the common one: an Aura that reads "Enchant creature you control"
+ * (Cradle of Safety) stays on the battlefield only while its controller still controls the host.
+ * An opponent's Act of Treason steals the host, so the Aura falls off — while an unrestricted
+ * "Enchant creature" Aura (Holy Strength) on the same creature is untouched, because a creature an
+ * opponent controls is still a legal host for it.
+ */
+class AuraEnchantRestrictionStateBasedActionTest : ScenarioTestBase() {
+
+    init {
+        context("an aura whose enchant restriction stops being met falls off") {
+            test("stealing the host sends an 'enchant creature you control' aura to the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Cradle of Safety", "Grizzly Bears")  // enchant creature you control
+                    .withCardAttachedTo(1, "Holy Strength", "Grizzly Bears")     // enchant creature
+                    .withCardInHand(2, "Act of Treason")
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpell(2, "Act of Treason", bears)
+                withClue("Player2 should be able to steal the enchanted creature: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Act of Treason gave Player2 control of the host") {
+                    game.state.projectedState.getController(bears) shouldBe game.player2Id
+                }
+                withClue("Cradle of Safety enchants 'a creature you control' — its host is now an opponent's, so it falls off") {
+                    game.isOnBattlefield("Cradle of Safety") shouldBe false
+                    game.isInGraveyard(1, "Cradle of Safety") shouldBe true
+                }
+                withClue("Holy Strength just enchants 'creature' — a stolen creature is still a legal host") {
+                    game.isOnBattlefield("Holy Strength") shouldBe true
+                }
+                withClue("The host itself is unharmed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("turning the host into a land sends an 'enchant creature' aura to the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Grizzly Bears")  // enchant creature
+                    .withCardInHand(2, "Imprisoned in the Moon")
+                    .withLandsOnBattlefield(2, "Island", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpell(2, "Imprisoned in the Moon", bears)
+                withClue("Imprisoned in the Moon can enchant a creature: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The host is now a land, not a creature") {
+                    game.state.projectedState.isCreature(bears) shouldBe false
+                    game.state.projectedState.hasType(bears, "LAND") shouldBe true
+                }
+                withClue("Holy Strength enchants a creature — its host is a land now, so it falls off") {
+                    game.isOnBattlefield("Holy Strength") shouldBe false
+                    game.isInGraveyard(1, "Holy Strength") shouldBe true
+                }
+                withClue("Imprisoned in the Moon enchants a creature, land, or planeswalker — a land host is still legal") {
+                    game.isOnBattlefield("Imprisoned in the Moon") shouldBe true
+                }
+                withClue("The host itself is unharmed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuraEnchantRestrictionStateBasedActionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuraEnchantRestrictionStateBasedActionTest.kt
@@ -12,11 +12,19 @@ import io.kotest.matchers.shouldBe
  * Aura is "attached to an illegal object" and is put into its owner's graveyard as a state-based
  * action.
  *
- * The case exercised here is the common one: an Aura that reads "Enchant creature you control"
- * (Cradle of Safety) stays on the battlefield only while its controller still controls the host.
- * An opponent's Act of Treason steals the host, so the Aura falls off — while an unrestricted
- * "Enchant creature" Aura (Holy Strength) on the same creature is untouched, because a creature an
- * opponent controls is still a legal host for it.
+ * For "Enchant creature you control", the Cartouche of Solidarity ruling (2017-04-18) states the
+ * consequence outright: "If another player gains control of either the Cartouche or the enchanted
+ * creature (but not both), then the Cartouche will be enchanting an illegal permanent and be put
+ * into its owner's graveyard as a state-based action." It is symmetric, and note the "but not both"
+ * — what matters is whether the Aura's controller controls the host, not whether control changed.
+ * Both directions are covered below: Act of Treason steals the host, Blatant Thievery steals the
+ * Aura. CR 303.4e is why the two come apart at all — changing control of an enchanted object
+ * doesn't change control of its Aura, or vice versa.
+ *
+ * The last test covers the type-change route instead, where the host stops being a creature at all.
+ * Every test also pins the negative half, because an over-eager check would be just as wrong: an
+ * unrestricted "Enchant creature" Aura survives the theft, and an Aura that lists the type it turns
+ * its own host into survives doing so.
  */
 class AuraEnchantRestrictionStateBasedActionTest : ScenarioTestBase() {
 
@@ -50,6 +58,40 @@ class AuraEnchantRestrictionStateBasedActionTest : ScenarioTestBase() {
                 }
                 withClue("Holy Strength just enchants 'creature' — a stolen creature is still a legal host") {
                     game.isOnBattlefield("Holy Strength") shouldBe true
+                }
+                withClue("The host itself is unharmed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("stealing the aura instead of the host breaks the restriction just as well") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Cradle of Safety", "Grizzly Bears")  // enchant creature you control
+                    .withCardInHand(2, "Blatant Thievery")
+                    .withLandsOnBattlefield(2, "Island", 7)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val aura = game.findPermanent("Cradle of Safety")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpell(2, "Blatant Thievery", aura)
+                withClue("Player2 should be able to steal the Aura itself: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The host stayed with Player1 — CR 303.4e keeps the two control changes separate") {
+                    game.state.projectedState.getController(bears) shouldBe game.player1Id
+                }
+                withClue("Player2 now controls an 'enchant creature you control' Aura on Player1's creature, so it falls off") {
+                    game.isOnBattlefield("Cradle of Safety") shouldBe false
+                }
+                withClue("704.5m sends it to its OWNER's graveyard (Player1), not its new controller's") {
+                    game.isInGraveyard(1, "Cradle of Safety") shouldBe true
+                    game.isInGraveyard(2, "Cradle of Safety") shouldBe false
                 }
                 withClue("The host itself is unharmed") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe true


### PR DESCRIPTION
## The bug

CR 303.4c makes an Aura's "Enchant …" ability a **continuous** restriction, not just a targeting requirement for the Aura spell:

> 303.4c If an Aura is enchanting an illegal object or player as defined by its enchant ability and other applicable effects, … the Aura is put into its owner's graveyard. (This is a state-based action.)

`UnattachedAurasCheck` re-checked three things about a live attachment — the host left the battlefield, the host is gone, and protection gained after the fact — plus the Equipment-specific legality rules of 704.5n. The Aura's *own* enchant restriction was validated at cast time by `TargetValidator` and never again, so an Aura stayed attached — and kept applying its continuous effects — to a host that had stopped qualifying.

Two reproductions, both in the new scenario test:

| Aura | What breaks the restriction | Before |
|---|---|---|
| Cradle of Safety — *Enchant creature you control* | opponent's Act of Treason steals the host | Aura stays, still granting +1/+1 to a creature its controller no longer controls |
| Holy Strength — *Enchant creature* | Imprisoned in the Moon turns the host into a land | Aura stays attached to a land |

## The fix

Re-read the restriction from the card's `auraTarget` and evaluate its filter against the **projected** host, so layer-4 type and control changes are seen. If it fails, 704.5m puts the Aura into its owner's graveyard.

Deliberately narrow in two ways:

- **Filter only, not full targeting legality.** An attached Aura isn't re-targeted, so hexproof/shroud/"can't be the target of" gained after the attachment landed don't dislodge it (CR 702.11b). Protection is the one quality that does, and the existing `hostProtectedFromAttachmentColor` branch right below already handles it.
- **Fails open.** An Aura the check can't judge — printing missing from the registry, an "enchant player" requirement, a filter scoped to a zone other than the battlefield — is left attached rather than destroyed. A wrong verdict here silently removes a card from the game.

The negative half of each test is the real guard against an over-eager implementation: Holy Strength (plain *Enchant creature*) survives the theft, and Imprisoned in the Moon (*Enchant creature, land, or planeswalker*) survives turning its own host into a land.

## A note for card authors

The change makes `auraTarget` load-bearing after resolution, so an Aura that type-changes its own host must list the resulting type in its filter — exactly as the printed cards do (Imprisoned in the Moon enchants "creature, land, or planeswalker"; Sugar Coat enchants "creature or Food"). Documented in `docs/card-sdk-language-reference.md`.

I audited every registered Aura that sets card types or subtypes on its host: all nine either keep the host a creature or already list the resulting type. None self-destruct.

## Verification

- `just test-class AuraEnchantRestrictionStateBasedActionTest` — 2 new tests; both fail without the engine change (confirmed) and pass with it.
- `just test-rules` — 9005 tests, 0 failures.
- `just test` — full suite green. No card-snapshot movement (no SDK behavior change).

Rule numbers checked against the current Comprehensive Rules text (2026-06-19): 303.4c, 704.5m, 704.5n, 702.11b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)