### PR TITLE
Add Lifecraft Engine, Cloudspire Coordinator, and Far Fortune, End Boss to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7377,8 +7377,9 @@ this turn").
   damage, and reset to 0 at end of turn. Backs `Conditions.YouDealtRedNoncombatDamageThisTurn(atLeast)` —
   Temple of Power's transform gate (back of Ojer Axonil, Deepest Might).
 
-`SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity?)` /
-`DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` —
+`SubtypeEnteredUnderControlThisTurn(player, subtypes, excludeTriggeringEntity?)` /
+`DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` /
+`DynamicAmounts.subtypesEnteredUnderControlThisTurn(subtypes, player?, excludeTriggeringEntity?)` —
 "the number of [other] [subtype]s that entered the battlefield under [player]'s control this turn"
 (Geralf, the Fleshwright — "each other Zombie that entered the battlefield under your control this
 turn"). It's a **turn-history** count: backed by `PermanentsEnteredUnderControlThisTurnComponent`,
@@ -7386,6 +7387,10 @@ which records each entrant's subtypes (from projected state) at entry, so a perm
 left the battlefield or lost the type still counts. `excludeTriggeringEntity = true` drops the
 permanent whose entry triggered the ability (giving "each *other*"); because every simultaneous
 entrant is recorded before the triggers resolve, each one sees the others (2024-04-12 ruling).
+`subtypes` is a **set with any-of semantics**, so the printed "Mounts and/or Vehicles" wording
+(Cloudspire Coordinator, via the plural facade) counts each qualifying entry exactly once — summing
+two single-subtype amounts would double-count a permanent carrying both. The singular facade is the
+ordinary one-tribe case.
 
 ---
 
@@ -7676,7 +7681,8 @@ The priority groups are (CR 616.1a–f):
   SourceFilter.Matching(GameObjectFilter.Any.youControl()), damageType = DamageType.NonCombat))` — a
   delirium-gated "double all noncombat damage from sources you control". The doubled damage stays
   attributed to the original source (the engine scales the amount in place).
-- `ModifyDamageAmount(modifier = 0, dynamicModifier = null, appliesTo)` — add an amount to matching
+- `ModifyDamageAmount(modifier = 0, dynamicModifier = null, restrictions = emptyList(), appliesTo)` —
+  add an amount to matching
   damage. Pass a flat `modifier` (Valley Flamecaller: "deals that much damage plus 1") or a
   `dynamicModifier: DynamicAmount?` evaluated at damage time against the replacement's **source**
   permanent (so `DynamicAmount.EntityProperty(Source, …)` / `DynamicAmounts.countersOnSelf(…)` reads
@@ -7685,7 +7691,12 @@ The priority groups are (CR 616.1a–f):
   SourceFilter.YouControl, recipient = RecipientFilter.OpponentOrPermanentTheyControl)` — "a source you
   control deals that much damage plus the number of fire counters on this enchantment to an opponent or
   a permanent an opponent controls". Applied in `DamageUtils.applyStaticDamageAmplification` (both the
