### PR TITLE
Add four Innistrad Remastered double-faced cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ShrillHowler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ShrillHowler.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shrill Howler // Howling Chorus (Eldritch Moon #168)
+ * {2}{G}
+ * Creature — Werewolf Horror 3/1 // Creature — Eldrazi Werewolf 3/5
+ *
+ * Front — "Creatures with power less than this creature's power can't block it."
+ *         "{5}{G}: Transform this creature."
+ * Back  — "Creatures with power less than this creature's power can't block it."
+ *         "Whenever this creature deals combat damage to a player, create a 3/2 colorless Eldrazi
+ *          Horror creature token."
+ *
+ * The evasion clause is the attacker-side static [CantBeBlockedByCreaturesWithLessPower] (Formation
+ * Breaker / Elusive Otter). It compares *projected* power on both sides at the moment blockers are
+ * declared, which is exactly the printed ruling — a later power change doesn't retroactively unblock
+ * the attacker, because the restriction is only consulted during the declare-blockers legality check.
+ * The clause is printed on **both** faces, so both faces carry it; the flip to a 3/5 lowers the
+ * threshold from 3 to… still 3, but a pump on either face moves it.
+ *
+ * The back is a colorless Eldrazi Werewolf (no mana cost, no color indicator on the printed card);
+ * `colorIdentity` stays "G" because identity is a property of the whole card. Its token is the
+ * ordinary 3/2 colorless Eldrazi Horror, whose art comes from Eldritch Moon's synced token set.
+ *
+ * This is not a Daybound/Nightbound werewolf — the flip is an ordinary activated [TransformEffect].
+ */
+
+private val ShrillHowlerFront = card("Shrill Howler") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Werewolf Horror"
+    power = 3
+    toughness = 1
+    oracleText = "Creatures with power less than this creature's power can't block it.\n" +
+        "{5}{G}: Transform this creature."
+
+    staticAbility {
+        ability = CantBeBlockedByCreaturesWithLessPower()
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = TransformEffect(EffectTarget.Self)
+        description = "Transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Matt Stewart"
+        flavorText = "\"A werewolf's howl is terrifying, to be sure. But this . . . this was a " +
+            "chilling sound I somehow felt. I fear what will reply to it.\"\n" +
+            "—Alena, trapper of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1783937445"
+        ruling(
+            "2016-07-13",
+            "The power of the blocking creature and that of Shrill Howler are compared only at the " +
+                "moment that blockers are chosen. Changing either creature's power later won't cause " +
+                "Shrill Howler to become unblocked."
+        )
+        ruling(
+            "2016-07-13",
+            "The power of the blocking creature and that of Howling Chorus are compared only at the " +
+                "moment that blockers are chosen. Changing either creature's power later won't cause " +
+                "Howling Chorus to become unblocked."
+        )
+    }
+}
+
+private val HowlingChorus = card("Howling Chorus") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Creature — Eldrazi Werewolf"
+    power = 3
+    toughness = 5
+    oracleText = "Creatures with power less than this creature's power can't block it.\n" +
+        "Whenever this creature deals combat damage to a player, create a 3/2 colorless Eldrazi " +
+        "Horror creature token."
+
+    staticAbility {
+        ability = CantBeBlockedByCreaturesWithLessPower()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 2,
+            colors = emptySet(),
+            creatureTypes = setOf("Eldrazi", "Horror"),
+        )
+        description = "Whenever this creature deals combat damage to a player, create a 3/2 " +
+            "colorless Eldrazi Horror creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1783937445"
+    }
+}
+
+val ShrillHowler: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ShrillHowlerFront,
+    backFace = HowlingChorus,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SmolderingWerewolf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SmolderingWerewolf.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Smoldering Werewolf // Erupting Dreadwolf (Eldritch Moon #142)
+ * {2}{R}{R}
+ * Creature — Werewolf Horror 3/2 // Creature — Eldrazi Werewolf 6/4
+ *
+ * Front — "When this creature enters, it deals 1 damage to each of up to two target creatures."
+ *         "{4}{R}{R}: Transform this creature."
+ * Back  — "Whenever this creature attacks, it deals 2 damage to any target."
+ *
+ * "Each of up to two target creatures" is **one** target requirement taking up to two objects
+ * (`TargetCreature(count = 2, optional = true)` → `minCount = 0`), not two independent slots — so
+ * the two picks must be different creatures (CR 601.2c) and choosing zero is legal. The damage is
+ * then dealt once per chosen creature via [ForEachTargetEffect]; leaving `damageSource` null
+ * attributes it to the trigger's source, matching "**it** deals 1 damage" (the Rollercrusher Ride
+ * idiom).
+ *
+ * The back face is a colorless Eldrazi Werewolf (no mana cost and no color indicator on the printed
+ * card), so it carries no `colorIndicator`; `colorIdentity` stays "R" because identity is a property
+ * of the whole card, not of one face.
+ *
+ * This is not a Daybound/Nightbound werewolf — the flip is an ordinary activated
+ * [TransformEffect], one-way (the back has no way back).
+ */
+
+private val SmolderingWerewolfFront = card("Smoldering Werewolf") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Werewolf Horror"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, it deals 1 damage to each of up to two target creatures.\n" +
+        "{4}{R}{R}: Transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(Effects.DealDamage(1, EffectTarget.ContextTarget(0)))
+        )
+        description = "When this creature enters, it deals 1 damage to each of up to two target creatures."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}{R}")
+        effect = TransformEffect(EffectTarget.Self)
+        description = "Transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Zack Stella"
+        flavorText = "\"Never thought I'd see the day I'd be wishing to see just a plain old werewolf.\"\n" +
+            "—Raf Gyel of the Quiver of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1783937460"
+        ruling(
+            "2016-07-13",
+            "Erupting Dreadwolf's triggered ability resolves before blockers are chosen. A creature " +
+                "dealt lethal damage this way won't be around to block."
+        )
+        ruling(
+            "2016-07-13",
+            "If you transform Smoldering Werewolf into Erupting Dreadwolf after it has attacked, " +
+                "Erupting Dreadwolf's triggered ability won't trigger that combat."
+        )
+    }
+}
+
+private val EruptingDreadwolf = card("Erupting Dreadwolf") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Creature — Eldrazi Werewolf"
+    power = 6
+    toughness = 4
+    oracleText = "Whenever this creature attacks, it deals 2 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val victim = target("any target", AnyTarget())
+        effect = Effects.DealDamage(2, victim)
+        description = "Whenever this creature attacks, it deals 2 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Zack Stella"
+        flavorText = "\". . . heck, I'd settle for anything that even resembled a werewolf.\"\n" +
+            "—Raf Gyel of the Quiver of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1783937460"
+    }
+}
+
+val SmolderingWerewolf: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = SmolderingWerewolfFront,
+    backFace = EruptingDreadwolf,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AberrantResearcherReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AberrantResearcherReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val AberrantResearcherReprint = Printing(
+    oracleId = "722ee05f-6815-41b7-9813-5ec3902c1e9f",
+    name = "Aberrant Researcher",
+    setCode = "INR",
+    collectorNumber = "52",
+    scryfallId = "41b0eddd-9364-4ca1-ac81-0175dd1387e8",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41b0eddd-9364-4ca1-ac81-0175dd1387e8.jpg?1783908174",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/4/1/41b0eddd-9364-4ca1-ac81-0175dd1387e8.jpg?1783908174",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DelverOfSecretsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DelverOfSecretsReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in ISD. */
+val DelverOfSecretsReprint = Printing(
+    oracleId = "edd531b9-f615-4399-8c8c-1c5e18c4acbf",
+    name = "Delver of Secrets",
+    setCode = "INR",
+    collectorNumber = "60",
+    scryfallId = "6904ea20-e504-47da-95a0-08739fdde260",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/6904ea20-e504-47da-95a0-08739fdde260.jpg?1783908173",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/6/9/6904ea20-e504-47da-95a0-08739fdde260.jpg?1783908173",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ShrillHowlerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ShrillHowlerReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val ShrillHowlerReprint = Printing(
+    oracleId = "30c3f88f-11d3-4b5f-8936-bab1c65bd693",
+    name = "Shrill Howler",
+    setCode = "INR",
+    collectorNumber = "214",
+    scryfallId = "e414e208-2e90-4b0d-b107-7a387b3f779b",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e414e208-2e90-4b0d-b107-7a387b3f779b.jpg?1783908095",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/4/e414e208-2e90-4b0d-b107-7a387b3f779b.jpg?1783908095",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SmolderingWerewolfReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SmolderingWerewolfReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val SmolderingWerewolfReprint = Printing(
+    oracleId = "372a01f7-6e58-4424-9405-0ee4acbb9346",
+    name = "Smoldering Werewolf",
+    setCode = "INR",
+    collectorNumber = "171",
+    scryfallId = "e724d16c-d44b-4b8f-9616-64923e2cdeb2",
+    artist = "Zack Stella",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e724d16c-d44b-4b8f-9616-64923e2cdeb2.jpg?1783908118",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/7/e724d16c-d44b-4b8f-9616-64923e2cdeb2.jpg?1783908118",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DelverOfSecrets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DelverOfSecrets.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Delver of Secrets // Insectile Aberration (Innistrad #51)
+ * {U}
+ * Creature — Human Wizard 1/1 // Creature — Human Insect 3/2
+ *
+ * Front — "At the beginning of your upkeep, look at the top card of your library. You may reveal
+ *          that card. If an instant or sorcery card is revealed this way, transform this creature."
+ * Back  — Flying.
+ *
+ * Nothing moves zones: the card is looked at, optionally revealed, and stays on top of the library
+ * either way (printed ruling). The pipeline is therefore gather-only —
+ * `GatherCards(TopOfLibrary(1))` puts the card in a collection without touching the library, and no
+ * `MoveCollection` follows.
+ *
+ * The "look at … you may reveal" pair is a single [SelectFromCollectionEffect] with
+ * `ChooseUpTo(1)` and `showAllCards = true`: the overlay *shows* the controller the top card (the
+ * look, private to them) and selecting it *is* the choice to reveal, while declining selects nothing.
+ * [RevealCollectionEffect] then publishes only what was actually selected, so an unrevealed card is
+ * never leaked to opponents.
+ *
+ * The transform is gated on the **revealed** collection, not the looked-at one — per the ruling you
+ * may reveal a card that isn't an instant or sorcery (no transform), and declining to reveal an
+ * instant or sorcery likewise doesn't transform.
+ *
+ * The back face has no mana cost, so its blue comes from a color indicator (CR 204).
+ */
+
+private val DelverOfSecretsFront = card("Delver of Secrets") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of your upkeep, look at the top card of your library. You may " +
+        "reveal that card. If an instant or sorcery card is revealed this way, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            // Look at the top card of your library — gather only; it stays on top either way.
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "delverLooked",
+            ),
+            // You may reveal that card. Selecting it is the reveal; declining selects nothing.
+            SelectFromCollectionEffect(
+                from = "delverLooked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "delverRevealed",
+                showAllCards = true,
+                prompt = "You may reveal the top card of your library",
+                selectedLabel = "Reveal",
+            ),
+            RevealCollectionEffect(from = "delverRevealed", revealToSelf = false),
+            // If an instant or sorcery card is revealed this way, transform this creature.
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch(
+                    "delverRevealed",
+                    GameObjectFilter.InstantOrSorcery,
+                ),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "At the beginning of your upkeep, look at the top card of your library. You " +
+            "may reveal that card. If an instant or sorcery card is revealed this way, transform " +
+            "this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1783940984"
+        ruling(
+            "2011-09-22",
+            "You may reveal the card even if it's not an instant or sorcery. Whether or not you " +
+                "reveal it, the card stays on top of your library."
+        )
+    }
+}
+
+private val InsectileAberration = card("Insectile Aberration") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Human Insect"
+    power = 3
+    toughness = 2
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Nils Hamm"
+        flavorText = "\"Unfortunately, all my test animals have died or escaped, so I shall be the " +
+            "final subject. I feel no fear. This is a momentous night.\"\n—Laboratory notes, final entry"
+        imageUri = "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1783940984"
+    }
+}
+
+val DelverOfSecrets: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = DelverOfSecretsFront,
+    backFace = InsectileAberration,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/DelverOfSecretsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/DelverOfSecretsReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad: Midnight Hunt printing; the canonical definition lives in ISD. */
+val DelverOfSecretsReprint = Printing(
+    oracleId = "edd531b9-f615-4399-8c8c-1c5e18c4acbf",
+    name = "Delver of Secrets",
+    setCode = "MID",
+    collectorNumber = "47",
+    scryfallId = "abff6c81-65a4-48fa-ba8f-580f87b0344a",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1783925652",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/a/b/abff6c81-65a4-48fa-ba8f-580f87b0344a.jpg?1783925652",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AberrantResearcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AberrantResearcher.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Aberrant Researcher // Perfected Form (Shadows over Innistrad #49)
+ * {3}{U}
+ * Creature — Human Insect 3/2 // Creature — Insect Horror 5/4
+ *
+ * Front — Flying; "At the beginning of your upkeep, mill a card. If an instant or sorcery card was
+ *         milled this way, transform this creature."
+ * Back  — Flying.
+ *
+ * One upkeep trigger doing two things in sequence — no player may act between them (printed
+ * ruling), which falls out for free: both steps live in a single [Effects.Composite] resolved as one
+ * ability. `Patterns.Library.mill(1)` publishes the milled card to the standard `"milled"`
+ * collection, and [Conditions.CollectionContainsMatch] reads that collection's card back for the
+ * instant-or-sorcery check (the Loafing Giant idiom).
+ *
+ * Because the check is against the *gathered card*, not against the graveyard, it also satisfies the
+ * second ruling: a replacement effect that sends the milled card somewhere other than the graveyard
+ * still transforms this creature if that card was an instant or sorcery.
+ *
+ * The back face has no mana cost, so its blue comes from a color indicator (CR 204).
+ */
+
+private val AberrantResearcherFront = card("Aberrant Researcher") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Insect"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, mill a card. If an instant or sorcery card was milled " +
+        "this way, transform this creature. (To mill a card, put the top card of your library into " +
+        "your graveyard.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Patterns.Library.mill(1),
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch("milled", GameObjectFilter.InstantOrSorcery),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "At the beginning of your upkeep, mill a card. If an instant or sorcery card " +
+            "was milled this way, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "49"
+        artist = "Nils Hamm"
+        flavorText = "\"Metamorphosis is a process.\"\n—Laboratory notes"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1783937809"
+        ruling(
+            "2016-04-08",
+            "No player may take any action between the two steps of Aberrant Researcher's triggered " +
+                "ability. If the card put into your graveyard is an instant or sorcery card, Aberrant " +
+                "Researcher will have transformed before a player can take any action."
+        )
+        ruling(
+            "2016-04-08",
+            "If a replacement effect causes the top card of your library to go to a zone other than " +
+                "your graveyard, Aberrant Researcher will still transform if that card was an instant " +
+                "or sorcery card."
+        )
+    }
+}
+
+private val PerfectedForm = card("Perfected Form") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Insect Horror"
+    power = 5
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "49"
+        artist = "Nils Hamm"
+        flavorText = "The final pages of the experiment log were blank. Investigators found it " +
+            "abandoned on a desk in the researcher's lab, open, the pages flipping in the wind from " +
+            "a shattered window."
+        imageUri = "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1783937809"
+    }
+}
+
+val AberrantResearcher: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = AberrantResearcherFront,
+    backFace = PerfectedForm,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1951,6 +1951,230 @@
     ]
 }
 
