### PR TITLE
Add three Aetherdrift cards: Demonic Junker, Oviya, Mu Yanling

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1340,6 +1340,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature."`, defined on the predefined `Mutagen`
   `CardDefinition` (so the ability is resolved automatically). The `DynamicAmount` overload serves X-count makers
   (Mutagen Man, Living Ooze — "create X Mutagen tokens").
+- `CreateVehicleToken(count?, controller?)` / `CreateVehicleToken(amount: DynamicAmount, controller?)` —
+  Aetherdrift's "3/2 colorless Vehicle artifact token with crew 1" (Mu Yanling, Wind Rider). A *noncreature*
+  artifact carrying printed P/T and the ordinary `crew 1` keyword, defined on the predefined `Vehicle`
+  `CardDefinition`, so it can't attack or block until something crews it and it crews through the normal path.
 - `CreatePermanentEmblem(name, abilities)` — planeswalker emblem with static abilities.
 
 ### Ability granting
@@ -3042,6 +3046,13 @@ work for abilities-on-stack (which carry no `CardComponent`).
   "was it attacking?" after the creature is already in the graveyard — Garna, Bloodfist of Keld:
   `Conditions.EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Any.attacking())`.
   Battlefield reads are unchanged; the fallback can only fire for an entity outside the battlefield.
