### PR TITLE
Add Feral Encounter and Virtue of Courage to Wilds of Eldraine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2168,7 +2168,7 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   player), e.g. Shadowfax, Lord of Horses ("put a creature card with lesser power from your hand onto
   the battlefield tapped and attacking").
 - `incubate(n)` — make an Incubator token with N counters.
-- `impulse(count?, expiry?)` — impulse draw: exile the top N of your library, may play those cards until `expiry` (default end of turn); played cards still pay their mana. For the play-free variant compose with `GrantPlayWithoutPayingCostEffect` (cf. `shuffleAndExileTopPlayFree`). Irascible Wolverine (1), Annie Flash, the Veteran (2). `MayPlayExpiry` options: `EndOfTurn` (default), `Permanent` ("for as long as it remains exiled"), `UntilControllerStep(step, includeCurrentTurn?)` / the `UntilEndOfNextTurn` + `UntilNextEndStep` shorthands (turn-keyed, cleaned up at the matching cleanup), and `UntilSourceExilesAnother` — a **self-superseding** permission that persists across turns (and survives the granting source leaving play) but is revoked the moment that *same source* grants another such permission (exiles another card), so only the source's most-recently-exiled card stays playable and the earlier one remains in exile but unplayable. Requires the grant to carry a source id (falls back to `Permanent` behaviour without one); models "you may play that card until you exile another card with this creature" (**Superior Foes of Spider-Man**).
+- `impulse(count?, expiry?)` — impulse draw: exile the top N of your library, may play those cards until `expiry` (default end of turn); played cards still pay their mana. `count` takes a plain `Int` or a `DynamicAmount` for "exile *that many* cards" (Virtue of Courage, counting off the noncombat damage just dealt via `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`). For the play-free variant compose with `GrantPlayWithoutPayingCostEffect` (cf. `shuffleAndExileTopPlayFree`). Irascible Wolverine (1), Annie Flash, the Veteran (2). `MayPlayExpiry` options: `EndOfTurn` (default), `Permanent` ("for as long as it remains exiled"), `UntilControllerStep(step, includeCurrentTurn?)` / the `UntilEndOfNextTurn` + `UntilNextEndStep` shorthands (turn-keyed, cleaned up at the matching cleanup), and `UntilSourceExilesAnother` — a **self-superseding** permission that persists across turns (and survives the granting source leaving play) but is revoked the moment that *same source* grants another such permission (exiles another card), so only the source's most-recently-exiled card stays playable and the earlier one remains in exile but unplayable. Requires the grant to carry a source id (falls back to `Permanent` behaviour without one); models "you may play that card until you exile another card with this creature" (**Superior Foes of Spider-Man**).
 - `returnLinkedExile(underOwnersControl?)` — bring back linked exile pile.
 - `takeFromLinkedExile()` — pull one card from linked exile.
 - `shuffleGraveyardIntoLibrary(target?)` — Elixir of Immortality shape.
@@ -4155,6 +4155,16 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
     - `NEXT_TURN` — stricter "on your next turn"-style timing: the current turn never qualifies
       regardless of step. Pair with `fireOnPlayer = PlayerRef(Player.You)` to land on the
       controller's upcoming own turn rather than an intervening opponent turn. (Kav Landseeker.)
+    - `THIS_TURN_ONLY` — "…the next [step] **this turn**": no turn floor, but the trigger is swept
+      at end of turn instead of waiting across the boundary, so a turn with no further matching step
+      drops it unfired. (Feral Encounter: cast it in a postcombat main phase and the combat ability
+      simply never triggers.) `CURRENT_TURN_OR_LATER` is the open-ended cousin.
+  - `targetRequirement` / `additionalTargetRequirements` — targets chosen *each time* the delayed
+    trigger fires (not when it's scheduled), exposed to the inner `effect` as `ContextTarget(0)`,
+    `ContextTarget(1)`, … in that order. One requirement is the common case (Rediscover the Way
+    chapter III, Fatal Fissure); the list carries the rest for a trigger that targets more than once
+    — Feral Encounter's "target creature you control deals damage equal to its power to up to one
+    target creature you don't control", where the *spell* takes no targets at all.
   - `repeatAtEachMatchingStep = true` keeps a step-based delayed trigger resident after it fires,
     repeating at every matching step until `expiry` removes it. The default is `false`, preserving
     the one-shot "at the beginning of the next ..." shape. Pair with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/ExilePatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/ExilePatterns.kt
@@ -106,9 +106,19 @@ object ExilePatterns {
         count: Int = 1,
         expiry: MayPlayExpiry = MayPlayExpiry.EndOfTurn,
         storeAs: String = "impulseExiled"
+    ): Effect = impulse(DynamicAmount.Fixed(count), expiry, storeAs)
+
+    /**
+     * Impulse draw whose card count is computed at resolution — "exile *that many* cards from the
+     * top of your library" (Virtue of Courage, where the count is the noncombat damage just dealt).
+     */
+    fun impulse(
+        count: DynamicAmount,
+        expiry: MayPlayExpiry = MayPlayExpiry.EndOfTurn,
+        storeAs: String = "impulseExiled"
     ): Effect = CompositeEffect(listOf(
         GatherCardsEffect(
-            source = CardSource.TopOfLibrary(DynamicAmount.Fixed(count)),
+            source = CardSource.TopOfLibrary(count),
             storeAs = storeAs
         ),
         MoveCollectionEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -654,7 +654,19 @@ enum class DelayedTriggerTiming {
      * rather than an intervening opponent turn. (Kav Landseeker.)
      */
     @SerialName("NextTurn")
-    NEXT_TURN
+    NEXT_TURN,
+
+    /**
+     * "…the next [step] **this turn**": no turn floor, but the trigger is discarded at end of turn
+     * if that step never comes around again. Feral Encounter ("at the beginning of the next combat
+     * phase this turn") is the shape — cast it in a postcombat main phase and the ability simply
+     * never triggers, rather than lying in wait for the opponent's combat.
+     *
+     * [CURRENT_TURN_OR_LATER] is the open-ended cousin: it also allows the current turn but keeps
+     * waiting across turn boundaries, which is what "at the beginning of the next end step" wants.
+     */
+    @SerialName("ThisTurnOnly")
+    THIS_TURN_ONLY
 }
 
 /**
@@ -739,6 +751,15 @@ data class CreateDelayedTriggerEffect(
      * Null for non-targeting delayed triggers (the common case).
      */
     val targetRequirement: TargetRequirement? = null,
+    /**
+     * Further target requirements beyond [targetRequirement], for a delayed trigger that targets
+     * more than once — Feral Encounter's "at the beginning of the next combat phase this turn,
+     * target creature you control deals damage equal to its power to up to one target creature you
+     * don't control". They are exposed to [effect] as
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.ContextTarget] 1, 2, … in order, with
+     * [targetRequirement] at index 0, and the whole list is chosen fresh each time the trigger fires.
+     */
+    val additionalTargetRequirements: List<TargetRequirement> = emptyList(),
     /**
      * For step-based delayed triggers: restrict firing to a specific player's matching step,
      * rather than every player's. Resolved to a concrete player entity id at scheduling time

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -657,7 +657,7 @@ object CardLinter {
                     "CreateDelayedTrigger" -> return walkDeferredEffect(
                         element, scope, state,
                         effectField = "effect",
-                        reqFields = listOf("targetRequirement"),
+                        reqFields = listOf("targetRequirement", "additionalTargetRequirements"),
                         label = "delayed trigger of ${scope.label}",
                     )
                 }
@@ -674,7 +674,8 @@ object CardLinter {
      * target requirements: a `ReflexiveTriggerEffect`'s reflexive effect targets via
      * `reflexiveTargetRequirements` (chosen when the reflexive trigger goes on the stack —
      * Foray of Orcs et al.), and a `CreateDelayedTriggerEffect`'s effect targets via its
-     * `targetRequirement` (chosen each time the delayed trigger fires — Rediscover the Way).
+     * `targetRequirement` plus `additionalTargetRequirements` (chosen each time the delayed trigger
+     * fires — Rediscover the Way for one, Feral Encounter for two).
      * `ContextTarget` indices inside the deferred effect are scoped to those requirements;
      * when none are declared, they inherit the outer ability's targets ("exile target card …
      * when you do, return it"). Pipeline collections flow through — the engine snapshots them

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FeralEncounter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FeralEncounter.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Feral Encounter
+ * {G}{G}
+ * Sorcery
+ * Look at the top five cards of your library. You may exile a creature card from among them. Put
+ * the rest on the bottom of your library in a random order. You may cast the exiled card this turn.
+ * At the beginning of the next combat phase this turn, target creature you control deals damage
+ * equal to its power to up to one target creature you don't control.
+ *
+ * Two independent halves in one `spell { }`:
+ *
+ *  1. The dig is the Pictures of Spider-Man pipeline — gather the top five, an optional
+ *     [SelectionMode.ChooseUpTo]`(1)` filtered to creature cards, the pick to exile with a
+ *     [GrantMayPlayFromExileEffect] play permission, the remainder to the bottom in a random order.
+ *     `showAllCards` keeps all five visible so the player sees what they're passing up, and
+ *     declining simply leaves the collection empty — the exile, the grant and the fight all no-op
+ *     independently.
+ *  2. The combat payoff is a **delayed** trigger, and per the card's ruling the spell itself takes
+ *     no targets: both targets are chosen when the delayed ability goes on the stack at the
+ *     beginning of combat. That's [CreateDelayedTriggerEffect.targetRequirement] plus
+ *     [CreateDelayedTriggerEffect.additionalTargetRequirements], exposed to the effect as
+ *     `ContextTarget(0)` / `ContextTarget(1)`.
+ *
+ * [DelayedTriggerTiming.THIS_TURN_ONLY] carries the "this turn" clause: cast in a postcombat main
+ * phase, no combat phase follows and the ability never triggers (the second ruling) rather than
+ * waiting around for the opponent's combat.
+ *
+ * "Up to one target creature you don't control" is an `optional` requirement, so the trigger still
+ * goes on the stack with no second target and the damage simply doesn't happen — matching the
+ * house reading of "you don't control" as [TargetFilter.Creature.opponentControls] (cf. Clear Shot,
+ * whose oracle line is identical).
+ */
+val FeralEncounter = card("Feral Encounter") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top five cards of your library. You may exile a creature card from " +
+        "among them. Put the rest on the bottom of your library in a random order. You may cast " +
+        "the exiled card this turn.\n" +
+        "At the beginning of the next combat phase this turn, target creature you control deals " +
+        "damage equal to its power to up to one target creature you don't control."
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(5)),
+                storeAs = "feralLooked"
+            ),
+            SelectFromCollectionEffect(
+                from = "feralLooked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Creature,
+                storeSelected = "feralExiled",
+                storeRemainder = "feralRest",
+                prompt = "You may exile a creature card. You may cast it this turn.",
+                selectedLabel = "Exile (you may cast it this turn)",
+                remainderLabel = "Put on the bottom of your library",
+                showAllCards = true
+            ),
+            MoveCollectionEffect(
+                from = "feralExiled",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            MoveCollectionEffect(
+                from = "feralRest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            ),
+            GrantMayPlayFromExileEffect("feralExiled"),
+            CreateDelayedTriggerEffect(
+                step = Step.BEGIN_COMBAT,
+                timing = DelayedTriggerTiming.THIS_TURN_ONLY,
+                targetRequirement = TargetCreature(filter = TargetFilter.Creature.youControl()),
+                additionalTargetRequirements = listOf(
+                    TargetCreature(optional = true, filter = TargetFilter.Creature.opponentControls())
+                ),
+                effect = DealDamageEffect(
+                    DynamicAmounts.targetPower(0),
+                    EffectTarget.ContextTarget(1),
+                    damageSource = EffectTarget.ContextTarget(0)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "169"
+        artist = "Fajareka Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg?1783915082"
+
+        ruling(
+            "2023-09-01",
+            "Casting Feral Encounter doesn't require any targets. As you put the delayed triggered " +
+                "ability on the stack at the beginning of the next combat phase this turn, you " +
+                "choose the target creature you control and up to one target creature you don't control."
+        )
+        ruling(
+            "2023-09-01",
+            "If you cast Feral Encounter and no combat phases occur later in that turn, the " +
+                "delayed triggered ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfCourage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VirtueOfCourage.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Virtue of Courage // Embereth Blaze
+ * {3}{R}{R}
+ * Enchantment
+ * Whenever a source you control deals noncombat damage to an opponent, you may exile that many
+ * cards from the top of your library. You may play those cards this turn.
+ *
+ * Adventure: Embereth Blaze — {1}{R}, Instant — Adventure
+ * Embereth Blaze deals 2 damage to any target.
+ *
+ * "A source you control" is the Niv-Mizzet, Visionary shape — a `DealsDamageEvent` with
+ * `sourceFilter = GameObjectFilter.Any.youControl()` and `TriggerBinding.ANY`, narrowed to
+ * noncombat damage aimed at an opponent. Any object you control counts, not just permanents, so
+ * the enchantment sees burn spells and its own Adventure half as readily as a pinger.
+ *
+ * "That many" reads [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] off the trigger context, and the
+ * exile-plus-permission half is the standard impulse recipe (`Patterns.Exile.impulse`) taking that
+ * dynamic count. The "you may" is an explicit [Gate.MayDecide] rather than `optional = true` on the
+ * trigger purely for the prompt: the gate's `descriptionOverride` is what the player is asked, and
+ * the pipeline's own description would read as gather/move/grant plumbing.
+ *
+ * Note the front face is an **enchantment**, not a creature; CR 715.3d puts no type restriction on
+ * the card exiled by a resolving Adventure, so this is the same `adventure { }` shape as the
+ * creature adventurers (cf. Virtue of Persistence).
+ */
+val VirtueOfCourage = card("Virtue of Courage") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a source you control deals noncombat damage to an opponent, you may " +
+        "exile that many cards from the top of your library. You may play those cards this turn."
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.NonCombat,
+            recipient = RecipientFilter.Opponent,
+            sourceFilter = GameObjectFilter.Any.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = GatedEffect(
+            gate = Gate.MayDecide(),
+            then = Patterns.Exile.impulse(
+                DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+            ),
+            // Becomes the yes/no prompt text — the pipeline's auto-description would read as
+            // gather/move/grant plumbing.
+            descriptionOverride = "You may exile that many cards from the top of your library. " +
+                "You may play those cards this turn."
+        )
+        description = "Whenever a source you control deals noncombat damage to an opponent, you " +
+            "may exile that many cards from the top of your library. You may play those cards " +
+            "this turn."
+    }
+
+    adventure("Embereth Blaze") {
+        manaCost = "{1}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may " +
+            "cast the enchantment later from exile.)"
+        spell {
+            val anyTarget = target("any target", Targets.Any)
+            effect = Effects.DealDamage(2, anyTarget)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "157"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1783915088"
+
+        ruling(
+            "2023-09-01",
+            "Combat damage is the damage that's dealt automatically by attacking and blocking " +
+                "creatures. Any other damage is noncombat damage, even if it's dealt during a " +
+                "combat phase by an attacking or blocking creature."
+        )
+        ruling(
+            "2023-09-01",
+            "You pay all costs and follow all normal timing rules for a card played this way. " +
+                "For example, if the exiled card is a land card, you may play it only during your " +
+                "main phase while the stack is empty."
+        )
+        ruling(
+            "2023-09-01",
+            "If a spell is cast as an Adventure, its controller exiles it instead of putting it " +
+                "into its owner's graveyard as it resolves. For as long as it remains exiled, " +
+                "that player may cast it as a permanent spell."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -5665,6 +5665,127 @@
     ]
 }
 
+// Feral Encounter
+{
+    "name": "Feral Encounter",
+    "manaCost": "{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top five cards of your library. You may exile a creature card from among them. Put the rest on the bottom of your library in a random order. You may cast the exiled card this turn.\nAt the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "feralLooked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "feralLooked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "feralExiled",
+                    "storeRemainder": "feralRest",
+                    "prompt": "You may exile a creature card. You may cast it this turn.",
+                    "selectedLabel": "Exile (you may cast it this turn)",
+                    "remainderLabel": "Put on the bottom of your library",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "feralExiled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "feralRest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "feralExiled"
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "step": "BEGIN_COMBAT",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 1
+                        },
+                        "damageSource": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "timing": "ThisTurnOnly",
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "additionalTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "RARE",
+        "artist": "Fajareka Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de21251f-40bf-4f7e-9e85-9033207a788f.jpg?1783915082",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Casting Feral Encounter doesn't require any targets. As you put the delayed triggered ability on the stack at the beginning of the next combat phase this turn, you choose the target creature you control and up to one target creature you don't control."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you cast Feral Encounter and no combat phases occur later in that turn, the delayed triggered ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Ferocious Werefox
 {
     "name": "Ferocious Werefox",
@@ -19199,6 +19320,113 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Virtue of Courage
+{
+    "name": "Virtue of Courage",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageNonCombat",
+                    "recipient": "RecipientOpponent",
+                    "sourceFilter": "ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "ContextProperty",
+                                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                                    }
+                                },
+                                "storeAs": "impulseExiled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "impulseExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "impulseExiled"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may exile that many cards from the top of your library. You may play those cards this turn."
+                },
+                "descriptionOverride": "Whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library. You may play those cards this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "MYTHIC",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b0e6daf-0dec-4718-af79-b7ce137c3135.jpg?1783915088",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Combat damage is the damage that's dealt automatically by attacking and blocking creatures. Any other damage is noncombat damage, even if it's dealt during a combat phase by an attacking or blocking creature."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "You pay all costs and follow all normal timing rules for a card played this way. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If a spell is cast as an Adventure, its controller exiles it instead of putting it into its owner's graveyard as it resolves. For as long as it remains exiled, that player may cast it as a permanent spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Embereth Blaze",
+            "manaCost": "{1}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Embereth Blaze deals 2 damage to any target. (Then exile this card. You may cast the enchantment later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DelayedTriggeredAbility.kt
@@ -68,6 +68,15 @@ data class DelayedTriggeredAbility(
      */
     val targetRequirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement? = null,
     /**
+     * Further target requirements beyond [targetRequirement], for a delayed trigger that targets
+     * more than once — Feral Encounter's "target creature you control deals damage equal to its
+     * power to up to one target creature you don't control". Mirrors
+     * [com.wingedsheep.sdk.scripting.TriggeredAbility.additionalTargetRequirements], which is where
+     * these end up on the synthesised ability; the whole list is chosen fresh each firing.
+     */
+    val additionalTargetRequirements: List<com.wingedsheep.sdk.scripting.targets.TargetRequirement> =
+        emptyList(),
+    /**
      * For step-based delayed triggers: the single "whose turn" gate. If non-null, only fires
      * when this player is the active player; null means it fires on the next matching step of
      * any turn. Setting it to the source's [controllerId] expresses the common "only on the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -466,7 +466,8 @@ class TriggerDetector(
                     trigger = EventPattern.StepEvent(Step.END, Player.Each),
                     binding = TriggerBinding.ANY,
                     effect = delayed.effect,
-                    targetRequirement = delayed.targetRequirement
+                    targetRequirement = delayed.targetRequirement,
+                    additionalTargetRequirements = delayed.additionalTargetRequirements
                 ),
                 sourceId = delayed.sourceId,
                 sourceName = delayed.sourceName,
@@ -858,7 +859,8 @@ class TriggerDetector(
                                     trigger = spec.event,
                                     binding = spec.binding,
                                     effect = delayed.effect,
-                                    targetRequirement = delayed.targetRequirement
+                                    targetRequirement = delayed.targetRequirement,
+                                    additionalTargetRequirements = delayed.additionalTargetRequirements
                                 ),
                                 sourceId = delayed.sourceId,
                                 sourceName = delayed.sourceName,
@@ -878,7 +880,8 @@ class TriggerDetector(
                             trigger = spec.event,
                             binding = spec.binding,
                             effect = delayed.effect,
-                            targetRequirement = delayed.targetRequirement
+                            targetRequirement = delayed.targetRequirement,
+                            additionalTargetRequirements = delayed.additionalTargetRequirements
                         ),
                         sourceId = delayed.sourceId,
                         sourceName = delayed.sourceName,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.DealDamagePerEntityInZoneEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -125,6 +126,17 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
                 if (onControllersTurn && endStepAlreadyStarted) state.turnNumber + 1 else null
             }
             DelayedTriggerTiming.CURRENT_TURN_OR_LATER -> null
+            DelayedTriggerTiming.THIS_TURN_ONLY -> null
+        }
+
+        // A step-based one-shot normally carries no expiry: "at the beginning of your next end
+        // step" has to survive the turn boundary when it's scheduled during the end step itself.
+        // THIS_TURN_ONLY is the opposite promise — "the next [step] *this turn*" — so it takes the
+        // end-of-turn sweep, and a turn with no further matching step drops it unfired.
+        val expiry = when {
+            effect.trigger != null || effect.repeatAtEachMatchingStep -> effect.expiry
+            effect.timing == DelayedTriggerTiming.THIS_TURN_ONLY -> DelayedTriggerExpiry.EndOfTurn
+            else -> null
         }
 
         val delayedTrigger = DelayedTriggeredAbility(
@@ -137,11 +149,12 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             trigger = resolvedTrigger,
             watchedEntityId = watchedEntityId,
             watchedRecipientId = watchedRecipientId,
-            expiry = if (effect.trigger != null || effect.repeatAtEachMatchingStep) effect.expiry else null,
+            expiry = expiry,
             fireOnce = effect.trigger != null && effect.fireOnce,
             repeatAtEachMatchingStep = effect.trigger == null && effect.repeatAtEachMatchingStep,
             notBeforeTurn = notBeforeTurn,
             targetRequirement = effect.targetRequirement,
+            additionalTargetRequirements = effect.additionalTargetRequirements,
             fireOnPlayerId = fireOnPlayerId
         )
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FeralEncounterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FeralEncounterScenarioTest.kt
@@ -1,0 +1,188 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Feral Encounter.
+ *
+ * Two pieces of new vocabulary get exercised here:
+ *  - [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.additionalTargetRequirements]
+ *    — the delayed combat trigger picks *two* targets when it fires.
+ *  - [com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming.THIS_TURN_ONLY] — "the next combat
+ *    phase **this turn**", so a copy cast after combat never fires.
+ */
+class FeralEncounterScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.ScenarioBuilder.withFiveCardLibrary() = this
+        .withCardInLibrary(1, "Grizzly Bears")
+        .withCardInLibrary(1, "Mountain")
+        .withCardInLibrary(1, "Mountain")
+        .withCardInLibrary(1, "Mountain")
+        .withCardInLibrary(1, "Mountain")
+
+    init {
+        context("the dig") {
+            test("exiles a creature card from the top five and lets you cast it this turn") {
+                val game = scenario()
+                    .withPlayers("Hunter", "Opponent")
+                    .withCardInHand(1, "Feral Encounter")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withFiveCardLibrary()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Feral Encounter").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").single()
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                game.isInExile(1, "Grizzly Bears") shouldBe true
+                // The other four went to the bottom rather than anywhere else.
+                game.librarySize(1) shouldBe 4
+
+                game.castSpellFromExile(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+
+            test("declining the exile leaves all five cards in the library") {
+                val game = scenario()
+                    .withPlayers("Hunter", "Opponent")
+                    .withCardInHand(1, "Feral Encounter")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withFiveCardLibrary()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Feral Encounter").error shouldBe null
+                game.resolveStack()
+
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                game.librarySize(1) shouldBe 5
+                game.isInExile(1, "Grizzly Bears") shouldBe false
+            }
+        }
+
+        context("the delayed combat trigger") {
+            test("picks both targets when it fires and deals power-equal damage") {
+                val game = scenario()
+                    .withPlayers("Hunter", "Opponent")
+                    .withCardInHand(1, "Feral Encounter")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withFiveCardLibrary()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mine = game.findPermanents("Grizzly Bears").first { entityId ->
+                    game.state.projectedState.getController(entityId) == game.player1Id
+                }
+                val theirs = game.findPermanents("Grizzly Bears").first { entityId ->
+                    game.state.projectedState.getController(entityId) == game.player2Id
+                }
+
+                game.castSpell(1, "Feral Encounter").error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeChooseTargets()
+                (decision as ChooseTargetsDecision).targetRequirements.size shouldBe 2
+
+                game.submitDecision(
+                    TargetsResponse(decision.id, mapOf(0 to listOf(mine), 1 to listOf(theirs)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                // A 2/2 dealing 2 to a 2/2 kills it; the attacker is untouched (not a fight).
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                game.state.projectedState.getController(theirs) shouldBe null
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            }
+
+            test("up to one — the trigger still fires with no creature to shoot") {
+                val game = scenario()
+                    .withPlayers("Hunter", "Opponent")
+                    .withCardInHand(1, "Feral Encounter")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withFiveCardLibrary()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Feral Encounter").error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeChooseTargets()
+                val mine = game.findPermanent("Grizzly Bears")!!
+                game.submitDecision(
+                    TargetsResponse(
+                        (decision as ChooseTargetsDecision).id,
+                        mapOf(0 to listOf(mine), 1 to emptyList())
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                game.getLifeTotal(2) shouldBe 20
+            }
+
+            test("cast after combat, the trigger never fires — it is scoped to this turn") {
+                val game = scenario()
+                    .withPlayers("Hunter", "Opponent")
+                    .withCardInHand(1, "Feral Encounter")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withFiveCardLibrary()
+                    // The opponent takes a turn below — they need something to draw.
+                    .withCardInLibrary(2, "Mountain")
+                    .withCardInLibrary(2, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Feral Encounter").error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                // Next combat phase in the game belongs to the opponent's turn.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.state.step shouldBe Step.BEGIN_COMBAT
+                game.state.activePlayerId shouldBe game.player2Id
+
+                game.hasPendingDecision() shouldBe false
+                game.findPermanents("Grizzly Bears").size shouldBe 2
+            }
+        }
+    }
+
+    private fun Any?.shouldBeChooseTargets() {
+        this shouldNotBe null
+        (this is ChooseTargetsDecision) shouldBe true
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirtueOfCourageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VirtueOfCourageScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Virtue of Courage // Embereth Blaze.
+ *
+ * The new vocabulary here is the dynamic-count impulse — `Patterns.Exile.impulse(DynamicAmount)` —
+ * driven off `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`, so the exiled count follows the noncombat
+ * damage just dealt. The Adventure face is ordinary machinery, smoke-tested at the end.
+ */
+class VirtueOfCourageScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Virtue of Courage") {
+            test("noncombat damage to an opponent exiles that many cards, playable this turn") {
+                val game = scenario()
+                    .withPlayers("Virtue", "Opponent")
+                    .withCardOnBattlefield(1, "Virtue of Courage")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(2) shouldBe 17
+
+                // "you may exile that many cards from the top of your library" — accept.
+                game.answerYesNo(true).error shouldBe null
+                game.resolveStack()
+
+                // Three damage → three cards, not a fixed count.
+                game.librarySize(1) shouldBe libraryBefore - 3
+                game.isInExile(1, "Grizzly Bears") shouldBe true
+
+                // "You may play those cards this turn."
+                game.castSpellFromExile(1, "Grizzly Bears").error shouldBe null
+            }
+
+            test("declining the may exiles nothing") {
+                val game = scenario()
+                    .withPlayers("Virtue", "Opponent")
+                    .withCardOnBattlefield(1, "Virtue of Courage")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                game.librarySize(1) shouldBe libraryBefore
+                game.isInExile(1, "Grizzly Bears") shouldBe false
+            }
+
+            test("noncombat damage to yourself does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Virtue", "Opponent")
+                    .withCardOnBattlefield(1, "Virtue of Courage")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.librarySize(1)
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(1) shouldBe 17
+                game.hasPendingDecision() shouldBe false
+                game.librarySize(1) shouldBe libraryBefore
+            }
+        }
+
+        context("Embereth Blaze") {
+            test("the Adventure deals 2 damage and exiles itself for the enchantment to be cast later") {
+                val game = scenario()
+                    .withPlayers("Virtue", "Opponent")
+                    .withCardInHand(1, "Virtue of Courage")
+                    .withLandsOnBattlefield(1, "Mountain", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val card = game.findCardsInHand(1, "Virtue of Courage").single()
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = card,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                        faceIndex = 0
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(2) shouldBe 18
+                game.isInExile(1, "Virtue of Courage") shouldBe true
+
+                game.castSpellFromExile(1, "Virtue of Courage").error shouldBe null
+                game.resolveStack()
+                game.isOnBattlefield("Virtue of Courage") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two more Wilds of Eldraine cards, taking the set from 256/266 to 258/266.

## Cards

**Feral Encounter** `{G}{G}` Sorcery — look at the top five, may exile a creature card and cast it this turn, rest to the bottom in a random order; at the beginning of the next combat phase this turn, target creature you control deals damage equal to its power to up to one target creature you don't control.

**Virtue of Courage // Embereth Blaze** `{3}{R}{R}` Enchantment — whenever a source you control deals noncombat damage to an opponent, you may exile that many cards from the top of your library and play them this turn. Adventure: `{1}{R}` instant dealing 2 damage to any target.

## SDK / engine changes

All three are widenings of existing vocabulary, not new effect types:

- `Patterns.Exile.impulse` accepts a `DynamicAmount` alongside the existing `Int`, so "exile *that many* cards" can read `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`.
- `CreateDelayedTriggerEffect.additionalTargetRequirements`, mirroring the shape `TriggeredAbility` already has, for a delayed trigger that targets more than once. Threaded through `DelayedTriggeredAbility` → `TriggerDetector`'s three synthesis sites; `TriggerProcessor` already handled `allTargetRequirements`. Per its ruling Feral Encounter's *spell* takes no targets — both are chosen when the delayed ability goes on the stack.
- `DelayedTriggerTiming.THIS_TURN_ONLY` — "…the next [step] **this turn**": no turn floor, but swept at end of turn. Without it, a Feral Encounter cast in a postcombat main phase would lie in wait and fire during the opponent's combat. `CURRENT_TURN_OR_LATER` stays the open-ended cousin that "at the beginning of your next end step" relies on (it has to survive the turn boundary when scheduled *during* the end step).
- `CardLinter` learns the new delayed-trigger requirement field, so `ContextTarget` indices in the deferred effect are counted against both requirements.
- `docs/card-sdk-language-reference.md` updated for all three.

## Verification

- `just build` — green.
- `FeralEncounterScenarioTest` (5 tests) and `VirtueOfCourageScenarioTest` (4 tests), one file per card.
- The `THIS_TURN_ONLY` test was re-run against a `CURRENT_TURN_OR_LATER` variant of the card and fails there, so it genuinely discriminates. (An earlier version of it passed vacuously because the opponent decked out before reaching combat — both players now have libraries.)
- `just check-card-printing` clean for both; WOE golden snapshot re-blessed, and only these two cards moved in it.

## Not attempted

Eight WOE cards remain, and they're the hard tail. Worth calling out one in particular:

- **Virtue of Strength** looks like a one-liner (`AdditionalManaOnSourceTap` over basic lands, +2 mirror mana) but that's a lookalike, not the card. Its ruling says two copies give **nine** times the mana, not five — it's a multiplicative replacement effect on mana production, and modelling it honestly means a new `MultiplyManaOnSourceTap` static threaded through `ManaSolver` / `CostPaymentService` / the manual mana-ability path. That's `add-feature` scope, so it's left out rather than shipped approximate.
- The other seven (Ashiok, Extraordinary Journey, Likeness Looter, Mosswood Dreadknight, Talion, The Irencrag, Yenna) each need genuinely new engine capability — a choose-a-number entry choice, a duration-bounded cast-from-graveyard-as-an-Adventure permission, becoming a copy of a graveyard card, Aura token-copy attachment, and so on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)