### PR TITLE
Let AI seats build and play their own Commander decks

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/CommanderDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/CommanderDeckGenerator.kt
@@ -1,0 +1,392 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.ai.draftsim.toScorerCard
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CommanderEligibility
+import kotlin.math.roundToInt
+import kotlin.random.Random
+import org.slf4j.LoggerFactory
+
+/**
+ * Builds a legal commander-shaped deck — a designated commander plus a library inside its colour
+ * identity — for a seat that has to bring one and hasn't.
+ *
+ * This is the third constructed builder, alongside [com.wingedsheep.ai.engine.SealedDeckGenerator]
+ * (open boosters, autobuild 40) and [ConstructedDeckGenerator] (60-card, four-of). It exists
+ * because those two answer "which cards", and a commander deck's hard part is the *structure*: the
+ * commander is chosen first and every later choice is downstream of it.
+ *
+ * ## The rules it implements
+ *
+ * - **CR 903.3 / 903.3a** — the commander is a legendary creature, or a card whose text says it can
+ *   be one. Read through [CommanderEligibility], the same predicate the server validates against.
+ * - **CR 903.5a / 903.12d** — the deck is exactly [DeckFormat]'s size *including* the commander, so
+ *   the library is one short of it.
+ * - **CR 903.5b** — singleton: every non-basic name appears once.
+ * - **CR 903.5c** — every card's colour identity fits inside the commander's.
+ * - **CR 903.5d** — a card with a basic land type is only legal if every colour it produces is in
+ *   the commander's identity, so the manabase only ever uses the commander's own colours.
+ *
+ * ## What it deliberately doesn't do
+ *
+ * - **Partners, Backgrounds, companions.** The deck model carries one commander; so does this.
+ * - **Colourless commanders.** CR 903.5d bans the five basics from a colourless-identity deck, and
+ *   Brawl's escape hatch (CR 903.12e, "any number of basics of one type") doesn't exist in
+ *   Commander. Rather than build a five-basic deck the validator would reject, an Eldrazi is simply
+ *   never picked — see [commanderCandidates].
+ * - **Non-basic manabases.** The library's lands are basics only. A commander pool's non-basic
+ *   lands are mostly narrow utility lands that Draftsim doesn't rate, and every one of them is a
+ *   fresh CR 903.5d question; a clean basics manabase is a better deck *and* an obviously legal one.
+ * - **Synergy.** Cards are picked on raw rating and curve, not on whether they do what the commander
+ *   wants. That is what makes this a legal deck rather than a good one.
+ */
+class CommanderDeckGenerator(
+    boosterGenerator: BoosterGenerator,
+    cardRegistry: CardRegistry,
+    /**
+     * Randomness source for the commander draw and the curve fill. Defaults to [Random.Default] so
+     * live lobbies keep drawing fresh decks; pass a seeded [Random] to make a run reproducible.
+     */
+    private val random: Random = Random.Default,
+) {
+    private val cardPool = FormatCardPool(boosterGenerator, cardRegistry)
+
+    /**
+     * Build a deck legal in the commander-shaped [format], drawing from the cards printed in
+     * [setCodes] (empty means the whole format-legal card base).
+     *
+     * @throws IllegalArgumentException if [format] is not commander-shaped.
+     * @return the deck, or null when the pool holds no legal commander with a buildable colour
+     *         identity behind it — the caller decides what to do instead, because "no Commander deck
+     *         from three Portal sets" is a lobby configuration, not a bug.
+     */
+    fun generate(setCodes: List<String>, format: DeckFormat): GeneratedDeck? {
+        require(format.isCommanderShape) {
+            "$format is not a commander-shape format; use ConstructedDeckGenerator."
+        }
+        val pool = cardPool.legalPool(setCodes, format)
+        if (pool.isEmpty()) {
+            logger.warn(
+                "No {}-legal cards in {}",
+                format.displayName,
+                if (setCodes.isEmpty()) "the card base" else setCodes.joinToString(", "),
+            )
+            return null
+        }
+        return build(
+            pool = pool,
+            basics = cardPool.basicLands(setCodes),
+            deckSize = deckSizeFor(format),
+            copyLimit = { 1 },
+            label = format.displayName,
+        )
+    }
+
+    /**
+     * Build a commander deck out of a *limited* pool — the cards a seat drafted or opened — rather
+     * than out of a format's legal card base.
+     *
+     * Three things differ from [generate], all because the pool is the legality universe here (see
+     * `DeckValidator.validateCommanderLimited`): [deckSize] is the lobby's minimum rather than a
+     * format constant, copies are capped by how many the seat actually owns, and singleton is the
+     * lobby's own toggle rather than CR 903.5b. The commander choice, the colour-identity filter and
+     * the basics-only manabase are the same, so they are the same code.
+     *
+     * The manabase stays on plain basic-land names here, deliberately: a limited lobby validates a
+     * submitted deck card-by-card against the pool it dealt, and a `Plains#196` art variant is not a
+     * name that pool contains.
+     *
+     * @param pool every card the seat owns, with duplicates repeated.
+     * @param deckSize total cards to build to, counting the commander.
+     * @param allowDuplicates the lobby's own singleton toggle — true (its default) lets the deck play
+     *        every copy the pool holds; false applies paper Commander's one-of rule to it.
+     */
+    fun generateFromPool(
+        pool: List<CardDefinition>,
+        deckSize: Int,
+        allowDuplicates: Boolean = true,
+    ): GeneratedDeck? {
+        val copies = pool.groupingBy { it.name }.eachCount()
+        return build(
+            pool = pool.distinctBy { it.name },
+            basics = emptyList(),
+            deckSize = deckSize,
+            copyLimit = if (allowDuplicates) ({ card -> copies[card.name] ?: 1 }) else ({ 1 }),
+            label = "Commander limited",
+        )
+    }
+
+    /**
+     * Pick a commander, then fill a library inside its colour identity.
+     *
+     * @param pool distinct candidate cards; already scoped to whatever legality the caller enforces.
+     * @param basics basic-land printings whose art the manabase is pinned to.
+     * @param deckSize total cards including the commander.
+     * @param copyLimit how many copies of a card may be played — 1 for singleton, the pool count
+     *        for limited.
+     */
+    private fun build(
+        pool: List<CardDefinition>,
+        basics: List<CardDefinition>,
+        deckSize: Int,
+        copyLimit: (CardDefinition) -> Int,
+        label: String,
+    ): GeneratedDeck? {
+        val commander = pickCommander(pool) ?: run {
+            logger.warn("No legal commander in a pool of {} cards ({})", pool.size, label)
+            return null
+        }
+        val identity = commander.colorIdentity
+
+        val body = pool.filter { card ->
+            card.name != commander.name &&
+                !card.isLand &&
+                card.colorIdentity.all { it in identity }
+        }
+
+        val librarySize = deckSize - 1
+        val landCount = (librarySize * LAND_RATIO).roundToInt()
+        val spells = pickSpells(body, librarySize - landCount, copyLimit)
+
+        // Whatever the pool couldn't fill becomes extra basics. They are the one card type with no
+        // copy cap (CR 903.5b), so this always reaches the exact size the format demands — a deck
+        // one card short is a deck the validator rejects and the seat can't play.
+        val basicsNeeded = librarySize - spells.size
+        val manabase = basicLands(spells + commander, identity, basicsNeeded)
+
+        val deckList = LinkedHashMap<String, Int>()
+        for (card in spells) deckList.merge(card.name, 1, Int::plus)
+        for ((name, count) in manabase) deckList.merge(name, count, Int::plus)
+
+        val pinned = BoosterGenerator.withBasicLandArt(deckList, basics.associateBy { it.name })
+        logger.info(
+            "Built a {} deck for {} ({}): {} spells, {} lands",
+            label,
+            commander.name,
+            identity.joinToString("/") { it.name.first().toString() }.ifEmpty { "C" },
+            spells.size,
+            basicsNeeded,
+        )
+        return GeneratedDeck(deckList = pinned, commander = commander.name)
+    }
+
+    /**
+     * Draw one commander from [pool], biased towards cards Draftsim rates highly and towards narrow
+     * colour identities.
+     *
+     * The identity bias is the load-bearing half. Identity is a *deck-construction* constraint here,
+     * not a bonus: a five-colour commander opens the whole pool but hands the builder a manabase of
+     * five basics split five ways, which casts nothing. One and two colours are the shapes an
+     * all-basics manabase actually supports, three is playable, and four or five is a last resort
+     * for a pool with nothing narrower in it.
+     */
+    private fun pickCommander(pool: List<CardDefinition>): CardDefinition? {
+        val ops = ConstructedRatings.ops()
+        val candidates = commanderCandidates(pool)
+        if (candidates.isEmpty()) return null
+        return candidates.weightedSample(1, random) { card ->
+            val rating = ops.ratingFallback(card.toScorerCard()).coerceAtLeast(ConstructedRatings.MIN_WEIGHT)
+            rating * (IDENTITY_WEIGHT[card.colorIdentity.size] ?: LAST_RESORT_IDENTITY_WEIGHT)
+        }.firstOrNull()
+    }
+
+    /**
+     * The cards in [pool] that could lead a deck.
+     *
+     * Colourless-identity commanders are excluded rather than supported: CR 903.5d allows a basic
+     * land in the deck only if every colour it produces is in the commander's identity, so an
+     * Eldrazi deck's manabase has to be Wastes or colourless utility lands — neither of which this
+     * builder's basics-only manabase can produce. Building one anyway would produce a deck the deck
+     * validator rejects for colour identity, which is worse than declining the commander.
+     */
+    private fun commanderCandidates(pool: List<CardDefinition>): List<CardDefinition> =
+        pool.filter { CommanderEligibility.isLegalCommander(it) && it.colorIdentity.isNotEmpty() }
+
+    /**
+     * Fill [slots] with the best cards [body] offers at each point on the curve.
+     *
+     * Bucket by mana value and draw each bucket's share separately, rather than taking the top
+     * [slots] cards overall: rating alone would hand back a pile of six-drops, because Draftsim
+     * rates a card's power and not its cost. Within a bucket the draw is rating-weighted, so the
+     * bombs come out and the filler still varies between games.
+     *
+     * A bucket the pool can't fill spills its deficit forward into the next one, and anything left
+     * at the end is taken from whatever remains at any cost — a slightly wrong curve beats a short
+     * deck. What the pool genuinely cannot supply comes back as fewer cards than [slots]; the caller
+     * turns the difference into basics.
+     */
+    private fun pickSpells(
+        body: List<CardDefinition>,
+        slots: Int,
+        copyLimit: (CardDefinition) -> Int,
+    ): List<CardDefinition> {
+        if (slots <= 0 || body.isEmpty()) return emptyList()
+        val ops = ConstructedRatings.ops()
+        val weight: (CardDefinition) -> Double = { card ->
+            val rating = ops.ratingFallback(card.toScorerCard()).coerceAtLeast(ConstructedRatings.MIN_WEIGHT)
+            rating * rating * rating
+        }
+        val byBucket = body.groupBy { minOf(it.cmc, TOP_CURVE_BUCKET) }
+
+        val picked = mutableListOf<CardDefinition>()
+        val takenNames = mutableSetOf<String>()
+        var carriedDeficit = 0
+        for ((bucket, share) in CURVE) {
+            val want = (slots * share).roundToInt() + carriedDeficit
+            if (want <= 0) continue
+            val available = byBucket[bucket].orEmpty().filterNot { it.name in takenNames }
+            val drawn = available.weightedSample(want, random, weight)
+            picked += drawn
+            drawn.forEach { takenNames += it.name }
+            carriedDeficit = want - drawn.size
+        }
+
+        // Curve targets are fractions and the pool is lumpy, so the buckets rarely land exactly on
+        // `slots`. Trim the overshoot from the top of the curve (the most expendable cards) and top
+        // up any shortfall from whatever the pool still has.
+        if (picked.size > slots) return picked.sortedBy { it.cmc }.take(slots)
+        if (picked.size < slots) {
+            val remaining = body.filterNot { it.name in takenNames }
+            picked += remaining.weightedSample(slots - picked.size, random, weight)
+        }
+        return duplicateToFill(picked, body, slots, copyLimit, weight)
+    }
+
+    /**
+     * Top a short selection up with extra copies of cards already in it, where the copy cap allows.
+     *
+     * A no-op under singleton, where [copyLimit] is always 1. It earns its keep on the limited path:
+     * a drafted pool holds several copies of the commons a seat wheeled, and playing the second copy
+     * of a good card beats playing another Island.
+     */
+    private fun duplicateToFill(
+        picked: List<CardDefinition>,
+        body: List<CardDefinition>,
+        slots: Int,
+        copyLimit: (CardDefinition) -> Int,
+        weight: (CardDefinition) -> Double,
+    ): List<CardDefinition> {
+        if (picked.size >= slots) return picked
+        val result = picked.toMutableList()
+        val counts = result.groupingBy { it.name }.eachCount().toMutableMap()
+        val repeatable = body
+            .filter { (counts[it.name] ?: 0) < copyLimit(it) && (counts[it.name] ?: 0) > 0 }
+            .sortedByDescending { weight(it) }
+        if (repeatable.isEmpty()) return result
+        var index = 0
+        // Round-robin over the repeatable cards so the extra copies spread over the good ones
+        // instead of stacking onto the single best.
+        while (result.size < slots) {
+            val card = repeatable[index % repeatable.size]
+            index++
+            val held = counts[card.name] ?: 0
+            if (held >= copyLimit(card)) {
+                if (repeatable.none { (counts[it.name] ?: 0) < copyLimit(it) }) break
+                continue
+            }
+            result += card
+            counts[card.name] = held + 1
+        }
+        return result
+    }
+
+    /**
+     * Split [count] basic lands across the commander's [identity], weighted by the coloured pips the
+     * deck actually asks for.
+     *
+     * Only the commander's own colours appear, which is CR 903.5d: a basic land is legal in the deck
+     * only if every colour it can produce is in the commander's identity. Every colour in the
+     * identity gets at least one land even when nothing in the library happens to need it — the
+     * commander itself has to be castable.
+     */
+    private fun basicLands(cards: List<CardDefinition>, identity: Set<Color>, count: Int): Map<String, Int> {
+        if (count <= 0 || identity.isEmpty()) return emptyMap()
+        val ordered = identity.sortedBy { it.ordinal }
+        val pips = ordered.associateWith { color ->
+            cards.sumOf { it.manaCost.colorCount[color] ?: 0 }
+        }
+        val totalPips = pips.values.sum()
+
+        val lands = LinkedHashMap<String, Int>()
+        var assigned = 0
+        for ((index, color) in ordered.withIndex()) {
+            val name = COLOR_TO_BASIC.getValue(color)
+            val share = if (index == ordered.lastIndex) {
+                // The last colour absorbs the rounding so the counts sum to exactly `count`.
+                count - assigned
+            } else if (totalPips == 0) {
+                count / ordered.size
+            } else {
+                ((count * (pips.getValue(color).toDouble() / totalPips)).toInt()).coerceAtLeast(1)
+            }
+            // Clamped to what's left so a deck with fewer lands than colours still sums to `count`
+            // rather than overshooting on the "every colour gets one" floor.
+            lands[name] = share.coerceIn(0, count - assigned)
+            assigned += lands.getValue(name)
+        }
+        return lands.filterValues { it > 0 }
+    }
+
+    /** Total cards the format wants, counting the commander (CR 903.5a, CR 903.12d). */
+    private fun deckSizeFor(format: DeckFormat): Int = when (format) {
+        DeckFormat.STANDARD_BRAWL -> STANDARD_BRAWL_DECK_SIZE
+        else -> SINGLETON_HUNDRED_DECK_SIZE
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(CommanderDeckGenerator::class.java)
+
+        /**
+         * Deck sizes, mirroring `DeckValidator`'s profiles: 100 for Commander and Arena-style Brawl
+         * (CR 903.5a), 60 for Standard Brawl. Paper Brawl's own 60 (CR 903.12d) isn't what our
+         * `BRAWL` format means — it maps to Scryfall's `brawl` key, which is the 100-card Arena
+         * variant.
+         */
+        private const val SINGLETON_HUNDRED_DECK_SIZE = 100
+        private const val STANDARD_BRAWL_DECK_SIZE = 60
+
+        /**
+         * Share of the library that is land. 38% is the paper-Commander consensus (37–38 of 99) and
+         * scales sanely down to the 60-card shapes (22 of 59). It runs a touch high for a 60-card
+         * deck by constructed standards, which is the right error for a builder that puts no ramp
+         * or card selection in the deck on purpose.
+         */
+        private const val LAND_RATIO = 0.38
+
+        /** Mana values 7+ are one bucket; nothing above it curves differently enough to matter. */
+        private const val TOP_CURVE_BUCKET = 7
+
+        /**
+         * Target curve as fractions of the non-land slots. Heavier at the top than a 60-card deck's
+         * because a singleton deck plays more lands and expects to reach six mana.
+         */
+        private val CURVE = linkedMapOf(
+            1 to 0.10,
+            2 to 0.20,
+            3 to 0.20,
+            4 to 0.17,
+            5 to 0.13,
+            6 to 0.10,
+            TOP_CURVE_BUCKET to 0.10,
+        )
+
+        /**
+         * How strongly a candidate commander's colour count counts against it. See [pickCommander]:
+         * an all-basics manabase supports one or two colours comfortably and three at a stretch.
+         */
+        private val IDENTITY_WEIGHT = mapOf(1 to 1.0, 2 to 0.9, 3 to 0.35)
+        private const val LAST_RESORT_IDENTITY_WEIGHT = 0.05
+
+        private val COLOR_TO_BASIC = mapOf(
+            Color.WHITE to "Plains",
+            Color.BLUE to "Island",
+            Color.BLACK to "Swamp",
+            Color.RED to "Mountain",
+            Color.GREEN to "Forest",
+        )
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedDeckGenerator.kt
@@ -1,17 +1,14 @@
 package com.wingedsheep.ai.engine.deck
 
 import com.wingedsheep.ai.draftsim.DraftsimCardOps
-import com.wingedsheep.ai.draftsim.DraftsimData
 import com.wingedsheep.ai.draftsim.DraftsimDeckBuilder
 import com.wingedsheep.ai.draftsim.DraftsimDeckShape
 import com.wingedsheep.ai.draftsim.DraftsimPoolCard
-import com.wingedsheep.ai.draftsim.DraftsimSetTables
 import com.wingedsheep.ai.draftsim.toScorerCard
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.core.DeckFormat
 import com.wingedsheep.sdk.model.CardDefinition
-import kotlin.math.pow
 import kotlin.random.Random
 import org.slf4j.LoggerFactory
 
@@ -30,8 +27,8 @@ import org.slf4j.LoggerFactory
  * **Per-card legality is the whole of the pool filter.** [CardDefinition.legalFormats] is
  * Scryfall-sourced and already accounts for bans and set legality, so "is this card allowed in
  * Pauper" needs no rarity check here. Structural rules on top of that (singleton, 100 cards, a
- * commander in the command zone) are *not* modelled: commander-shape formats are rejected outright
- * rather than approximated — see [generate].
+ * commander in the command zone) are *not* modelled here: commander-shape formats are rejected
+ * outright and belong to [CommanderDeckGenerator], which builds that shape instead.
  */
 class ConstructedDeckGenerator(
     private val boosterGenerator: BoosterGenerator,
@@ -44,33 +41,30 @@ class ConstructedDeckGenerator(
      */
     private val random: Random = Random.Default,
 ) {
+    private val cardPool = FormatCardPool(boosterGenerator, cardRegistry)
+
     /**
      * Builds a format-legal deck from the cards printed in [setCodes].
      *
      * @param setCodes sets to draw from. Empty means "every set" — the full format-legal pool.
      * @param format the constructed format the deck must be legal in.
-     * @throws IllegalArgumentException if [format] is commander-shaped (see class doc), or if the
-     *         legal pool is too thin to build from.
+     * @throws IllegalArgumentException if [format] is commander-shaped (use [CommanderDeckGenerator]
+     *         for those), or if the legal pool is too thin to build from.
      */
     fun generate(setCodes: List<String>, format: DeckFormat): Map<String, Int> {
         require(!format.isCommanderShape) {
             "Commander-shape formats need a designated commander and singleton rules; " +
-                "ConstructedDeckGenerator only builds the 60-card constructed shape."
+                "ConstructedDeckGenerator only builds the 60-card constructed shape. " +
+                "Use CommanderDeckGenerator instead."
         }
 
-        val pool = legalPool(setCodes, format)
+        val pool = cardPool.legalPool(setCodes, format)
         require(pool.isNotEmpty()) {
             "No ${format.displayName}-legal cards available" +
                 if (setCodes.isEmpty()) "" else " in ${setCodes.joinToString(", ")}"
         }
 
-        // Basic lands come from the chosen sets so the deck's art matches the pool it was built
-        // from; an all-sets build falls back to whatever the generator has registered.
-        val basics = if (setCodes.isEmpty()) {
-            boosterGenerator.availableSets.values.firstOrNull()?.basicLands.orEmpty()
-        } else {
-            boosterGenerator.getBasicLands(setCodes).values.toList()
-        }
+        val basics = cardPool.basicLands(setCodes)
 
         logger.info(
             "Building a {} deck from {} legal cards ({})",
@@ -117,7 +111,7 @@ class ConstructedDeckGenerator(
      * is mostly narrow utility lands — a bad trade against a clean basics manabase.
      */
     private fun draftsimBuild(pool: List<CardDefinition>): Map<String, Int>? {
-        val tables = draftsimTables()
+        val tables = ConstructedRatings.tables()
         val shortlist = shortlist(pool.filterNot { it.isLand }, DraftsimCardOps(tables))
         if (shortlist.isEmpty()) return null
 
@@ -157,68 +151,18 @@ class ConstructedDeckGenerator(
     /**
      * Draw [SHORTLIST_SIZE] cards from [pool], biased hard towards the ones Draftsim rates highly.
      *
-     * Efraimidis–Spirakis weighted sampling without replacement: key each card with `u^(1/w)` and
-     * keep the highest keys. The weight is the rating *cubed*, so bombs almost always make the cut
-     * while the tail still turns over between games — a constructed lobby that seated the identical
-     * AI deck every time would be a worse experience than the unrated random build this replaces.
+     * The weight is the rating *cubed*, so bombs almost always make the cut while the tail still
+     * turns over between games — a constructed lobby that seated the identical AI deck every time
+     * would be a worse experience than the unrated random build this replaces.
      *
      * Unrated cards (a set Draftsim never covered, or our own content) fall back to the rarity
      * ladder rather than dropping out, so a pool with no ratings at all still shortlists sanely.
      */
-    private fun shortlist(pool: List<CardDefinition>, ops: DraftsimCardOps): List<CardDefinition> {
-        if (pool.size <= SHORTLIST_SIZE) return pool
-        return pool
-            .map { card ->
-                val weight = ops.ratingFallback(card.toScorerCard()).coerceAtLeast(MIN_WEIGHT)
-                card to random.nextDouble().pow(1.0 / (weight * weight * weight))
-            }
-            .sortedByDescending { it.second }
-            .take(SHORTLIST_SIZE)
-            .map { it.first }
-    }
-
-    /**
-     * The Draftsim tables a constructed build reads.
-     *
-     * Every rated set is merged in, regardless of which sets the pool was scoped to: ratings and the
-     * removal list are per-*card* judgements that transfer straight to constructed, and a constructed
-     * pool spans reprints from everywhere, so the widest name coverage is the most useful. The merge
-     * is cached inside [DraftsimData], so it is paid once per process.
-     *
-     * The archetype tables are deliberately dropped. They encode one limited environment's synergy
-     * pairs ("BLB Bats", "OTJ Outlaws"); merged across 40-odd sets they would have the builder rank a
-     * nonsense mix of them. Empty archetypes put the builder on its no-archetype path, which ranks
-     * the ten two-colour guilds instead — exactly the hypothesis space a 60-card two-colour deck
-     * wants.
-     */
-    private fun draftsimTables(): DraftsimSetTables =
-        DraftsimData.tablesFor(DraftsimData.ratedSetCodes()).copy(archetypes = emptyMap())
-
-    /**
-     * Every card legal in [format], scoped to [setCodes] when non-empty.
-     *
-     * Set scoping reads [BoosterGenerator.SetConfig.cards] *and* resolves the set's reprint
-     * [BoosterGenerator.SetConfig.printings] rows through the registry: a reprint's canonical
-     * `CardDefinition` lives in its earliest printing's set, so a set that is mostly reprints
-     * (a core set, a precon set) would otherwise look almost empty.
-     */
-    private fun legalPool(setCodes: List<String>, format: DeckFormat): List<CardDefinition> {
-        val candidates = if (setCodes.isEmpty()) {
-            cardRegistry.allCardNames().mapNotNull { cardRegistry.getCard(it) }
-        } else {
-            setCodes.flatMap { setCode ->
-                val config = boosterGenerator.availableSets[setCode]
-                    ?: throw IllegalArgumentException("Unknown set code: $setCode")
-                config.cards + config.printings.mapNotNull { cardRegistry.getCard(it.name) }
-            }
+    private fun shortlist(pool: List<CardDefinition>, ops: DraftsimCardOps): List<CardDefinition> =
+        pool.weightedSample(SHORTLIST_SIZE, random) { card ->
+            val rating = ops.ratingFallback(card.toScorerCard()).coerceAtLeast(ConstructedRatings.MIN_WEIGHT)
+            rating * rating * rating
         }
-        return candidates
-            .distinctBy { it.name }
-            // An empty `legalFormats` means we have no Scryfall legality data for the card at all
-            // (custom//unreleased content). Excluding it keeps the deck honestly format-legal
-            // rather than silently smuggling unknowns in.
-            .filter { format in it.legalFormats }
-    }
 
     private companion object {
         private val logger = LoggerFactory.getLogger(ConstructedDeckGenerator::class.java)
@@ -235,9 +179,6 @@ class ConstructedDeckGenerator(
 
         /** Instances per shortlisted card — Draftsim's own four-of cap, so it can build four-ofs. */
         private const val COPIES_PER_CARD = 4
-
-        /** Floor on the sampling weight; a zero would make `1/w` divide by zero. */
-        private const val MIN_WEIGHT = 0.1
 
         private val COLOR_TO_BASIC =
             mapOf("W" to "Plains", "U" to "Island", "B" to "Swamp", "R" to "Mountain", "G" to "Forest")

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedRatings.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/ConstructedRatings.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.ai.draftsim.DraftsimCardOps
+import com.wingedsheep.ai.draftsim.DraftsimData
+import com.wingedsheep.ai.draftsim.DraftsimSetTables
+import kotlin.math.pow
+import kotlin.random.Random
+
+/**
+ * The Draftsim card ratings a *constructed* build reads, and the sampler that uses them.
+ *
+ * Every rated set is merged in, regardless of which sets the pool was scoped to: ratings and the
+ * removal list are per-*card* judgements that transfer straight to constructed, and a constructed
+ * pool spans reprints from everywhere, so the widest name coverage is the most useful. The merge is
+ * cached inside [DraftsimData], so it is paid once per process.
+ *
+ * The archetype tables are deliberately dropped. They encode one limited environment's synergy
+ * pairs ("BLB Bats", "OTJ Outlaws"); merged across 40-odd sets they would have a builder rank a
+ * nonsense mix of them. Empty archetypes put Draftsim's autobuilder on its no-archetype path, which
+ * ranks the ten two-colour guilds instead.
+ */
+internal object ConstructedRatings {
+
+    fun tables(): DraftsimSetTables =
+        DraftsimData.tablesFor(DraftsimData.ratedSetCodes()).copy(archetypes = emptyMap())
+
+    fun ops(): DraftsimCardOps = DraftsimCardOps(tables())
+
+    /** Floor on a sampling weight; a zero would make `1/w` divide by zero. */
+    const val MIN_WEIGHT = 0.1
+}
+
+/**
+ * Draw [count] elements without replacement, biased towards high [weight].
+ *
+ * Efraimidis–Spirakis weighted sampling: key each element with `u^(1/w)` and keep the highest keys.
+ * Both constructed builders want the same thing from it — the bombs almost always make the cut while
+ * the tail still turns over between games, so the AI doesn't seat the identical deck every time.
+ *
+ * Callers supply the weight already shaped (the generators cube the rating to sharpen the bias);
+ * weights are floored at [ConstructedRatings.MIN_WEIGHT] here so a zero-rated card can't divide by
+ * zero.
+ */
+internal fun <T> List<T>.weightedSample(count: Int, random: Random, weight: (T) -> Double): List<T> {
+    if (count >= size) return this
+    if (count <= 0) return emptyList()
+    return this
+        .map { element ->
+            val w = weight(element).coerceAtLeast(ConstructedRatings.MIN_WEIGHT)
+            element to random.nextDouble().pow(1.0 / w)
+        }
+        .sortedByDescending { it.second }
+        .take(count)
+        .map { it.first }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/FormatCardPool.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/FormatCardPool.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.model.CardDefinition
+
+/**
+ * The card pool a constructed build draws from: every card legal in a [DeckFormat], plus the basic
+ * lands whose art the finished deck should use.
+ *
+ * Shared by [ConstructedDeckGenerator] (60-card constructed) and [CommanderDeckGenerator]
+ * (singleton commander shapes) because "what may I build out of" is the same question for both and
+ * the answer has two non-obvious parts — reprint resolution and the empty-set-codes default — that
+ * are easy to get subtly different in a second copy.
+ */
+class FormatCardPool(
+    private val boosterGenerator: BoosterGenerator,
+    private val cardRegistry: CardRegistry,
+) {
+    /**
+     * Every card legal in [format], scoped to [setCodes] when non-empty.
+     *
+     * Set scoping reads [BoosterGenerator.SetConfig.cards] *and* resolves the set's reprint
+     * [BoosterGenerator.SetConfig.printings] rows through the registry: a reprint's canonical
+     * `CardDefinition` lives in its earliest printing's set, so a set that is mostly reprints
+     * (a core set, a precon set) would otherwise look almost empty.
+     *
+     * @throws IllegalArgumentException if a set code doesn't resolve.
+     */
+    fun legalPool(setCodes: List<String>, format: DeckFormat): List<CardDefinition> {
+        val candidates = if (setCodes.isEmpty()) {
+            cardRegistry.allCardNames().mapNotNull { cardRegistry.getCard(it) }
+        } else {
+            setCodes.flatMap { setCode ->
+                val config = boosterGenerator.availableSets[setCode]
+                    ?: throw IllegalArgumentException("Unknown set code: $setCode")
+                config.cards + config.printings.mapNotNull { cardRegistry.getCard(it.name) }
+            }
+        }
+        return candidates
+            .distinctBy { it.name }
+            // An empty `legalFormats` means we have no Scryfall legality data for the card at all
+            // (custom/unreleased content). Excluding it keeps the deck honestly format-legal
+            // rather than silently smuggling unknowns in.
+            .filter { format in it.legalFormats }
+    }
+
+    /**
+     * Basic-land printings to pin the deck's basics to, so their art matches the pool the deck was
+     * built from. An all-sets build has no set to match, so it takes whatever the generator has
+     * registered first.
+     */
+    fun basicLands(setCodes: List<String>): List<CardDefinition> =
+        if (setCodes.isEmpty()) {
+            boosterGenerator.availableSets.values.firstOrNull()?.basicLands.orEmpty()
+        } else {
+            boosterGenerator.getBasicLands(setCodes).values.toList()
+        }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/GeneratedDeck.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/GeneratedDeck.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.ai.engine.deck
+
+/**
+ * A deck a generator built for a seat that didn't bring one: the library, plus the commander when
+ * the format wants one.
+ *
+ * The two travel together because they are one decision. They used to be two: the server resolved a
+ * deck list from the seat's spec and read the commander off that spec separately, so a *generated*
+ * commander deck had nowhere to put the commander it picked and commander-shaped formats had to be
+ * refused. Anything that can answer "what does this seat play" answers both halves here.
+ *
+ * [deckList] **excludes** the commander, matching
+ * [com.wingedsheep.sdk.model.Deck.cards] and `GameSession.addPlayer` — the commander starts in the
+ * command zone, not the library (CR 903.6). Note the *wire* convention is the opposite: a submitted
+ * deck list counts the commander, and the handlers strip it before game init.
+ */
+data class GeneratedDeck(
+    /** Card names (or `Name#CollectorNumber` basic-land variants) to counts. Never the commander. */
+    val deckList: Map<String, Int>,
+    /** The designated commander, or null for an ordinary deck. */
+    val commander: String? = null,
+) {
+    /** Total cards including the commander — the number Commander's exact-size rule counts. */
+    val totalCards: Int get() = deckList.values.sum() + if (commander != null) 1 else 0
+
+    /**
+     * The deck list in *submission* form: the commander counted in with the rest.
+     *
+     * That is the convention every deck-submission path uses — a lobby seat's `submittedDeck` is
+     * expected to contain its commander, and the match handlers strip one copy back out at game
+     * start. Two things depend on it that a bare [deckList] would get wrong: the card count the
+     * lobby shows next to the seat, and a limited lobby's derived sideboard, which is `pool −
+     * deck` and would otherwise put the seat's commander in its sideboard as well as its command
+     * zone.
+     */
+    val submissionList: Map<String, Int>
+        get() = commander?.let { deckList + (it to (deckList[it] ?: 0) + 1) } ?: deckList
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/deck/CommanderDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/deck/CommanderDeckGeneratorTest.kt
@@ -1,0 +1,279 @@
+package com.wingedsheep.ai.engine.deck
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CommanderEligibility
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The Commander build behind an AI seat that has to bring a deck and hasn't.
+ *
+ * Every case here is a deck-construction rule the server's `DeckValidator` will independently
+ * enforce on the same deck, so a build that violates one is a seat the lobby refuses to start:
+ * CR 903.3 (a legal commander), 903.5a (exact size, counting the commander), 903.5b (singleton
+ * outside basics), 903.5c (colour identity bounds the deck) and 903.5d (which basics are even
+ * allowed). The two remaining cases pin the deliberate limitations — no colourless commanders, and a
+ * pool with nothing legal to lead it comes back null instead of throwing.
+ */
+class CommanderDeckGeneratorTest : FunSpec({
+
+    fun spell(name: String, cost: String, rarity: Rarity = Rarity.COMMON): CardDefinition =
+        CardDefinition.creature(
+            name = name,
+            manaCost = ManaCost.parse(cost),
+            subtypes = emptySet(),
+            power = 2,
+            toughness = 2,
+            metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity),
+        ).copy(legalFormats = setOf(DeckFormat.COMMANDER, DeckFormat.BRAWL, DeckFormat.STANDARD_BRAWL))
+
+    fun legend(name: String, cost: String): CardDefinition =
+        CardDefinition.creature(
+            name = name,
+            manaCost = ManaCost.parse(cost),
+            subtypes = emptySet(),
+            power = 4,
+            toughness = 4,
+            supertypes = setOf(Supertype.LEGENDARY),
+            metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = Rarity.RARE),
+        ).copy(legalFormats = setOf(DeckFormat.COMMANDER, DeckFormat.BRAWL, DeckFormat.STANDARD_BRAWL))
+
+    val basics = listOf(
+        CardDefinition.basicLand("Plains", Subtype.PLAINS, ScryfallMetadata(collectorNumber = "301")),
+        CardDefinition.basicLand("Island", Subtype.ISLAND, ScryfallMetadata(collectorNumber = "302")),
+        CardDefinition.basicLand("Swamp", Subtype.SWAMP, ScryfallMetadata(collectorNumber = "303")),
+        CardDefinition.basicLand("Mountain", Subtype.MOUNTAIN, ScryfallMetadata(collectorNumber = "304")),
+        CardDefinition.basicLand("Forest", Subtype.FOREST, ScryfallMetadata(collectorNumber = "305")),
+    )
+    val basicNames = basics.map { it.name }.toSet()
+
+    /** A deck-list key is either a bare card name or `Name#CollectorNumber` for a pinned basic. */
+    fun baseName(key: String) = key.substringBefore('#')
+
+    /**
+     * Deep enough in one colour to fill a 99, plus off-colour cards a colour-identity violation
+     * would reach for and one legend of every relevant identity shape.
+     */
+    fun pool(): List<CardDefinition> =
+        (1..120).map { spell("Green $it", "{${it % 6}}{G}") } +
+            (1..60).map { spell("Blue $it", "{${it % 4}}{U}") } +
+            (1..20).map { spell("Colorless $it", "{${it % 4}}") } +
+            listOf(
+                legend("Mono Green Legend", "{2}{G}"),
+                legend("Green Blue Legend", "{1}{G}{U}"),
+            )
+
+    fun generatorOver(cards: List<CardDefinition>, random: kotlin.random.Random = kotlin.random.Random(7)):
+        CommanderDeckGenerator {
+        val registry = CardRegistry()
+        registry.register(cards)
+        registry.register(basics)
+        val booster = BoosterGenerator(
+            mapOf("AAA" to BoosterGenerator.SetConfig("AAA", "Set AAA", cards, basics))
+        )
+        return CommanderDeckGenerator(booster, registry, random)
+    }
+
+    test("builds exactly 100 cards counting the commander (CR 903.5a)") {
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.commander shouldNotBe null
+        deck.deckList.values.sum() shouldBe 99
+        deck.totalCards shouldBe 100
+    }
+
+    test("Standard Brawl builds the 60-card shape instead") {
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.STANDARD_BRAWL)!!
+
+        deck.totalCards shouldBe 60
+    }
+
+    test("the commander is a legal commander (CR 903.3)") {
+        val registry = CardRegistry().apply { register(pool()); register(basics) }
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        val card = registry.getCard(deck.commander!!)!!
+        CommanderEligibility.isLegalCommander(card) shouldBe true
+    }
+
+    test("a 'can be your commander' planeswalker can lead the deck (CR 903.3a)") {
+        // The only legal commander in the pool is a planeswalker with the override clause, so a
+        // build that only ever looked for legendary creatures would come back null here.
+        val daretti = CardDefinition.planeswalker(
+            name = "Daretti, Scrap Savant",
+            manaCost = ManaCost.parse("{4}{R}"),
+            subtypes = setOf(Subtype("Daretti")),
+            startingLoyalty = 3,
+            oracleText = "Daretti, Scrap Savant can be your commander.",
+        ).copy(legalFormats = setOf(DeckFormat.COMMANDER))
+        val red = (1..120).map { spell("Red $it", "{${it % 6}}{R}") }
+
+        val deck = generatorOver(red + daretti).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.commander shouldBe "Daretti, Scrap Savant"
+    }
+
+    test("every non-basic name appears once (CR 903.5b)") {
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.deckList.filterKeys { baseName(it) !in basicNames }.forEach { (name, count) ->
+            withClue("$name appeared $count times in a singleton deck") { count shouldBe 1 }
+        }
+    }
+
+    test("no card falls outside the commander's colour identity (CR 903.5c)") {
+        val registry = CardRegistry().apply { register(pool()); register(basics) }
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+        val identity = registry.getCard(deck.commander!!)!!.colorIdentity
+
+        deck.deckList.keys.forEach { key ->
+            val card = registry.getCard(baseName(key))!!
+            withClue("${card.name} (${card.colorIdentity}) is outside $identity") {
+                card.colorIdentity.all { it in identity } shouldBe true
+            }
+        }
+    }
+
+    test("the manabase only uses basics the identity allows (CR 903.5d)") {
+        // A mono-green commander is the only one on offer here, so an Island in the deck would be
+        // both an unproducible colour and a colour-identity violation.
+        val monoGreen = (1..120).map { spell("Green $it", "{${it % 6}}{G}") } +
+            (1..40).map { spell("Blue $it", "{${it % 4}}{U}") } +
+            legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(monoGreen).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.commander shouldBe "Mono Green Legend"
+        val basicsUsed = deck.deckList.keys.map { baseName(it) }.filter { it in basicNames }.toSet()
+        basicsUsed shouldBe setOf("Forest")
+    }
+
+    test("a two-colour commander's manabase covers both of its colours") {
+        val greenBlueOnly = (1..80).map { spell("Green $it", "{${it % 6}}{G}") } +
+            (1..80).map { spell("Blue $it", "{${it % 6}}{U}") } +
+            legend("Green Blue Legend", "{1}{G}{U}")
+
+        val deck = generatorOver(greenBlueOnly).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        val basicsUsed = deck.deckList.keys.map { baseName(it) }.filter { it in basicNames }.toSet()
+        basicsUsed shouldBe setOf("Forest", "Island")
+    }
+
+    test("a colourless-identity commander is never chosen") {
+        // CR 903.5d leaves a colourless deck no legal basic land, and Brawl's "any number of one
+        // basic type" exception (CR 903.12e) doesn't exist in Commander. Declining the commander is
+        // the honest answer; building it would produce a deck the validator rejects.
+        val eldrazi = legend("Void Titan", "{8}").copy(colorIdentityOverride = emptySet())
+        val colorless = (1..60).map { spell("Colorless $it", "{${it % 5}}") }
+
+        generatorOver(colorless + eldrazi).generate(listOf("AAA"), DeckFormat.COMMANDER) shouldBe null
+    }
+
+    test("a pool with no legal commander returns null rather than throwing") {
+        val deck = generatorOver((1..80).map { spell("Green $it", "{${it % 5}}{G}") })
+            .generate(listOf("AAA"), DeckFormat.COMMANDER)
+
+        deck shouldBe null
+    }
+
+    test("still reaches the exact size when the identity-legal pool is tiny") {
+        // Ten castable spells and a 99-card library: the rest has to come back as basics, because a
+        // deck one card short is a deck the validator rejects.
+        val thin = (1..10).map { spell("Green $it", "{${it % 4}}{G}") } + legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(thin).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.totalCards shouldBe 100
+        deck.deckList.keys.map { baseName(it) }.filter { it in basicNames }.toSet() shouldBe setOf("Forest")
+    }
+
+    test("refuses a non-commander format") {
+        shouldThrow<IllegalArgumentException> {
+            generatorOver(pool()).generate(listOf("AAA"), DeckFormat.MODERN)
+        }
+    }
+
+    test("successive builds are not the identical deck") {
+        val gen = generatorOver(pool(), kotlin.random.Random.Default)
+
+        val decks = (1..6).map { gen.generate(listOf("AAA"), DeckFormat.COMMANDER) }
+
+        decks.distinct().size shouldNotBe 1
+    }
+
+    test("keeps roughly the paper land ratio") {
+        val deck = generatorOver(pool()).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        val lands = deck.deckList.entries.filter { baseName(it.key) in basicNames }.sumOf { it.value }
+        withClue("$lands lands in a 99-card library") { (lands in 34..42) shouldBe true }
+    }
+
+    test("a limited pool builds to the lobby's deck size and may repeat what it owns") {
+        // The drafted/sealed path: the pool is the legality universe, duplicates are allowed, and
+        // the manabase stays on plain basic names so the lobby's pool check recognises it.
+        val drafted = (1..12).flatMap { i -> List(3) { spell("Green $i", "{${i % 4}}{G}") } } +
+            legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(drafted).generateFromPool(drafted, deckSize = 60)!!
+
+        deck.totalCards shouldBe 60
+        deck.commander shouldBe "Mono Green Legend"
+        deck.deckList.keys.filter { it in basicNames }.toSet() shouldBe setOf("Forest")
+        deck.deckList.keys.none { it.contains('#') } shouldBe true
+        withClue("expected the extra copies the pool holds to be used: ${deck.deckList}") {
+            deck.deckList.filterKeys { it !in basicNames }.values.any { it > 1 } shouldBe true
+        }
+    }
+
+    test("a limited build never plays more copies than the pool holds") {
+        val drafted = (1..12).flatMap { i -> List(2) { spell("Green $i", "{${i % 4}}{G}") } } +
+            legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(drafted).generateFromPool(drafted, deckSize = 60)!!
+
+        deck.deckList.filterKeys { it !in basicNames }.forEach { (name, count) ->
+            withClue("$name: $count copies from a pool holding 2") { (count <= 2) shouldBe true }
+        }
+    }
+
+    test("a limited build honours the lobby's singleton toggle") {
+        val drafted = (1..40).flatMap { i -> List(3) { spell("Green $i", "{${i % 4}}{G}") } } +
+            legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(drafted).generateFromPool(drafted, deckSize = 60, allowDuplicates = false)!!
+
+        deck.deckList.filterKeys { it !in basicNames }.values.forEach { it shouldBe 1 }
+    }
+
+    test("a limited pool with no legal commander returns null") {
+        val drafted = (1..30).map { spell("Green $it", "{${it % 4}}{G}") }
+
+        generatorOver(drafted).generateFromPool(drafted, deckSize = 60) shouldBe null
+    }
+
+    test("colour identity is read from oracle text, not just the mana cost") {
+        // CR 903.4: a mana symbol anywhere in the rules text counts. A green commander's deck can't
+        // contain a colourless-costed card whose activated ability needs {U}.
+        val offColour = spell("Sneaky Artifact", "{2}")
+            .copy(oracleText = "{U}, {T}: Draw a card.")
+        val monoGreen = (1..120).map { spell("Green $it", "{${it % 6}}{G}") } +
+            offColour +
+            legend("Mono Green Legend", "{2}{G}")
+
+        val deck = generatorOver(monoGreen).generate(listOf("AAA"), DeckFormat.COMMANDER)!!
+
+        deck.deckList.keys.contains("Sneaky Artifact") shouldBe false
+    }
+})

--- a/backlog/commander-format.md
+++ b/backlog/commander-format.md
@@ -298,9 +298,23 @@ there. What was left was small, and it shipped:
   is the single statement of the 2HG conflict, and the client renders a **Rules** row between Cards and
   Table. The Commander pack formats and commander deck legality now only *default* the axis.
 
+- ✅ **Commander with AI seats** (issue #1453). `CommanderDeckGenerator` (`:ai`) picks a legal commander
+  (CR 903.3, via the SDK's shared `CommanderEligibility`) and builds a singleton deck inside its colour
+  identity to the format's exact size — CR 903.5a/b/c, with a basics-only manabase so CR 903.5d holds by
+  construction. `RandomDeckResolver` returns a `GeneratedDeck` (list *plus* commander) so the two halves
+  are decided together, and it asks for commander-ness on the **Rules** axis rather than reading it off
+  `DeckFormat`, which is what a premade Commander pod with no legality restriction needs. Every entry
+  point is un-gated: quick-lobby Auto / From sets, a human's Random pool, premade tournament seats, and
+  limited pools (`generateFromPool`, for a drafted or sealed Commander seat).
+
 Deliberately still open:
 
-- Commander with AI seats — auto-deckbuild never designates a commander (issue #1453).
+- Commander-aware *play* — commander tax when evaluating casts, commander damage as a win/loss axis, and
+  an intentional CR 903.9a command-zone choice. The AI plays legal Commander today (it answers the zone
+  choice by simulating both branches, and `CostCalculator` already charges it the tax), just not well.
+  See "AI advisor coverage" under Risks below.
+- Commander deck *synergy* — the generator picks on rating and curve, not on what the commander wants.
+  Partners / Backgrounds and colourless-identity commanders are out of its scope too (Phase 4).
 - AI politics (group dynamics, kingmaker avoidance) — separate research project.
 - **Out of scope permanently:** range of influence (CR 801) — `backlog/multiplayer.md` says so too — and
   the politics mechanics (monarch / initiative / voting).

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -396,7 +396,7 @@ sealed, or premade), then one N-player game".
   (`ai/engine/Sides.kt`) and a 2HG team's pooled life as one total. `FreeForAllHandler` wires each AI
   seat to the pod's `GameSession` when the game starts and marks them ready between games, so only
   the humans are ever waited on. Where the AI's deck comes from follows the format: a generated pool
-  is built by `buildAiSealedDeck`, and `PREMADE_DECKS` — which generates no pool — has one rolled by
+  is built by `buildAiPoolDeck`, and `PREMADE_DECKS` — which generates no pool — has one rolled by
   `RandomDeckResolver` at the moment the AI sits down, the same component and the same rule the quick
   lobby's `vsAi` seat has always used. Changing the lobby's format or `deckFormat` afterwards
   re-rolls it, since both decide what may be in it.
@@ -409,10 +409,13 @@ sealed, or premade), then one N-player game".
   seat's deck is re-rolled immediately rather than at game start: the premade start gate wants every
   seat to have submitted, so the deck has to exist while the host is still looking at the lobby.
   Rejected outside `PREMADE_DECKS`, where the AI builds from the pool it was dealt.
-- **Commander AI requires a chosen deck.** The generated `auto` / `sets` paths still do not pick a
-  commander, so Commander limited pools remain unavailable to AI seats. In `PREMADE_DECKS`, the host
-  may seat an AI and choose a `deck` spec with a designated commander; the server validates the full
-  Commander deck and holds the lobby at its normal deck-submission gate until that choice exists.
+- **Commander AI.** Every source picks its own commander. `auto` / `sets` build a singleton deck to
+  the lobby's commander-shaped `deckFormat` — or to paper Commander when the Rules axis says Commander
+  and no legality was set — and a limited pool is built from with `CommanderDeckGenerator.generateFromPool`.
+  A `deck` spec is the one source that can be *missing* a commander, since the host chose the list; the
+  server validates the full Commander deck on arrival and the lobby holds at its normal deck-submission
+  gate until the choice exists. A seat whose pool holds no legal commander at all stays un-submitted
+  rather than seating a deck the engine would refuse at init.
 - **Attack rule.** The same two messages also carry an optional `attackMode` (default `MULTIPLE`),
   echoed by `LobbySettings.attackMode`, choosing which opponents creatures may attack in the FFA
   game (CR 802 / 803; CR 806.2b requires exactly one): `MULTIPLE` (any opponent), `LEFT`, or

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/RandomDeckResolver.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/RandomDeckResolver.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.gameserver.ai
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.CommanderDeckGenerator
 import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
+import com.wingedsheep.ai.engine.deck.GeneratedDeck
 import com.wingedsheep.gameserver.lobby.AiDeckSpec
 import com.wingedsheep.sdk.core.DeckFormat
 import org.slf4j.LoggerFactory
@@ -16,28 +18,33 @@ import org.springframework.stereotype.Component
  * honoured the lobby format while a human on Random always got a 40-card sealed pool, so a Pauper
  * lobby could seat a rare-filled sealed deck opposite a legal 60-card Pauper deck. The matrix:
  *
- * |                | no format / limited lobby   | constructed format (Standard, Pauper, …) |
- * |----------------|-----------------------------|------------------------------------------|
- * | AI [AiDeckSpec.Auto]  | sealed pool, human's set | 60-card legal deck, whole card base |
- * | AI [AiDeckSpec.Sets]  | sealed pool, chosen sets | 60-card legal deck, chosen sets     |
- * | AI [AiDeckSpec.Fixed] | the submitted list       | the submitted list (validated on submit) |
- * | human "Random"        | sealed pool, their set   | 60-card legal deck, whole card base |
+ * |                | no format / limited lobby   | constructed format | commander-shape format |
+ * |----------------|-----------------------------|--------------------|------------------------|
+ * | AI [AiDeckSpec.Auto]  | sealed pool, human's set | 60-card legal deck, whole card base | singleton deck + commander, whole card base |
+ * | AI [AiDeckSpec.Sets]  | sealed pool, chosen sets | 60-card legal deck, chosen sets | singleton deck + commander, chosen sets |
+ * | AI [AiDeckSpec.Fixed] | the submitted list       | the submitted list (validated on submit) | the submitted list and its commander |
+ * | human "Random"        | sealed pool, their set   | 60-card legal deck, whole card base | singleton deck + commander, whole card base |
  *
  * A seat's *set* choice is a limited-pool concept: it says which boosters to open. Under a
  * constructed format the format defines the pool instead, so the set choice drops out — for the
  * human exactly as it already did for the AI's Auto.
  *
- * **Commander-shape formats are a known gap.** Commander / Brawl / Standard Brawl need a designated
- * commander in the command zone, singleton construction and a colour-identity constraint over the
- * whole deck — none of which the builders model. Rather than ship an illegal 100-card approximation,
- * those lobbies fall through to the limited path and the client says so on the AI panel. A host who
- * wants a real Commander opponent can still pick [AiDeckSpec.Fixed] and hand the AI a real
- * Commander decklist.
+ * Every path returns a [GeneratedDeck] rather than a bare decklist, because a commander-shape lobby
+ * has *two* answers to "what does this seat play" and they have to be decided together. Before
+ * [CommanderDeckGenerator] existed there was only one, and commander shapes fell through to a
+ * limited deck with no commander that the engine then refused to start.
+ *
+ * **Commander-ness is its own parameter, not a reading of [DeckFormat].** A lobby says "this game
+ * has commanders" on its Rules axis; a commander-shaped deck *legality* only defaults that axis.
+ * A premade Commander pod with no legality restriction is the case that separates them, and
+ * inferring from the format alone would hand its AI seats a commander-less deck the engine refuses
+ * to start. Callers pass what their lobby's Rules axis says.
  */
 @Component
 class RandomDeckResolver(
     private val sealedDeckGenerator: SealedDeckGenerator,
     private val constructedDeckGenerator: ConstructedDeckGenerator,
+    private val commanderDeckGenerator: CommanderDeckGenerator,
 ) {
     private val logger = LoggerFactory.getLogger(RandomDeckResolver::class.java)
 
@@ -48,17 +55,26 @@ class RandomDeckResolver(
      * @param format the lobby's deck-format restriction, or null for none.
      * @param fallbackSetCode the set the lobby already resolved for its random pools — used by
      *        [AiDeckSpec.Auto] on the limited path so the AI and the human open the same set.
+     * @param commanderRules whether this lobby's games use commanders.
      */
-    fun resolve(spec: AiDeckSpec, format: DeckFormat?, fallbackSetCode: String): Map<String, Int> {
+    fun resolve(
+        spec: AiDeckSpec,
+        format: DeckFormat?,
+        fallbackSetCode: String,
+        commanderRules: Boolean,
+    ): GeneratedDeck {
         // A fixed list is the host's explicit answer and was validated against the format when it
-        // was submitted; nothing left to decide.
-        if (spec is AiDeckSpec.Fixed) return spec.deckList
+        // was submitted; nothing left to decide. Its commander rides along — under a non-commander
+        // format the caller drops it, exactly as it does for a human's saved deck.
+        if (spec is AiDeckSpec.Fixed) {
+            return GeneratedDeck(spec.deckList, spec.commander?.takeIf { it.isNotBlank() })
+        }
 
         // An empty set selection means the host cleared the picker rather than that they want an
         // empty pool — treat it as Auto instead of failing the game start.
         val setCodes = (spec as? AiDeckSpec.Sets)?.setCodes?.filter { it.isNotBlank() }.orEmpty()
 
-        return randomDeck(format, setCodes, fallbackSetCode)
+        return randomDeck(format, setCodes, fallbackSetCode, commanderRules)
     }
 
     /**
@@ -67,16 +83,20 @@ class RandomDeckResolver(
      * failure. Same three answers, same order of preference — the two lobby kinds differ only in
      * where the fallback set comes from.
      */
-    fun resolve(spec: AiDeckSpec, format: DeckFormat?, setCodes: List<String>): Map<String, Int> =
-        resolve(spec, format, fallbackSetFrom(setCodes))
+    fun resolve(
+        spec: AiDeckSpec,
+        format: DeckFormat?,
+        setCodes: List<String>,
+        commanderRules: Boolean,
+    ): GeneratedDeck = resolve(spec, format, fallbackSetFrom(setCodes), commanderRules)
 
     /**
      * A generated deck for a seat that pinned no set of its own — [resolve] without a spec, for the
      * seats that never had one to state.
      */
-    fun randomDeck(format: DeckFormat?, setCodes: List<String>): Map<String, Int> {
+    fun randomDeck(format: DeckFormat?, setCodes: List<String>, commanderRules: Boolean): GeneratedDeck {
         val pinned = setCodes.filter { it.isNotBlank() }
-        return randomDeck(format, pinned, fallbackSetFrom(pinned))
+        return randomDeck(format, pinned, fallbackSetFrom(pinned), commanderRules)
     }
 
     /** The set to open boosters from when nothing pinned one: the lobby's first, else any set. */
@@ -86,18 +106,59 @@ class RandomDeckResolver(
     /**
      * A generated deck for a seat with no submitted list, honouring the lobby's [format].
      *
+     * Each branch falls back to the one below it rather than failing the game start: a commander
+     * build that can't find a legal commander in a narrow set selection drops to the constructed
+     * path, and a constructed build with too thin a legal pool drops to a sealed one. A deck the
+     * seat can actually play beats an error message — with one exception, noted at the commander
+     * branch, where the fallback is itself unplayable.
+     *
      * @param format the lobby's deck-format restriction, or null for none.
      * @param setCodes sets the seat pinned its pool to; empty means "whatever the lobby resolved",
      *        i.e. [fallbackSetCode] on the limited path and the whole legal card base on the
      *        constructed one.
      * @param fallbackSetCode the single set to open boosters from when [setCodes] is empty.
+     * @param commanderRules whether this lobby's games use commanders — see the class doc for why
+     *        this is asked separately from [format].
      */
-    fun randomDeck(format: DeckFormat?, setCodes: List<String>, fallbackSetCode: String): Map<String, Int> {
-        if (format != null && !format.isCommanderShape) {
+    fun randomDeck(
+        format: DeckFormat?,
+        setCodes: List<String>,
+        fallbackSetCode: String,
+        commanderRules: Boolean,
+    ): GeneratedDeck {
+        // Which commander-shaped format to build to: the lobby's own when it set one, else paper
+        // Commander — the broadest commander-legal pool, and the right default for a lobby that
+        // asked for commanders without restricting legality.
+        val commanderFormat = when {
+            format != null && format.isCommanderShape -> format
+            commanderRules -> DeckFormat.COMMANDER
+            else -> null
+        }
+        if (commanderFormat != null) {
+            // Commander lobby: pick a commander and build a singleton deck inside its colour
+            // identity. Falling through to a commander-less deck is *not* a graceful degradation
+            // here — the engine refuses to start a commander game without one — so the caller has
+            // to notice a null commander and refuse the start rather than seat a broken deck.
+            val built = runCatching { commanderDeckGenerator.generate(setCodes, commanderFormat) }
+                .onFailure { error ->
+                    logger.warn(
+                        "Commander deck for {} ({}) failed",
+                        commanderFormat.displayName,
+                        if (setCodes.isEmpty()) "all sets" else setCodes.joinToString(", "),
+                        error,
+                    )
+                }
+                .getOrNull()
+            if (built != null) return built
+            logger.warn(
+                "No {} deck could be built from {}; falling back to a deck with no commander",
+                commanderFormat.displayName,
+                if (setCodes.isEmpty()) "all sets" else setCodes.joinToString(", "),
+            )
+        } else if (format != null) {
             // Constructed lobby: build to the format so both sides of the table play under the
             // same restriction. Falls back to the limited path if the legal pool is unusably thin
-            // (a narrow format crossed with a narrow set selection) — a limited deck the seat can
-            // actually play beats failing the game start.
+            // (a narrow format crossed with a narrow set selection).
             val built = runCatching { constructedDeckGenerator.generate(setCodes, format) }
                 .onFailure { error ->
                     logger.warn(
@@ -108,18 +169,14 @@ class RandomDeckResolver(
                     )
                 }
                 .getOrNull()
-            if (built != null) return built
-        } else if (format != null) {
-            logger.info(
-                "Lobby format {} is commander-shaped; the seat falls back to a limited deck",
-                format.displayName,
-            )
+            if (built != null) return GeneratedDeck(built)
         }
 
-        return if (setCodes.isEmpty()) {
+        val sealed = if (setCodes.isEmpty()) {
             sealedDeckGenerator.generate(fallbackSetCode)
         } else {
             sealedDeckGenerator.generate(setCodes)
         }
+        return GeneratedDeck(sealed)
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.config
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.CommanderDeckGenerator
 import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
 import com.wingedsheep.ai.engine.deck.RandomDeckGenerator
 import com.wingedsheep.engine.limited.BoosterGenerator
@@ -125,6 +126,16 @@ class GameBeansConfig(
         boosterGenerator: BoosterGenerator,
         cardRegistry: CardRegistry,
     ): ConstructedDeckGenerator = ConstructedDeckGenerator(boosterGenerator, cardRegistry)
+
+    /**
+     * Builds legal Commander / Brawl decks for the AI seat — the singleton shape
+     * [constructedDeckGenerator] refuses, with a designated commander picked first.
+     */
+    @Bean
+    fun commanderDeckGenerator(
+        boosterGenerator: BoosterGenerator,
+        cardRegistry: CardRegistry,
+    ): CommanderDeckGenerator = CommanderDeckGenerator(boosterGenerator, cardRegistry)
 
     @Bean
     fun randomDeckGenerator(): RandomDeckGenerator {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/DeckValidator.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/DeckValidator.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.gameserver.protocol.DeckEntryDTO
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.DeckFormat
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CommanderEligibility
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.PrintingRef
 import org.springframework.beans.factory.annotation.Autowired

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -61,6 +61,7 @@ class LobbyHandler(
     private val freeForAllHandler: FreeForAllHandler,
     private val deckValidator: DeckValidator,
     private val randomDeckResolver: com.wingedsheep.gameserver.ai.RandomDeckResolver,
+    private val commanderDeckGenerator: com.wingedsheep.ai.engine.deck.CommanderDeckGenerator,
     private val tournamentResultSink: com.wingedsheep.gameserver.stats.TournamentResultSink
 ) {
     private val logger = LoggerFactory.getLogger(LobbyHandler::class.java)
@@ -1461,15 +1462,6 @@ class LobbyHandler(
             return
         }
 
-        if (lobby.usesCommanderRules && lobby.format != TournamentFormat.PREMADE_DECKS) {
-            sender.sendError(
-                session,
-                ErrorCode.INVALID_ACTION,
-                "The AI can't build a Commander deck from a limited pool yet — use Bring a deck to choose one for it"
-            )
-            return
-        }
-
         val aiIdentity = aiGameManager.createAiIdentity()
         lobby.addPlayer(aiIdentity)
         ensureAiPremadeDeck(lobby, aiIdentity.playerId)
@@ -1611,28 +1603,41 @@ class LobbyHandler(
         if (lobby.format != TournamentFormat.PREMADE_DECKS) return
         val playerState = lobby.players[aiPlayerId] ?: return
         if (playerState.hasSubmittedDeck) return
-        if (lobby.usesCommanderRules &&
-            (playerState.aiDeckSpec as? AiDeckSpec.Fixed)?.commander.isNullOrBlank()
-        ) {
-            return
-        }
 
-        val deck = runCatching {
-            randomDeckResolver.resolve(playerState.aiDeckSpec, lobby.deckFormat, lobby.setCodes)
+        val generated = runCatching {
+            randomDeckResolver.resolve(
+                playerState.aiDeckSpec,
+                lobby.deckFormat,
+                lobby.setCodes,
+                lobby.usesCommanderRules,
+            )
         }
             .onFailure { logger.error("Could not generate a deck for AI seat ${aiPlayerId.value}", it) }
             .getOrNull() ?: return
 
-        val commander = (playerState.aiDeckSpec as? AiDeckSpec.Fixed)
-            ?.commander
-            ?.takeIf { lobby.usesCommanderRules }
-        when (val result = lobby.submitDeck(aiPlayerId, deck, commander = commander)) {
+        val commander = generated.commander?.takeIf { lobby.usesCommanderRules }
+        // Under Commander rules a deck with no commander can't be seated at all, so leave the seat
+        // un-submitted rather than submit one: the lobby's own start gate then blocks on "not every
+        // seat has a deck", which is a state the host can fix by picking a deck for the AI.
+        if (lobby.usesCommanderRules && commander == null) {
+            logger.warn(
+                "No commander for AI seat {} in lobby {}; leaving the seat without a deck",
+                aiPlayerId.value,
+                lobby.lobbyId,
+            )
+            return
+        }
+        // Submitted in wire form — commander counted in, as `LobbyPlayerState.commander` documents
+        // and as the match handlers' strip-at-start expects.
+        val submitted = if (commander != null) generated.submissionList else generated.deckList
+        when (val result = lobby.submitDeck(aiPlayerId, submitted, commander = commander)) {
             is TournamentLobby.DeckSubmissionResult.Success ->
                 logger.info(
-                    "AI {} brought a generated {} deck ({} cards) to premade lobby {}",
+                    "AI {} brought a generated {} deck ({} cards{}) to premade lobby {}",
                     playerState.identity.playerName,
                     lobby.deckFormat?.displayName ?: "sealed",
-                    deck.values.sum(),
+                    generated.totalCards,
+                    commander?.let { ", led by $it" } ?: "",
                     lobby.lobbyId,
                 )
             is TournamentLobby.DeckSubmissionResult.Error ->
@@ -1689,11 +1694,17 @@ class LobbyHandler(
         ctx.draftScope.launch(Dispatchers.IO) {
             for ((playerId, playerState) in aiPlayers) {
                 try {
-                    val deck = buildAiSealedDeck(playerState.cardPool, heuristicDeckbuilding)
-                    val result = lobby.submitDeck(playerId, deck)
+                    val built = buildAiPoolDeck(lobby, playerState.cardPool, heuristicDeckbuilding)
+                    val submitted = built.submissionList
+                    val result = lobby.submitDeck(playerId, submitted, commander = built.commander)
                     when (result) {
                         is TournamentLobby.DeckSubmissionResult.Success -> {
-                            logger.info("AI ${playerState.identity.playerName} auto-submitted sealed deck (${deck.values.sum()} cards)")
+                            logger.info(
+                                "AI {} auto-submitted a {}-card deck{}",
+                                playerState.identity.playerName,
+                                submitted.values.sum(),
+                                built.commander?.let { " led by $it" } ?: "",
+                            )
                         }
                         is TournamentLobby.DeckSubmissionResult.Error -> {
                             logger.warn("AI deck submission failed: ${result.message}")
@@ -1813,6 +1824,35 @@ class LobbyHandler(
         if (ws != null) {
             gridDraftHandler.handleGridDraftPick(ws, ClientMessage.GridDraftPick(selection))
         }
+    }
+
+    /**
+     * The deck an AI seat builds from the pool it was dealt.
+     *
+     * Two shapes, chosen by the lobby's Rules axis rather than by its pool format: a commander game
+     * needs a designated commander, a singleton-ish deck inside its colour identity and the lobby's
+     * own deck size, none of which the 40-card sealed autobuilder models. A commander build that
+     * finds no legal commander in the pool falls back to the sealed one — the resulting deck can't
+     * be seated under Commander rules, but reporting *that* through the normal submission path is
+     * more useful than throwing out of a background coroutine.
+     */
+    private fun buildAiPoolDeck(
+        lobby: TournamentLobby,
+        pool: List<com.wingedsheep.sdk.model.CardDefinition>,
+        heuristic: Boolean,
+    ): com.wingedsheep.ai.engine.deck.GeneratedDeck {
+        if (lobby.usesCommanderRules) {
+            val built = runCatching { commanderDeckGenerator.generateFromPool(pool, lobby.deckSizeMin, lobby.allowDuplicates) }
+                .onFailure { logger.error("Commander deck build from pool failed in lobby ${lobby.lobbyId}", it) }
+                .getOrNull()
+            if (built != null) return built
+            logger.warn(
+                "No legal commander in the {}-card pool for lobby {}; falling back to a sealed build",
+                pool.size,
+                lobby.lobbyId,
+            )
+        }
+        return com.wingedsheep.ai.engine.deck.GeneratedDeck(buildAiSealedDeck(pool, heuristic))
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.handler
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.GeneratedDeck
 import com.wingedsheep.gameserver.ai.AiGameManager
 import com.wingedsheep.gameserver.ai.RandomDeckResolver
 import com.wingedsheep.gameserver.config.GameProperties
@@ -536,16 +537,18 @@ class QuickGameLobbyHandler(
                 sender.sendError(session, ErrorCode.INVALID_ACTION, "Pick a deck before readying up")
                 return@withLock
             }
-            if (message.ready && current.vsAi && current.usesCommanderRules) {
-                val aiDeck = current.aiDeckSpec as? AiDeckSpec.Fixed
-                if (aiDeck?.commander.isNullOrBlank()) {
-                    sender.sendError(
-                        session,
-                        ErrorCode.INVALID_ACTION,
-                        "Pick a Commander deck for the AI before readying up",
-                    )
-                    return@withLock
-                }
+            // A host-supplied AI deck under Commander rules has to name its commander; the
+            // generated paths pick their own, so only a Fixed spec can be missing one.
+            val aiDeck = current.aiDeckSpec
+            if (message.ready && current.vsAi && current.usesCommanderRules &&
+                aiDeck is AiDeckSpec.Fixed && aiDeck.commander.isNullOrBlank()
+            ) {
+                sender.sendError(
+                    session,
+                    ErrorCode.INVALID_ACTION,
+                    "Pick a Commander deck for the AI before readying up",
+                )
+                return@withLock
             }
             player.ready = message.ready
             broadcastState(current)
@@ -563,22 +566,6 @@ class QuickGameLobbyHandler(
             broadcastClosed(lobby, conflict)
             lobbyRepository.remove(lobby.lobbyId)
             return
-        }
-
-        // A Commander lobby with a human player who never designated a commander would crash
-        // mid-init when GameInitializer requires `commanderCardName`. Surface the error early so
-        // the player can pick a different deck before everyone gets disconnected.
-        if (lobby.usesCommanderRules) {
-            val missing = lobby.players.firstOrNull { !it.isAi && it.deckList?.isNotEmpty() == true && it.commander.isNullOrBlank() }
-            if (missing != null) {
-                logger.warn("Lobby ${lobby.lobbyId}: human player ${missing.playerName} has no commander designated for ${lobby.format} game start")
-                broadcastClosed(
-                    lobby,
-                    "${missing.playerName}'s deck has no commander designated — pick a deck with a commander to play ${lobby.format?.displayName ?: "Commander"}",
-                )
-                lobbyRepository.remove(lobby.lobbyId)
-                return
-            }
         }
 
         // Ranked play only counts when every human seat is a signed-in account (no guests). A guest may
@@ -639,21 +626,63 @@ class QuickGameLobbyHandler(
         }
         gameSession.publicSpectate = lobby.isPublic && !lobby.vsAi
 
-        for (lobbyPlayer in humanPlayers) {
+        // Every seat's deck is resolved *before* anyone is seated. Under Commander rules a deck with
+        // no designated commander can't be seated at all — GameInitializer requires one — and
+        // discovering that halfway through the seating loop would leave the seats already wired
+        // pointing at a game that never starts.
+        //
+        // For Momir Basic every seat plays the same fixed 60 basics. Otherwise: a human's own
+        // submitted deck, or (for a Random pool, and for the AI seat's spec) whatever the resolver
+        // builds under the lobby's format — which for a commander shape now includes picking the
+        // commander.
+        val humanDecks = humanPlayers.associate { lobbyPlayer ->
+            // Momir Basic has no deckbuilding: the fixed 60 basics are substituted at seating time.
+            if (lobby.momirBasic) return@associate lobbyPlayer.playerId to GeneratedDeck(emptyMap())
             // In a vs-AI lobby, share the resolved set with the single human so a random pool draws
             // from the same set the AI got; multi-human lobbies keep each player's own set, rolling
             // an independent random when they didn't pick one.
-            // Momir Basic uses a fixed deck (resolved below), so skip the random sealed-pool roll.
-            val deckList = if (lobby.momirBasic) {
-                emptyMap()
-            } else {
-                val randomFallbackSet = if (lobby.vsAi) aiSetCode else deckGenerator.randomSetCode()
-                EasterEggDeckInjector.maybeInjectEasterEggs(
+            val randomFallbackSet = if (lobby.vsAi) aiSetCode else deckGenerator.randomSetCode()
+            val resolved = resolveDeck(lobbyPlayer, randomFallbackSet, lobby.format, lobby.usesCommanderRules)
+            lobbyPlayer.playerId to resolved.copy(
+                deckList = EasterEggDeckInjector.maybeInjectEasterEggs(
                     lobbyPlayer.playerName,
-                    resolveDeck(lobbyPlayer, randomFallbackSet, lobby.format),
+                    resolved.deckList,
                     gameProperties.easterEggs.enabled,
+                ),
+                // A submitted deck names its own commander on the lobby seat; a generated one names
+                // it on the resolved deck. Either way the seat needs exactly one.
+                commander = lobbyPlayer.commander ?: resolved.commander,
+            )
+        }
+        val aiDeck = when {
+            !lobby.vsAi -> null
+            lobby.momirBasic -> GeneratedDeck(MomirBasicSetup.fixedBasicDeck)
+            else -> randomDeckResolver.resolve(lobby.aiDeckSpec, lobby.format, aiSetCode, lobby.usesCommanderRules)
+        }
+
+        if (lobby.usesCommanderRules && !lobby.momirBasic) {
+            val seatWithoutCommander = humanPlayers.firstOrNull { humanDecks[it.playerId]?.commander == null }
+            if (seatWithoutCommander != null) {
+                logger.warn(
+                    "Lobby ${lobby.lobbyId}: no commander for ${seatWithoutCommander.playerName} at ${lobby.format} game start",
                 )
+                broadcastClosed(
+                    lobby,
+                    "${seatWithoutCommander.playerName}'s deck has no commander designated — pick a deck with a commander to play ${lobby.format?.displayName ?: "Commander"}",
+                )
+                lobbyRepository.remove(lobby.lobbyId)
+                return
             }
+            if (aiDeck != null && aiDeck.commander == null) {
+                logger.error("Lobby ${lobby.lobbyId}: could not build a ${lobby.format?.displayName ?: "Commander"} deck for the AI seat")
+                broadcastClosed(lobby, "Could not build a Commander deck for the AI — pick one for it and try again")
+                lobbyRepository.remove(lobby.lobbyId)
+                return
+            }
+        }
+
+        for (lobbyPlayer in humanPlayers) {
+            val deckList = humanDecks.getValue(lobbyPlayer.playerId).deckList
             val playerSession = sessionRegistry
                 .getAllIdentities()
                 .firstOrNull { it.playerId == lobbyPlayer.playerId }
@@ -671,7 +700,8 @@ class QuickGameLobbyHandler(
             // commander on a saved deck doesn't accidentally route into a Standard game. Strip
             // one copy of the commander out of the wire deck list so the engine sees `cards`
             // (= library) excluding the commander, matching `Deck.cards` convention.
-            val commander = if (lobby.usesCommanderRules) lobbyPlayer.commander else null
+            val commander = humanDecks.getValue(lobbyPlayer.playerId).commander
+                ?.takeIf { lobby.usesCommanderRules }
             // Momir Basic ignores any submitted deck: every seat plays the same fixed 60 basics.
             val engineDeckList = when {
                 lobby.momirBasic -> MomirBasicSetup.fixedBasicDeck
@@ -689,17 +719,9 @@ class QuickGameLobbyHandler(
 
         gameRepository.save(gameSession)
 
-        if (lobby.vsAi) {
-            // AI is added by AiGameManager. For Momir Basic it plays the same fixed 60-basic deck
-            // as the human; otherwise the host's AiDeckSpec decides — a hand-picked list, a build
-            // from chosen sets, or the Auto default that mirrors the human's set (and honours a
-            // constructed format restriction). Resolved here rather than inside AiGameManager so
-            // the deck-source policy lives next to the lobby state that configures it.
-            val aiDeck = if (lobby.momirBasic) {
-                MomirBasicSetup.fixedBasicDeck
-            } else {
-                randomDeckResolver.resolve(lobby.aiDeckSpec, lobby.format, aiSetCode)
-            }
+        if (aiDeck != null) {
+            // AI is added by AiGameManager, from the deck resolved above — the deck-source policy
+            // lives next to the lobby state that configures it, not inside AiGameManager.
             aiGameManager.createAiOpponent(
                 gameSession = gameSession,
                 setCode = aiSetCode,
@@ -707,10 +729,10 @@ class QuickGameLobbyHandler(
                 onMulliganKeep = { id -> gamePlayHandler.handleAiMulliganKeep(gameSession, id) },
                 onMulliganTake = { id -> gamePlayHandler.handleAiMulliganTake(gameSession, id) },
                 onBottomCards = { id, cardIds -> gamePlayHandler.handleAiBottomCards(gameSession, id, cardIds) },
-                deckOverride = aiDeck,
-                commanderCardName = (lobby.aiDeckSpec as? AiDeckSpec.Fixed)
-                    ?.commander
-                    ?.takeIf { lobby.usesCommanderRules },
+                deckOverride = aiDeck.deckList,
+                // Cleared outside Commander rules so a commander on a host-picked deck can't route
+                // into a Standard game.
+                commanderCardName = aiDeck.commander?.takeIf { lobby.usesCommanderRules },
             )
         }
 
@@ -774,17 +796,20 @@ class QuickGameLobbyHandler(
         player: QuickGameLobbyPlayer,
         randomFallbackSet: String,
         format: DeckFormat?,
-    ): Map<String, Int> {
+        commanderRules: Boolean,
+    ): GeneratedDeck {
         val submitted = player.deckList ?: emptyMap()
         if (submitted.isEmpty()) {
             // Player chose Random. Under a constructed format that means a legal 60-card deck built
             // from the format's pool — the same thing the AI seat's Auto gets — not a sealed pool
-            // that ignores the restriction their opponent's list was validated against. Without a
-            // format it stays a sealed pool from their own set choice, falling back to the caller's
-            // pre-resolved set (shared with the AI in a vs-AI lobby so both play the same set).
-            return randomDeckResolver.randomDeck(format, player.setCodes, randomFallbackSet)
+            // that ignores the restriction their opponent's list was validated against. Under a
+            // commander shape it means a generated deck *and* its commander, so "Random" is a legal
+            // Commander seat rather than one the engine refuses at init. Without a format it stays a
+            // sealed pool from their own set choice, falling back to the caller's pre-resolved set
+            // (shared with the AI in a vs-AI lobby so both play the same set).
+            return randomDeckResolver.randomDeck(format, player.setCodes, randomFallbackSet, commanderRules)
         }
-        return submitted
+        return GeneratedDeck(submitted)
     }
 
     private fun broadcastState(lobby: QuickGameLobby) {
@@ -871,14 +896,20 @@ class QuickGameLobbyHandler(
 
     /** Player-list label for the AI seat, describing what the host chose for it. */
     private fun aiDeckLabel(lobby: QuickGameLobby): String = when (val spec = lobby.aiDeckSpec) {
-        is AiDeckSpec.Auto -> if (lobby.format != null && !lobby.format!!.isCommanderShape) {
-            "Auto (${lobby.format!!.displayName})"
-        } else {
-            "Auto (sealed)"
-        }
+        is AiDeckSpec.Auto -> autoAiDeckLabel(lobby)
         is AiDeckSpec.Sets ->
-            if (spec.setCodes.isEmpty()) "Auto (sealed)" else "Built from ${spec.setCodes.joinToString(", ")}"
+            if (spec.setCodes.isEmpty()) autoAiDeckLabel(lobby) else "Built from ${spec.setCodes.joinToString(", ")}"
         is AiDeckSpec.Fixed -> "${spec.label} (${spec.deckList.values.sum() + if (spec.commander != null) 1 else 0})"
+    }
+
+    /**
+     * What "let the server decide" resolves to, named by the axis that decides it. A lobby can run
+     * Commander with no deck-legality restriction at all, and "sealed" would be a lie there.
+     */
+    private fun autoAiDeckLabel(lobby: QuickGameLobby): String = when {
+        lobby.format != null -> "Auto (${lobby.format!!.displayName})"
+        lobby.usesCommanderRules -> "Auto (Commander)"
+        else -> "Auto (sealed)"
     }
 
     private fun validateAiDeck(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/AiDeckSpec.kt
@@ -25,8 +25,9 @@ sealed interface AiDeckSpec {
 
     /**
      * The historical behaviour: the server picks for you. A generated deck mirroring the human's
-     * set for limited-shaped lobbies, or a format-legal constructed deck when the lobby carries a
-     * deck-format restriction.
+     * set for limited-shaped lobbies, a format-legal constructed deck when the lobby carries a
+     * deck-format restriction, or a singleton deck behind a commander the builder picks itself when
+     * the lobby runs Commander rules.
      */
     @Serializable
     @SerialName("auto")
@@ -48,6 +49,9 @@ sealed interface AiDeckSpec {
      *
      * [label] is what the lobby shows next to the AI seat ("Mono-Red Burn"); it is display-only and
      * never round-trips into the engine.
+     *
+     * The only source that can arrive at a Commander lobby *without* a commander — the generated
+     * ones choose their own — which is why the ready-up gate asks about this variant specifically.
      */
     @Serializable
     @SerialName("deck")

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/FreeForAllLobbyTest.kt
@@ -410,7 +410,10 @@ class FreeForAllLobbyTest : FunSpec() {
             }
         }
 
-        test("a Commander premade lobby seats an AI once the host chooses its commander deck") {
+        test("a Commander premade lobby deals an AI its own commander deck, and the host can override it") {
+            // Adding the AI is enough: the server builds it a legal Commander deck and designates a
+            // commander, the same way a quick game rolls one. Before there was a builder for that
+            // shape the seat sat there deckless until the host picked a list for it.
             val host = createClient()
             host.connectAs("Commander Host")
             host.send(ClientMessage.CreateTournamentLobby(
@@ -429,7 +432,9 @@ class FreeForAllLobbyTest : FunSpec() {
                 host.latestLobbyUpdate()?.players?.size shouldBe 2
             }
             val ai = host.latestLobbyUpdate()!!.players.first { it.isAi }
-            ai.deckSubmitted shouldBe false
+            eventually(20.seconds) {
+                host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe true
+            }
 
             host.send(ClientMessage.SetLobbyAiDeck(
                 playerId = ai.playerId,
@@ -439,14 +444,19 @@ class FreeForAllLobbyTest : FunSpec() {
                     commander = "Zetalpa, Primal Dawn",
                 ),
             ))
+            // The seat already had a deck, so `deckSubmitted` can't tell the override apart from the
+            // generated one — the commander on the spec is what changed.
             eventually(10.seconds) {
-                host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe true
+                val seat = host.latestLobbyUpdate()?.players?.first { it.isAi }
+                seat?.deckSubmitted shouldBe true
+                seat?.aiDeck?.commander shouldBe "Zetalpa, Primal Dawn"
             }
-            host.latestLobbyUpdate()?.players?.first { it.isAi }?.aiDeck?.commander shouldBe
-                "Zetalpa, Primal Dawn"
         }
 
-        test("a premade lobby holding an AI can switch to Commander and waits for its commander deck") {
+        test("a premade lobby holding an AI re-rolls its deck when the host switches to Commander") {
+            // `resyncAiDecks` drops the AI's non-commander deck on the switch; what it builds instead
+            // has to be a legal commander deck, or the seat would sit there deckless and the lobby
+            // would never be startable.
             val host = createClient()
             host.connectAs("Rules Switch Host")
             host.send(ClientMessage.CreateTournamentLobby(
@@ -464,10 +474,10 @@ class FreeForAllLobbyTest : FunSpec() {
             }
 
             host.send(ClientMessage.UpdateLobbySettings(rules = "COMMANDER"))
-            eventually(5.seconds) {
+            eventually(20.seconds) {
                 host.latestLobbyUpdate()?.settings?.rules shouldBe "COMMANDER"
+                host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe true
             }
-            host.latestLobbyUpdate()?.players?.first { it.isAi }?.deckSubmitted shouldBe false
         }
 
         test("a sealed FFA pod of one human and two AI builds its decks, starts, and the AI plays") {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/QuickGameLobbyCommanderAiTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/QuickGameLobbyCommanderAiTest.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.gameserver.protocol.ClientMessage
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.sdk.core.DeckFormat
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.seconds
 
@@ -65,6 +67,81 @@ class QuickGameLobbyCommanderAiTest : GameServerTestBase() {
             client.send(ClientMessage.SetQuickGameLobbyReady(true))
 
             eventually(10.seconds) {
+                client.messages.any { it is ServerMessage.GameCreated } shouldBe true
+            }
+            client.allErrors() shouldBe emptyList()
+        }
+
+        test("AI quick lobby starts Commander with a generated AI deck") {
+            // The Auto spec — the default, and what the lobby seats when the host never picks a
+            // deck for the AI. It used to be unstartable under Commander rules: no generated deck
+            // named a commander, and the engine refuses to initialise a commander game without one.
+            val client = createClient()
+            client.connectAs("Auto Commander Host")
+
+            client.send(ClientMessage.CreateQuickGameLobby(vsAi = true, format = DeckFormat.COMMANDER))
+            eventually(5.seconds) {
+                client.messages.any { it is ServerMessage.QuickGameLobbyState } shouldBe true
+            }
+
+            client.send(
+                ClientMessage.SubmitQuickGameLobbyDeck(
+                    deckList = mapOf("Plains" to 99),
+                    commander = "Zetalpa, Primal Dawn",
+                )
+            )
+            client.send(ClientMessage.SetQuickGameLobbyReady(true))
+
+            eventually(30.seconds) {
+                client.messages.any { it is ServerMessage.GameCreated } shouldBe true
+            }
+
+            // "Start *and complete*": the AI has to keep its hand and take turns, not just be seated.
+            // A seat holding a commander-less deck would have failed at game init instead.
+            eventually(30.seconds) {
+                client.messages.any { it is ServerMessage.MulliganDecision } shouldBe true
+            }
+            client.send(ClientMessage.KeepHand)
+            eventually(30.seconds) {
+                client.messages.any { it is ServerMessage.StateUpdate } shouldBe true
+            }
+            // Routine updates are deltas; resync for a full state to assert the table's shape on.
+            client.send(ClientMessage.RequestResync)
+            eventually(30.seconds) {
+                val state = client.latestState()
+                state.shouldNotBeNull()
+                state.players shouldHaveSize 2
+                // CR 903.7 — 40 life each — and CR 903.6: every seat's commander in its own
+                // command zone, the AI's generated one included.
+                state.players.all { it.life == 40 } shouldBe true
+                for (player in state.players) {
+                    val commandZone = state.zones.firstOrNull {
+                        it.zoneId.ownerId == player.playerId &&
+                            it.zoneId.zoneType == com.wingedsheep.sdk.core.Zone.COMMAND
+                    }
+                    commandZone.shouldNotBeNull()
+                    commandZone.size shouldBe 1
+                }
+            }
+            client.allErrors() shouldBe emptyList()
+        }
+
+        test("a Random-pool human seat gets a commander too under Commander rules") {
+            // An empty deck list is "Random pool". Under Commander rules that now means a generated
+            // deck *and* its commander for the human seat as well, rather than a 40-card sealed pool
+            // the engine then refuses to seat.
+            val client = createClient()
+            client.connectAs("Random Commander Host")
+
+            client.send(ClientMessage.CreateQuickGameLobby(vsAi = true, format = DeckFormat.COMMANDER))
+            eventually(5.seconds) {
+                client.messages.any { it is ServerMessage.QuickGameLobbyState } shouldBe true
+            }
+
+            client.send(ClientMessage.SubmitQuickGameLobbyDeck(deckList = emptyMap()))
+            client.send(ClientMessage.SetQuickGameLobbyReady(true))
+
+            eventually(30.seconds) {
                 client.messages.any { it is ServerMessage.GameCreated } shouldBe true
             }
             client.allErrors() shouldBe emptyList()

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/RandomDeckResolverTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/RandomDeckResolverTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.ai
 
 import com.wingedsheep.ai.engine.SealedDeckGenerator
+import com.wingedsheep.ai.engine.deck.CommanderDeckGenerator
 import com.wingedsheep.ai.engine.deck.ConstructedDeckGenerator
 import com.wingedsheep.ai.engine.deck.RandomDeckGenerator
 import com.wingedsheep.engine.limited.BoosterGenerator
@@ -9,6 +10,7 @@ import com.wingedsheep.gameserver.lobby.AiDeckSpec
 import com.wingedsheep.sdk.core.DeckFormat
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.model.ScryfallMetadata
@@ -24,10 +26,13 @@ import io.kotest.matchers.shouldNotBe
  * to apply only to a *submitted* deck, so a Pauper or Standard lobby seated a 40-card sealed pool
  * opposite a validated constructed deck. The AI seat was fixed first; a human on "Random" kept the
  * old behaviour until it was routed through this same resolver, which is what the `randomDeck` cases
- * at the bottom pin. Each case covers one cell of the matrix, including the two deliberate fallbacks
- * (commander-shape formats, and a legal pool too thin to build from).
+ * at the bottom pin. Each case covers one cell of the matrix, including the deliberate fallbacks: a
+ * legal pool too thin to build from, and a commander-shape lobby whose pool holds no legal commander.
  */
 class RandomDeckResolverTest : FunSpec({
+
+    /** Every format the synthetic pool claims legality in, so one `card()` covers every case. */
+    val allFormats = setOf(DeckFormat.PAUPER, DeckFormat.MODERN, DeckFormat.COMMANDER, DeckFormat.STANDARD)
 
     fun card(name: String, cost: String, rarity: Rarity, formats: Set<DeckFormat>) =
         CardDefinition.creature(
@@ -39,18 +44,37 @@ class RandomDeckResolverTest : FunSpec({
             metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = rarity),
         ).copy(legalFormats = formats)
 
+    fun legend(name: String, formats: Set<DeckFormat>) =
+        CardDefinition.creature(
+            name = name,
+            manaCost = ManaCost.parse("{3}{G}"),
+            subtypes = emptySet(),
+            power = 4,
+            toughness = 4,
+            supertypes = setOf(Supertype.LEGENDARY),
+            metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString(), rarity = Rarity.RARE),
+        ).copy(legalFormats = formats)
+
     /**
      * Deep enough to open 8 boosters without exhausting a rarity, and past the 200-card standalone
      * threshold `randomSetCode()` enforces. Commons are Pauper-legal; rares are Modern-only, so a
-     * Pauper build has to leave them behind.
+     * Pauper build has to leave them behind. Everything green so a mono-green commander can lead a
+     * full 99.
+     *
+     * Only set AAA prints legendary creatures, which is what makes BBB a pool with no legal
+     * commander in it — the case the resolver has to fall back from.
      */
     fun pool(prefix: String): List<CardDefinition> =
         (1..200).map {
-            card("$prefix Common $it", "{${it % 5}}{G}", Rarity.COMMON, setOf(DeckFormat.PAUPER, DeckFormat.MODERN))
+            card("$prefix Common $it", "{${it % 5}}{G}", Rarity.COMMON, allFormats - DeckFormat.STANDARD)
         } + (1..40).map {
-            card("$prefix Uncommon $it", "{${it % 5}}{G}", Rarity.UNCOMMON, setOf(DeckFormat.PAUPER, DeckFormat.MODERN))
+            card("$prefix Uncommon $it", "{${it % 5}}{G}", Rarity.UNCOMMON, allFormats - DeckFormat.STANDARD)
         } + (1..20).map {
-            card("$prefix Rare $it", "{${it % 5}}{G}", Rarity.RARE, setOf(DeckFormat.MODERN))
+            card("$prefix Rare $it", "{${it % 5}}{G}", Rarity.RARE, setOf(DeckFormat.MODERN, DeckFormat.COMMANDER))
+        } + if (prefix == "AAA") {
+            (1..5).map { legend("$prefix Legend $it", setOf(DeckFormat.MODERN, DeckFormat.COMMANDER)) }
+        } else {
+            emptyList()
         }
 
     val basics = listOf(
@@ -70,111 +94,149 @@ class RandomDeckResolverTest : FunSpec({
         val registry = CardRegistry()
         configs.values.forEach { registry.register(it.cards) }
         registry.register(basics)
-        return RandomDeckResolver(SealedDeckGenerator(booster), ConstructedDeckGenerator(booster, registry))
+        return RandomDeckResolver(
+            SealedDeckGenerator(booster),
+            ConstructedDeckGenerator(booster, registry),
+            CommanderDeckGenerator(booster, registry),
+        )
     }
 
     val sealedSize = 40
     val constructedSize = RandomDeckGenerator.DECK_SIZE
+    /** CR 903.5a — 100 cards *including* the commander, which lives outside `deckList`. */
+    val commanderLibrarySize = 99
 
     test("Auto with no format opens a sealed pool from the lobby's set") {
-        val deck = resolver().resolve(AiDeckSpec.Auto, format = null, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = null, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe sealedSize
+        deck.deckList.values.sum() shouldBe sealedSize
     }
 
     test("Auto under a constructed format builds to that format instead") {
-        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.MODERN, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.MODERN, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe constructedSize
+        deck.deckList.values.sum() shouldBe constructedSize
     }
 
     test("Auto under Pauper uses only Pauper-legal cards") {
         // The regression this feature closes: the AI's deck must respect the same restriction the
         // human's deck was validated against.
-        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.PAUPER, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.PAUPER, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.contains("Rare") shouldBe false }
+        deck.deckList.keys.filterNot { it.startsWith("Forest") }.forEach { it.contains("Rare") shouldBe false }
     }
 
     test("Sets pins the sealed pool to the chosen sets") {
-        val deck = resolver().resolve(AiDeckSpec.Sets(listOf("BBB")), format = null, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Sets(listOf("BBB")), format = null, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe sealedSize
-        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+        deck.deckList.values.sum() shouldBe sealedSize
+        deck.deckList.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
     }
 
     test("Sets under a constructed format builds to the format from those sets") {
         val deck = resolver()
-            .resolve(AiDeckSpec.Sets(listOf("BBB")), format = DeckFormat.MODERN, fallbackSetCode = "AAA")
+            .resolve(AiDeckSpec.Sets(listOf("BBB")), format = DeckFormat.MODERN, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe constructedSize
-        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+        deck.deckList.values.sum() shouldBe constructedSize
+        deck.deckList.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
     }
 
     test("an empty set selection falls back to Auto rather than failing the game start") {
-        val deck = resolver().resolve(AiDeckSpec.Sets(emptyList()), format = null, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Sets(emptyList()), format = null, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe sealedSize
+        deck.deckList.values.sum() shouldBe sealedSize
     }
 
     test("Fixed plays the submitted list verbatim, whatever the format") {
         val list = mapOf("Anything" to 4, "Forest" to 56)
 
-        resolver().resolve(AiDeckSpec.Fixed(list), format = null, fallbackSetCode = "AAA") shouldBe list
-        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.PAUPER, "AAA") shouldBe list
-        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.COMMANDER, "AAA") shouldBe list
+        resolver().resolve(AiDeckSpec.Fixed(list), format = null, fallbackSetCode = "AAA", commanderRules = false).deckList shouldBe list
+        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.PAUPER, "AAA", commanderRules = false).deckList shouldBe list
+        resolver().resolve(AiDeckSpec.Fixed(list), DeckFormat.COMMANDER, "AAA", commanderRules = true).deckList shouldBe list
     }
 
-    test("a commander-shape format falls back to a limited deck instead of an illegal 60") {
-        // Known gap: the builders can't construct a commander deck (singleton, 100 cards, a
-        // commander in the command zone). Falling back beats seating something illegal.
-        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.COMMANDER, fallbackSetCode = "AAA")
+    test("Fixed carries the host's designated commander through") {
+        val spec = AiDeckSpec.Fixed(mapOf("Anything" to 99), commander = "AAA Legend 1")
 
-        deck.values.sum() shouldBe sealedSize
+        resolver().resolve(spec, DeckFormat.COMMANDER, "AAA", commanderRules = true).commander shouldBe "AAA Legend 1"
+    }
+
+    test("Auto under Commander builds a 100-card singleton deck led by a legal commander") {
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.COMMANDER, fallbackSetCode = "AAA", commanderRules = true)
+
+        deck.commander shouldNotBe null
+        deck.commander!!.contains("Legend") shouldBe true
+        deck.totalCards shouldBe 100
+        deck.deckList.values.sum() shouldBe commanderLibrarySize
+        // CR 903.5b: singleton other than basic lands.
+        deck.deckList.filterKeys { !it.startsWith("Forest") }.values.forEach { it shouldBe 1 }
+    }
+
+    test("Commander rules with no deck-format restriction still build a commander deck") {
+        // The premade Commander pod: its Rules axis says commanders, its legality axis says
+        // nothing. Reading commander-ness off the format alone would seat a 40-card sealed pool
+        // with no commander, which the engine refuses to start.
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = null, fallbackSetCode = "AAA", commanderRules = true)
+
+        deck.commander shouldNotBe null
+        deck.totalCards shouldBe 100
+    }
+
+    test("a commander-shape lobby whose pool holds no legal commander falls back") {
+        // Set BBB prints no legendary creatures, so there is nothing to lead a deck. The caller has
+        // to notice the missing commander and refuse the start; the resolver's job is not to throw.
+        val deck = resolver()
+            .resolve(AiDeckSpec.Sets(listOf("BBB")), format = DeckFormat.COMMANDER, fallbackSetCode = "BBB", commanderRules = true)
+
+        deck.commander shouldBe null
+        deck.deckList.values.sum() shouldBe sealedSize
     }
 
     test("a format with no legal cards falls back to a limited deck") {
         // Nothing in the synthetic pool is Standard-legal, so the constructed build throws and the
         // resolver has to recover rather than propagate.
-        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.STANDARD, fallbackSetCode = "AAA")
+        val deck = resolver().resolve(AiDeckSpec.Auto, format = DeckFormat.STANDARD, fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe sealedSize
+        deck.deckList.values.sum() shouldBe sealedSize
     }
 
     test("successive Auto resolutions are not identical decks") {
         // Each game start re-rolls; a cached deck would make every AI game the same match.
         val resolver = resolver()
-        val decks = (1..8).map { resolver.resolve(AiDeckSpec.Auto, null, "AAA") }
+        val decks = (1..8).map { resolver.resolve(AiDeckSpec.Auto, null, "AAA", commanderRules = false) }
 
         decks.distinct().size shouldNotBe 1
     }
 
     test("a human Random seat with no format opens a sealed pool from their set") {
-        val deck = resolver().randomDeck(format = null, setCodes = emptyList(), fallbackSetCode = "BBB")
+        val deck = resolver().randomDeck(format = null, setCodes = emptyList(), fallbackSetCode = "BBB", commanderRules = false)
 
-        deck.values.sum() shouldBe sealedSize
-        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
+        deck.deckList.values.sum() shouldBe sealedSize
+        deck.deckList.keys.filterNot { it.startsWith("Forest") }.forEach { it.startsWith("BBB") shouldBe true }
     }
 
     test("a human Random seat under a constructed format builds to that format") {
         // The asymmetry this closes: the AI seat honoured the lobby format while a human on Random
         // always got a 40-card sealed pool, so a Pauper lobby could seat a rare-filled sealed deck
         // opposite a validated 60-card Pauper deck.
-        val deck = resolver().randomDeck(DeckFormat.MODERN, setCodes = emptyList(), fallbackSetCode = "AAA")
+        val deck = resolver().randomDeck(DeckFormat.MODERN, setCodes = emptyList(), fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe constructedSize
+        deck.deckList.values.sum() shouldBe constructedSize
     }
 
     test("a human Random seat under Pauper uses only Pauper-legal cards") {
-        val deck = resolver().randomDeck(DeckFormat.PAUPER, setCodes = emptyList(), fallbackSetCode = "AAA")
+        val deck = resolver().randomDeck(DeckFormat.PAUPER, setCodes = emptyList(), fallbackSetCode = "AAA", commanderRules = false)
 
-        deck.values.sum() shouldBe constructedSize
-        deck.keys.filterNot { it.startsWith("Forest") }.forEach { it.contains("Rare") shouldBe false }
+        deck.deckList.values.sum() shouldBe constructedSize
+        deck.deckList.keys.filterNot { it.startsWith("Forest") }.forEach { it.contains("Rare") shouldBe false }
     }
 
-    test("a human Random seat in a commander lobby still falls back to a limited deck") {
-        val deck = resolver().randomDeck(DeckFormat.COMMANDER, setCodes = emptyList(), fallbackSetCode = "AAA")
+    test("a human Random seat in a commander lobby gets a commander deck too") {
+        // "Random" used to hand a Commander seat a 40-card sealed pool with no commander, which the
+        // engine then refused to start on.
+        val deck = resolver().randomDeck(DeckFormat.COMMANDER, setCodes = emptyList(), fallbackSetCode = "AAA", commanderRules = true)
 
-        deck.values.sum() shouldBe sealedSize
+        deck.commander shouldNotBe null
+        deck.totalCards shouldBe 100
     }
 })

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/GeneratedCommanderDeckLegalityTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/GeneratedCommanderDeckLegalityTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.ai.engine.deck.CommanderDeckGenerator
+import com.wingedsheep.sdk.core.DeckFormat
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * The contract between the two halves of AI Commander support: whatever
+ * [CommanderDeckGenerator] builds, [DeckValidator] has to accept.
+ *
+ * `CommanderDeckGeneratorTest` pins each construction rule against a synthetic pool, which is where
+ * the rules are readable. This is the other end — the *real* card base, the *real* validator — and
+ * it's the one that catches the mismatches a synthetic pool can't have: a card whose Scryfall
+ * colour-identity override disagrees with the heuristic, a "deck can have any number" card, a
+ * commander the eligibility rule and the validator read differently. A generated deck that fails
+ * here is a lobby that refuses to start.
+ */
+// RANDOM_PORT rather than the default MOCK: the app's WebSocket config needs a real servlet
+// container to start at all.
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GeneratedCommanderDeckLegalityTest(
+    @param:Autowired private val commanderDeckGenerator: CommanderDeckGenerator,
+    @param:Autowired private val deckValidator: DeckValidator,
+) : FunSpec({
+
+    /**
+     * Enough builds to cross several commanders and colour identities; each one re-rolls, so a
+     * rule the builder gets wrong for one identity shape shows up within a handful of draws.
+     */
+    val builds = 10
+
+    listOf(DeckFormat.COMMANDER, DeckFormat.BRAWL, DeckFormat.STANDARD_BRAWL).forEach { format ->
+        test("every generated ${format.displayName} deck passes the deck validator") {
+            val decks = (1..builds).map { commanderDeckGenerator.generate(emptyList(), format) }
+
+            if (decks.all { it == null }) {
+                // A format the implemented card base can't supply a commander for. Only Standard
+                // Brawl is allowed to be in that position today — no implemented set is
+                // Standard-legal — and it stops being exempt the moment one is, because these
+                // assertions then start running against real decks.
+                withClue("no ${format.displayName} deck could be built from the whole card base") {
+                    format shouldBe DeckFormat.STANDARD_BRAWL
+                }
+                return@test
+            }
+
+            decks.forEach { generated ->
+                withClue("a ${format.displayName} build came back empty after an earlier one succeeded") {
+                    generated shouldNotBe null
+                }
+                val deck = Deck(
+                    cards = generated!!.deckList.flatMap { (name, count) -> List(count) { name } },
+                    commander = generated.commander,
+                )
+
+                val result = deckValidator.validate(deck, format)
+
+                withClue("${generated.commander}: ${result.errors.joinToString { it.message }}") {
+                    result.valid shouldBe true
+                }
+            }
+        }
+    }
+})

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CommanderEligibility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CommanderEligibility.kt
@@ -1,7 +1,6 @@
-package com.wingedsheep.gameserver.deck
+package com.wingedsheep.sdk.model
 
 import com.wingedsheep.sdk.core.Supertype
-import com.wingedsheep.sdk.model.CardDefinition
 
 /**
  * Determines whether a card is a legal commander under CR 903.3 (Commander) and the analogous
@@ -15,6 +14,11 @@ import com.wingedsheep.sdk.model.CardDefinition
  * Partner / Background / Friends Forever pairs are deliberately out of scope here — the
  * surrounding deck model only carries a single commander. When pair support is added,
  * eligibility will need to consider both commanders together.
+ *
+ * It lives in the SDK rather than next to the deck validator because two modules ask the same
+ * question of the same pure card data: `game-server` validates a submitted commander, and the
+ * `ai` module's commander deck builder has to *pick* one. A second copy of the rule is exactly
+ * how a deck the builder produces becomes a deck the validator rejects.
  */
 object CommanderEligibility {
 

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/CommanderEligibilityTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/model/CommanderEligibilityTest.kt
@@ -1,12 +1,10 @@
-package com.wingedsheep.gameserver.deck
+package com.wingedsheep.sdk.model
 
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.core.TypeLine
-import com.wingedsheep.sdk.model.CardDefinition
-import com.wingedsheep.sdk.model.CreatureStats
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 

--- a/web-client/src/components/lobby/AiOpponentPanel.tsx
+++ b/web-client/src/components/lobby/AiOpponentPanel.tsx
@@ -28,8 +28,16 @@ import styles from '../ui/GameUI.module.css'
 
 type Source = 'auto' | 'sets' | 'deck'
 
-/** Commander-shape formats the AI builders can't construct for — see `RandomDeckResolver`. */
+/** Commander-shape formats — the AI builds a singleton deck and picks its own commander for these. */
 const COMMANDER_SHAPES = ['COMMANDER', 'BRAWL', 'STANDARD_BRAWL']
+
+/**
+ * Deck size for a commander shape, matching `DeckValidator`'s profiles. A lobby running Commander
+ * rules with no legality restriction builds to paper Commander, which is the same 100.
+ */
+function commanderDeckSize(format: string | null): number {
+  return format === 'STANDARD_BRAWL' ? 60 : 100
+}
 
 export type AiDeckSource = Source
 
@@ -41,6 +49,7 @@ export function initialAiSource(aiDeck: AiDeckSpecView | null | undefined): Sour
 export function AiOpponentRow({
   aiDeck,
   format,
+  commanderRules,
   disabled,
   source,
   onSourceChange,
@@ -49,6 +58,12 @@ export function AiOpponentRow({
   aiDeck: AiDeckSpecView | null
   /** The lobby's deck-format restriction, upper-case, or null. */
   format: string | null
+  /**
+   * Whether the lobby's Rules axis says Commander. Asked separately from {@link format} because a
+   * lobby can run Commander with no deck-legality restriction at all, and the AI still needs a
+   * commander there — the same split `RandomDeckResolver` makes server-side.
+   */
+  commanderRules: boolean
   /** True once the host has readied up — the choice is locked in at that point. */
   disabled: boolean
   /** Selected source. Lifted to `LobbyScreen` so it can place {@link AiDeckSection} outside. */
@@ -61,7 +76,8 @@ export function AiOpponentRow({
   const [setCodes, setSetCodes] = useState<readonly string[]>(aiDeck?.setCodes ?? [])
   const [showSetPicker, setShowSetPicker] = useState(false)
 
-  const isCommanderShape = format !== null && COMMANDER_SHAPES.includes(format)
+  const isCommanderShape = commanderRules || (format !== null && COMMANDER_SHAPES.includes(format))
+  const commanderSize = commanderDeckSize(format)
 
   const pick = (next: Source) => {
     onSourceChange(next)
@@ -109,7 +125,7 @@ export function AiOpponentRow({
         {source === 'auto' && (
           <div className={styles.variantCaption}>
             {isCommanderShape
-              ? `The AI can't build a ${format === 'COMMANDER' ? 'Commander' : 'Brawl'} deck yet. Use “Pick a deck” and choose one with a designated commander.`
+              ? `The server picks the AI a commander and builds it a ${commanderSize}-card singleton deck in that commander's colours.`
               : format
                 ? `The server builds the AI a 60-card ${format.replace('_', ' ').toLowerCase()}-legal deck.`
                 : 'The server opens eight boosters from your set and auto-builds the AI a 40-card deck.'}
@@ -151,7 +167,7 @@ export function AiOpponentRow({
               {setCodes.length === 0
                 ? 'Pick one or more sets — until you do, the AI falls back to Auto.'
                 : isCommanderShape
-                  ? 'Commander decks aren’t buildable from sets yet. Use “Pick a deck” and choose one with a designated commander.'
+                  ? `The AI's commander and its ${commanderSize}-card deck are drawn from these sets.`
                   : format
                     ? `Only ${format.replace('_', ' ').toLowerCase()}-legal cards from these sets are used.`
                     : 'Eight boosters are opened across these sets and auto-built into a deck.'}
@@ -253,6 +269,7 @@ export function QuickAiDeckModal({
   playerName,
   aiDeck,
   format,
+  commanderRules,
   disabled,
   source,
   onSourceChange,
@@ -261,6 +278,7 @@ export function QuickAiDeckModal({
   playerName: string
   aiDeck: AiDeckSpecView | null
   format: string | null
+  commanderRules: boolean
   disabled: boolean
   source: AiDeckSource
   onSourceChange: (source: AiDeckSource) => void
@@ -281,6 +299,7 @@ export function QuickAiDeckModal({
         <AiOpponentRow
           aiDeck={aiDeck}
           format={format}
+          commanderRules={commanderRules}
           disabled={disabled}
           source={source}
           onSourceChange={onSourceChange}

--- a/web-client/src/components/lobby/LobbyAxes.tsx
+++ b/web-client/src/components/lobby/LobbyAxes.tsx
@@ -22,7 +22,6 @@ import { useEffect } from 'react'
 import {
   cardsLabel,
   cardsSeatCap,
-  commanderAiBlock,
   isCommanderLimited,
   legalityOptionsForRules,
   rulesTableBlock,
@@ -320,12 +319,10 @@ function AxisButtons<V extends CardsKind | RulesAxis | TableAxis | EventAxis>({
 /**
  * Why a Cards sub-shape can't be picked here, or null.
  *
- * Three reasons, all facts shared with the landing wizard rather than numbers written at the call
- * site: the shape seats fewer players than this lobby is holding ({@link cardsSeatCap}); it would
+ * Two reasons, both facts shared with the landing wizard rather than numbers written at the call
+ * site: the shape seats fewer players than this lobby is holding ({@link cardsSeatCap}), or it would
  * default the Rules axis to Commander at a table that can't have it ({@link rulesTableBlock} — the
- * one statement of that rule, so this row can never offer what the Rules row refuses); or it would
- * default those rules on with an AI in the lobby, which no generator can deckbuild for
- * ({@link commanderAiBlock}).
+ * one statement of that rule, so this row can never offer what the Rules row refuses).
  */
 function shapeBlock(view: UnifiedLobbyView, cards: CardsAxis): string | null {
   const cap = cardsSeatCap(cards)
@@ -335,10 +332,7 @@ function shapeBlock(view: UnifiedLobbyView, cards: CardsAxis): string | null {
   // Picking a Commander pack shape defaults Rules to Commander, so it inherits both of the rules'
   // own blocks; a non-commander shape asks them of the rules the lobby already has.
   const wouldRun: RulesAxis = isCommanderLimited(cards) ? 'COMMANDER' : view.axes.rules
-  const conflict = rulesTableBlock(wouldRun, view.axes.table)
-  if (conflict !== null) return conflict
-  if (view.players.some((p) => p.isAi)) return commanderAiBlock(wouldRun, cards)
-  return null
+  return rulesTableBlock(wouldRun, view.axes.table)
 }
 
 function ShapeButton({

--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -446,6 +446,7 @@ export function LobbyScreen() {
             playerName={ai.name}
             aiDeck={quickLobby.aiDeck ?? null}
             format={quickLobby.format ?? null}
+            commanderRules={view.axes.rules === 'COMMANDER'}
             disabled={view.you?.tone === 'ready'}
             source={aiSource}
             onSourceChange={setAiSource}

--- a/web-client/src/components/lobby/axes.ts
+++ b/web-client/src/components/lobby/axes.ts
@@ -179,7 +179,7 @@ export function cardsKindLabel(kind: CardsKind): string {
  * bracket of 1v1 Commander matches, which is exactly what has always been supported. The server
  * never had the restriction — `LobbyHandler.kt:605-616` caps Winston, Grid, 2HG, Teams and FFA and
  * puts everything else at 2–8, and its start guard only asks for two players. What genuinely is
- * missing is Commander at a Two-Headed Giant table and Commander with AI seats; both are stated where
+ * missing is Commander at a Two-Headed Giant table, stated where
  * they apply — see {@link COMMANDER_NEEDS_ITS_OWN_LIFE_TOTAL} and {@link COMMANDER_LIMITED_HAS_NO_AI}.
  */
 export function cardsSeatCap(cards: CardsAxis): number {
@@ -256,27 +256,6 @@ export function rulesTableBlock(rules: RulesAxis, table: TableAxis): string | nu
  */
 export const COMMANDER_NEEDS_ITS_OWN_LIFE_TOTAL =
   'Commander can’t be played as Two-Headed Giant — a 2HG team shares one life total, and Commander gives every player their own 40. Free-for-All and Team vs. Team pods work.'
-
-/**
- * AI seats in a Commander limited lobby.
- *
- * No generated AI deck picks a commander.
- * `LobbyHandler.buildAiSealedDeck` builds a 40-card deck out of a pool without one, and
- * `RandomDeckResolver` declines commander shapes outright rather than ship an illegal 100-card
- * approximation. Keyed on the **Rules** axis rather than on the Commander pack shape, because that
- * is the axis that decides whether the game wants a commander at all: a premade Commander pod asks
- * for one just as much as a Commander Draft does, and the pack-shape reading could not see it.
- */
-export const COMMANDER_HAS_NO_AI =
-  'The AI can’t build a Commander deck from a limited pool yet. Choose Bring a deck and pick a Commander deck for it.'
-
-/**
- * Why an AI can't use this rules/cards combination, or null. A brought deck is allowed because the
- * host can designate its commander; generated limited pools remain blocked.
- */
-export function commanderAiBlock(rules: RulesAxis, cards: CardsAxis): string | null {
-  return rules === 'COMMANDER' && cards.kind !== 'BRING_A_DECK' ? COMMANDER_HAS_NO_AI : null
-}
 
 /**
  * The Commander life / commander-damage presets, mirroring `CommanderPreset` in

--- a/web-client/src/components/lobby/axisChoices.ts
+++ b/web-client/src/components/lobby/axisChoices.ts
@@ -29,7 +29,6 @@ import {
   TABLE_VALUES,
   cardsFromTournamentFormat,
   cardsKindLabel,
-  commanderAiBlock,
   eventFromGameMode,
   eventLabel,
   gameModeForTable,
@@ -160,12 +159,8 @@ export function rulesChoices(view: UnifiedLobbyView): AxisChoice<RulesAxis>[] {
 function rulesAvailability(view: UnifiedLobbyView, rules: RulesAxis): ChoiceAvailability {
   const conflict = rulesTableBlock(rules, view.axes.table)
   if (conflict !== null) return blocked(conflict)
-  if (rules === view.axes.rules) return DIRECT
-  // A brought AI deck can designate its commander. Generated limited pools cannot yet do so.
-  if (view.players.some((p) => p.isAi)) {
-    const aiBlock = commanderAiBlock(rules, view.axes.cards)
-    if (aiBlock !== null) return blocked(aiBlock)
-  }
+  // An AI seat is no longer a reason to refuse Commander: it builds its own legal deck, and picks
+  // its own commander, from a brought-deck lobby or from the pool it is dealt.
   return DIRECT
 }
 

--- a/web-client/src/components/lobby/commanderAi.test.ts
+++ b/web-client/src/components/lobby/commanderAi.test.ts
@@ -1,0 +1,157 @@
+/**
+ * AI seats under Commander rules.
+ *
+ * Every surface used to refuse the combination: no generated deck named a commander, so the wizard,
+ * the lobby's Rules and Cards rows, the Add-AI button and the quick lobby's ready gate all said
+ * "bring a deck for it". The server now builds the AI a legal commander deck from a format's card
+ * base *or* from the pool it is dealt, so the only thing left to ask for is the one case the host
+ * genuinely has to answer: they picked an exact list and didn't say which card leads it.
+ *
+ * These tests are the four surfaces agreeing on that. A surface that still refuses an AI Commander
+ * seat is a lobby the server would happily have started.
+ */
+import { describe, expect, it } from 'vitest'
+import type { CardsAxis } from './axes'
+import { rulesChoices } from './axisChoices'
+import { fromQuickGameLobby, fromTournamentLobby, type UnifiedLobbyView } from './lobbyViewModel'
+import { shapeChoices } from './modeMatrix'
+import type { LobbySettings, QuickGameLobbyStateMessage, TournamentFormat } from '@/types'
+import type { LobbyState } from '@/store/slices/types'
+
+const COMMANDER_CARDS: readonly CardsAxis[] = [
+  { kind: 'DRAFT', shape: 'COMMANDER' },
+  { kind: 'SEALED', shape: 'COMMANDER' },
+  { kind: 'BRING_A_DECK', legality: 'COMMANDER' },
+]
+
+function settings(overrides: Partial<LobbySettings>): LobbySettings {
+  return {
+    setCodes: ['CMR'],
+    setNames: ['Commander Legends'],
+    availableSets: [],
+    format: 'COMMANDER_DRAFT',
+    boosterCount: 3,
+    boosterDistribution: {},
+    maxPlayers: 8,
+    pickTimeSeconds: 45,
+    picksPerRound: 2,
+    gamesPerMatch: 1,
+    isPublic: false,
+    rules: 'COMMANDER',
+    deckSizeMin: 60,
+    allowDuplicates: true,
+    commanderPreset: 'BRAWL',
+    chaosBoosters: false,
+    bannedCardNames: [],
+    aiAssistEnabled: false,
+    gameMode: 'TOURNAMENT',
+    attackMode: 'MULTIPLE',
+    randomTeams: true,
+    teamAssignments: {},
+    ...overrides,
+  } as LobbySettings
+}
+
+/** A Commander lobby holding one human host and one AI seat. */
+function lobbyWithAi(format: TournamentFormat): LobbyState {
+  return {
+    lobbyId: 'lobby-1',
+    state: 'WAITING_FOR_PLAYERS',
+    players: [
+      { playerId: 'p0', playerName: 'Host', isHost: true, isAi: false, isConnected: true, deckSubmitted: false },
+      { playerId: 'ai-1', playerName: 'Robot', isHost: false, isAi: true, isConnected: true, deckSubmitted: false },
+    ],
+    settings: settings({ format }),
+    isHost: true,
+    draftState: null,
+    winstonDraftState: null,
+    gridDraftState: null,
+  } as unknown as LobbyState
+}
+
+function view(format: TournamentFormat): UnifiedLobbyView {
+  return fromTournamentLobby(lobbyWithAi(format), { aiEnabled: true, playerId: 'p0' })
+}
+
+function quickLobby(aiDeck: QuickGameLobbyStateMessage['aiDeck']): QuickGameLobbyStateMessage {
+  return {
+    lobbyId: 'quick-1',
+    vsAi: true,
+    setCode: null,
+    players: [
+      {
+        playerId: 'p0', playerName: 'Host', isAi: false, ready: false,
+        deckSelected: true, deckCardCount: 100, deckLabel: 'Custom (100)', setCodes: [],
+      },
+      {
+        playerId: 'ai-1', playerName: 'Robot', isAi: true, ready: false,
+        deckSelected: true, deckCardCount: 100, deckLabel: 'Auto (Commander)', setCodes: [],
+      },
+    ],
+    youPlayerId: 'p0',
+    canStart: false,
+    isPublic: false,
+    format: 'COMMANDER',
+    rules: 'COMMANDER',
+    aiDeck,
+  } as unknown as QuickGameLobbyStateMessage
+}
+
+describe('an AI seat in a Commander lobby', () => {
+  it('the wizard offers every shape to a solo Commander player', () => {
+    // A solo lobby is an AI lobby. Blocking the AI blocked the whole Commander branch of the wizard.
+    for (const cards of COMMANDER_CARDS) {
+      for (const choice of shapeChoices('SOLO', cards)) {
+        if (choice.value === 'TWO_HEADED_GIANT') continue
+        // A limited pool still declines the two-seat single game, which is its own rule.
+        if (choice.value === 'ONE_GAME' && cards.kind !== 'BRING_A_DECK') continue
+        expect(choice.disabledReason, `${choice.value} / ${JSON.stringify(cards)}`).toBeUndefined()
+      }
+    }
+  })
+
+  it('the Rules axis lets a lobby with an AI seat switch to Commander', () => {
+    const standard = fromTournamentLobby(
+      { ...lobbyWithAi('PREMADE_DECKS'), settings: settings({ format: 'PREMADE_DECKS', rules: 'STANDARD' }) } as LobbyState,
+      { aiEnabled: true, playerId: 'p0' },
+    )
+
+    const commander = rulesChoices(standard).find((c) => c.value === 'COMMANDER')
+
+    expect(commander?.availability.kind).not.toBe('BLOCKED')
+  })
+
+  it('the host can still add an AI to a Commander limited lobby', () => {
+    for (const format of ['COMMANDER_DRAFT', 'COMMANDER_SEALED', 'PREMADE_DECKS'] as const) {
+      // Seats are free (maxPlayers 8), so the only thing that could refuse is the Commander rule.
+      expect(view(format).canAddAi, format).toBe(true)
+    }
+  })
+
+  it('a quick lobby readies up against a generated AI Commander deck', () => {
+    const generated = quickLobby({ kind: 'auto', setCodes: [], label: null, cardCount: 0, commander: null })
+
+    const action = fromQuickGameLobby(generated, { deckValid: true, deckTab: undefined, aiEnabled: true }).primaryAction
+
+    expect(action?.disabled).toBe(false)
+  })
+
+  it('but still asks for a commander when the host picked an exact list without one', () => {
+    // The one case the host has to answer: a `deck` spec names its cards but not its leader. The
+    // server's ready-up gate refuses the same thing, so the button has to say why first.
+    const picked = quickLobby({ kind: 'deck', setCodes: [], label: 'Chosen deck', cardCount: 100, commander: null })
+
+    const action = fromQuickGameLobby(picked, { deckValid: true, deckTab: undefined, aiEnabled: true }).primaryAction
+
+    expect(action?.disabled).toBe(true)
+    expect(action?.reason).toBe('Pick a Commander deck for the AI')
+  })
+
+  it('and is satisfied once that list designates one', () => {
+    const led = quickLobby({ kind: 'deck', setCodes: [], label: 'Chosen deck', cardCount: 100, commander: 'Zetalpa, Primal Dawn' })
+
+    const action = fromQuickGameLobby(led, { deckValid: true, deckTab: undefined, aiEnabled: true }).primaryAction
+
+    expect(action?.disabled).toBe(false)
+  })
+})

--- a/web-client/src/components/lobby/lobbyViewModel.ts
+++ b/web-client/src/components/lobby/lobbyViewModel.ts
@@ -20,7 +20,6 @@ import type { DeckPickerTab } from '../ui/DeckPicker'
 import {
   axesFromLobbySettings,
   axesFromQuickGameLobby,
-  commanderAiBlock,
   effectiveCommanderPreset,
   rulesFromLobbySettings,
   rulesTableBlock,
@@ -147,8 +146,11 @@ export function fromQuickGameLobby(
   const youReady = you?.ready ?? false
   const needsDeck = !isMomir && (!opts.deckValid || !you?.deckSelected)
   const axes = axesFromQuickGameLobby(lobby, you, opts.deckTab)
+  // Only a host-*picked* deck can be missing a commander; the generated sources choose their own.
+  // Mirrors the server's ready-up gate in `QuickGameLobbyHandler.handleSetReady`.
   const needsAiCommander =
-    lobby.vsAi && axes.rules === 'COMMANDER' && !lobby.aiDeck?.commander
+    lobby.vsAi && axes.rules === 'COMMANDER'
+    && lobby.aiDeck?.kind === 'deck' && !lobby.aiDeck.commander
 
   const players = lobby.players.map((p): LobbyViewPlayer => ({
     playerId: p.playerId,
@@ -370,10 +372,9 @@ export function fromTournamentLobby(
     guidance,
     blockGroup: blockReason?.group ?? null,
     isPublic: s.isPublic,
-    // Commander AI is available when the host brings its deck and designates its commander.
-    // Generated limited pools remain blocked because their builders cannot make that choice.
-    canAddAi: isWaiting && lobbyState.isHost && opts.aiEnabled
-      && commanderAiBlock(axes.rules, axes.cards) === null && playerCount < maxPlayers,
+    // No Commander carve-out: an AI seat builds its own legal commander deck, whether the lobby
+    // brings decks or deals a pool.
+    canAddAi: isWaiting && lobbyState.isHost && opts.aiEnabled && playerCount < maxPlayers,
     // Ranked is a 1v1-bracket-only concept server-side (`TournamentLobby.rankedEligible`).
     ranked: { available: axes.table === 'ONE_V_ONE', on: s.ranked ?? false },
     teams: tournamentTeams(lobbyState),

--- a/web-client/src/components/lobby/modeMatrix.ts
+++ b/web-client/src/components/lobby/modeMatrix.ts
@@ -38,7 +38,6 @@ import {
   cardsKindLabel,
   cardsLabel,
   cardsSeatCap,
-  commanderAiBlock,
   rulesForCards,
   rulesTableBlock,
   tournamentFormatForCards,
@@ -315,9 +314,7 @@ export function shapeChoices(roster: Roster, cards: CardsAxis): Choice<ShapeId>[
     // through the same shared predicates the group branch uses, so a solo pod and a human pod cannot
     // disagree about which table a Commander pool can sit at.
     const reasonFor = (shape: ShapeId): string | undefined =>
-      rulesTableBlock(rulesForCards(cards), shapeAxes(shape).table)
-      ?? commanderAiBlock(rulesForCards(cards), cards)
-      ?? undefined
+      rulesTableBlock(rulesForCards(cards), shapeAxes(shape).table) ?? undefined
     if (kind === 'BRING_A_DECK') {
       return [
         choice('ONE_GAME'),
@@ -329,7 +326,7 @@ export function shapeChoices(roster: Roster, cards: CardsAxis): Choice<ShapeId>[
     // shape it declines — the pod and the bracket both play it out.
     return [
       choice('ONE_GAME', LIMITED_ALWAYS_RUNS_AS_A_BRACKET),
-      choice('BRACKET', commanderAiBlock(rulesForCards(cards), cards) ?? undefined),
+      choice('BRACKET'),
       ...MULTIPLAYER_SHAPES.map((s) => choice(s, reasonFor(s))),
     ]
   }


### PR DESCRIPTION
Closes the remaining work on #1453 (P1). AI seats can now start **and complete** a legal Commander game through every supported lobby flow, with a commander they picked themselves.

## The problem

Every generated AI deck was commander-less, and `GameInitializer` refuses to start a commander game without one. So every surface refused the combination instead — `RandomDeckResolver` fell through to a 40-card sealed pool, `LobbyHandler` rejected Add-AI in a Commander limited lobby, and the client had a `commanderAiBlock` predicate wired into the wizard, the Rules row, the Cards row and the Add-AI button.

## What's here

**`CommanderDeckGenerator` (`:ai`)** — the third constructed builder, alongside `SealedDeckGenerator` and `ConstructedDeckGenerator`. It exists because those two answer *which cards*, and a commander deck's hard part is the structure: the commander is chosen first and everything else is downstream of it.

- **CR 903.3 / 903.3a** — a legendary creature, or a card whose text says it can be one. Read through `CommanderEligibility`, which **moves to `:mtg-sdk`** so the builder and the server's `DeckValidator` can't drift — a second copy of that rule is exactly how a deck the builder produces becomes a deck the validator rejects.
- **CR 903.5a / 903.12d** — exactly 100 (60 for Standard Brawl) *including* the commander.
- **CR 903.5b** — singleton outside basics.
- **CR 903.5c** — colour identity bounds the deck. Read off `CardDefinition.colorIdentity`, so an off-colour mana symbol in rules text excludes the card too.
- **CR 903.5d** — the manabase is basics in the commander's own colours only, so it holds by construction. That is also why a **colourless-identity commander is declined** rather than approximated: 903.5d leaves it no legal basic, and Brawl's escape hatch (903.12e) doesn't exist in Commander.

Cards are drawn per curve bucket with a rating-weighted sample, so the decks are playable and vary between games. It also builds from a **limited pool** (`generateFromPool`) for a drafted or sealed Commander seat, honouring the lobby's own deck size and its `allowDuplicates` toggle.

**`RandomDeckResolver` returns a `GeneratedDeck`** — list *plus* commander. The two halves of "what does this seat play" are one decision; before, the server resolved a list from the spec and read the commander off the spec separately, which is why a generated deck had nowhere to put one. It also takes **commander-ness as its own parameter** rather than reading it off `DeckFormat` — a premade Commander pod says "commanders" on its Rules axis and nothing about legality, and inferring from the format alone hands that lobby a commander-less deck.

**Un-gated end to end**: quick-lobby `Auto` / `From sets`, a human's **Random pool** (which under Commander rules used to be an unstartable seat), premade tournament seats, Commander draft/sealed pools, and the client's four surfaces. The only remaining ask is the one a human has to answer: a host-picked exact list that names no commander.

A seat that genuinely can't be built for — a set selection with no legal commander in it — is refused with a readable reason before anything is seated, rather than throwing mid-init. In the quick lobby all seats are now resolved *before* the seating loop for exactly that reason.

## Still open (P2)

Commander-aware **play** — commander tax when evaluating casts, commander damage as a win/loss axis, and an intentional CR 903.9a command-zone choice. The AI plays legal Commander today (`CostCalculator` already charges it the tax, and it answers the zone choice by simulating both branches, defaulting to the command zone on a tie) — just not well. Recorded in `backlog/commander-format.md`; worth a linked follow-up issue, which the issue's completion criteria explicitly allows.

Deck *synergy* is out of scope too: cards are picked on rating and curve, not on what the commander wants.

## Verification

- `:ai` — `CommanderDeckGeneratorTest`, 19 cases, one per construction rule plus the deliberate limitations.
- `:game-server` — `GeneratedCommanderDeckLegalityTest` runs generated decks through the **real** card base and the **real** `DeckValidator` for all three commander formats; `RandomDeckResolverTest` covers the extended policy matrix; `QuickGameLobbyCommanderAiTest` starts a generated-AI Commander game, mulligans through it, and asserts 40 life with both commanders in their own command zones (CR 903.6 / 903.7); `FreeForAllLobbyTest` updated where AI seats are now dealt a deck instead of waiting for one.
- `:mtg-sdk`, `:ai`, `:game-server` suites green; every module's main + test sources compile.
- web-client: `typecheck`, `build`, 375 vitest tests, plus a new `commanderAi.test.ts` pinning the four client surfaces agreeing.

No engine/rules changes, so no card-SDK reference update and no mtgish emitter work — this adds no SDK effect or IR tag. Docs updated: `docs/data-contracts.md` and `backlog/commander-format.md`.

No UI screenshot: the visible change is copy on the AI-deck panel and the removal of disabled states, both covered by the client tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)