+- `IsAttackingAnOpponent` (filter builder `attackingAnOpponent()`) — attacking one of *your* opponents,
+  where "you" is the controller of the ability applying the filter. Strictly narrower than `IsAttacking`:
+  the attacker's defender must be an opponent **player**, so an attacker aimed at a planeswalker or battle
+  drops out. Controller-relative rather than attacker-relative, so a creature someone else controls that's
+  attacking your opponent matches, and one attacking *you* doesn't. Fails closed without controller context,
+  and has no last-known fallback (the exit snapshot records *that* it was attacking, not whom). Oviya,
+  Automech Artisan: `GrantKeyword(Keyword.TRAMPLE, GroupFilter(GameObjectFilter.Creature.attackingAnOpponent()))`.
 - `IsBlocking` — declared as blocker this combat.
 - `HasLockedDoor` (filter builder `hasLockedDoor()`) — a Room permanent (CR 709.5) with at least one locked
   door, i.e. a half lacking its "unlocked" designation (CR 709.5c). Reads the engine's

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2620,6 +2620,20 @@ object Effects {
         CreatePredefinedTokenEffect("Munitions", count)
 
     /**
+     * Create Aetherdrift's "3/2 colorless Vehicle artifact token with crew 1" — a *noncreature*
+     * artifact with power and toughness, so it does nothing until something crews it.
+     *
+     * @param count Number of tokens to create
+     * @param controller Who controls the tokens (null = the effect's controller)
+     */
+    fun CreateVehicleToken(count: Int = 1, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Vehicle", count, controller)
+
+    /** Dynamic-count variant of [CreateVehicleToken]. */
+    fun CreateVehicleToken(count: DynamicAmount, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Vehicle", controller = controller, dynamicCount = count)
+
+    /**
      * Create Mutagen artifact tokens (Teenage Mutant Ninja Turtles).
      * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
      *  Activate only as a sorcery."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -647,6 +647,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must be attacking one of *your* opponents — the player themselves, so an attacker pointed at
+     * an opponent's planeswalker or battle doesn't match. Narrower than [attacking]; "you" is the
+     * controller of whatever ability applies the filter.
+     */
+    fun attackingAnOpponent() = copy(
+        statePredicates = statePredicates + StatePredicate.IsAttackingAnOpponent
+    )
+
+    /**
      * Must have been declared as an attacker at least once during the current turn.
      * Survives leaving combat; cleared at end-of-turn cleanup.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -56,6 +56,23 @@ sealed interface StatePredicate {
         override val description: String = "attacking"
     }
 
+    /**
+     * Attacking one of *your* opponents — the player, not their planeswalkers or battles
+     * (Oviya, Automech Artisan: "Each creature that's attacking one of your opponents has
+     * trample"). "You" is the controller of the ability doing the asking, so this matches
+     * regardless of who controls the attacker: a creature an ally controls that's attacking your
+     * opponent qualifies, and a creature attacking *you* does not.
+     *
+     * Strictly narrower than [IsAttacking], which is also true of a creature attacking a
+     * planeswalker or battle. Fails closed when there's no controller context to scope "your"
+     * against.
+     */
+    @SerialName("IsAttackingAnOpponent")
+    @Serializable
+    data object IsAttackingAnOpponent : Entity {
+        override val description: String = "attacking one of your opponents"
+    }
+
     @SerialName("IsBlocking")
     @Serializable
     data object IsBlocking : Entity {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DemonicJunker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/DemonicJunker.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Demonic Junker — Aetherdrift #83
+ * {6}{B} · Artifact — Vehicle · 4/3
+ *
+ * Affinity for artifacts
+ * When this Vehicle enters, for each player, destroy up to one target creature that player
+ * controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this
+ * Vehicle.
+ * Crew 2
+ *
+ * Modeling notes:
+ *
+ *  - **"For each player, destroy up to one target creature that player controls"** — a *targeted*
+ *    per-player fan-out, rendered as one optional target slot per player, the same two-slot
+ *    approximation Kitesail Larcenist and Unstable Glyphbridge document for two-player games:
+ *    `yours` (up to one creature you control) and `theirs` (up to one creature an opponent
+ *    controls). A creature has exactly one controller, so the two control-scoped filters can never
+ *    overlap and the same creature can't fill both slots. Both are `optional = true` — "up to one"
+ *    means the controller may pick none for a player.
+ *
+ *  - **One simultaneous destruction, not two.** Both slots are gathered together and destroyed in a
+ *    single [MoveType.Destroy] move, so the creatures die at the same time (CR 701.7b) and any
+ *    "whenever another creature dies" trigger sees one batch rather than two sequential deaths.
+ *
+ *  - **"If a creature you controlled was destroyed this way"** — *destroyed*, not merely targeted.
+ *    An indestructible or regenerated creature, or one that left the battlefield in response, is
+ *    not destroyed, so it must not pay off. The pipeline partitions the chosen targets into yours /
+ *    theirs *before* the move (a permanent's `ControllerComponent` is stripped on the way to the
+ *    graveyard), destroys the union with `moveTracked` to record which ones actually died, then
+ *    subtracts the opponent's half — what remains are the creatures *you* controlled that were
+ *    genuinely destroyed. Non-empty ⇒ the two counters go on.
+ *
+ *  - **The counters land on the Vehicle itself** ([EffectTarget.Self]) and only if it's still on
+ *    the battlefield; the trigger targeting its own controller's creature can't have destroyed it,
+ *    since a Vehicle isn't a creature unless crewed.
+ */
+val DemonicJunker = card("Demonic Junker") {
+    manaCost = "{6}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you " +
+        "control.)\n" +
+        "When this Vehicle enters, for each player, destroy up to one target creature that player " +
+        "controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on " +
+        "this Vehicle.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 3
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+
+        // "for each player, destroy up to one target creature that player controls"
+        // (two-player rendering: one optional slot per player — see KDoc).
+        target(
+            "up to one target creature you control",
+            TargetPermanent(filter = TargetFilter.Creature.youControl(), optional = true)
+        )
+        target(
+            "up to one target creature an opponent controls",
+            TargetPermanent(filter = TargetFilter.Creature.opponentControls(), optional = true)
+        )
+
+        effect = Effects.Pipeline(
+            descriptionOverride = "For each player, destroy up to one target creature that player " +
+                "controls. If a creature you controlled was destroyed this way, put two +1/+1 " +
+                "counters on this Vehicle."
+        ) {
+            val chosen = gather(CardSource.ChosenTargets)
+            // Split before destroying: controller information is gone once a permanent hits the
+            // graveyard.
+            val split = filterSplit(chosen, GameObjectFilter.Creature.youControl())
+            val destroyed = moveTracked(
+                chosen,
+                CardDestination.ToZone(Zone.GRAVEYARD),
+                moveType = MoveType.Destroy
+            )
+            // Everything actually destroyed, minus the opponent's half ⇒ the creatures you
+            // controlled that were destroyed this way.
+            val destroyedYours = exclude(destroyed, split.rest)
+            ifNotEmpty(destroyedYours) {
+                run(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self))
+            }
+        }
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Stephan Martiniere"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg?1783907896"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MuYanlingWindRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/MuYanlingWindRider.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.OneOrMoreDealCombatDamageToPlayerEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Mu Yanling, Wind Rider — Aetherdrift #52
+ * {2}{U}{U} · Legendary Creature — Human Wizard Pilot · 2/4
+ *
+ * When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with crew 1.
+ * Vehicles you control have flying.
+ * Whenever one or more creatures you control with flying deal combat damage to a player, draw a
+ * card.
+ *
+ * Modeling notes:
+ *
+ *  - **The Vehicle token** is the set's standard 3/2 crew-1 Vehicle, so it's a predefined token
+ *    (`PredefinedTokens.Vehicle`) rather than an inline token spec — a *noncreature* artifact with
+ *    printed power and toughness, which is what makes the second and third abilities interact:
+ *    the token has flying from Mu Yanling immediately, but only counts for the draw trigger once
+ *    something crews it into a creature.
+ *
+ *  - **"Vehicles you control have flying"** is a Layer 6 grant over every Vehicle you control, not
+ *    just creature ones — an uncrewed Vehicle is a noncreature artifact, hence a bare subtype
+ *    filter rather than `GameObjectFilter.Creature`.
+ *
+ *  - **The draw is a batch trigger** (CR 603.2c): one card per *damaged player* per combat, no
+ *    matter how many fliers connected with them. `OneOrMoreDealCombatDamageToPlayerEvent` already
+ *    scopes to sources you control, so the filter only has to say "creature with flying". It's
+ *    matched against projected state, so a crewed Vehicle flying courtesy of Mu Yanling herself
+ *    counts, and a creature that lost flying before damage doesn't.
+ */
+val MuYanlingWindRider = card("Mu Yanling, Wind Rider") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Wizard Pilot"
+    oracleText = "When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with crew 1.\n" +
+        "Vehicles you control have flying.\n" +
+        "Whenever one or more creatures you control with flying deal combat damage to a player, " +
+        "draw a card."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateVehicleToken()
+        description = "When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with " +
+            "crew 1."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FLYING,
+            GroupFilter(GameObjectFilter.Any.withSubtype(Subtype.VEHICLE).youControl())
+        )
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            OneOrMoreDealCombatDamageToPlayerEvent(
+                sourceFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+            ),
+            TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever one or more creatures you control with flying deal combat damage " +
+            "to a player, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "52"
+        artist = "Justyna Dura"
+        flavorText = "The search for her lost mentor continued."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg?1783907905"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OviyaAutomechArtisan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/OviyaAutomechArtisan.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Oviya, Automech Artisan — Aetherdrift #173
+ * {3}{G} · Legendary Creature — Human Artificer · 1/2
+ *
+ * Each creature that's attacking one of your opponents has trample.
+ * {G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put
+ * an artifact onto the battlefield this way, put two +1/+1 counters on it.
+ *
+ * Modeling notes:
+ *
+ *  - **"Each creature that's attacking one of your opponents"** is deliberately not "each attacking
+ *    creature you control": the grant follows the *defender*, not the attacker's controller. A
+ *    creature attacking an opponent's planeswalker or battle is attacking, but it isn't attacking
+ *    *the opponent*, so it gets no trample; a creature an ally controls that's attacking your
+ *    opponent does. `StatePredicate.IsAttackingAnOpponent` is that check — the attacker's
+ *    `defenderId` must be one of Oviya's controller's opponents, and `getOpponents` only ever
+ *    yields players, so planeswalker/battle attacks drop out by construction.
+ *
+ *  - **"You may put …"** is a resolution-time choice from a hidden zone, not a target — so the pool
+ *    is gathered from hand at resolution and offered as `chooseUpTo(1)`. Declining is legal (the
+ *    activation still costs {G} and the tap).
+ *
+ *  - **"If you put an artifact onto the battlefield this way"** is checked *after* the move, on the
+ *    permanent as it now exists — per the card's 2025-02-07 ruling, a nonartifact card can pick up
+ *    the counters when something like Mycosynth Lattice makes it an artifact on the battlefield.
+ *    The pipeline therefore filters the *moved* collection (post-move entity ids, already on the
+ *    battlefield) for artifacts rather than pre-screening the hand pick. Nothing chosen, or a
+ *    nonartifact creature chosen ⇒ the filter is empty and no counters are placed.
+ *
+ *  - **The counters go on the new permanent** ("on it"), not on Oviya, hence
+ *    `AddCountersToCollection` over the filtered slot rather than a `Self`-targeted effect.
+ */
+val OviyaAutomechArtisan = card("Oviya, Automech Artisan") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Artificer"
+    oracleText = "Each creature that's attacking one of your opponents has trample.\n" +
+        "{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If " +
+        "you put an artifact onto the battlefield this way, put two +1/+1 counters on it."
+    power = 1
+    toughness = 2
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.attackingAnOpponent())
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        effect = Effects.Pipeline(
+            descriptionOverride = "You may put a creature or Vehicle card from your hand onto the " +
+                "battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 " +
+                "counters on it."
+        ) {
+            val hand = gather(
+                CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.CreatureOrVehicle)
+            )
+            val chosen = chooseUpTo(
+                1,
+                from = hand,
+                prompt = "You may put a creature or Vehicle card from your hand onto the battlefield",
+                selectedLabel = "Put onto the battlefield"
+            )
+            val put = moveTracked(chosen, CardDestination.ToZone(Zone.BATTLEFIELD, Player.You))
+            // Artifact-ness is read off the permanent that just entered, not off the card in hand.
+            val artifacts = filter(put, GameObjectFilter.Artifact)
+            run(Effects.AddCountersToCollection(artifacts.key, Counters.PLUS_ONE_PLUS_ONE, 2))
+        }
+        description = "{G}, {T}: You may put a creature or Vehicle card from your hand onto the " +
+            "battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 " +
+            "counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "173"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg?1783907867"
+        ruling(
+            "2025-02-07",
+            "In some rare cases, a nonartifact card put onto the battlefield this way will get two " +
+                "+1/+1 counters because some other effect (like that of Mycosynth Lattice) makes it " +
+                "an artifact on the battlefield."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.GrantWard
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
@@ -657,6 +658,26 @@ object PredefinedTokens {
     }
 
     /**
+     * Vehicle token — the 3/2 colorless Vehicle artifact token with crew 1 that Aetherdrift's
+     * Pilots hand out (Mu Yanling, Wind Rider; Chandra, Spark Hunter; …).
+     *
+     * A *noncreature* artifact, like the printed token: it has power and toughness but no Creature
+     * card type, so it can't attack or block until something crews it. Crew is the ordinary
+     * [KeywordAbility.crew] keyword, so it goes through the same crew path as a printed Vehicle.
+     */
+    val Vehicle = card("Vehicle") {
+        typeLine = "Artifact — Vehicle"
+        power = 3
+        toughness = 2
+
+        keywordAbility(KeywordAbility.crew(1))
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/a/3/a3803365-ed78-409f-8ca5-7aa3634faf76.jpg?1783907677"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -684,6 +705,7 @@ object PredefinedTokens {
         Everywhere,
         Munitions,
         Mutagen,
-        Frog
+        Frog,
+        Vehicle
     )
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -3772,6 +3772,121 @@
     ]
 }
 
+// Demonic Junker
+{
+    "name": "Demonic Junker",
+    "manaCost": "{6}{B}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhen this Vehicle enters, for each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "AFFINITY",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        },
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "creature ctrl:you"
+                            },
+                            "storeMatching": "matching1",
+                            "storeNonMatching": "rest1"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy",
+                            "storeMovedAs": "moved2"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "moved2",
+                            "filter": {
+                                "type": "ExcludeOtherCollection",
+                                "otherCollectionName": "rest1"
+                            },
+                            "storeMatching": "matching3"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "matching3",
+                            "ifNotEmpty": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 2,
+                                "target": "Self"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "For each player, destroy up to one target creature that player controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this Vehicle."
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "up to one target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "up to one target creature an opponent controls"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Stephan Martiniere",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4aad569e-4acb-4416-9d4f-64e6991de3ed.jpg?1783907896"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Detention Chariot
 {
     "name": "Detention Chariot",
@@ -9988,6 +10103,69 @@
     "colorIdentityOverride": []
 }
 
+// Mu Yanling, Wind Rider
+{
+    "name": "Mu Yanling, Wind Rider",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Legendary Creature — Human Wizard Pilot",
+    "oracleText": "When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with crew 1.\nVehicles you control have flying.\nWhenever one or more creatures you control with flying deal combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Vehicle"
+                },
+                "descriptionOverride": "When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with crew 1."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "OneOrMoreDealCombatDamageToPlayerEvent",
+                    "sourceFilter": "creature kw:flying"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever one or more creatures you control with flying deal combat damage to a player, draw a card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING",
+                "filter": {
+                    "baseFilter": "Vehicle ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "MYTHIC",
+        "artist": "Justyna Dura",
+        "flavorText": "The search for her lost mentor continued.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76423446-d62f-4cc5-a23a-3175be88bd73.jpg?1783907905"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Muraganda Raceway
 {
     "name": "Muraganda Raceway",
@@ -10613,6 +10791,123 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Oviya, Automech Artisan
+{
+    "name": "Oviya, Automech Artisan",
+    "manaCost": "{3}{G}",
+    "typeLine": "Legendary Creature — Human Artificer",
+    "oracleText": "Each creature that's attacking one of your opponents has trample.\n{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "creature|Vehicle"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected1",
+                            "prompt": "You may put a creature or Vehicle card from your hand onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "storeMovedAs": "moved2"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "moved2",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "artifact"
+                            },
+                            "storeMatching": "matching3"
+                        },
+                        {
+                            "type": "AddCountersToCollection",
+                            "collectionName": "matching3",
+                            "counterType": "+1/+1",
+                            "count": 2
+                        }
+                    ],
+                    "descriptionOverride": "You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it."
+                },
+                "descriptionOverride": "{G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put an artifact onto the battlefield this way, put two +1/+1 counters on it."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsAttackingAnOpponent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "RARE",
+        "artist": "Julia Metzger",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee5f504c-33fc-4a91-b69b-8ef555987c79.jpg?1783907867",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "In some rare cases, a nonartifact card put onto the battlefield this way will get two +1/+1 counters because some other effect (like that of Mycosynth Lattice) makes it an artifact on the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -489,6 +489,7 @@ class BeginningPhaseManager(
         StatePredicate.IsTapped,
         StatePredicate.IsUntapped,
         StatePredicate.IsAttacking,
+        StatePredicate.IsAttackingAnOpponent,
         StatePredicate.IsBlocking,
         StatePredicate.IsBlocked,
         StatePredicate.IsUnblocked,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1825,6 +1825,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsTapped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsUntapped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttacking,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttackingAnOpponent,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsBlocking,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsBlocked,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsUnblocked,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -956,6 +956,15 @@ class PredicateEvaluator {
             StatePredicate.IsAttacking ->
                 container.get<AttackingComponent>() != null ||
                     container.get<LastKnownPermanentComponent>()?.snapshot?.wasAttacking == true
+            // "Attacking one of your opponents": the defender has to be an opponent *player* of
+            // the asking ability's controller — `getOpponents` only ever yields players, so an
+            // attacker pointed at a planeswalker or battle never matches. No last-known fallback:
+            // the frozen snapshot records only *that* the permanent was attacking, not whom.
+            StatePredicate.IsAttackingAnOpponent -> {
+                val you = context?.controllerId
+                val defenderId = container.get<AttackingComponent>()?.defenderId
+                you != null && defenderId != null && defenderId in state.getOpponents(you)
+            }
             StatePredicate.IsBlocking -> container.has<BlockingComponent>()
             StatePredicate.IsBlocked -> {
                 // Check if this attacking creature has any blockers assigned

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -390,6 +390,14 @@ internal class AffectsFilterResolver {
         StatePredicate.IsTapped -> container.has<TappedComponent>()
         StatePredicate.IsUntapped -> !container.has<TappedComponent>()
         StatePredicate.IsAttacking -> container.has<AttackingComponent>()
+        // "Attacking one of your opponents" — the defender must be an opponent *player* of the
+        // static ability's controller, so an attacker aimed at a planeswalker or battle drops out.
+        // Fails closed without a controller to scope "your" against.
+        StatePredicate.IsAttackingAnOpponent -> {
+            val defenderId = container.get<AttackingComponent>()?.defenderId
+            sourceController != null && defenderId != null &&
+                defenderId in state.getOpponents(sourceController)
+        }
         StatePredicate.IsBlocking -> container.has<BlockingComponent>()
         StatePredicate.IsBlocked -> {
             container.has<AttackingComponent>() && state.getBattlefield().any { blockerId ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicJunkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemonicJunkerScenarioTest.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Demonic Junker (DFT #83) — {6}{B} Artifact — Vehicle (4/3).
+ *
+ * "Affinity for artifacts
+ *  When this Vehicle enters, for each player, destroy up to one target creature that player
+ *  controls. If a creature you controlled was destroyed this way, put two +1/+1 counters on this
+ *  Vehicle.
+ *  Crew 2"
+ *
+ * The interesting clause is the payoff: it asks whether a creature you controlled was *destroyed*,
+ * not whether you targeted one. The pipeline splits the chosen targets by controller before the
+ * move, destroys them together, and subtracts the opponent's half from what actually died — so an
+ * indestructible pick, or targeting only the opponent, leaves the Vehicle bare.
+ */
+class DemonicJunkerScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /**
+     * The two "up to one" slots are separate target requirements — index 0 is your creature,
+     * index 1 the opponent's — so each has to be answered on its own key. Pass null to decline a
+     * slot.
+     */
+    private fun chooseVictims(game: TestGame, yours: EntityId?, theirs: EntityId?) {
+        val decisionId = game.getPendingDecision()!!.id
+        game.submitDecision(
+            TargetsResponse(
+                decisionId,
+                mapOf(0 to listOfNotNull(yours), 1 to listOfNotNull(theirs))
+            )
+        ).error shouldBe null
+    }
+
+    init {
+        context("Demonic Junker's enters trigger") {
+
+            test("destroying one creature per player pays off — both die, the Vehicle gets two counters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Demonic Junker")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Demonic Junker").error shouldBe null
+                game.resolveStack()
+                chooseVictims(game, yours = bears, theirs = giant)
+                game.resolveStack()
+
+                withClue("your own creature was destroyed") { game.isInGraveyard(1, "Grizzly Bears") shouldBe true }
+                withClue("the opponent's creature was destroyed") { game.isInGraveyard(2, "Hill Giant") shouldBe true }
+
+                val junker = game.findPermanent("Demonic Junker")
+                withClue("the Vehicle is on the battlefield") { junker shouldNotBe null }
+                withClue("a creature you controlled died ⇒ two +1/+1 counters") {
+                    plusOneCounters(game, junker!!) shouldBe 2
+                }
+            }
+
+            test("destroying only the opponent's creature leaves the Vehicle without counters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Demonic Junker")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Demonic Junker").error shouldBe null
+                game.resolveStack()
+                // "up to one" per player — decline the slot pointed at your own board.
+                chooseVictims(game, yours = null, theirs = giant)
+                game.resolveStack()
+
+                withClue("your creature was never targeted, so it lives") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("the opponent's creature was destroyed") { game.isInGraveyard(2, "Hill Giant") shouldBe true }
+
+                val junker = game.findPermanent("Demonic Junker")!!
+                withClue("no creature you controlled was destroyed ⇒ no counters") {
+                    plusOneCounters(game, junker) shouldBe 0
+                }
+            }
+
+            test("an indestructible creature of yours is targeted but not destroyed — no counters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Demonic Junker")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardOnBattlefield(1, "Zetalpa, Primal Dawn", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zetalpa = game.findPermanent("Zetalpa, Primal Dawn")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Demonic Junker").error shouldBe null
+                game.resolveStack()
+                chooseVictims(game, yours = zetalpa, theirs = giant)
+                game.resolveStack()
+
+                withClue("indestructible — it survives the destroy") {
+                    game.isOnBattlefield("Zetalpa, Primal Dawn") shouldBe true
+                }
+                withClue("the opponent's creature still dies") { game.isInGraveyard(2, "Hill Giant") shouldBe true }
+
+                val junker = game.findPermanent("Demonic Junker")!!
+                withClue("\"destroyed this way\" — targeting isn't enough, so no counters") {
+                    plusOneCounters(game, junker) shouldBe 0
+                }
+            }
+        }
+
+        context("Affinity for artifacts") {
+
+            test("each artifact you control cuts {1} off the cost") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Demonic Junker")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // {6}{B} is seven mana; two artifacts you control knock it to {4}{B} — exactly the
+                // five Swamps on the battlefield, so this cast only happens because of affinity.
+                withClue("affinity made it castable off five Swamps") {
+                    game.castSpell(1, "Demonic Junker").error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MuYanlingWindRiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MuYanlingWindRiderScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Mu Yanling, Wind Rider (DFT #52) — {2}{U}{U} Legendary Creature — Human Wizard
+ * Pilot (2/4).
+ *
+ * "When Mu Yanling enters, create a 3/2 colorless Vehicle artifact token with crew 1.
+ *  Vehicles you control have flying.
+ *  Whenever one or more creatures you control with flying deal combat damage to a player, draw a
+ *  card."
+ *
+ * Covers the new predefined `Vehicle` token (a *noncreature* artifact with printed P/T and crew 1),
+ * the blanket flying grant over Vehicles — which has to reach an uncrewed, noncreature Vehicle —
+ * and the batched draw trigger.
+ */
+class MuYanlingWindRiderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mu Yanling, Wind Rider") {
+
+            test("entering creates a 3/2 Vehicle token that is not a creature but does have flying") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Mu Yanling, Wind Rider")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Mu Yanling, Wind Rider").error shouldBe null
+                game.resolveStack()
+
+                val token = game.findPermanent("Vehicle")
+                withClue("the ETB trigger created the Vehicle token") { token shouldNotBe null }
+
+                val projected = game.state.projectedState
+                withClue("an uncrewed Vehicle is a noncreature artifact") {
+                    projected.isCreature(token!!) shouldBe false
+                }
+                withClue("\"Vehicles you control have flying\" reaches the uncrewed token too") {
+                    projected.hasKeyword(token!!, Keyword.FLYING) shouldBe true
+                }
+                withClue("the token is the printed 3/2") {
+                    projected.getPower(token!!) shouldBe 3
+                    projected.getToughness(token) shouldBe 2
+                }
+            }
+
+            test("a flier connecting draws exactly one card, and a groundling draws none") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Mu Yanling, Wind Rider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Wind Drake", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.declareAttackers(mapOf("Wind Drake" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.resolveStack()
+
+                withClue("the flying attacker connected, so Mu Yanling drew one card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("a nonflying attacker connecting draws nothing") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Mu Yanling, Wind Rider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.resolveStack()
+
+                withClue("no flier connected, so the trigger never fired") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("two fliers hitting the same player still draw only one card (batch trigger)") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Mu Yanling, Wind Rider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Wind Drake", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Storm Crow", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.declareAttackers(mapOf("Wind Drake" to 2, "Storm Crow" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+                game.resolveStack()
+
+                withClue("CR 603.2c — one trigger per damaged player, not per creature") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OviyaAutomechArtisanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OviyaAutomechArtisanScenarioTest.kt
@@ -1,0 +1,187 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dft.cards.OviyaAutomechArtisan
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Oviya, Automech Artisan (DFT #173) — {3}{G} Legendary Creature — Human
+ * Artificer (1/2).
+ *
+ * "Each creature that's attacking one of your opponents has trample.
+ *  {G}, {T}: You may put a creature or Vehicle card from your hand onto the battlefield. If you put
+ *  an artifact onto the battlefield this way, put two +1/+1 counters on it."
+ *
+ * The trample grant is what motivates `StatePredicate.IsAttackingAnOpponent`: it follows the
+ * *defender*, so an attacker aimed at an opponent's planeswalker is attacking but is not attacking
+ * the opponent, and gets nothing. These tests pin both halves of that distinction plus the
+ * conditional counters on the activated ability.
+ */
+class OviyaAutomechArtisanScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        val putAbilityId = OviyaAutomechArtisan.activatedAbilities.first().id
+
+        context("Each creature that's attacking one of your opponents has trample") {
+
+            test("a creature attacking the opponent gains trample; it has none before combat") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("no trample before the Bear is attacking anything") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe false
+                }
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+
+                withClue("attacking P1's opponent ⇒ trample") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("Oviya's controller is not an opponent of themselves — a creature attacking them gets nothing") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the opponent's attacker is aimed at Oviya's controller, not at an opponent of theirs") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+
+            test("attacking an opponent's planeswalker is not attacking the opponent — no trample") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Chandra, Flameshaper")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackersWithPlaneswalkerTargets(
+                    planeswalkerAttackers = mapOf("Grizzly Bears" to "Chandra, Flameshaper")
+                ).error shouldBe null
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the defender is a planeswalker, so the attacker isn't attacking a player") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+        }
+
+        context("{G}, {T}: put a creature or Vehicle card from your hand onto the battlefield") {
+
+            test("an artifact put this way enters with two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Ornithopter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oviya = game.findPermanent("Oviya, Automech Artisan")!!
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = oviya, abilityId = putAbilityId)
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val thopterInHand = game.findCardsInHand(1, "Ornithopter")
+                if (thopterInHand.isNotEmpty()) game.selectCards(thopterInHand)
+                game.resolveStack()
+
+                val thopter = game.findPermanent("Ornithopter")
+                withClue("the artifact creature was put onto the battlefield") { thopter shouldNotBe null }
+                withClue("an artifact put this way gets two +1/+1 counters") {
+                    plusOneCounters(game, thopter!!) shouldBe 2
+                }
+            }
+
+            test("a nonartifact creature put this way gets no counters") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oviya = game.findPermanent("Oviya, Automech Artisan")!!
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = oviya, abilityId = putAbilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val bearsInHand = game.findCardsInHand(1, "Grizzly Bears")
+                if (bearsInHand.isNotEmpty()) game.selectCards(bearsInHand)
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")
+                withClue("the creature was put onto the battlefield") { bears shouldNotBe null }
+                withClue("it isn't an artifact, so the counters clause does nothing") {
+                    plusOneCounters(game, bears!!) shouldBe 0
+                }
+            }
+
+            test("declining the optional put leaves the card in hand and the battlefield unchanged") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Oviya, Automech Artisan", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Ornithopter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oviya = game.findPermanent("Oviya, Automech Artisan")!!
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = oviya, abilityId = putAbilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) game.skipSelection()
+                game.resolveStack()
+
+                withClue("\"you may\" — declining is legal and the card stays in hand") {
+                    game.isInHand(1, "Ornithopter") shouldBe true
+                }
+                withClue("nothing entered the battlefield") {
+                    game.isOnBattlefield("Ornithopter") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three of Aetherdrift's 18 remaining unimplemented cards. DFT goes from 258/276 to 261/276.

## Cards

**Demonic Junker** — {6}{B} Artifact — Vehicle 4/3, affinity for artifacts, crew 2.
"For each player, destroy up to one target creature that player controls" uses the two-optional-target-slot rendering Kitesail Larcenist established for per-player fan-out in two-player games. The payoff asks whether a creature you *controlled* was *destroyed*, so the pipeline splits the chosen targets by controller before the move (a permanent loses its `ControllerComponent` on the way to the graveyard), destroys the union in one `MoveType.Destroy` so both die simultaneously, then subtracts the opponent's half from what actually died — an indestructible or untargeted creature of yours leaves the Vehicle bare.

**Oviya, Automech Artisan** — {3}{G} Legendary Creature — Human Artificer 1/2.
The activated ability is a pipeline: the optional put is a resolution-time choice from hand, and the two +1/+1 counters are gated on the *moved* collection being an artifact — checked post-move on the permanent as it now exists, per the card's 2025-02-07 ruling about Mycosynth Lattice.

**Mu Yanling, Wind Rider** — {2}{U}{U} Legendary Creature — Human Wizard Pilot 2/4.
"Vehicles you control have flying" is a bare subtype grant rather than a creature filter, so it reaches an uncrewed Vehicle; the draw is a `OneOrMoreDealCombatDamageToPlayerEvent` batch (one card per damaged player), matched against projected state so a crewed Vehicle flying courtesy of Mu Yanling herself counts.

## New SDK vocabulary

- **`StatePredicate.IsAttackingAnOpponent`** (filter builder `attackingAnOpponent()`) — Oviya's trample grant follows the *defender*, not the attacker's controller, and means the **player**: a creature attacking an opponent's planeswalker or battle is attacking but isn't attacking the opponent. The attacker's `defenderId` must be one of the asking ability's controller's opponents, and `getOpponents` only ever yields players, so planeswalker/battle attacks drop out by construction. Wired into the projection path (`AffectsFilterResolver`, which already carries the source controller) and `PredicateEvaluator`; the two exhaustive-`when` fallthrough groups list it alongside `IsAttacking`.
- **`Vehicle` predefined token + `Effects.CreateVehicleToken`** — Aetherdrift's standard 3/2 crew-1 Vehicle token, a *noncreature* artifact with printed P/T and the ordinary crew keyword, so it crews through the normal path. Several other DFT cards create the same token.

`docs/card-sdk-language-reference.md` updated for both.

## Cards considered and deferred

The other 15 missing DFT cards each need an engine feature first, so they're `add-feature` work rather than `add-card`: Ketramose (no cards-in-exile condition, no batched exile-from-graveyard/battlefield trigger), Captain Howler (no composite `WardCost` — mana *and* life), Boom Scholar (`ReduceActivatedAbilityCost` has no ability-kind filter, so it can't scope to exhaust abilities), Webstrike Elite / Valor's Flagship (no X in a cycling cost), Skyseer's Chariot (no activated-cost *increase* by chosen name), plus the two planeswalkers, The Aetherspark, Mimeoplasm, and the exhaust-manipulation cards.

## Verification

- `scripts/gradle-locked test` — full suite green.
- 14 new scenario tests across three files (one per card), all passing. Coverage includes the negatives that motivated the new predicate: an attacker aimed at a planeswalker gets no trample, an opponent's attacker aimed at Oviya's controller gets none, an indestructible target doesn't pay off Demonic Junker, a declined "you may" leaves the card in hand, and two fliers connecting still draw only one card.
- DFT card snapshot re-blessed; the diff is only the three new cards.
- `just check-card-printing` clean for all three (DFT is the canonical printing for each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)