+// Shrill Howler
+{
+    "name": "Shrill Howler",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Werewolf Horror",
+    "oracleText": "Creatures with power less than this creature's power can't block it.\n{5}{G}: Transform this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": "Transform",
+                "descriptionOverride": "Transform this creature."
+            }
+        ],
+        "staticAbilities": [
+            "CantBeBlockedByCreaturesWithLessPower"
+        ]
+    },
+    "backFace": {
+        "name": "Howling Chorus",
+        "manaCost": "",
+        "typeLine": "Creature — Eldrazi Werewolf",
+        "oracleText": "Creatures with power less than this creature's power can't block it.\nWhenever this creature deals combat damage to a player, create a 3/2 colorless Eldrazi Horror creature token.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 5
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 3,
+                        "toughness": 2,
+                        "colors": [],
+                        "creatureTypes": [
+                            "Eldrazi",
+                            "Horror"
+                        ]
+                    },
+                    "descriptionOverride": "Whenever this creature deals combat damage to a player, create a 3/2 colorless Eldrazi Horror creature token."
+                }
+            ],
+            "staticAbilities": [
+                "CantBeBlockedByCreaturesWithLessPower"
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "168",
+            "rarity": "UNCOMMON",
+            "artist": "Matt Stewart",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1783937445"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "flavorText": "\"A werewolf's howl is terrifying, to be sure. But this . . . this was a chilling sound I somehow felt. I fear what will reply to it.\"\n—Alena, trapper of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a63c30c0-369a-4a75-b352-edab4d263d1b.jpg?1783937445",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "The power of the blocking creature and that of Shrill Howler are compared only at the moment that blockers are chosen. Changing either creature's power later won't cause Shrill Howler to become unblocked."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "The power of the blocking creature and that of Howling Chorus are compared only at the moment that blockers are chosen. Changing either creature's power later won't cause Howling Chorus to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Smoldering Werewolf
+{
+    "name": "Smoldering Werewolf",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Werewolf Horror",
+    "oracleText": "When this creature enters, it deals 1 damage to each of up to two target creatures.\n{4}{R}{R}: Transform this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to two target creatures"
+                },
+                "descriptionOverride": "When this creature enters, it deals 1 damage to each of up to two target creatures."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}{R}"
+                    }
+                },
+                "effect": "Transform",
+                "descriptionOverride": "Transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Erupting Dreadwolf",
+        "manaCost": "",
+        "typeLine": "Creature — Eldrazi Werewolf",
+        "oracleText": "Whenever this creature attacks, it deals 2 damage to any target.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 4
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    },
+                    "descriptionOverride": "Whenever this creature attacks, it deals 2 damage to any target."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "142",
+            "rarity": "UNCOMMON",
+            "artist": "Zack Stella",
+            "flavorText": "\". . . heck, I'd settle for anything that even resembled a werewolf.\"\n—Raf Gyel of the Quiver of Kessig",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1783937460"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Zack Stella",
+        "flavorText": "\"Never thought I'd see the day I'd be wishing to see just a plain old werewolf.\"\n—Raf Gyel of the Quiver of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b0eab47-af62-4ee8-99cf-a864fadade2d.jpg?1783937460",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "Erupting Dreadwolf's triggered ability resolves before blockers are chosen. A creature dealt lethal damage this way won't be around to block."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If you transform Smoldering Werewolf into Erupting Dreadwolf after it has attacked, Erupting Dreadwolf's triggered ability won't trigger that combat."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Soul Separator
 {
     "name": "Soul Separator",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -895,6 +895,119 @@
     ]
 }
 
