### PR TITLE
Fix attachment tap orientation and rest sideways cards on the row baseline

### DIFF
--- a/web-client/src/components/game/board/Battlefield.tsx
+++ b/web-client/src/components/game/board/Battlefield.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useBattlefieldCards, groupCards, visibleStackDepth, useSplitOutTargetIds, selectViewingPlayerId } from '@/store/selectors.ts'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
-import { ResponsiveContext, useResponsiveContext, useSlotSizedResponsive, handleImageError } from './shared'
+import { ResponsiveContext, useResponsiveContext, useSlotSizedResponsive, handleImageError, attachmentStackLayout } from './shared'
 import { styles } from './styles'
 import { CardStack } from '../card'
 import { GameCard } from '../card'
@@ -224,8 +224,10 @@ function BattlefieldContent({
    * Renders a permanent with any attached cards (auras, equipment) stacked underneath.
    * Works for any permanent type - creatures, lands, planeswalkers, etc.
    *
-   * Untapped: attachments peek vertically from above the parent card.
-   * Tapped: attachments peek horizontally to the right of the parent card.
+   * Attachments peek vertically from above the parent card. Each card rotates itself
+   * when tapped, so orientation is per-card: tapping the equipped creature leaves an
+   * untapped Equipment upright (it's a separate permanent, CR 301.5d, and is still
+   * available to tap), and a tapped Equipment reads as tapped on an untapped host.
    */
   const renderWithAttachments = (group: GroupedCard) => {
     const resolved = attachmentsByCardId.get(group.card.id)
@@ -255,24 +257,18 @@ function BattlefieldContent({
     // still signalling that attachments exist.
     const collapsed = attachments.length >= ATTACHMENT_COLLAPSE_THRESHOLD
     const visibleAttachments = collapsed ? attachments.slice(0, 1) : attachments
-    const visiblePeek = visibleAttachments.length * attachmentPeek
     const cardWidth = responsive.battlefieldCardWidth
-    // Lay out the whole stack (peeking attachments, main card, tab, click-catcher) in a
-    // portrait inner container. When the parent is tapped, rotate that inner container 90°
-    // so every element rotates together — no per-element offset math required. The outer
-    // container takes the rotated footprint so the flex row reserves landscape space.
-    const portraitWidth = cardWidth
-    const portraitHeight = cardHeight + visiblePeek
-    // A tapped (rotated) card is visually much wider than a portrait one, so the default
-    // row gap feels tight next to its upright neighbours. Reserve a bit of extra space
-    // inside the outer container so the rotated card doesn't sit flush against the next.
-    const tappedGutter = parentTapped ? (responsive.isMobile ? 18 : 28) : 0
-    const containerWidth = parentTapped ? portraitHeight + tappedGutter : portraitWidth
-    // Match the non-attachment tapped container height (cardHeight) so the main card's
-    // vertical center sits at the same row-bottom offset in both tapped and untapped
-    // states. Using portraitWidth here would shrink the container and pull the card
-    // downward by (cardHeight - cardWidth) / 2 on tap.
-    const containerHeight = parentTapped ? cardHeight : portraitHeight
+    const layout = attachmentStackLayout({
+      cardWidth,
+      cardHeight,
+      peek: attachmentPeek,
+      hostTapped: parentTapped,
+      attachmentsTapped: visibleAttachments.map((tagged) => tagged.card.isTapped === true),
+      // A sideways card is much wider than an upright one, so the default row gap feels
+      // tight next to upright neighbours — reserve a little extra beside it.
+      gutter: responsive.isMobile ? 18 : 28,
+    })
+    const { containerWidth, containerHeight, columnLeft } = layout
     const tabHeight = responsive.isMobile ? 14 : 16
     const actionable = hasActionableAttachment(attachments)
     // Show the tab (and click-catcher) whenever browsing is the right path:
@@ -291,140 +287,122 @@ function BattlefieldContent({
           height: containerHeight,
         }}
       >
-        <div
-          style={{
-            position: 'absolute',
-            width: portraitWidth,
-            height: portraitHeight,
-            // Center the portrait inner inside the outer landscape box so rotation around
-            // the center keeps the visual centered in the reserved slot.
-            left: (containerWidth - portraitWidth) / 2,
-            top: (containerHeight - portraitHeight) / 2,
-            transform: parentTapped ? 'rotate(90deg)' : undefined,
-            transformOrigin: 'center center',
-          }}
-        >
-          {/* Attachments peek above the main card.
-           * When collapsed, the visible peek is non-interactive — clicks go through the overlay
-           * catcher below so the attachments browser is the single selection path. */}
-          {visibleAttachments.map((tagged, index) => {
-            const { card: attachment, kind } = tagged
-            // Attachments controlled by the player are interactive even on the opponent's battlefield
-            // (e.g., aura cast on opponent's creature — caster can still activate abilities)
-            const attachmentInteractive = !collapsed && !spectatorMode && attachment.controllerId === viewingPlayerId
-            return (
-              <div
-                key={attachment.id}
-                style={{
-                  position: 'absolute',
-                  left: 0,
-                  top: index * attachmentPeek,
-                  zIndex: index,
-                  pointerEvents: 'none',
-                }}
-              >
-                <GameCard
-                  card={attachment}
-                  interactive={attachmentInteractive}
-                  battlefield
-                  isOpponentCard={isOpponent}
-                  // Inner wrapper handles the tap rotation for the whole stack; individual
-                  // cards must stay unrotated so they don't double-rotate.
-                  suppressTapRotation
-                  hideKeywordIcons
-                  isGhost={kind === 'linkedExile'}
-                />
-              </div>
-            )
-          })}
-          {showBrowserAffordance && (
+        {/* Attachments peek above the main card.
+         * When collapsed, the visible peek is non-interactive — clicks go through the overlay
+         * catcher below so the attachments browser is the single selection path. */}
+        {visibleAttachments.map((tagged, index) => {
+          const { card: attachment, kind } = tagged
+          // Attachments controlled by the player are interactive even on the opponent's battlefield
+          // (e.g., aura cast on opponent's creature — caster can still activate abilities)
+          const attachmentInteractive = !collapsed && !spectatorMode && attachment.controllerId === viewingPlayerId
+          const box = layout.attachments[index]
+          return (
             <div
-              onClick={(e) => {
-                e.stopPropagation()
-                setBrowsingAttachmentsOf(group.card)
-              }}
-              title={`${attachments.length} attached — click to browse`}
+              key={attachment.id}
               style={{
                 position: 'absolute',
-                left: 0,
-                top: 0,
-                width: portraitWidth,
-                height: attachmentPeek + 6,
-                zIndex: visibleAttachments.length,
-                cursor: 'pointer',
-                pointerEvents: 'auto',
-              }}
-            />
-          )}
-          {/* Main card, on top of the peeking attachments */}
-          <div style={{
-            position: 'absolute',
-            left: 0,
-            top: visiblePeek,
-            zIndex: visibleAttachments.length + 1,
-            pointerEvents: 'none',
-          }}>
-            <GameCard
-              card={group.card}
-              // A face-down permanent (morph/manifest) must keep rendering as a card back
-              // even once it gains an attachment — the no-attachment path (CardStack) passes
-              // this too; omitting it here flips an enchanted/equipped morph face-up for its
-              // controller, who receives the real card data + isFaceDown from the server.
-              faceDown={group.card.isFaceDown}
-              interactive={interactive}
-              battlefield
-              isOpponentCard={isOpponent}
-              // Suppress GameCard's own tap rotation — the outer wrapper rotates instead.
-              suppressTapRotation
-            />
-          </div>
-          {showBrowserAffordance && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                setBrowsingAttachmentsOf(group.card)
-              }}
-              title={
-                actionable
-                  ? `${attachments.length} attached — action available`
-                  : `${attachments.length} attached — click to browse`
-              }
-              style={{
-                position: 'absolute',
-                // Folder tab above the first peeking attachment. Rotates with the inner
-                // wrapper when the card is tapped, so it always follows the card.
-                top: -tabHeight + 1,
-                left: 6,
-                height: tabHeight,
-                minWidth: tabHeight + 4,
-                background: 'rgba(124, 58, 237, 0.95)',
-                color: 'white',
-                fontWeight: 700,
-                fontSize: responsive.isMobile ? 10 : 11,
-                padding: '0 8px',
-                borderRadius: '6px 6px 0 0',
-                border: actionable
-                  ? `2px solid ${TARGET_COLOR}`
-                  : '1px solid rgba(255, 255, 255, 0.35)',
-                borderBottom: 'none',
-                cursor: 'pointer',
-                pointerEvents: 'auto',
-                zIndex: visibleAttachments.length + 2,
-                boxShadow: actionable
-                  ? `0 -1px 4px ${TARGET_GLOW}, 0 0 10px ${TARGET_SHADOW}`
-                  : '0 -1px 3px rgba(0, 0, 0, 0.45)',
-                userSelect: 'none',
-                lineHeight: 1,
-                whiteSpace: 'nowrap',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
+                left: box?.left ?? columnLeft,
+                top: box?.top ?? index * attachmentPeek,
+                zIndex: index,
+                pointerEvents: 'none',
               }}
             >
-              {attachments.length}
-            </button>
-          )}
+              <GameCard
+                card={attachment}
+                interactive={attachmentInteractive}
+                battlefield
+                isOpponentCard={isOpponent}
+                hideKeywordIcons
+                isGhost={kind === 'linkedExile'}
+              />
+            </div>
+          )
+        })}
+        {showBrowserAffordance && (
+          <div
+            onClick={(e) => {
+              e.stopPropagation()
+              setBrowsingAttachmentsOf(group.card)
+            }}
+            title={`${attachments.length} attached — click to browse`}
+            style={{
+              position: 'absolute',
+              left: columnLeft,
+              top: 0,
+              width: cardWidth,
+              height: attachmentPeek + 6,
+              zIndex: visibleAttachments.length,
+              cursor: 'pointer',
+              pointerEvents: 'auto',
+            }}
+          />
+        )}
+        {/* Main card, on top of the peeking attachments */}
+        <div style={{
+          position: 'absolute',
+          left: layout.host.left,
+          top: layout.host.top,
+          zIndex: visibleAttachments.length + 1,
+          pointerEvents: 'none',
+        }}>
+          <GameCard
+            card={group.card}
+            // A face-down permanent (morph/manifest) must keep rendering as a card back
+            // even once it gains an attachment — the no-attachment path (CardStack) passes
+            // this too; omitting it here flips an enchanted/equipped morph face-up for its
+            // controller, who receives the real card data + isFaceDown from the server.
+            faceDown={group.card.isFaceDown}
+            interactive={interactive}
+            battlefield
+            isOpponentCard={isOpponent}
+          />
         </div>
+        {showBrowserAffordance && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setBrowsingAttachmentsOf(group.card)
+            }}
+            title={
+              actionable
+                ? `${attachments.length} attached — action available`
+                : `${attachments.length} attached — click to browse`
+            }
+            style={{
+              position: 'absolute',
+              // Folder tab above the first peeking attachment, on the upright column axis
+              // so it stays put when the host taps and rotates underneath it.
+              top: -tabHeight + 1,
+              left: columnLeft + 6,
+              height: tabHeight,
+              minWidth: tabHeight + 4,
+              background: 'rgba(124, 58, 237, 0.95)',
+              color: 'white',
+              fontWeight: 700,
+              fontSize: responsive.isMobile ? 10 : 11,
+              padding: '0 8px',
+              borderRadius: '6px 6px 0 0',
+              border: actionable
+                ? `2px solid ${TARGET_COLOR}`
+                : '1px solid rgba(255, 255, 255, 0.35)',
+              borderBottom: 'none',
+              cursor: 'pointer',
+              pointerEvents: 'auto',
+              zIndex: visibleAttachments.length + 2,
+              boxShadow: actionable
+                ? `0 -1px 4px ${TARGET_GLOW}, 0 0 10px ${TARGET_SHADOW}`
+                : '0 -1px 3px rgba(0, 0, 0, 0.45)',
+              userSelect: 'none',
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {attachments.length}
+          </button>
+        )}
       </div>
     )
   }