-  general and combat damage paths), once per damage event, after `DoubleDamage`.
+  general and combat damage paths), once per damage event, after `DoubleDamage`. `restrictions` (a
+  `List<Condition>`, ALL must hold) gates *when* the bonus applies; like the rest of the damage family
+  — and unlike the draw / life-total replacements, whose restrictions read the *affected* player — each
+  entry is evaluated against the **replacement source's controller**. That asymmetry is what lets Far
+  Fortune, End Boss's `maxSpeed { replacementEffect(ModifyDamageAmount(modifier = 1, …)) }` gate on
+  *your* speed while the damage lands on an opponent.
 - `RedirectDamage(redirectTo, appliesTo, condition = null)` — redirect matching damage to another
   recipient. Now wired as a continuous static replacement (each source applies at most once per damage
   event). `redirectTo` supports `EffectTarget.ControllerOfDamageSource` (the controller of the damaging
@@ -7942,8 +7953,8 @@ The priority groups are (CR 616.1a–f):
   Quantum Riddler plus Vnwxt is `(3 + 1)` announced and then each of the four draws doubled = 8.
   Modelling Vnwxt here instead would drop both into one CR 616.1e pool and let the player choose an
   order giving 7. Several applicable announcement effects are cumulative — two doublers quadruple
-  the draw. `restrictions` is also the seam for a "Max speed —" gate, which `maxSpeed { }` cannot
-  apply to a replacement effect.
+  the draw. `restrictions` is also the seam a "Max speed —" gate folds into — declare the replacement
+  inside `maxSpeed { replacementEffect(…) }` and the builder fills the slot.
 - `ModifyMillAmount(modifier, restrictions, appliesTo)` — modify the number of cards a *mill* announces
   by a fixed amount (the mill twin of `ModifyDrawAmount`): a player who would mill N instead mills
   `N + modifier`, clamped to ≥ 0. `appliesTo` is an `EventPattern.MillEvent` whose `player` filter
@@ -8375,11 +8386,17 @@ Card authors rarely reference these directly; they are created/updated by the ma
     holding the clamp and the CR 702.179c "no speed + N ⇒ N" rule.
   - Client: `ClientPlayer.speed` (public info, unmasked) plus `ClientEvent.SpeedChanged`; the UI renders
     a four-bar `SpeedGauge` that redlines at max speed.
-  - **Gap:** a max-speed-gated *replacement* effect (Vnwxt, Verbose Host; Far Fortune, End Boss) is not
-    supported. Replacement effects are read straight off `ReplacementEffectSourceComponent` at ~20
-    independent interception sites, none of which evaluates a condition, so gating one needs a shared
-    conditional-replacement seam that doesn't exist yet. `MaxSpeedBuilder` deliberately offers no
-    `replacementEffect` slot rather than approximating it per site.
+  - **Replacement effects** use a third seam, `maxSpeed { replacementEffect(…) }`, for the same reason
+    as the two static exceptions: they're read straight off `ReplacementEffectSourceComponent` at ~20
+    independent interception sites, so a `ConditionalStaticAbility`-style wrapper would be invisible to
+    every one of them. The builder folds the gate into the effect's own `restrictions` list, which only
+    some replacement types have — anything else throws rather than silently emitting an ungated effect.
+    Vnwxt, Verbose Host ("Max speed — If you would draw a card, draw two cards instead") is a
+    `ReplaceDrawWithEffect`; Far Fortune, End Boss's damage rider is a `ModifyDamageAmount`. Know which
+    player the restrictions read before reaching for it: the damage family evaluates them against the
+    *source's controller* (so Far Fortune taxes opponents while gating on your speed), while the draw /
+    life-total ones read the *affected* player — fine for a `Player.You` pattern like Vnwxt's own draws,
+    wrong for a `Player.EachOpponent` one.
 - **Siege (named-mode entry)** — `EntersWithChoice(ChoiceType.MODE, modeOptions = ...)` + `SourceChosenModeIs("id")`.
 - **Morph** — `morph = "{2}{U}"` (top-level) + `morphFaceUpEffect` for "as it turns face up".
 - **Warp** — `warp = "{1}{R}"`; alt-cost that exiles end of turn. Like morph and cycle, a warp card

--- a/docs/continuous-effect-dependency-system.md
+++ b/docs/continuous-effect-dependency-system.md
@@ -236,6 +236,28 @@ class StateProjector(val state: GameState) {
 This effectively solves the hardest logic problem in the engine while keeping the core `GameAction` logic pure and
 simple.
 
+### Affects-filter dependencies inside Layer 4
+
+`EffectSorter.dependsOn` compares the two effects' **already-resolved** `affectedEntities` sets, which
+cannot see one class of Rule 613.8a dependency: an effect whose *affected set* is only populated **by**
+another effect in the same layer. Lifecraft Engine is the case that surfaced it — "Vehicle creatures you
+control are the chosen creature type" affects nothing until something animates a Vehicle, and crew's
+animation is itself a Layer 4 effect. At sort time the grant's set is empty, so no edge is found, and a
+flat single-pass Layer 4 would apply the grant before the animation and silently do nothing.
+
+`StateProjector` handles it with the same two-phase move it already uses *between* layer bands, applied
+*within* Layer 3–4:
+
+1. apply the effects whose filters don't read creature status, in dependency + timestamp order;
+2. then, for each effect whose filter *is* creature-dependent (`AffectsFilterResolver
+   .isCreatureDependentFilter`), re-resolve its affected set against the now-updated projection and
+   apply it.
+
+Phase 2 is the dependency: such an effect applies after every Layer 4 type change regardless of
+timestamp, which is what CR 613.8a requires. A CR 613.6 locked group keeps its frozen set through the
+re-resolve (`lockAffected` short-circuits), and the extra work is one filter re-resolution for the small
+subset of Layer 4 effects that read creature status.
+
 ## 6. Cross-Layer Grouping (Rule 613.6)
 
 Dependencies (613.8) order effects *within* a layer. Rule **613.6** governs a different problem: a *single* continuous

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Subtype.kt
@@ -131,6 +131,7 @@ value class Subtype(val value: String) {
         val MINION = Subtype("Minion")
         val MINOTAUR = Subtype("Minotaur")
         val MOONFOLK = Subtype("Moonfolk")
+        val MOUNT = Subtype("Mount")
         val MOUSE = Subtype("Mouse")
         val MUTANT = Subtype("Mutant")
         val MYR = Subtype("Myr")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -454,7 +454,19 @@ object DynamicAmounts {
         player: Player = Player.You,
         excludeTriggeringEntity: Boolean = false
     ): DynamicAmount =
-        DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity)
+        DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, setOf(subtype), excludeTriggeringEntity)
+
+    /**
+     * "The number of As and/or Bs that entered the battlefield under [player]'s control this turn"
+     * (Cloudspire Coordinator — "Mounts and/or Vehicles"). Any-of over [subtypes], so a permanent
+     * carrying several of them still counts once; summing per-subtype amounts would not.
+     */
+    fun subtypesEnteredUnderControlThisTurn(
+        subtypes: Set<com.wingedsheep.sdk.core.Subtype>,
+        player: Player = Player.You,
+        excludeTriggeringEntity: Boolean = false
+    ): DynamicAmount =
+        DynamicAmount.SubtypeEnteredUnderControlThisTurn(player, subtypes, excludeTriggeringEntity)
 
     /**
      * "The number of times [player] descended this turn" (CR 700.11) — count of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SpeedDsl.kt
@@ -5,9 +5,19 @@ import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.DoubleDamage
 import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.LifeLossFloor
 import com.wingedsheep.sdk.scripting.MayCastSelfFromZones
+import com.wingedsheep.sdk.scripting.ModifyDamageAmount
+import com.wingedsheep.sdk.scripting.ModifyDrawAmount
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.ModifyLifeLoss
+import com.wingedsheep.sdk.scripting.ModifyMillAmount
 import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
+import com.wingedsheep.sdk.scripting.ReplacementEffect
 import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
@@ -76,19 +86,36 @@ fun CardBuilder.startYourEngines() {
  * }
  * ```
  *
- * **Not covered:** a max-speed-gated *replacement* effect (Far Fortune, End Boss's damage rider).
- * Replacement effects are read straight off `ReplacementEffectSourceComponent` at ~20 independent
- * interception sites, none of which evaluates a condition, so gating one *in general* needs a shared
- * conditional-replacement seam that doesn't exist yet — deliberately left out rather than
- * approximated per site.
+ * **Replacement effects** go in the block too, via `replacementEffect(…)`, but only the ones that
+ * carry their own `restrictions` slot — the same fold-it-in trick used for [ModifySpellCost] and
+ * [MayCastSelfFromZones], and for the same reason: replacement effects are read straight off
+ * `ReplacementEffectSourceComponent` at ~20 independent interception sites, so a
+ * [ConditionalStaticAbility]-style wrapper would simply be invisible to all of them. A type without
+ * a `restrictions` slot is rejected loudly rather than silently ungated — gating one *in general*
+ * still needs a shared conditional-replacement seam that doesn't exist.
  *
- * The exception, and why it isn't in this block: a replacement type that already carries its own
- * condition slot can fold the gate in itself, the same trick this builder uses for
- * [ModifySpellCost] and [MayCastSelfFromZones]. Vnwxt, Verbose Host's "Max speed — If you would draw
- * a card, draw two cards instead" is a `ModifyDrawAmount` with
- * `restrictions = listOf(Conditions.YouHaveMaxSpeed)`, declared through the ordinary
- * `replacementEffect(…)` on [CardBuilder] plus a hand-written [Keyword.MAX_SPEED] badge. Route a
- * second such card through here only once there are two of them to share the path.
+ * One wrinkle worth knowing before reaching for it: `restrictions` are evaluated in the *affected
+ * player's* context for the draw / life-total replacements and in the *source controller's* context
+ * for the damage family. "Your speed is 4" means the source's controller either way for
+ * `Player.You`-scoped `appliesTo` patterns (Vnwxt's own draws), and the damage family gets it right
+ * by construction (Far Fortune's rider taxes opponents while reading your speed) — but a
+ * `Player.EachOpponent` draw/life replacement gated this way would read the wrong player's speed.
+ *
+ * Example (Far Fortune, End Boss — "Max speed — If a source you control would deal damage to an
+ * opponent or a permanent an opponent controls, it deals that much damage plus 1 instead"):
+ * ```kotlin
+ * maxSpeed {
+ *     replacementEffect(
+ *         ModifyDamageAmount(
+ *             modifier = 1,
+ *             appliesTo = EventPattern.DamageEvent(
+ *                 source = SourceFilter.YouControl,
+ *                 recipient = RecipientFilter.OpponentOrPermanentTheyControl,
+ *             ),
+ *         )
+ *     )
+ * }
+ * ```
  */
 fun CardBuilder.maxSpeed(init: MaxSpeedBuilder.() -> Unit) {
     val builder = MaxSpeedBuilder()
@@ -97,6 +124,7 @@ fun CardBuilder.maxSpeed(init: MaxSpeedBuilder.() -> Unit) {
     staticAbilities.addAll(builder.gatedStaticAbilities())
     activatedAbilities.addAll(builder.gatedActivatedAbilities())
     triggeredAbilities.addAll(builder.gatedTriggeredAbilities())
+    builder.gatedReplacementEffects().forEach { replacementEffect(it) }
 }
 
 /**
@@ -112,6 +140,7 @@ class MaxSpeedBuilder {
     private val statics: MutableList<StaticAbility> = mutableListOf()
     private val activated: MutableList<ActivatedAbility> = mutableListOf()
     private val triggered: MutableList<TriggeredAbility> = mutableListOf()
+    private val replacements: MutableList<ReplacementEffect> = mutableListOf()
 
     /**
      * "Max speed — This creature has [keywords]." Sugar for a [GrantKeyword] on the source per
@@ -141,6 +170,16 @@ class MaxSpeedBuilder {
         val builder = TriggeredAbilityBuilder()
         builder.init()
         triggered.add(builder.build())
+    }
+
+    /**
+     * A max-speed replacement effect, e.g. Far Fortune, End Boss's "Max speed — If a source you
+     * control would deal damage to an opponent …, it deals that much damage plus 1 instead."
+     * Declare it exactly as you would through [CardBuilder.replacementEffect]; the gate is folded
+     * into the effect's own `restrictions` slot by [gatedReplacementEffects].
+     */
+    fun replacementEffect(effect: ReplacementEffect) {
+        replacements.add(effect)
     }
 
     internal fun gatedStaticAbilities(): List<StaticAbility> = statics.map { ability ->
@@ -184,6 +223,31 @@ class MaxSpeedBuilder {
             restrictions = ability.restrictions + ActivationRestriction.OnlyIfCondition(MAX_SPEED_GATE),
             descriptionOverride = MAX_SPEED_PREFIX + (ability.descriptionOverride ?: ability.description)
         )
+    }
+
+    /**
+     * Folds the max-speed gate into each replacement effect's own `restrictions` list. Only the
+     * replacement types that *have* that slot can be gated — a wrapper would be invisible to the
+     * interception sites, which read `ReplacementEffectSourceComponent` directly — so anything else
+     * is refused rather than silently emitted ungated.
+     */
+    internal fun gatedReplacementEffects(): List<ReplacementEffect> = replacements.map { effect ->
+        when (effect) {
+            is PreventDamage -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is DoubleDamage -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ModifyDamageAmount -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ModifyDrawAmount -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ModifyMillAmount -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ReplaceDrawWithEffect -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ModifyLifeGain -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is ModifyLifeLoss -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            is LifeLossFloor -> effect.copy(restrictions = effect.restrictions + MAX_SPEED_GATE)
+            else -> throw IllegalArgumentException(
+                "Max speed cannot gate ${effect::class.simpleName}: it has no restrictions slot to " +
+                    "fold the gate into, and a conditional wrapper would be invisible to the " +
+                    "replacement interception sites. Add a restrictions slot to that type first."
+            )
+        }
     }
 
     internal fun gatedTriggeredAbilities(): List<TriggeredAbility> = triggered.map { ability ->

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -726,24 +726,43 @@ data class DoubleDamage(
  * When [dynamicModifier] is non-null it is evaluated with the replacement's source
  * permanent as the resolution source (so `DynamicAmount.EntityProperty(Source, …)` reads
  * the source's own characteristics/counters); otherwise the flat [modifier] is added.
+ *
+ * The optional [restrictions] list gates the bonus on further conditions, mirroring
+ * [PreventDamage.restrictions] / [DoubleDamage.restrictions]. Like the rest of the damage family —
+ * and unlike the draw/life-total replacements, whose restrictions read the *affected* player — each
+ * entry is evaluated against the **replacement source's controller**, so a `Player.You` condition
+ * reads as "the controller of the permanent with this ability". That's what lets Far Fortune, End
+ * Boss's "Max speed — …" rider gate on *your* speed while the damage lands on an opponent.
  */
 @SerialName("ModifyDamageAmount")
 @Serializable
 data class ModifyDamageAmount(
     val modifier: Int = 0,
     val dynamicModifier: DynamicAmount? = null,
+    override val restrictions: List<Condition> = emptyList(),
     override val appliesTo: EventPattern
 ) : ReplacementEffect {
     override val description: String = buildString {
         val bonus = dynamicModifier?.description ?: "$modifier"
-        append("If ${appliesTo.description}, it deals that much damage plus $bonus instead")
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", it deals that much damage plus $bonus instead")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)
         val newDynamic = dynamicModifier?.applyTextReplacement(replacer)
-        return if (newAppliesTo !== appliesTo || newDynamic !== dynamicModifier)
-            copy(appliesTo = newAppliesTo, dynamicModifier = newDynamic)
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo || newDynamic !== dynamicModifier ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged)
+            copy(appliesTo = newAppliesTo, dynamicModifier = newDynamic, restrictions = newRestrictions)
         else this
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1425,11 +1425,16 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
-     * The number of permanents of creature [subtype] that entered the battlefield under
+     * The number of permanents with **any** of [subtypes] that entered the battlefield under
      * [player]'s control this turn (counting even those that have since left or changed type —
      * the entry event is what's tracked). When [excludeTriggeringEntity] is true, the permanent
      * whose entry triggered the ability is not counted, giving "each *other* [subtype]" wording
      * (Geralf, the Fleshwright). Simultaneous entries each see the others (2024-04-12 ruling).
+     *
+     * [subtypes] is a set with any-of semantics rather than a single subtype so the printed
+     * "Mounts and/or Vehicles" wording (Cloudspire Coordinator) counts each qualifying entry
+     * exactly **once** — summing two single-subtype amounts would double-count a permanent that is
+     * both. A one-element set is the ordinary single-tribe case.
      *
      * Backed by `PermanentsEnteredUnderControlThisTurnComponent`; the triggering entity is read
      * from the resolution context's triggering-entity id.
@@ -1438,18 +1443,18 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     @Serializable
     data class SubtypeEnteredUnderControlThisTurn(
         val player: Player,
-        val subtype: com.wingedsheep.sdk.core.Subtype,
+        val subtypes: Set<com.wingedsheep.sdk.core.Subtype>,
         val excludeTriggeringEntity: Boolean = false
     ) : DynamicAmount {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount {
-            val new = replacer.replaceSubtype(subtype)
-            return if (new == subtype) this else copy(subtype = new)
+            val new = subtypes.map { replacer.replaceSubtype(it) }.toSet()
+            return if (new == subtypes) this else copy(subtypes = new)
         }
         override val description: String = buildString {
             append("the number of ")
             if (excludeTriggeringEntity) append("other ")
-            append(subtype.value)
-            append("s that entered the battlefield under ")
+            append(subtypes.joinToString(" and/or ") { "${it.value}s" })
+            append(" that entered the battlefield under ")
             append(player.possessive)
             append(" control this turn")
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CloudspireCoordinator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CloudspireCoordinator.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+
+/**
+ * Cloudspire Coordinator
+ * {R}{W}
+ * Creature — Human Pilot
+ * 3/1
+ *
+ * When this creature enters, scry 2.
+ * {T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or
+ * Vehicles that entered the battlefield under your control this turn. The tokens have "This token
+ * saddles Mounts and crews Vehicles as though its power were 2 greater."
+ *
+ * X reads the per-player entry log (`PermanentsEnteredUnderControlThisTurnComponent`) rather than
+ * scanning the battlefield, so a Vehicle that entered and has since died or been exiled still
+ * counts — the entry event is what the card asks about.
+ *
+ * "Mounts and/or Vehicles" is one any-of amount, not two summed ones: a permanent carrying both
+ * subtypes must count once. Hence `subtypesEnteredUnderControlThisTurn(setOf(MOUNT, VEHICLE))`.
+ */
+val CloudspireCoordinator = card("Cloudspire Coordinator") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Pilot"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, scry 2.\n" +
+        "{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts " +
+        "and/or Vehicles that entered the battlefield under your control this turn. The tokens " +
+        "have \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\""
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.subtypesEnteredUnderControlThisTurn(setOf(Subtype.MOUNT, Subtype.VEHICLE)),
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Pilot"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+            staticAbilities = listOf(CrewSaddleContribution(modifier = 2))
+        )
+        // The auto-derived text inlines the dynamic amount ("Create the number of Mounts and/or
+        // Vehicles that entered … 1/1 Pilot creature tokens"), and this string is the action-menu
+        // button label. Use the printed wording instead.
+        description = "{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of " +
+            "Mounts and/or Vehicles that entered the battlefield under your control this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "196"
+        artist = "Eduardo Francisco"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg?1783907860"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FarFortuneEndBoss.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/FarFortuneEndBoss.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
+import com.wingedsheep.sdk.dsl.startYourEngines
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyDamageAmount
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Far Fortune, End Boss
+ * {2}{B}{R}
+ * Legendary Creature — Human Mercenary
+ * 4/5
+ *
+ * Start your engines!
+ * Whenever you attack, Far Fortune deals 1 damage to each opponent.
+ * Max speed — If a source you control would deal damage to an opponent or a permanent an opponent
+ * controls, it deals that much damage plus 1 instead.
+ *
+ * The rider is a replacement effect, so it goes through `maxSpeed { replacementEffect(…) }`, which
+ * folds the "your speed is 4" gate into [ModifyDamageAmount]'s own `restrictions` slot. The damage
+ * family evaluates those restrictions against the *replacement source's controller*, which is what
+ * makes the card work: the damage lands on an opponent while the gate reads **your** speed.
+ *
+ * Consequences that fall out of modelling it as a plain additive replacement, matching the rulings:
+ *  - The extra 1 is dealt by the original source, not by Far Fortune (the replacement adjusts the
+ *    would-be amount; it doesn't create new damage from a new source).
+ *  - Trample/divided damage is assigned first and each resulting amount is then bumped, because the
+ *    replacement runs per damage event at the point the amount is applied.
+ *  - Fully prevented damage is never "damage dealt", so nothing is bumped.
+ */
+val FarFortuneEndBoss = card("Far Fortune, End Boss") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Mercenary"
+    power = 4
+    toughness = 5
+    oracleText = "Start your engines! (If you have no speed, it starts at 1. It increases once on " +
+        "each of your turns when an opponent loses life. Max speed is 4.)\n" +
+        "Whenever you attack, Far Fortune deals 1 damage to each opponent.\n" +
+        "Max speed — If a source you control would deal damage to an opponent or a permanent an " +
+        "opponent controls, it deals that much damage plus 1 instead."
+
+    startYourEngines()
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = Effects.DealDamage(
+            amount = 1,
+            target = EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+        description = "Whenever you attack, Far Fortune deals 1 damage to each opponent."
+    }
+
+    maxSpeed {
+        replacementEffect(
+            ModifyDamageAmount(
+                modifier = 1,
+                appliesTo = EventPattern.DamageEvent(
+                    source = SourceFilter.YouControl,
+                    recipient = RecipientFilter.OpponentOrPermanentTheyControl,
+                ),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "203"
+        artist = "Javier Charro"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg?1783907858"
+
+        ruling(
+            "2025-02-07",
+            "The additional 1 damage from Far Fortune's last ability is dealt by the same source as " +
+                "the original source of damage. The damage isn't dealt by Far Fortune unless Far " +
+                "Fortune is the original source of damage."
+        )
+        ruling(
+            "2025-02-07",
+            "If another effect modifies how much damage your sources would deal, including preventing " +
+                "some of it, the player being dealt damage or the controller of the permanent being " +
+                "dealt damage chooses an order in which to apply those effects. If all of the damage " +
+                "is prevented, Far Fortune's last ability no longer applies."
+        )
+        ruling(
+            "2025-02-07",
+            "If damage dealt by a source you control is being divided or assigned among multiple " +
+                "permanents an opponent controls or among an opponent and one or more permanents they " +
+                "control, divide the original amount before adding 1. For example, if you attack with " +
+                "a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can " +
+                "assign 2 damage to the blocker and 3 damage to the defending player. These amounts " +
+                "are then modified to 3 and 4, respectively."
+        )
+        ruling("2025-02-07", "A player \"has max speed\" if their speed is 4.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LifecraftEngine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LifecraftEngine.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantChosenSubtype
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Lifecraft Engine
+ * {3}
+ * Artifact — Vehicle
+ * 4/4
+ *
+ * As this Vehicle enters, choose a creature type.
+ * Vehicle creatures you control are the chosen creature type in addition to their other types.
+ * Each creature you control of the chosen type other than this Vehicle gets +1/+1.
+ * Crew 3
+ *
+ * The same shape as Adaptive Automaton, one step wider: [EntersWithChoice] captures the creature
+ * type durably, [GrantChosenSubtype] adds it (Layer 4) and the lord [ModifyStats] pays it off
+ * (Layer 7c). The two differences from Automaton are what make the card interesting:
+ *
+ *  - The grant's filter is **Vehicle creatures you control**, not the source. A Vehicle is only a
+ *    creature while something animates it (crew, or an effect like Chandra's), so the affected set
+ *    is exactly the currently-animated Vehicles — including this one once it's crewed, which the
+ *    oracle wording deliberately includes.
+ *  - That makes the grant *depend* on the crew animation under CR 613.8a: applying the animation
+ *    changes which permanents the grant applies to, so the animation is applied first no matter
+ *    which effect has the earlier timestamp. `LifecraftEngineScenarioTest` pins that ordering.
+ *
+ * The lord reads `excludeSelf` for "other than this Vehicle", so a crewed Lifecraft Engine is the
+ * chosen type (from its own first ability) but never buffs itself.
+ */
+val LifecraftEngine = card("Lifecraft Engine") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    power = 4
+    toughness = 4
+    oracleText = "As this Vehicle enters, choose a creature type.\n" +
+        "Vehicle creatures you control are the chosen creature type in addition to their other types.\n" +
+        "Each creature you control of the chosen type other than this Vehicle gets +1/+1.\n" +
+        "Crew 3"
+
+    // As this Vehicle enters, choose a creature type.
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    // Vehicle creatures you control are the chosen creature type in addition to their other types.
+    staticAbility {
+        ability = GrantChosenSubtype(
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.VEHICLE)).youControl()
+        )
+    }
+
+    // Each creature you control of the chosen type other than this Vehicle gets +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter.ChosenSubtypeCreatures(excludeSelf = true).youControl()
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg?1783907849"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VnwxtVerboseHost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/VnwxtVerboseHost.kt
@@ -1,8 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.dft.cards
 
-import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.maxSpeed
 import com.wingedsheep.sdk.dsl.startYourEngines
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.EventPattern
@@ -21,13 +20,11 @@ import com.wingedsheep.sdk.scripting.references.Player
  * You have no maximum hand size.
  * Max speed — If you would draw a card, draw two cards instead.
  *
- * The max-speed clause is a *replacement* effect, so it can't go through the `maxSpeed { }`
- * block — that gates static/activated/triggered abilities, and replacement effects are read
- * straight off `ReplacementEffectSourceComponent` at interception sites that don't evaluate a
- * gate. [ReplaceDrawWithEffect] carries its own `restrictions` slot, evaluated in the drawing
- * player's context, so the gate folds into the effect itself exactly the way `maxSpeed { }`
- * folds it into `ModifySpellCost.gating`. The display-only [Keyword.MAX_SPEED] badge is added
- * by hand for the same reason.
+ * The max-speed clause is a *replacement* effect, declared through `maxSpeed { replacementEffect(…) }`.
+ * That path folds the gate into [ReplaceDrawWithEffect]'s own `restrictions` slot — evaluated in the
+ * drawing player's context, which is this card's controller for a `Player.You` draw — because a
+ * conditional wrapper would be invisible to the interception sites that read
+ * `ReplacementEffectSourceComponent` directly.
  *
  * Modelled per card draw rather than as a [ModifyDrawAmount] on the announcement, because the
  * oracle text says "if you would draw a card" — it does not refer to the number of cards drawn,
@@ -52,19 +49,19 @@ val VnwxtVerboseHost = card("Vnwxt, Verbose Host") {
         "Max speed — If you would draw a card, draw two cards instead."
 
     startYourEngines()
-    keywords(Keyword.MAX_SPEED)
 
     staticAbility {
         ability = NoMaximumHandSize
     }
 
-    replacementEffect(
-        ReplaceDrawWithEffect(
-            replacementEffect = DrawCardsEffect(2),
-            restrictions = listOf(Conditions.YouHaveMaxSpeed),
-            appliesTo = EventPattern.DrawEvent(player = Player.You),
+    maxSpeed {
+        replacementEffect(
+            ReplaceDrawWithEffect(
+                replacementEffect = DrawCardsEffect(2),
+                appliesTo = EventPattern.DrawEvent(player = Player.You),
+            )
         )
-    )
+    }
 
     metadata {
         rarity = Rarity.RARE

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2844,6 +2844,74 @@
     ]
 }
 
+// Cloudspire Coordinator
+{
+    "name": "Cloudspire Coordinator",
+    "manaCost": "{R}{W}",
+    "typeLine": "Creature — Human Pilot",
+    "oracleText": "When this creature enters, scry 2.\n{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or Vehicles that entered the battlefield under your control this turn. The tokens have \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "SubtypeEnteredUnderControlThisTurn",
+                        "player": "You",
+                        "subtypes": [
+                            "Mount",
+                            "Vehicle"
+                        ]
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Pilot"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                    "staticAbilities": [
+                        {
+                            "type": "CrewSaddleContribution",
+                            "modifier": 2
+                        }
+                    ]
+                },
+                "descriptionOverride": "{T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or Vehicles that entered the battlefield under your control this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "UNCOMMON",
+        "artist": "Eduardo Francisco",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eef16cda-9150-4e7d-8490-d9f287b81b62.jpg?1783907860"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Cloudspire Skycycle
 {
     "name": "Cloudspire Skycycle",
@@ -4909,6 +4977,93 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Far Fortune, End Boss
+{
+    "name": "Far Fortune, End Boss",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Legendary Creature — Human Mercenary",
+    "oracleText": "Start your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\nWhenever you attack, Far Fortune deals 1 damage to each opponent.\nMax speed — If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus 1 instead.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "START_YOUR_ENGINES",
+        "MAX_SPEED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "Whenever you attack, Far Fortune deals 1 damage to each opponent."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyDamageAmount",
+                "modifier": 1,
+                "restrictions": [
+                    {
+                        "type": "Compare",
+                        "left": "Speed",
+                        "operator": "EQ",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                ],
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "OpponentOrPermanentTheyControl",
+                    "source": "SourceYouControl"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "RARE",
+        "artist": "Javier Charro",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f523e96d-9df1-4854-accb-9876aef787e5.jpg?1783907858",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "The additional 1 damage from Far Fortune's last ability is dealt by the same source as the original source of damage. The damage isn't dealt by Far Fortune unless Far Fortune is the original source of damage."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If another effect modifies how much damage your sources would deal, including preventing some of it, the player being dealt damage or the controller of the permanent being dealt damage chooses an order in which to apply those effects. If all of the damage is prevented, Far Fortune's last ability no longer applies."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If damage dealt by a source you control is being divided or assigned among multiple permanents an opponent controls or among an opponent and one or more permanents they control, divide the original amount before adding 1. For example, if you attack with a 5/5 creature with trample and your opponent blocks with a 2/2 creature, you can assign 2 damage to the blocker and 3 damage to the defending player. These amounts are then modified to 3 and 4, respectively."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "A player \"has max speed\" if their speed is 4."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -8223,6 +8378,61 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Lifecraft Engine
+{
+    "name": "Lifecraft Engine",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "As this Vehicle enters, choose a creature type.\nVehicle creatures you control are the chosen creature type in addition to their other types.\nEach creature you control of the chosen type other than this Vehicle gets +1/+1.\nCrew 3",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantChosenSubtype",
+                "filter": {
+                    "baseFilter": "creature Vehicle ctrl:you"
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true,
+                    "chosenSubtypeKey": "chosenCreatureType"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40c92203-17df-4f10-92c6-ebcc79f01357.jpg?1783907849"
+    },
+    "colorIdentityOverride": []
 }
 
 // Lightshield Parry

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -6837,7 +6837,9 @@
                     "amount": {
                         "type": "SubtypeEnteredUnderControlThisTurn",
                         "player": "You",
-                        "subtype": "Zombie",
+                        "subtypes": [
+                            "Zombie"
+                        ],
                         "excludeTriggeringEntity": true
                     },
                     "target": "TriggeringEntity"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -664,16 +664,18 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.SubtypeEnteredUnderControlThisTurn -> {
                 val playerIds = resolveUnifiedPlayerIds(state, amount.player, context)
-                val wanted = amount.subtype.value
+                val wanted = amount.subtypes.map { it.value }
                 val excludeId = if (amount.excludeTriggeringEntity) context.triggeringEntityId else null
                 playerIds.sumOf { playerId ->
                     val entries = state.getEntity(playerId)
                         ?.get<com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent>()
                         ?.entries
                         ?: emptyList()
+                    // Any-of over the wanted subtypes, counted per *entry* — an entry carrying two
+                    // of them ("Mounts and/or Vehicles") still contributes 1.
                     entries.count { rec ->
                         rec.entityId != excludeId &&
-                            rec.subtypes.any { it.equals(wanted, ignoreCase = true) }
+                            rec.subtypes.any { have -> wanted.any { have.equals(it, ignoreCase = true) } }
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1510,6 +1510,18 @@ object DamageUtils {
                 val damageEvent = effect.appliesTo
                 if (damageEvent !is com.wingedsheep.sdk.scripting.EventPattern.DamageEvent) continue
 
+                // Additional gating conditions, evaluated against the *replacement source's*
+                // controller like the PreventDamage / DoubleDamage sites above — so Far Fortune,
+                // End Boss's "Max speed — …" rider reads Far Fortune's controller's speed, not the
+                // damaged opponent's.
+                if (effect.restrictions.isNotEmpty()) {
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = sourceControllerId,
+                    )
+                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                }
+
                 // Check if the damage source matches the source filter
                 val sourceMatches = when (val sourceFilter = damageEvent.source) {
                     is SourceFilter.Any -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -209,9 +209,32 @@ class StateProjector(
         // === Layers 3-4 (Text + Type) ===
         // Apply type-changing effects first so creature-dependent filters in layers 5-6
         // see permanents that became creatures (e.g., Opalescence making enchantments creatures).
+        //
+        // Layer 4 is not one flat pass, because CR 613.8a dependencies exist *inside* it: an effect
+        // whose affected set reads creature status ("Vehicle creatures you control" — Lifecraft
+        // Engine) depends on the Layer-4 effects that grant or remove the CREATURE type (crew's
+        // animation, Opalescence), since applying those changes which permanents it applies to. Such
+        // an effect therefore applies after them whatever its timestamp, with its filter re-resolved
+        // once they have landed — the same two-phase trick this method already uses between layer
+        // bands. Effects whose filters don't read creature status keep plain timestamp order among
+        // themselves, and a locked CR 613.6 group keeps its frozen set through the re-resolve.
         val typeLayerEffects = nonControlNonPTEffects.filter { it.layer == Layer.TEXT || it.layer == Layer.TYPE }
-        for (effect in typeLayerEffects) {
+        val (creatureDependentTypeEffects, plainTypeEffects) = typeLayerEffects.partition { effect ->
+            val filter = effect.affectsFilter
+            filter != null && filterResolver.isCreatureDependentFilter(filter)
+        }
+        for (effect in plainTypeEffects) {
             effectApplicator.applyEffect(effect, state, projectedValues)
+        }
+        for (effect in creatureDependentTypeEffects) {
+            val resolved = effect.affectsFilter
+                ?.let { filterResolver.resolveAffectedEntities(state, effect.sourceId, it, projectedValues) }
+                ?: effect.affectedEntities
+            effectApplicator.applyEffect(
+                effect.copy(affectedEntities = lockAffected(effect, resolved)),
+                state,
+                projectedValues
+            )
         }
 
         // CR 701.54c: a player's Ring-bearer is legendary (the Ring emblem's first ability).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudspireCoordinatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudspireCoordinatorScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dft.cards.CloudspireCoordinator
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cloudspire Coordinator (DFT) — {R}{W} 3/1 Creature — Human Pilot
+ *
+ * "When this creature enters, scry 2.
+ *  {T}: Create X 1/1 colorless Pilot creature tokens, where X is the number of Mounts and/or
+ *  Vehicles that entered the battlefield under your control this turn. …"
+ *
+ * X comes from the per-player entry log, so these tests put the Mounts/Vehicles onto the
+ * battlefield by *casting* them — the driver's direct-placement helpers bypass the tracker.
+ */
+class CloudspireCoordinatorScenarioTest : FunSpec({
+
+    val tapAbilityId = CloudspireCoordinator.activatedAbilities[0].id
+
+    val testMount = card("Test Mount") {
+        manaCost = "{1}"
+        typeLine = "Creature — Horse Mount"
+        power = 1
+        toughness = 1
+    }
+
+    val testVehicle = card("Test Vehicle") {
+        manaCost = "{1}"
+        typeLine = "Artifact — Vehicle"
+        power = 2
+        toughness = 2
+        keywordAbility(KeywordAbility.crew(1))
+    }
+
+    // Synthetic: no printed card carries both subtypes, but the any-of count must still tally such
+    // a permanent once rather than twice, so pin it directly.
+    val testMountVehicle = card("Test Mount Vehicle") {
+        manaCost = "{1}"
+        typeLine = "Artifact Creature — Vehicle Mount"
+        power = 2
+        toughness = 2
+    }
+
+    val testBear = card("Test Bear") {
+        manaCost = "{1}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CloudspireCoordinator)
+        listOf(testMount, testVehicle, testMountVehicle, testBear).forEach { driver.registerCard(it) }
+        return driver
+    }
+
+    /** Cast [cardName] from hand and resolve the whole stack. */
+    fun GameTestDriver.castPermanent(playerId: EntityId, cardName: String) {
+        val cardId = putCardInHand(playerId, cardName)
+        giveColorlessMana(playerId, 1)
+        castSpell(playerId, cardId)
+        var guard = 0
+        while (stackSize > 0 && guard++ < 20) bothPass()
+    }
+
+    fun pilotTokens(driver: GameTestDriver, playerId: EntityId): List<EntityId> =
+        driver.getCreatures(playerId).filter { driver.getCardName(it) == "Pilot Token" }
+
+    fun GameTestDriver.setUpCoordinator(playerId: EntityId): EntityId {
+        val coordinator = putCreatureOnBattlefield(playerId, "Cloudspire Coordinator")
+        removeSummoningSickness(coordinator)
+        return coordinator
+    }
+
+    test("X counts each Mount and each Vehicle that entered under your control this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+
+        val coordinator = driver.setUpCoordinator(me)
+        driver.castPermanent(me, "Test Mount")
+        driver.castPermanent(me, "Test Vehicle")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = coordinator, abilityId = tapAbilityId))
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) driver.bothPass()
+
+        pilotTokens(driver, me).size shouldBe 2
+    }
+
+    test("a permanent that is both a Mount and a Vehicle counts once, not twice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+
+        val coordinator = driver.setUpCoordinator(me)
+        driver.castPermanent(me, "Test Mount Vehicle")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = coordinator, abilityId = tapAbilityId))
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) driver.bothPass()
+
+        pilotTokens(driver, me).size shouldBe 1
+    }
+
+    test("permanents that are neither a Mount nor a Vehicle are not counted") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+
+        val coordinator = driver.setUpCoordinator(me)
+        driver.castPermanent(me, "Test Bear")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = coordinator, abilityId = tapAbilityId))
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) driver.bothPass()
+
+        pilotTokens(driver, me).size shouldBe 0
+    }
+
+    test("a Vehicle that entered and then died still counts — the entry is what's tracked") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.player1
+
+        val coordinator = driver.setUpCoordinator(me)
+        driver.castPermanent(me, "Test Vehicle")
+        val vehicle = driver.getPermanents(me).single { driver.getCardName(it) == "Test Vehicle" }
+        driver.moveToGraveyard(vehicle)
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = coordinator, abilityId = tapAbilityId))
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) driver.bothPass()
+
+        pilotTokens(driver, me).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FarFortuneEndBossScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FarFortuneEndBossScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.speed.SpeedService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Speed
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Far Fortune, End Boss (DFT #203) — {2}{B}{R} Legendary Creature — Human Mercenary, 4/5.
+ *
+ * "Start your engines!
+ *  Whenever you attack, Far Fortune deals 1 damage to each opponent.
+ *  Max speed — If a source you control would deal damage to an opponent or a permanent an opponent
+ *  controls, it deals that much damage plus 1 instead."
+ *
+ * The rider is the first max-speed-gated *replacement* effect on the damage side, so the things
+ * worth pinning are the gate and the recipient filter:
+ *
+ *  - at max speed a source you control deals +1 to an opponent and to their permanents;
+ *  - below max speed nothing changes (Start your engines! only puts you at 1, so the gate is the
+ *    only thing standing between the two cases);
+ *  - the filter is one-directional — damage to *you* or to *your own* permanents is untouched, which
+ *    is what stops the rider from taxing its own controller;
+ *  - the attack trigger stacks with the rider: 1 damage becomes 2 at max speed, since Far Fortune
+ *    is itself a source you control.
+ */
+class FarFortuneEndBossScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Far Fortune's max-speed damage rider") {
+
+            test("a source you control deals +1 to an opponent at max speed") {
+                val game = farFortuneGame(maxSpeed = true)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Bolt's 3 becomes 4") { game.getLifeTotal(2) shouldBe 16 }
+            }
+
+            test("the same Bolt deals its printed 3 below max speed") {
+                val game = farFortuneGame(maxSpeed = false)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Start your engines! only sets speed 1 — the gate must hold") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+
+            test("damage to a permanent an opponent controls is bumped too") {
+                // A 4/4 survives Bolt's printed 3 and dies to 4, which is what makes the +1 on a
+                // permanent observable at all.
+                val game = farFortuneGame(maxSpeed = true, opponentCreature = "Charging Rhino")
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val rhino = game.findPermanent("Charging Rhino")!!
+                game.castSpell(1, "Lightning Bolt", rhino).error shouldBe null
+                game.resolveStack()
+
+                withClue("3 + 1 = 4 is lethal to a 4/4") { game.isOnBattlefield("Charging Rhino") shouldBe false }
+            }
+
+            test("the same 4/4 survives below max speed") {
+                val game = farFortuneGame(maxSpeed = false, opponentCreature = "Charging Rhino")
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                val rhino = game.findPermanent("Charging Rhino")!!
+                game.castSpell(1, "Lightning Bolt", rhino).error shouldBe null
+                game.resolveStack()
+
+                withClue("3 damage on a 4/4 is not lethal") { game.isOnBattlefield("Charging Rhino") shouldBe true }
+            }
+
+            test("damage to yourself is not bumped — the rider only taxes opponents") {
+                val game = farFortuneGame(maxSpeed = true)
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("RecipientFilter.OpponentOrPermanentTheyControl excludes you") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+            }
+
+            test("the attack trigger's 1 damage becomes 2 at max speed") {
+                val game = farFortuneGame(maxSpeed = true)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                game.declareAttackers(mapOf("Far Fortune, End Boss" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Far Fortune is itself a source you control, so 1 → 2") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("the attack trigger deals its printed 1 below max speed") {
+                val game = farFortuneGame(maxSpeed = false)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                game.declareAttackers(mapOf("Far Fortune, End Boss" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(2) shouldBe 19
+            }
+        }
+    }
+
+    /**
+     * Far Fortune already on the battlefield with a Bolt in hand and Mountains to cast it. Speed is
+     * stamped directly rather than raced up through opponent life loss — Start your engines! has
+     * already put the controller at 1 by then via its state-based action.
+     */
+    private fun farFortuneGame(
+        maxSpeed: Boolean,
+        opponentCreature: String? = null
+    ): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Far Fortune, End Boss", summoningSickness = false)
+            .withCardInHand(1, "Lightning Bolt")
+            .withLandsOnBattlefield(1, "Mountain", 3)
+        if (opponentCreature != null) {
+            builder.withCardOnBattlefield(2, opponentCreature)
+        }
+        builder.withCardInLibrary(1, "Grizzly Bears")
+        builder.withCardInLibrary(2, "Grizzly Bears")
+        val game = builder
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UPKEEP)
+            .build()
+        if (maxSpeed) {
+            game.state = SpeedService.set(game.state, game.player1Id, Speed.MAX, "test").first
+        }
+        return game
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LifecraftEngineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LifecraftEngineScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dft.cards.LifecraftEngine
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private val projector = StateProjector()
+
+/**
+ * Lifecraft Engine (DFT) — {3} 4/4 Artifact — Vehicle
+ *
+ * "As this Vehicle enters, choose a creature type.
+ *  Vehicle creatures you control are the chosen creature type in addition to their other types.
+ *  Each creature you control of the chosen type other than this Vehicle gets +1/+1.
+ *  Crew 3"
+ *
+ * The interaction worth pinning is the CR 613.8a dependency: the type grant applies to *Vehicle
+ * creatures*, so crew's animation changes which permanents the grant affects and must be applied
+ * first within Layer 4 — even though the Engine's static has the earlier timestamp.
+ */
+class LifecraftEngineScenarioTest : FunSpec({
+
+    val pilot = CardDefinition.creature(
+        name = "Test Pilot",
+        manaCost = ManaCost.parse("{1}{W}"),
+        subtypes = setOf(Subtype("Pilot")),
+        power = 2,
+        toughness = 2
+    )
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    // A second Vehicle, cheap to crew, so the grant has a non-source Vehicle to act on.
+    val scooter = card("Test Scooter") {
+        manaCost = "{2}"
+        typeLine = "Artifact — Vehicle"
+        power = 3
+        toughness = 3
+        keywordAbility(KeywordAbility.crew(1))
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LifecraftEngine, pilot, bear))
+        driver.registerCard(scooter)
+        return driver
+    }
+
+    /** Put the Engine out with [type] already locked into its creature-type choice slot. */
+    fun GameTestDriver.putEngine(playerId: EntityId, type: String): EntityId {
+        val engine = putPermanentOnBattlefield(playerId, "Lifecraft Engine")
+        replaceState(state.updateEntity(engine) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice(type))))
+        })
+        return engine
+    }
+
+    test("creatures you control of the chosen type get +1/+1; others and opponents' do not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+        val opponent = driver.getOpponent(you)
+
+        val engine = driver.putEngine(you, "Pilot")
+        val yourPilot = driver.putCreatureOnBattlefield(you, "Test Pilot")
+        val yourBear = driver.putCreatureOnBattlefield(you, "Test Bear")
+        val theirPilot = driver.putCreatureOnBattlefield(opponent, "Test Pilot")
+
+        val projected = projector.project(driver.state)
+
+        projected.getPower(yourPilot) shouldBe 3
+        projected.getToughness(yourPilot) shouldBe 3
+
+        // Not the chosen type.
+        projected.getPower(yourBear) shouldBe 2
+        projected.getToughness(yourBear) shouldBe 2
+
+        // "creature you control" — an opponent's Pilot is untouched.
+        projected.getPower(theirPilot) shouldBe 2
+        projected.getToughness(theirPilot) shouldBe 2
+
+        // Uncrewed, the Engine is not a creature, so its own type grant doesn't reach it.
+        projected.hasSubtype(engine, "Pilot") shouldBe false
+    }
+
+    test("a crewed Vehicle you control becomes the chosen type and gets +1/+1 (CR 613.8a dependency)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+
+        // The Engine's static is on the battlefield first, so it holds the earlier timestamp.
+        driver.putEngine(you, "Pilot")
+        val scooterId = driver.putPermanentOnBattlefield(you, "Test Scooter")
+
+        // Before crewing: not a creature, so no chosen type and no buff.
+        projector.project(driver.state).hasSubtype(scooterId, "Pilot") shouldBe false
+
+        val crewer = driver.putCreatureOnBattlefield(you, "Test Bear")
+        driver.submitSuccess(CrewVehicle(you, scooterId, listOf(crewer)))
+        driver.bothPass() // resolve the crew ability
+
+        val projected = projector.project(driver.state)
+
+        // Crew's Layer 4 animation is applied before the Engine's Layer 4 grant even though it has
+        // the later timestamp, because the grant's affected set depends on it.
+        projected.isCreature(scooterId) shouldBe true
+        projected.hasSubtype(scooterId, "Pilot") shouldBe true
+        projected.hasSubtype(scooterId, "Vehicle") shouldBe true
+
+        // Layer 7c then sees a Pilot creature you control: 3/3 base becomes 4/4.
+        projected.getPower(scooterId) shouldBe 4
+        projected.getToughness(scooterId) shouldBe 4
+    }
+
+    test("the crewed Engine is the chosen type but never buffs itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.player1
+
+        val engine = driver.putEngine(you, "Pilot")
+        // Crew 3 — one 2/2 isn't enough, so bring two.
+        val crewA = driver.putCreatureOnBattlefield(you, "Test Bear")
+        val crewB = driver.putCreatureOnBattlefield(you, "Test Bear")
+        driver.submitSuccess(CrewVehicle(you, engine, listOf(crewA, crewB)))
+        driver.bothPass() // resolve the crew ability
+
+        val projected = projector.project(driver.state)
+
+        projected.isCreature(engine) shouldBe true
+        projected.hasSubtype(engine, "Pilot") shouldBe true
+
+        // "other than this Vehicle" — the lord skips the Engine, which stays a base 4/4.
+        projected.getPower(engine) shouldBe 4
+        projected.getToughness(engine) shouldBe 4
+    }
+})


### PR DESCRIPTION
Three cards from the Aetherdrift tail (255/276 → 258/276). Each needed one contained engine/SDK gap closed first — the remaining DFT cards are all in that category, which is why this is three and not ten.

## Cards

| Card | Shape |
|---|---|
| **Lifecraft Engine** (R) | Vehicle; chosen creature type → type grant (Layer 4) + lord (Layer 7c); Crew 3 |
| **Cloudspire Coordinator** (U) | ETB scry 2; `{T}`: X Pilot tokens, X = Mounts and/or Vehicles that entered this turn |
| **Far Fortune, End Boss** (R) | Start your engines!; attack trigger; max-speed damage rider |

## Engine / SDK changes

**Layer 4 affects-filter dependencies** (`StateProjector`). Lifecraft Engine's grant applies to *"Vehicle creatures you control"*. A Vehicle is only a creature while animated, and crew's animation is itself a Layer 4 effect — so the grant's affected set is populated **by** another effect in its own layer. `EffectSorter.dependsOn` can't see that: it compares already-resolved `affectedEntities`, and the grant's set is empty at sort time. A flat single-pass Layer 4 applied the grant first and silently did nothing.

Fixed by splitting Layer 3–4 the same way `project()` already splits *between* layer bands: apply the effects whose filters don't read creature status first, then re-resolve and apply the creature-dependent ones. That ordering *is* the CR 613.8a dependency. A locked CR 613.6 group keeps its frozen set; the extra cost is one filter re-resolution for the small subset of Layer 4 effects that read creature status.

**Any-of entered-subtype count.** `DynamicAmount.SubtypeEnteredUnderControlThisTurn` took a single `Subtype`; it now takes a `Set<Subtype>` with any-of semantics, plus a plural facade. Cloudspire Coordinator's printed *"Mounts and/or Vehicles"* must count a permanent carrying both exactly once — summing two single-subtype amounts would double-count it. Geralf, the Fleshwright keeps the singular facade unchanged.

**Max-speed-gated replacement effects.** `SpeedDsl` documented this gap by name. `ModifyDamageAmount` gained a `restrictions` slot and the damage site now evaluates it — against the *replacement source's controller*, like the rest of the damage family and unlike the draw/life replacements, which read the affected player. That asymmetry is exactly what Far Fortune needs: the rider taxes opponents while gating on **your** speed. `maxSpeed { }` grew a `replacementEffect(...)` path that folds the gate into whichever `restrictions` slot the effect carries, and throws for types that have none rather than quietly emitting an ungated effect.

Vnwxt, Verbose Host moves onto that shared path (it was the hand-rolled precedent). **Its card snapshot is byte-identical**, so the migration is behavior-preserving.

## Verification

- `just build` green across all modules.
- Full rules-engine suite green — the layer-4 change caused no regressions.
- Three new scenario tests, 14 cases: the crew↔grant layer dependency in both directions, the any-of count (including the both-subtypes and entered-then-died cases), and the max-speed gate above and below max speed for player damage, permanent damage, self-damage, and the attack trigger.
- Card goldens re-blessed: DFT gains the three cards, OTJ shifts only Geralf's renamed field. No removals.
- `just check-card-printing` clean for all three (DFT is the earliest real printing of each).
- `docs/card-sdk-language-reference.md` and `docs/continuous-effect-dependency-system.md` updated in the same change.

## Not included

The other 18 DFT cards each need a new primitive rather than a contained fix — X in cycling costs (Webstrike Elite, Valor's Flagship), exhaust-reset permissions and exhaust-scoped cost reduction (Elvish Refueler, Boom Scholar), granting embalm at a computed cost (Cursecloth Wrappings), non-creature Vehicle tokens (Mu Yanling, Chandra), per-player target sets (Demonic Junker), a "spend only to activate abilities" mana restriction (Pit Automaton, Redshift), and the planeswalkers. Each is its own `add-feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)