+// Delver of Secrets
+{
+    "name": "Delver of Secrets",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "delverLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "delverLooked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "delverRevealed",
+                            "prompt": "You may reveal the top card of your library",
+                            "selectedLabel": "Reveal",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "delverRevealed",
+                            "revealToSelf": false
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "delverRevealed",
+                                    "filter": "instant|sorcery"
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Insectile Aberration",
+        "manaCost": "",
+        "typeLine": "Creature — Human Insect",
+        "oracleText": "Flying",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 2
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "metadata": {
+            "collectorNumber": "51",
+            "artist": "Nils Hamm",
+            "flavorText": "\"Unfortunately, all my test animals have died or escaped, so I shall be the final subject. I feel no fear. This is a momentous night.\"\n—Laboratory notes, final entry",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1783940984"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11bf83bb-c95b-4b4f-9a56-ce7a1816307a.jpg?1783940984",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "You may reveal the card even if it's not an instant or sorcery. Whether or not you reveal it, the card stays on top of your library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Demonmail Hauberk
 {
     "name": "Demonmail Hauberk",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1,3 +1,120 @@
+// Aberrant Researcher
+{
+    "name": "Aberrant Researcher",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Insect",
+    "oracleText": "Flying\nAt the beginning of your upkeep, mill a card. If an instant or sorcery card was milled this way, transform this creature. (To mill a card, put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "milled",
+                                    "filter": "instant|sorcery"
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, mill a card. If an instant or sorcery card was milled this way, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Perfected Form",
+        "manaCost": "",
+        "typeLine": "Creature — Insect Horror",
+        "oracleText": "Flying",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "metadata": {
+            "collectorNumber": "49",
+            "rarity": "UNCOMMON",
+            "artist": "Nils Hamm",
+            "flavorText": "The final pages of the experiment log were blank. Investigators found it abandoned on a desk in the researcher's lab, open, the pages flipping in the wind from a shattered window.",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1783937809"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Metamorphosis is a process.\"\n—Laboratory notes",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5c9649e-9ae5-4926-bf08-71ba23aa37f1.jpg?1783937809",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "No player may take any action between the two steps of Aberrant Researcher's triggered ability. If the card put into your graveyard is an instant or sorcery card, Aberrant Researcher will have transformed before a player can take any action."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "If a replacement effect causes the top card of your library to go to a zone other than your graveyard, Aberrant Researcher will still transform if that card was an instant or sorcery card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Aim High
 {
     "name": "Aim High",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AberrantResearcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AberrantResearcherScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aberrant Researcher // Perfected Form (SOI #49).
+ *
+ * "Flying
+ *  At the beginning of your upkeep, mill a card. If an instant or sorcery card was milled this way,
+ *  transform this creature."
+ *
+ * The mill is mandatory either way; only the transform is gated. Both branches are covered, plus the
+ * printed ruling that no player acts between the mill and the transform (they resolve as one ability,
+ * so the flip is already done when the stack is next empty).
+ */
+class AberrantResearcherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Aberrant Researcher") {
+
+            /** Player 1 controls the Researcher; [topCard] is the top of their library. */
+            fun gameWithTopCard(topCard: String) = run {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Aberrant Researcher", summoningSickness = false)
+                    .withCardInLibrary(1, topCard) // first added = index 0 = top
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Grizzly Bears") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Grizzly Bears") }
+                builder.build()
+            }
+
+            test("milling an instant transforms it into Perfected Form") {
+                val game = gameWithTopCard("Lightning Bolt")
+                val researcher = game.findPermanent("Aberrant Researcher")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("the card was milled") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("an instant was milled → transformed, with no window in between") {
+                    game.state.getEntity(researcher)!!.get<CardComponent>()!!.name shouldBe "Perfected Form"
+                }
+            }
+
+            test("milling a creature card does not transform it") {
+                val game = gameWithTopCard("Grizzly Bears")
+                val researcher = game.findPermanent("Aberrant Researcher")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("the mill still happens") {
+                    game.graveyardSize(1) shouldBe 1
+                }
+                withClue("no instant or sorcery milled → stays Aberrant Researcher") {
+                    game.state.getEntity(researcher)!!.get<CardComponent>()!!.name shouldBe "Aberrant Researcher"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DelverOfSecretsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DelverOfSecretsScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Delver of Secrets // Insectile Aberration (ISD #51).
+ *
+ * "At the beginning of your upkeep, look at the top card of your library. You may reveal that card.
+ *  If an instant or sorcery card is revealed this way, transform this creature."
+ *
+ * Three branches of the same gate:
+ *  - reveal an instant → transforms (and the card stays on top of the library),
+ *  - decline to reveal an instant → no transform (the ruling: the transform keys off the *reveal*),
+ *  - reveal a non-instant/sorcery → no transform (revealing a creature is legal, just useless).
+ */
+class DelverOfSecretsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Delver of Secrets") {
+
+            /**
+             * Player 1 controls Delver; [topCard] is the top card of their library. Starts on player
+             * 2's main phase so the very next upkeep is player 1's (and no draw step intervenes
+             * before it, leaving [topCard] on top).
+             */
+            fun gameWithTopCard(topCard: String) = run {
+                var builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Delver of Secrets", summoningSickness = false)
+                    .withCardInLibrary(1, topCard) // first added = index 0 = top
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Grizzly Bears") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Grizzly Bears") }
+                builder.build()
+            }
+
+            test("revealing an instant from the top transforms it into Insectile Aberration") {
+                val game = gameWithTopCard("Lightning Bolt")
+                val delver = game.findPermanent("Delver of Secrets")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                // The "you may reveal" choice: select the looked-at card to reveal it.
+                withClue("the upkeep trigger should pause for the reveal choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val topCard = game.findCardsInLibrary(1, "Lightning Bolt").first()
+                game.selectCards(listOf(topCard))
+                game.resolveStack()
+
+                withClue("an instant was revealed → transformed") {
+                    game.state.getEntity(delver)!!.get<CardComponent>()!!.name shouldBe "Insectile Aberration"
+                }
+                withClue("the card stays on top of the library — nothing moved zones") {
+                    game.state.getLibrary(game.player1Id).first() shouldBe topCard
+                }
+            }
+
+            test("declining to reveal leaves it as Delver of Secrets") {
+                val game = gameWithTopCard("Lightning Bolt")
+                val delver = game.findPermanent("Delver of Secrets")!!
+                val libraryBefore = game.librarySize(1)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("nothing was revealed → no transform even though the top card is an instant") {
+                    game.state.getEntity(delver)!!.get<CardComponent>()!!.name shouldBe "Delver of Secrets"
+                }
+                withClue("the library is untouched") {
+                    game.librarySize(1) shouldBe libraryBefore
+                }
+            }
+
+            test("revealing a creature card does not transform it") {
+                val game = gameWithTopCard("Grizzly Bears")
+                val delver = game.findPermanent("Delver of Secrets")!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                val topCard = game.state.getLibrary(game.player1Id).first()
+                game.selectCards(listOf(topCard))
+                game.resolveStack()
+
+                withClue("a creature was revealed → no transform") {
+                    game.state.getEntity(delver)!!.get<CardComponent>()!!.name shouldBe "Delver of Secrets"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShrillHowlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShrillHowlerScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Shrill Howler // Howling Chorus (EMN #168).
+ *
+ *   Front (3/1) — "Creatures with power less than this creature's power can't block it."
+ *                 "{5}{G}: Transform this creature."
+ *   Back  (3/5) — same evasion clause, plus "Whenever this creature deals combat damage to a player,
+ *                 create a 3/2 colorless Eldrazi Horror creature token."
+ *
+ * Covers the attacker-side power evasion on the front face, the activated flip, and the back face's
+ * combat-damage token trigger.
+ */
+class ShrillHowlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature("Test Runt", ManaCost.parse("{2}"), emptySet(), power = 2, toughness = 2)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Test Bruiser", ManaCost.parse("{3}"), emptySet(), power = 3, toughness = 3)
+        )
+
+        context("Shrill Howler") {
+
+            test("a power-2 creature can't block the power-3 Shrill Howler") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shrill Howler", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Runt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Shrill Howler" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Runt" to listOf("Shrill Howler")))
+                withClue("power 2 < power 3 — the block is illegal") {
+                    block.error shouldNotBe null
+                }
+            }
+
+            test("a power-3 creature can block it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shrill Howler", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Bruiser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Shrill Howler" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Bruiser" to listOf("Shrill Howler")))
+                withClue("equal power is not *less* power — the block is legal: ${block.error}") {
+                    block.error shouldBe null
+                }
+            }
+
+            test("{5}{G} transforms it into a 3/5 Howling Chorus that keeps the evasion") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shrill Howler", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withCardOnBattlefield(2, "Test Runt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val howler = game.findPermanent("Shrill Howler")!!
+                val abilityId = cardRegistry.getCard("Shrill Howler")!!.activatedAbilities.first().id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = howler, abilityId = abilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("transformed to the back face") {
+                    game.state.getEntity(howler)!!.get<CardComponent>()!!.name shouldBe "Howling Chorus"
+                    game.state.projectedState.getPower(howler) shouldBe 3
+                    game.state.projectedState.getToughness(howler) shouldBe 5
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Howling Chorus" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Runt" to listOf("Howling Chorus")))
+                withClue("the back face carries the same evasion clause") {
+                    block.error shouldNotBe null
+                }
+            }
+
+            test("Howling Chorus makes a 3/2 Eldrazi Horror on combat damage to a player") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shrill Howler", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val howler = game.findPermanent("Shrill Howler")!!
+                val abilityId = cardRegistry.getCard("Shrill Howler")!!.activatedAbilities.first().id
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = howler, abilityId = abilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Howling Chorus" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("3 combat damage went through unblocked") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                // The CreateToken facade names type-only tokens "<types> Token".
+                val tokens = game.findAllPermanents("Eldrazi Horror Token")
+                withClue("the combat-damage trigger created one 3/2 Eldrazi Horror") {
+                    tokens.size shouldBe 1
+                    game.state.projectedState.getPower(tokens.first()) shouldBe 3
+                    game.state.projectedState.getToughness(tokens.first()) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmolderingWerewolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmolderingWerewolfScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Smoldering Werewolf // Erupting Dreadwolf (EMN #142).
+ *
+ *   Front (3/2) — "When this creature enters, it deals 1 damage to each of up to two target
+ *                  creatures." / "{4}{R}{R}: Transform this creature."
+ *   Back  (6/4) — "Whenever this creature attacks, it deals 2 damage to any target."
+ *
+ * Covers the up-to-two-target ETB (both slots used, and zero slots used), the activated flip, and
+ * the back face's attack trigger.
+ */
+class SmolderingWerewolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature("Test Weakling", ManaCost.parse("{1}"), emptySet(), power = 1, toughness = 1)
+        )
+
+        context("Smoldering Werewolf") {
+
+            test("entering deals 1 damage to each of two target creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Smoldering Werewolf")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardOnBattlefield(2, "Test Weakling")
+                    .withCardOnBattlefield(2, "Test Weakling")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victims = game.findAllPermanents("Test Weakling")
+                victims.size shouldBe 2
+
+                game.castSpell(1, "Smoldering Werewolf").error shouldBe null
+                game.resolveStack()
+
+                // The enters trigger asks for its (up to two) targets.
+                withClue("the enters trigger should ask for targets") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(victims)
+                game.resolveStack()
+
+                withClue("1 damage killed both 1/1s") {
+                    game.findAllPermanents("Test Weakling") shouldBe emptyList()
+                    game.isInGraveyard(2, "Test Weakling") shouldBe true
+                }
+            }
+
+            test("the enters trigger may choose no targets at all") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Smoldering Werewolf")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardOnBattlefield(2, "Test Weakling")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Smoldering Werewolf").error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.skipTargets()
+                    game.resolveStack()
+                }
+
+                withClue("'up to two' allows zero — the 1/1 survives") {
+                    game.findAllPermanents("Test Weakling").size shouldBe 1
+                }
+                game.isOnBattlefield("Smoldering Werewolf") shouldBe true
+            }
+
+            test("{4}{R}{R} transforms it into a 6/4 Erupting Dreadwolf") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smoldering Werewolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Smoldering Werewolf")!!
+                val abilityId = cardRegistry.getCard("Smoldering Werewolf")!!.activatedAbilities.first().id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = wolf, abilityId = abilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("transformed to the back face") {
+                    game.state.getEntity(wolf)!!.get<CardComponent>()!!.name shouldBe "Erupting Dreadwolf"
+                    game.state.projectedState.getPower(wolf) shouldBe 6
+                    game.state.projectedState.getToughness(wolf) shouldBe 4
+                }
+            }
+
+            test("Erupting Dreadwolf's attack trigger deals 2 damage to any target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smoldering Werewolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Smoldering Werewolf")!!
+                val abilityId = cardRegistry.getCard("Smoldering Werewolf")!!.activatedAbilities.first().id
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = wolf, abilityId = abilityId)
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                game.state.getEntity(wolf)!!.get<CardComponent>()!!.name shouldBe "Erupting Dreadwolf"
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Erupting Dreadwolf" to 2)).error shouldBe null
+
+                // The attack trigger targets the defending player.
+                if (game.hasPendingDecision()) game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("2 damage from the attack trigger (combat damage has not happened yet)") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Innistrad Remastered transform cards. INR is a remaster set, so
each canonical `CardDefinition` lands in the card's **earliest real printing** and
INR gets a `Printing` row:

| Card | Canonical | Printing rows added |
|---|---|---|
| Delver of Secrets // Insectile Aberration | ISD #51 | MID #47, INR #60 |
| Aberrant Researcher // Perfected Form | SOI #49 | INR #52 |
| Smoldering Werewolf // Erupting Dreadwolf | EMN #142 | INR #171 |
| Shrill Howler // Howling Chorus | EMN #168 | INR #214 |

All four compose existing SDK primitives — no new vocabulary — so
`docs/card-sdk-language-reference.md` is unchanged.

## Modelling notes

**Delver of Secrets.** "Look at the top card of your library. You may reveal that
card." Nothing moves zones, so the pipeline is gather-only (`GatherCards(TopOfLibrary(1))`
with no `MoveCollection`). The look-and-may-reveal pair is a single
`SelectFromCollection(ChooseUpTo(1), showAllCards = true)`: the overlay shows the
controller the card (the private look) and selecting it *is* the reveal.
`RevealCollection` then publishes only what was selected, so an unrevealed card never
leaks. The transform gates on the **revealed** collection, not the looked-at one — per
the printed ruling, declining to reveal an instant does not flip, and revealing a
creature is legal but does nothing.

**Aberrant Researcher.** Reuses `Patterns.Library.mill(1)`'s `"milled"` collection for
the instant-or-sorcery gate (the Loafing Giant idiom). Both steps live in one
`Composite`, so no player acts between them (printed ruling), and because the check is
against the gathered *card* rather than the graveyard it also satisfies the second
ruling about a replacement effect redirecting the milled card elsewhere.