--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -196,13 +196,14 @@ describe('attachmentStackLayout', () => {
   // A sideways attachment is already wider than its host, so it shows down both flanks
   // without needing height above the card. Riding above the host just pushed it away
   // from the permanent it belongs to; tuck it under instead.
+  // GameCard bottom-aligns a sideways card's visible band inside its own box, so a box
+  // ending at the container bottom puts the band on the host's lower edge.
   it('bottom-aligns a sideways attachment level with the host', () => {
-    const { attachments, containerHeight } = layout(false, [true])
+    const { attachments, host, containerHeight } = layout(false, [true])
     const box = attachments[0]!
-    // The visible band of a sideways card is `cardWidth` tall, centered in its box.
-    const bandBottom = box.top + (CARD_HEIGHT + CARD_WIDTH) / 2
 
-    expect(bandBottom).toBe(containerHeight)
+    expect(box.top + CARD_HEIGHT).toBe(containerHeight)
+    expect(box.top).toBe(host.top)
   })
 
   it('gives a sideways attachment no peek height of its own', () => {

--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -181,16 +181,43 @@ describe('attachmentStackLayout', () => {
     expect(host.width).toBe(SIDEWAYS_BOX)
   })
 
-  // Each attachment shows one more `peek` of itself than the card in front of it,
-  // and that ladder must not shift when anything taps — otherwise a peeking
+  // Each upright attachment shows one more `peek` of itself than the card in front of
+  // it, and that ladder must not shift when the *host* taps — otherwise a peeking
   // Equipment would jump around as its host taps and untaps.
-  it('stacks the peek ladder by index regardless of tap state', () => {
-    const untapped = layout(false, [false, false])
+  it('stacks the upright peek ladder by index regardless of host tap state', () => {
+    const untappedHost = layout(false, [false, false])
     const tappedHost = layout(true, [false, false])
 
-    expect(untapped.attachments.map((a) => a.top)).toEqual([0, PEEK])
+    expect(untappedHost.attachments.map((a) => a.top)).toEqual([0, PEEK])
     expect(tappedHost.attachments.map((a) => a.top)).toEqual([0, PEEK])
     expect(tappedHost.host.top).toBe(2 * PEEK)
+  })
+
+  // A sideways attachment is already wider than its host, so it shows down both flanks
+  // without needing height above the card. Riding above the host just pushed it away
+  // from the permanent it belongs to; tuck it under instead.
+  it('bottom-aligns a sideways attachment level with the host', () => {
+    const { attachments, containerHeight } = layout(false, [true])
+    const box = attachments[0]!
+    // The visible band of a sideways card is `cardWidth` tall, centered in its box.
+    const bandBottom = box.top + (CARD_HEIGHT + CARD_WIDTH) / 2
+
+    expect(bandBottom).toBe(containerHeight)
+  })
+
+  it('gives a sideways attachment no peek height of its own', () => {
+    // One upright attachment earns a peek; adding a sideways one must not add another.
+    expect(layout(false, [true]).containerHeight).toBe(CARD_HEIGHT)
+    expect(layout(false, [false, true]).containerHeight).toBe(CARD_HEIGHT + PEEK)
+  })
+
+  // The upright ladder counts rungs, not raw indices, so a sideways attachment earlier in
+  // the list doesn't leave a gap in the peek ladder above the host.
+  it('does not let a sideways attachment consume an upright ladder rung', () => {
+    const { attachments } = layout(false, [true, false, false])
+
+    expect(attachments[1]?.top).toBe(0)
+    expect(attachments[2]?.top).toBe(PEEK)
   })
 
   // Rows are bottom-aligned (`alignItems: flex-end`), so the host's box must end flush

--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldShowCastModal } from './shared'
+import { attachmentStackLayout, shouldShowCastModal } from './shared'
 import type { LegalActionInfo } from '../../../types'
 import { entityId } from '../../../types'
 
@@ -122,5 +122,109 @@ describe('shouldShowCastModal', () => {
 
   it('opens the menu for multiple casting variants (morph + normal cast)', () => {
     expect(shouldShowCastModal([castSpell(), morph()])).toBe(true)
+  })
+})
+
+// --- attachmentStackLayout --------------------------------------------------
+
+describe('attachmentStackLayout', () => {
+  // Realistic desktop numbers: a 100x140 card, 16px peek, 28px sideways gutter.
+  const CARD_WIDTH = 100
+  const CARD_HEIGHT = 140
+  const PEEK = 16
+  const GUTTER = 28
+  // GameCard reserves `height + 8` for a card lying sideways.
+  const UPRIGHT_BOX = CARD_WIDTH
+  const SIDEWAYS_BOX = CARD_HEIGHT + 8
+
+  function layout(hostTapped: boolean, attachmentsTapped: readonly boolean[]) {
+    return attachmentStackLayout({
+      cardWidth: CARD_WIDTH,
+      cardHeight: CARD_HEIGHT,
+      peek: PEEK,
+      hostTapped,
+      attachmentsTapped,
+      gutter: GUTTER,
+    })
+  }
+
+  // The reported bug: with the whole stack sharing one rotated wrapper, tapping the
+  // equipped creature rotated its Equipment too, so an untapped Equipment looked
+  // tapped and players couldn't tell it was still available to tap. An Equipment and
+  // its host are independent permanents (CR 301.5d) — orientation is per-card.
+  it('leaves an untapped attachment upright when the host is tapped', () => {
+    const { attachments, host } = layout(true, [false])
+
+    expect(attachments[0]?.width).toBe(UPRIGHT_BOX)
+    expect(host.width).toBe(SIDEWAYS_BOX)
+  })
+
+  it('lays a tapped attachment sideways even while the host is untapped', () => {
+    const { attachments, host } = layout(false, [true])
+
+    expect(attachments[0]?.width).toBe(SIDEWAYS_BOX)
+    expect(host.width).toBe(UPRIGHT_BOX)
+  })
+
+  it('keeps every card upright when nothing is tapped, reserving no sideways gutter', () => {
+    const { attachments, host, containerWidth } = layout(false, [false])
+
+    expect(attachments[0]?.width).toBe(UPRIGHT_BOX)
+    expect(host.width).toBe(UPRIGHT_BOX)
+    expect(containerWidth).toBe(CARD_WIDTH)
+  })
+
+  it('orients each card independently in a mixed stack', () => {
+    const { attachments, host } = layout(true, [false, true])
+
+    expect(attachments.map((a) => a.width)).toEqual([UPRIGHT_BOX, SIDEWAYS_BOX])
+    expect(host.width).toBe(SIDEWAYS_BOX)
+  })
+
+  // Each attachment shows one more `peek` of itself than the card in front of it,
+  // and that ladder must not shift when anything taps — otherwise a peeking
+  // Equipment would jump around as its host taps and untaps.
+  it('stacks the peek ladder by index regardless of tap state', () => {
+    const untapped = layout(false, [false, false])
+    const tappedHost = layout(true, [false, false])
+
+    expect(untapped.attachments.map((a) => a.top)).toEqual([0, PEEK])
+    expect(tappedHost.attachments.map((a) => a.top)).toEqual([0, PEEK])
+    expect(tappedHost.host.top).toBe(2 * PEEK)
+  })
+
+  // Rows are bottom-aligned (`alignItems: flex-end`), so the host's box must end flush
+  // with the container bottom. That keeps an attached permanent on the same baseline as
+  // an unattached one whether or not either is tapped.
+  it('sits the host box flush with the container bottom in every orientation', () => {
+    for (const hostTapped of [false, true]) {
+      for (const attachmentTapped of [false, true]) {
+        const { host, containerHeight } = layout(hostTapped, [attachmentTapped])
+        expect(host.top + CARD_HEIGHT).toBe(containerHeight)
+      }
+    }
+  })
+
+  // A card's visual center must not move when it rotates — otherwise tapping a
+  // permanent would slide it sideways within its slot.
+  it('centers every card box on a shared vertical axis', () => {
+    const { attachments, host, containerWidth } = layout(true, [false, true])
+    const center = containerWidth / 2
+
+    for (const box of [...attachments, host]) {
+      expect(box.left + box.width / 2).toBe(center)
+    }
+  })
+
+  it('reserves the sideways footprint when only an attachment is tapped', () => {
+    // The host stays upright, but the stack still has to make room for the sideways
+    // Equipment behind it or it would overlap its neighbours in the row.
+    expect(layout(false, [true]).containerWidth).toBe(SIDEWAYS_BOX + GUTTER)
+  })
+
+  it('grows the container by one peek per attachment', () => {
+    expect(layout(false, []).containerHeight).toBe(CARD_HEIGHT)
+    expect(layout(false, [false]).containerHeight).toBe(CARD_HEIGHT + PEEK)
+    expect(layout(false, [false, false]).containerHeight).toBe(CARD_HEIGHT + 2 * PEEK)
   })
 })

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -339,6 +339,11 @@ export interface AttachmentStackLayout {
  * the same whichever way it faces. The host's box sits flush with the container
  * bottom; rows are bottom-aligned (`alignItems: flex-end`), which keeps the host on
  * the same baseline as an unattached permanent whether or not it's tapped.
+ *
+ * The two orientations peek from opposite ends. An *upright* attachment peeks above
+ * the host, where its title bar is what shows. A *sideways* one is already wider than
+ * the host, so it shows down both flanks on its own — it bottom-aligns instead, tucking
+ * under the host rather than riding above it, and claims no peek height of its own.
  */
 export function attachmentStackLayout(input: {
   cardWidth: number
@@ -355,20 +360,26 @@ export function attachmentStackLayout(input: {
   // A sideways card is as wide as an upright one is tall.
   const boxWidth = (tapped: boolean) => (tapped ? cardHeight + LANDSCAPE_CONTAINER_PAD : cardWidth)
 
-  const visiblePeek = attachmentsTapped.length * peek
+  // Only upright attachments claim peek height above the host; sideways ones tuck under it.
+  const visiblePeek = attachmentsTapped.filter((tapped) => !tapped).length * peek
   const anySideways = hostTapped || attachmentsTapped.some(Boolean)
   const containerWidth = (anySideways ? cardHeight + LANDSCAPE_CONTAINER_PAD : cardWidth) +
     (anySideways ? gutter : 0)
   const containerHeight = cardHeight + visiblePeek
   const centeredLeft = (tapped: boolean) => (containerWidth - boxWidth(tapped)) / 2
+  // A sideways card's visible band is its width, centered in a box that stays cardHeight
+  // tall (GameCard rotates in place). Offset the box so that band ends at the container
+  // bottom, level with the host's lower edge.
+  const bottomAlignedTop = containerHeight - (cardHeight + cardWidth) / 2
 
+  let uprightRung = 0
   return {
     containerWidth,
     containerHeight,
     columnLeft: (containerWidth - cardWidth) / 2,
-    attachments: attachmentsTapped.map((tapped, index) => ({
+    attachments: attachmentsTapped.map((tapped) => ({
       left: centeredLeft(tapped),
-      top: index * peek,
+      top: tapped ? bottomAlignedTop : uprightRung++ * peek,
       width: boxWidth(tapped),
     })),
     host: {

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -367,10 +367,10 @@ export function attachmentStackLayout(input: {
     (anySideways ? gutter : 0)
   const containerHeight = cardHeight + visiblePeek
   const centeredLeft = (tapped: boolean) => (containerWidth - boxWidth(tapped)) / 2
-  // A sideways card's visible band is its width, centered in a box that stays cardHeight
-  // tall (GameCard rotates in place). Offset the box so that band ends at the container
-  // bottom, level with the host's lower edge.
-  const bottomAlignedTop = containerHeight - (cardHeight + cardWidth) / 2
+  // GameCard drops a sideways card's visible band onto the bottom of its own box, so a box
+  // flush with the container bottom puts the band level with the host's lower edge — the
+  // same placement the host itself gets.
+  const bottomAlignedTop = containerHeight - cardHeight
 
   let uprightRung = 0
   return {

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -302,6 +302,84 @@ export function useSlotSizedResponsive(
 }
 
 /**
+ * Extra width GameCard's own wrapper reserves for a card lying sideways on the
+ * battlefield (see the `needsLandscapeContainer` branch in GameCard.tsx). Kept in
+ * sync with that constant so the stack reserves the same footprint GameCard uses.
+ */
+const LANDSCAPE_CONTAINER_PAD = 8
+
+/** Placement of one card inside an attachment stack, in container-local pixels. */
+export interface AttachmentStackBox {
+  left: number
+  top: number
+  /** Footprint GameCard reserves at this card's current orientation. */
+  width: number
+}
+
+export interface AttachmentStackLayout {
+  containerWidth: number
+  containerHeight: number
+  /** Peeking attachments in render order; index 0 peeks furthest out from behind the host. */
+  attachments: AttachmentStackBox[]
+  host: AttachmentStackBox
+  /** Left edge of the upright card column — the folder tab and click-catcher align to it. */
+  columnLeft: number
+}
+
+/**
+ * Geometry for a permanent rendered with its attachments peeking out from behind it.
+ *
+ * Every card is placed in its own box and rotates *itself* when tapped, so a card's
+ * orientation depends only on its own tap state. That matters for rules clarity: an
+ * Equipment and its equipped creature are independent permanents (CR 301.5d), so
+ * tapping the creature must not make the still-untapped Equipment look tapped — and
+ * a tapped Equipment must read as tapped even while its host is untapped.
+ *
+ * Boxes are horizontally centered on a shared axis, so a card's *visual* center is
+ * the same whichever way it faces. The host's box sits flush with the container
+ * bottom; rows are bottom-aligned (`alignItems: flex-end`), which keeps the host on
+ * the same baseline as an unattached permanent whether or not it's tapped.
+ */
+export function attachmentStackLayout(input: {
+  cardWidth: number
+  cardHeight: number
+  /** How much of each attachment shows above the card in front of it. */
+  peek: number
+  hostTapped: boolean
+  /** Tap state per peeking attachment, in render order. */
+  attachmentsTapped: readonly boolean[]
+  /** Breathing room reserved beside a sideways card so it doesn't sit flush against neighbours. */
+  gutter: number
+}): AttachmentStackLayout {
+  const { cardWidth, cardHeight, peek, hostTapped, attachmentsTapped, gutter } = input
+  // A sideways card is as wide as an upright one is tall.
+  const boxWidth = (tapped: boolean) => (tapped ? cardHeight + LANDSCAPE_CONTAINER_PAD : cardWidth)
+
+  const visiblePeek = attachmentsTapped.length * peek
+  const anySideways = hostTapped || attachmentsTapped.some(Boolean)
+  const containerWidth = (anySideways ? cardHeight + LANDSCAPE_CONTAINER_PAD : cardWidth) +
+    (anySideways ? gutter : 0)
+  const containerHeight = cardHeight + visiblePeek
+  const centeredLeft = (tapped: boolean) => (containerWidth - boxWidth(tapped)) / 2
+
+  return {
+    containerWidth,
+    containerHeight,
+    columnLeft: (containerWidth - cardWidth) / 2,
+    attachments: attachmentsTapped.map((tapped, index) => ({
+      left: centeredLeft(tapped),
+      top: index * peek,
+      width: boxWidth(tapped),
+    })),
+    host: {
+      left: centeredLeft(hostTapped),
+      top: visiblePeek,
+      width: boxWidth(hostTapped),
+    },
+  }
+}
+
+/**
  * Check if a card has multiple potential casting options.
  * Returns true if the card has more than one way to be used.
  * The server now sends all potential actions (including unaffordable ones),

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1174,6 +1174,17 @@ function GameCardImpl({
   const containerWidth = needsLandscapeContainer && battlefield ? height + 8 : width
   const containerHeight = height
 
+  // A sideways card rotates about its center, so its visible band is only `width` tall and
+  // sits (height - width) / 2 inside the box top *and* bottom. Left there it floats: a tapped
+  // permanent shares no edge with its upright neighbours in a bottom-aligned row. Drop it so
+  // the band's lower edge rests on the container bottom — the line upright cards sit on — and
+  // tapping reads as the card lying down in place rather than shrinking toward its middle.
+  const landscapeDrop = needsLandscapeContainer && battlefield ? (height - width) / 2 : 0
+  // Top edge of the visible band relative to the container, after the drop. The commander
+  // crown and non-legendary chip hang off this rather than the box, so they keep hugging the
+  // card instead of drifting above it when it turns sideways.
+  const bandTop = landscapeDrop * 2
+
   const cardElement = (
     <div
       data-card-id={card.id}
@@ -1197,7 +1208,9 @@ function GameCardImpl({
         cursor,
         border: isBeheldPulsing ? '3px solid #eab308' : borderStyle,
         pointerEvents: 'auto',
-        transform: `${totalRotateDeg ? `rotate(${totalRotateDeg}deg)` : ''} ${isSelected && (!isInCombatMode || !isCombatRoleCard) ? 'translateY(-8px)' : ''}`,
+        // `translateY(landscapeDrop)` is listed first so it applies in screen space, outside
+        // the rotation; the selection lift stays after it, as before.
+        transform: `${landscapeDrop ? `translateY(${landscapeDrop}px)` : ''} ${totalRotateDeg ? `rotate(${totalRotateDeg}deg)` : ''} ${isSelected && (!isInCombatMode || !isCombatRoleCard) ? 'translateY(-8px)' : ''}`,
         transformOrigin: 'center',
         // Commander gold *glow* — soft halo, deliberately no hard 1–2px rim so it doesn't read
         // like the playable-action outline. Inner halo sits close to the card for readable
@@ -2678,7 +2691,7 @@ function GameCardImpl({
         title="Commander"
         style={{
           position: 'absolute',
-          top: -crownHeight - 3,
+          top: bandTop - crownHeight - 3,
           left: '50%',
           transform: 'translateX(-50%)',
           width: crownWidth,
@@ -2723,7 +2736,7 @@ function GameCardImpl({
         title={`Not legendary — copy effect stripped the Legendary supertype (${card.typeLine})`}
         style={{
           position: 'absolute',
-          top: -Math.round(chipHeight * 0.55),
+          top: bandTop - Math.round(chipHeight * 0.55),
           left: '50%',
           transform: 'translateX(-50%)',
           height: chipHeight,


### PR DESCRIPTION
## What

Two related rendering problems with tapped permanents.

**1. Attachment orientation followed the host, not the card.** An attached permanent and its host are **independent permanents** (CR 301.5d), but the battlefield rendered the whole stack — peeking attachments, host card, folder tab, click-catcher — inside a *single* wrapper that rotated 90° when the **host** was tapped, with every `GameCard` passed `suppressTapRotation`. So:

- **Tapping an equipped creature laid its untapped Equipment sideways too**, so the Equipment looked tapped and you couldn't tell it was still available to tap.
- **The reverse also mis-rendered**: a tapped Equipment on an untapped creature peeked out upright, reading as untapped.

**2. Sideways cards floated off the row baseline.** A tapped card rotates about its center, so its visible band is only `width` tall and sits `(height − width) / 2` inside its box at *both* top and bottom. Rows are bottom-aligned, so a tapped permanent shared no edge with its upright neighbours. Measured on a mixed board: sideways cards ended at `y=620` while upright ones ended at `y=636` (and `786` vs `802` in the land row).

## Before / after

Same board both times — tapped and untapped creatures, lands, and both attachment cases: **Grizzly Bears tapped + Bonesplitter untapped**, **Hill Giant untapped + Leonin Scimitar tapped**. Relic Barrier is there to make the point concrete: it taps target artifact.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/attachment-tap-rotation-screenshots/before-board.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/attachment-tap-rotation-screenshots/after-board.png) |

After, every card in a row ends on the same line — `636` in the creature row, `802` in the land row — the only exception being an attachment's deliberate upward peek.

> The `attachment-tap-rotation-screenshots` branch is a throwaway image host, not part of this change — delete it whenever.

## How

**`GameCard`** drops a sideways battlefield card's rotated band onto the bottom of its container. The card's lower edge stays put as it taps and only the top edge comes down, so tapping reads as the card lying down in place rather than shrinking toward its middle. This is the `needsLandscapeContainer && battlefield` path, so it covers tapped permanents and always-landscape Rooms; hand, stack and the combat board (which passes `suppressTapRotation`) are untouched.

The commander crown and non-legendary chip now hang off the band's top edge rather than the box, so they keep hugging the card. They were already loose by half this distance on tapped cards; without the fix they'd have doubled.

**`attachmentStackLayout`** — a new pure function in `board/shared.ts` — replaces the shared rotated wrapper. It:

- centers every card's box on one vertical axis, so a card's *visual* center doesn't move when it rotates;
- **peeks the two orientations from opposite ends** — an upright attachment peeks above the host (its title bar is what shows), while a sideways one is already wider than the host and shows down both flanks, so it bottom-aligns under the host and claims no peek height of its own;
- counts the upright peek ladder in rungs, so a sideways attachment doesn't leave a gap above the host and a peeking Equipment doesn't jump as its host taps and untaps;
- sits the host box flush with the container bottom, keeping an attached permanent on the same baseline as an unattached one;
- reserves the sideways footprint whenever *any* card in the stack is tapped (previously only the host's tap state widened the container, so a sideways Equipment on an upright host had no room reserved).

Each `GameCard` now applies its own tap rotation, so it also keeps its own tap visuals and counter-rotated badges instead of having them suppressed.

## Notes for review

- The JSX block that lost its wrapper is **dedented one level** in the first commit. `git diff -w` shows that commit is **74 lines, not 274** — worth reviewing with whitespace ignored.
- Commit 3 is the only one with reach beyond attachments; it changes how every tapped battlefield card is positioned.
- No engine change. Targeting is unaffected: an attached Equipment *is* a legal target for "tap target artifact" (CR 115.2 — permanents are legal targets; CR 301.5c — an Equipment remains on the battlefield). This PR only makes its tap state legible.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx vitest run` — 381 passed, including **13 new `attachmentStackLayout` cases**. Mutation-checked: reintroducing the old host-driven orientation fails exactly the 3 tests that pin the original bug.
- `npx playwright test tests/legions/daru-stinger tests/khans/molting-snakeskin` — 2 passed (the specs that exercise attached permanents)
- **DOM edge measurements** on a board mixing tapped/untapped creatures, lands and attachments, rather than eyeballing the screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)