**Shrill Howler // Howling Chorus.** Both faces carry the attacker-side
`CantBeBlockedByCreaturesWithLessPower` static (Formation Breaker / Elusive Otter),
which compares projected power at declare-blockers — exactly the printed ruling. The
back's token uses the `Effects.CreateToken` facade rather than a raw
`CreateTokenEffect` so it stays mtgish-AUTO-matchable.

**Smoldering Werewolf.** The ETB is **one** "up to two target creatures" requirement
(`TargetCreature(count = 2, optional = true)`) plus `ForEachTarget`, not two independent
slots — so the two picks must be distinct (CR 601.2c) and choosing zero is legal.

Both EMN back faces are printed colorless (no color indicator); the SOI/ISD back faces
get `colorIndicator = "U"` per CR 204.

## Verification

- `just build` — green.
- Four new scenario tests, 13 cases, all passing: `DelverOfSecretsScenarioTest`,
  `AberrantResearcherScenarioTest`, `SmolderingWerewolfScenarioTest`,
  `ShrillHowlerScenarioTest` (one card per file).
- Per-set card snapshots re-blessed for ISD / SOI / EMN — the diffs are additions only,
  no existing card moved.
- `just check-card-printing` clean for all four (this is what surfaced the missing MID
  Delver row, also added here).
- Every `imageUri` / `backFaceImageUri` verified HTTP 200 against Scryfall.
- INR coverage: 223 → 227 of 290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)