### PR TITLE
Fix Twinflame Tyrant never doubling damage

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7728,7 +7728,12 @@ The priority groups are (CR 616.1a–f):
   Ride: `DoubleDamage(restrictions = listOf(Conditions.Delirium(4)), appliesTo = DamageEvent(source =
   SourceFilter.Matching(GameObjectFilter.Any.youControl()), damageType = DamageType.NonCombat))` — a
   delirium-gated "double all noncombat damage from sources you control". The doubled damage stays
-  attributed to the original source (the engine scales the amount in place).
+  attributed to the original source (the engine scales the amount in place). Source and recipient
+  filters are matched by the shared `DamageUtils` matchers, so every `SourceFilter` /
+  `RecipientFilter` the prevention and `ModifyDamageAmount` paths understand works here too —
+  including `RecipientFilter.OpponentOrPermanentTheyControl` (Twinflame Tyrant). Each hosting
+  permanent is its own replacement and applies once (CR 616.1): two Twinflame Tyrants quadruple.
+  A player who is a legal recipient sees a "Damage Doubled" badge on their life orb.
 - `ModifyDamageAmount(modifier = 0, dynamicModifier = null, restrictions = emptyList(), appliesTo)` —
   add an amount to matching
   damage. Pass a flat `modifier` (Valley Flamecaller: "deals that much damage plus 1") or a

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3091,6 +3091,7 @@
     },
     "metadata": {
         "collectorNumber": "124",
+        "rarity": "RARE",
         "artist": "Caroline Gariba",
         "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1783915097"
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -40,6 +40,7 @@ import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.player.DamageBonusComponent
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.scripting.NoncombatDamageBonus
@@ -81,6 +82,18 @@ sealed interface DeflectOutcome {
         val events: List<com.wingedsheep.engine.core.GameEvent>
     ) : DeflectOutcome
 }
+
+/**
+ * One [DoubleDamage] replacement that currently applies to damage dealt to a player, as reported by
+ * [DamageUtils.damageDoublersAffectingPlayer] for the client's player badges.
+ */
+data class ActiveDamageDoubler(
+    /** The battlefield permanent hosting the replacement (Twinflame Tyrant, Gratuitous Violence). */
+    val sourceId: EntityId,
+    val sourceName: String,
+    /** Whether the doubling is scoped to combat or noncombat damage (CR 616 damage-type filter). */
+    val damageType: DamageType,
+)
 
 /**
  * Utility functions for dealing damage, applying damage prevention/amplification/redirection,
@@ -212,8 +225,10 @@ object DamageUtils {
             }
         }
 
-        // Apply damage amplification (e.g., Gratuitous Violence - DoubleDamage)
-        var effectiveAmount = applyStaticDamageAmplification(state, targetId, amount, sourceId)
+        // Apply damage amplification (e.g., Gratuitous Violence - DoubleDamage). The combat flag has
+        // to ride along: a doubler scoped to one damage type (The Rollercrusher Ride — noncombat
+        // only) reads it to decide whether it applies.
+        var effectiveAmount = applyStaticDamageAmplification(state, targetId, amount, sourceId, isCombatDamage)
         var newState = state
 
         // Check for damage-to-counters replacement (Force Bubble)
@@ -1303,6 +1318,165 @@ object DamageUtils {
     }
 
     /**
+     * Whether the source of a damage instance matches a damage replacement's [SourceFilter].
+     *
+     * Shared by every `EventPattern.DamageEvent`-scoped replacement scan below (prevention,
+     * doubling, flat/dynamic modification) so the three cannot drift apart — a filter supported by
+     * one is supported by all. That drift was a real bug: [DoubleDamage] silently ignored
+     * [SourceFilter.YouControl] and fell through to "no match", so Twinflame Tyrant never doubled
+     * anything.
+     *
+     * @param hostId the permanent hosting the replacement effect
+     * @param hostControllerId that permanent's *current* controller — the "you" in "a source you
+     *   control" (see [replacementHostController])
+     * @param recipientId the entity being damaged, exposed to source-relative predicates
+     */
+    private fun damageSourceMatches(
+        state: GameState,
+        projected: ProjectedState,
+        filter: SourceFilter,
+        sourceId: EntityId?,
+        hostId: EntityId,
+        hostControllerId: EntityId,
+        recipientId: EntityId,
+    ): Boolean = when (filter) {
+        is SourceFilter.Any -> true
+        is SourceFilter.Self -> sourceId != null && sourceId == hostId
+        is SourceFilter.EnchantedCreature -> {
+            val attachedTo = state.getEntity(hostId)?.get<AttachedToComponent>()?.targetId
+            sourceId != null && sourceId == attachedTo
+        }
+        // "A source you control" — any source (permanent, spell, or ability) whose controller is
+        // this replacement's controller. Projected control for battlefield permanents; the base
+        // ControllerComponent for spells and abilities on the stack.
+        is SourceFilter.YouControl -> {
+            if (sourceId == null) false
+            else {
+                val sourceController = projected.getController(sourceId)
+                    ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
+                sourceController == hostControllerId
+            }
+        }
+        is SourceFilter.Matching -> {
+            if (sourceId == null) false
+            else {
+                val context = PredicateContext(
+                    controllerId = hostControllerId,
+                    sourceId = hostId,
+                    recipientId = recipientId,
+                )
+                predicateEvaluator.matches(state, projected, sourceId, filter.filter, context)
+            }
+        }
+        else -> false
+    }
+
+    /**
+     * Whether the recipient of a damage instance matches a damage replacement's [RecipientFilter].
+     * Companion to [damageSourceMatches]; see that doc for why the matching is shared.
+     *
+     * @param hostId the permanent hosting the replacement effect
+     * @param hostControllerId that permanent's current controller — the "you" the filters are
+     *   relative to
+     */
+    private fun damageRecipientMatches(
+        state: GameState,
+        projected: ProjectedState,
+        filter: RecipientFilter,
+        targetId: EntityId,
+        hostId: EntityId,
+        hostControllerId: EntityId,
+    ): Boolean {
+        // Projected control for battlefield permanents, base control for anything else (a
+        // planeswalker mid-zone-change, a stack object). Null for players.
+        fun controllerOf(entityId: EntityId): EntityId? = projected.getController(entityId)
+            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+
+        return when (filter) {
+            is RecipientFilter.Any -> true
+            is RecipientFilter.Self -> targetId == hostId
+            is RecipientFilter.You -> targetId == hostControllerId
+            is RecipientFilter.Opponent -> targetId in state.turnOrder && targetId != hostControllerId
+            is RecipientFilter.AnyPlayer -> targetId in state.turnOrder
+            is RecipientFilter.AnyPlayerOrPlaneswalker ->
+                targetId in state.turnOrder || projected.isPlaneswalker(targetId)
+            is RecipientFilter.EnchantedCreature, is RecipientFilter.EquippedCreature -> {
+                val attachedTo = state.getEntity(hostId)?.get<AttachedToComponent>()?.targetId
+                targetId == attachedTo
+            }
+            is RecipientFilter.AnyCreature -> projected.isCreature(targetId)
+            is RecipientFilter.CreatureYouControl ->
+                projected.isCreature(targetId) && controllerOf(targetId) == hostControllerId
+            is RecipientFilter.CreatureOpponentControls ->
+                projected.isCreature(targetId) &&
+                    controllerOf(targetId).let { it != null && it != hostControllerId }
+            is RecipientFilter.AnyPermanent -> targetId in state.getBattlefield()
+            is RecipientFilter.PermanentYouControl ->
+                targetId in state.getBattlefield() && controllerOf(targetId) == hostControllerId
+            // "An opponent or a permanent an opponent controls" (Twinflame Tyrant, Fated Firepower).
+            is RecipientFilter.OpponentOrPermanentTheyControl ->
+                if (targetId in state.turnOrder) targetId != hostControllerId
+                else controllerOf(targetId).let { it != null && it != hostControllerId }
+            is RecipientFilter.Matching -> {
+                // sourceId is the permanent that owns the replacement (e.g. Camel), so
+                // source-relative recipient predicates like InSameBandAsSource can resolve
+                // "this creature and creatures banded with it".
+                val context = PredicateContext(controllerId = hostControllerId, sourceId = hostId)
+                predicateEvaluator.matches(state, projected, targetId, filter.filter, context)
+            }
+        }
+    }
+
+    /**
+     * Battlefield permanents whose [DoubleDamage] replacement currently applies to damage dealt to
+     * [playerId] — what the client turns into the player's "damage doubled" badge, the counterpart
+     * of the prevention-shield badges.
+     *
+     * One entry per applicable replacement, because each applies once (CR 616.1): two Twinflame
+     * Tyrants means two entries and quadrupled damage. Recipient-side only — the source-side filter
+     * needs a concrete damage source to evaluate, so an entry means "damage dealt to this player
+     * can be doubled by this permanent", not that every instance will be.
+     */
+    fun damageDoublersAffectingPlayer(state: GameState, playerId: EntityId): List<ActiveDamageDoubler> {
+        val projected = state.projectedState
+        val doublers = mutableListOf<ActiveDamageDoubler>()
+
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val hostControllerId = replacementHostController(state, entityId) ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is DoubleDamage) continue
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is EventPattern.DamageEvent) continue
+
+                // Gated doublers (The Rollercrusher Ride's delirium) only warn while the gate holds.
+                if (effect.restrictions.isNotEmpty()) {
+                    val context = EffectContext(sourceId = entityId, controllerId = hostControllerId)
+                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                }
+
+                val matches = damageRecipientMatches(
+                    state, projected, damageEvent.recipient, playerId,
+                    hostId = entityId, hostControllerId = hostControllerId,
+                )
+                if (!matches) continue
+
+                doublers.add(
+                    ActiveDamageDoubler(
+                        sourceId = entityId,
+                        sourceName = container.get<CardComponent>()?.name ?: "A permanent",
+                        damageType = damageEvent.damageType,
+                    )
+                )
+            }
+        }
+
+        return doublers
+    }
+
+    /**
      * Apply static damage reduction from permanents on the battlefield.
      *
      * Scans all battlefield entities for ReplacementEffectSourceComponent containing
@@ -1363,50 +1537,17 @@ object DamageUtils {
                 }
 
                 // Check if the damage source matches the source filter
-                val sourceMatches = when (val source = damageEvent.source) {
-                    is SourceFilter.Any -> true
-                    is SourceFilter.Self -> sourceId != null && sourceId == entityId
-                    is SourceFilter.EnchantedCreature -> {
-                        val attachedTo = container.get<AttachedToComponent>()?.targetId
-                        sourceId != null && sourceId == attachedTo
-                    }
-                    is SourceFilter.Matching -> {
-                        if (sourceId == null) false
-                        else {
-                            val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
-                            predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
-                        }
-                    }
-                    else -> false
-                }
+                val sourceMatches = damageSourceMatches(
+                    state, projected, damageEvent.source, sourceId,
+                    hostId = entityId, hostControllerId = sourceControllerId, recipientId = targetId,
+                )
                 if (!sourceMatches) continue
 
                 // Check if the target matches the recipient filter
-                val recipientMatches = when (val recipient = damageEvent.recipient) {
-                    is RecipientFilter.Self -> targetId == entityId
-                    is RecipientFilter.You -> targetId == sourceControllerId
-                    is RecipientFilter.EnchantedCreature, is RecipientFilter.EquippedCreature -> {
-                        val attachedTo = container.get<AttachedToComponent>()?.targetId
-                        targetId == attachedTo
-                    }
-                    is RecipientFilter.Matching -> {
-                        // sourceId here is the permanent that owns the prevention effect (e.g.
-                        // Camel), so source-relative recipient predicates like InSameBandAsSource
-                        // can resolve "this creature and creatures banded with it".
-                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
-                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
-                    }
-                    is RecipientFilter.CreatureYouControl -> {
-                        val isCreature = projected.isCreature(targetId)
-                        val isControlled = projected.getController(targetId) == sourceControllerId
-                        isCreature && isControlled
-                    }
-                    is RecipientFilter.AnyCreature -> projected.isCreature(targetId)
-                    is RecipientFilter.AnyPlayer -> targetId in state.turnOrder
-                    is RecipientFilter.AnyPermanent -> targetId in state.getBattlefield()
-                    is RecipientFilter.Any -> true
-                    else -> false
-                }
+                val recipientMatches = damageRecipientMatches(
+                    state, projected, damageEvent.recipient, targetId,
+                    hostId = entityId, hostControllerId = sourceControllerId,
+                )
 
                 if (recipientMatches) {
                     val preventAmount = effect.amount
@@ -1475,35 +1616,21 @@ object DamageUtils {
                 }
 
                 // Check if the damage source matches the source filter
-                val sourceMatches = when (val sourceFilter = damageEvent.source) {
-                    is SourceFilter.Any -> true
-                    is SourceFilter.Matching -> {
-                        if (sourceId == null) false
-                        else {
-                            val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
-                            predicateEvaluator.matches(state, projected, sourceId, sourceFilter.filter, context)
-                        }
-                    }
-                    else -> false
-                }
+                val sourceMatches = damageSourceMatches(
+                    state, projected, damageEvent.source, sourceId,
+                    hostId = entityId, hostControllerId = sourceControllerId, recipientId = targetId,
+                )
                 if (!sourceMatches) continue
 
                 // Check if the target matches the recipient filter
-                val recipientMatches = when (val recipient = damageEvent.recipient) {
-                    is RecipientFilter.Any -> true
-                    is RecipientFilter.Matching -> {
-                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
-                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
-                    }
-                    is RecipientFilter.CreatureYouControl -> {
-                        val isCreature = projected.isCreature(targetId)
-                        val isControlled = projected.getController(targetId) == sourceControllerId
-                        isCreature && isControlled
-                    }
-                    else -> false
-                }
+                val recipientMatches = damageRecipientMatches(
+                    state, projected, damageEvent.recipient, targetId,
+                    hostId = entityId, hostControllerId = sourceControllerId,
+                )
                 if (!recipientMatches) continue
 
+                // Each DoubleDamage source is its own replacement effect and applies once
+                // (CR 616.1), so two Twinflame Tyrants quadruple rather than double.
                 amplifiedAmount *= 2
             }
         }
@@ -1547,56 +1674,17 @@ object DamageUtils {
                 }
 
                 // Check if the damage source matches the source filter
-                val sourceMatches = when (val sourceFilter = damageEvent.source) {
-                    is SourceFilter.Any -> true
-                    is SourceFilter.YouControl -> {
-                        // "A source you control" — any source (permanent, spell, ability) whose
-                        // controller is this replacement's controller. Read projected control for
-                        // battlefield permanents; fall back to the base ControllerComponent for
-                        // spells/abilities on the stack.
-                        if (sourceId == null) false
-                        else {
-                            val srcController = projected.getController(sourceId)
-                                ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
-                            srcController == sourceControllerId
-                        }
-                    }
-                    is SourceFilter.Matching -> {
-                        if (sourceId == null) false
-                        else {
-                            val context = PredicateContext(controllerId = sourceControllerId)
-                            predicateEvaluator.matches(state, projected, sourceId, sourceFilter.filter, context)
-                        }
-                    }
-                    else -> false
-                }
+                val sourceMatches = damageSourceMatches(
+                    state, projected, damageEvent.source, sourceId,
+                    hostId = entityId, hostControllerId = sourceControllerId, recipientId = targetId,
+                )
                 if (!sourceMatches) continue
 
                 // Check if the target matches the recipient filter
-                val recipientMatches = when (val recipient = damageEvent.recipient) {
-                    is RecipientFilter.Any -> true
-                    is RecipientFilter.OpponentOrPermanentTheyControl -> {
-                        if (targetId in state.turnOrder) {
-                            // An opponent player of the replacement's controller.
-                            targetId != sourceControllerId
-                        } else {
-                            // A permanent an opponent controls.
-                            val ctrl = projected.getController(targetId)
-                                ?: state.getEntity(targetId)?.get<ControllerComponent>()?.playerId
-                            ctrl != null && ctrl != sourceControllerId
-                        }
-                    }
-                    is RecipientFilter.Matching -> {
-                        val context = PredicateContext(controllerId = sourceControllerId)
-                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
-                    }
-                    is RecipientFilter.CreatureYouControl -> {
-                        val isCreature = projected.isCreature(targetId)
-                        val isControlled = projected.getController(targetId) == sourceControllerId
-                        isCreature && isControlled
-                    }
-                    else -> false
-                }
+                val recipientMatches = damageRecipientMatches(
+                    state, projected, damageEvent.recipient, targetId,
+                    hostId = entityId, hostControllerId = sourceControllerId,
+                )
                 if (!recipientMatches) continue
 
                 // Additive bonus: a dynamic amount (evaluated against the replacement's source

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -28,7 +28,9 @@ import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComp
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.composite.asConditional
+import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.engine.state.permissions.hasMayPlayFor
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -1946,6 +1948,43 @@ class ClientStateTransformer(
                     name = "Prevent from $sourceName",
                     description = "All damage that would be dealt to you by $sourceName this turn is prevented",
                     icon = "prevent-damage"
+                )
+            )
+        }
+
+        // Damage-doubling warnings — the mirror image of the prevention shields above, so a player
+        // about to take double damage can see it before they attack into it (Twinflame Tyrant,
+        // Gratuitous Violence). One badge per replacement: each applies once (CR 616.1), so two
+        // Tyrants show two badges and quadruple the damage.
+        for (doubler in DamageUtils.damageDoublersAffectingPlayer(state, playerId)) {
+            val scope = when (doubler.damageType) {
+                is DamageType.Combat -> "Combat damage"
+                is DamageType.NonCombat -> "Noncombat damage"
+                is DamageType.Any -> "Damage"
+            }
+            effects.add(
+                ClientPlayerEffect(
+                    effectId = "damage_doubled_${doubler.sourceId.value}",
+                    name = "Damage Doubled",
+                    description = "$scope dealt to you is doubled by ${doubler.sourceName}",
+                    icon = "double-damage"
+                )
+            )
+        }
+
+        // Player-scoped damage doubling from a floating effect (Lightning, Army of One's "Stagger").
+        // Same badge, but it outlives its source, so it's named for the effect rather than a card.
+        for (floatingEffect in state.floatingEffects) {
+            val modification = floatingEffect.effect.modification
+            if (modification !is SerializableModification.DoubleDamageToPlayer) continue
+            if (modification.playerId != playerId) continue
+            val attribution = floatingEffect.sourceName?.let { " ($it)" } ?: ""
+            effects.add(
+                ClientPlayerEffect(
+                    effectId = "damage_doubled_player_${floatingEffect.id.value}",
+                    name = "Damage Doubled",
+                    description = "Damage dealt to you and to permanents you control is doubled$attribution",
+                    icon = "double-damage"
                 )
             )
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinflameTyrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinflameTyrantScenarioTest.kt
@@ -1,0 +1,303 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.TwinflameTyrant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Twinflame Tyrant (FDN #97).
+ *
+ * {3}{R}{R} Creature — Dragon 3/5
+ * Flying
+ * If a source you control would deal damage to an opponent or a permanent an opponent controls,
+ * it deals double that damage instead.
+ *
+ * Covers every damage path the doubling has to reach — combat damage to the defending player,
+ * combat damage to a blocker, noncombat spell damage to a player and to a permanent — plus the
+ * scope boundaries (your own permanents and yourself are untouched, an opponent's source is
+ * untouched) and the stacking case: two Tyrants are two separate replacement effects, each applied
+ * once (CR 616.1), so the damage is quadrupled.
+ */
+class TwinflameTyrantScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TwinflameTyrant))
+        return driver
+    }
+
+    /** Put a ready-to-attack Twinflame Tyrant onto [playerId]'s battlefield. */
+    fun GameTestDriver.tyrantFor(playerId: EntityId): EntityId {
+        val tyrant = putCreatureOnBattlefield(playerId, "Twinflame Tyrant")
+        removeSummoningSickness(tyrant)
+        return tyrant
+    }
+
+    test("combat damage to the defending player is doubled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tyrant = driver.tyrantFor(active)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(tyrant), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+
+        withClue("3 power doubled to 6 combat damage") {
+            driver.getLifeTotal(opponent) shouldBe 14
+        }
+    }
+
+    test("combat damage to a creature an opponent controls is doubled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The Tyrant stays home — it doubles damage from *any* source you control, and its own
+        // flying would otherwise stop the blocker from being declared at all.
+        driver.tyrantFor(active)
+        val attacker = driver.putCreatureOnBattlefield(active, "Centaur Courser") // 3/3
+        driver.removeSummoningSickness(attacker)
+        // 12/12 so it survives and keeps the marked damage readable.
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Ghalta, Primal Hunger")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attacker), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(attacker))).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+
+        withClue("3 power doubled to 6 damage marked on the blocker") {
+            driver.state.getEntity(blocker)?.get<DamageComponent>()?.amount shouldBe 6
+        }
+    }
+
+    test("noncombat spell damage to an opponent is doubled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tyrantFor(active)
+
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("Lightning Bolt's 3 damage doubled to 6") {
+            driver.getLifeTotal(opponent) shouldBe 14
+        }
+    }
+
+    test("noncombat spell damage to a permanent an opponent controls is doubled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tyrantFor(active)
+        // 5/5 — survives an unamplified Bolt, dies to the doubled 6.
+        val theirCreature = driver.putCreatureOnBattlefield(opponent, "Force of Nature")
+
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, theirCreature)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("6 damage is lethal to the 5/5") {
+            driver.getGraveyardCardNames(opponent) shouldBe listOf("Force of Nature")
+        }
+    }
+
+    test("scope: only sources you control, only opponents and their permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tyrantFor(active)
+        val myCreature = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+        val myOtherCreature = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+        val theirCreature = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        withClue("your source dealing 3 to an opponent → 6") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = opponent, amount = 3, sourceId = myCreature
+            ) shouldBe 6
+        }
+        withClue("your source dealing 3 to a permanent an opponent controls → 6") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = theirCreature, amount = 3, sourceId = myCreature
+            ) shouldBe 6
+        }
+        withClue("your source dealing 3 to your own creature is NOT doubled") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = myOtherCreature, amount = 3, sourceId = myCreature
+            ) shouldBe 3
+        }
+        withClue("your source dealing 3 to you is NOT doubled") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = active, amount = 3, sourceId = myCreature
+            ) shouldBe 3
+        }
+        withClue("an opponent's source dealing 3 to you is NOT doubled") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = active, amount = 3, sourceId = theirCreature
+            ) shouldBe 3
+        }
+        withClue("an opponent's source dealing 3 to their own creature is NOT doubled") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = theirCreature, amount = 3, sourceId = theirCreature
+            ) shouldBe 3
+        }
+    }
+
+    test("the opponent's Twinflame Tyrant doubles damage aimed back at you") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tyrantFor(opponent)
+        val theirCreature = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val myCreature = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+
+        withClue("their source dealing 3 to you → 6") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = active, amount = 3, sourceId = theirCreature
+            ) shouldBe 6
+        }
+        withClue("their source dealing 3 to your creature → 6") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = myCreature, amount = 3, sourceId = theirCreature
+            ) shouldBe 6
+        }
+        withClue("your source dealing 3 to them is NOT doubled by their Tyrant") {
+            DamageUtils.applyStaticDamageAmplification(
+                driver.state, targetId = opponent, amount = 3, sourceId = myCreature
+            ) shouldBe 3
+        }
+    }
+
+    test("two Twinflame Tyrants quadruple the damage (each replacement applies once)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tyrantFor(active)
+        driver.tyrantFor(active)
+
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("3 → 6 → 12: each Tyrant doubles once") {
+            driver.getLifeTotal(opponent) shouldBe 8
+        }
+    }
+
+    test("the threatened player gets a Damage Doubled badge, its controller does not") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val transformer = ClientStateTransformer(driver.cardRegistry)
+        fun doubledBadgesOn(playerId: EntityId): List<String?> =
+            transformer.transform(driver.state, playerId)
+                .players.first { it.playerId == playerId }
+                .activeEffects.filter { it.effectId.startsWith("damage_doubled") }
+                .map { it.description }
+
+        withClue("no Tyrant yet — no badge on either player") {
+            doubledBadgesOn(opponent) shouldBe emptyList()
+            doubledBadgesOn(active) shouldBe emptyList()
+        }
+
+        driver.tyrantFor(active)
+
+        withClue("the opponent is warned") {
+            doubledBadgesOn(opponent) shouldBe
+                listOf("Damage dealt to you is doubled by Twinflame Tyrant")
+        }
+        withClue("its own controller is not a legal recipient, so no badge") {
+            doubledBadgesOn(active) shouldBe emptyList()
+        }
+
+        driver.tyrantFor(active)
+
+        withClue("two Tyrants are two replacements — two badges, x4 damage") {
+            doubledBadgesOn(opponent).size shouldBe 2
+        }
+    }
+
+    test("two Twinflame Tyrants quadruple combat damage too") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.tyrantFor(active)
+        driver.tyrantFor(active)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attacker), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+
+        withClue("3 power → 6 → 12 combat damage") {
+            driver.getLifeTotal(opponent) shouldBe 8
+        }
+    }
+})

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -812,6 +812,8 @@ export function getEffectIcon(icon: string): string {
       return '⚔️'
     case 'prevent-damage':
       return '🛡️'
+    case 'double-damage':
+      return '🔥'
     case 'regeneration':
       return '♻️'
     case 'emblem':


### PR DESCRIPTION
## The bug

Twinflame Tyrant's damage doubling never fired — not in combat, not on burn, not on anything.

`DamageUtils.applyStaticDamageAmplification`'s `DoubleDamage` branch only knew three recipient
filters (`Any`, `Matching`, `CreatureYouControl`) and fell through to `else -> false` for the rest.
Twinflame Tyrant's recipient is `RecipientFilter.OpponentOrPermanentTheyControl` ("an opponent or a
permanent an opponent controls"), so it always landed on the fall-through and the replacement was
skipped. `SourceFilter.YouControl` was missing from the same branch.

The root cause is duplication: the three `EventPattern.DamageEvent` scans — prevention
(`applyStaticDamageReduction`), doubling, and additive modification (`ModifyDamageAmount`) — each
carried their own copy of the source/recipient matching, and the three copies had drifted to
different coverage. `ModifyDamageAmount` knew `OpponentOrPermanentTheyControl` (that's why Fated
Firepower works); `DoubleDamage` didn't.

## The fix

One shared `damageSourceMatches` / `damageRecipientMatches` pair, used by all three scans, so a
filter understood by one is understood by all. The recipient matcher is an **exhaustive `when`** over
the sealed `RecipientFilter`, so a future filter is a compile error instead of a silent non-match.

Also: `dealDamageToTarget` was calling the amplification without forwarding `isCombatDamage`, so a
damage-type-scoped doubler (The Rollercrusher Ride — noncombat only) read the default `false` on
that path. Forwarded.

Two Twinflame Tyrants **quadruple** — each hosting permanent is its own replacement and applies once
(CR 616.1). That behaviour was already correct; it's now pinned by a test.

## UI: "Damage Doubled" badge

A player who is a legal recipient of a doubling replacement now gets a badge on their life orb — the
mirror of the existing prevention-shield badges — so you can see it before attacking into it. One
badge per replacement, so two Tyrants show two badges. The floating player-scoped doubler (Lightning,
Army of One's "Stagger") gets the same badge; it previously had no indicator at all.

![board](https://raw.githubusercontent.com/wingedsheep/argentum-engine/twinflame-double-damage-screenshots/board.png)

Hover for the attribution:

![tooltip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/twinflame-double-damage-screenshots/tooltip.png)

*(Screenshots live on the throwaway branch `twinflame-double-damage-screenshots`, not in this diff.)*

## Tests

New `TwinflameTyrantScenarioTest` (9 tests), all failing before the fix:

- combat damage to the defending player → 6
- combat damage to a blocking creature an opponent controls → 6 marked
- noncombat spell damage to an opponent → 6
- noncombat spell damage to a permanent an opponent controls (kills a 5/5)
- scope: your own permanents, yourself, and an opponent's sources are untouched
- an opponent's Tyrant doubles damage aimed back at you
- two Tyrants quadruple, both on the spell path and the combat path
- the threatened player gets the badge; the Tyrant's controller does not

## Verification

- `just test-class TwinflameTyrantScenarioTest` — 9/9 pass (all 9 fail on `main`)
- `just test-rules` — 9095 tests, 0 failures (the shared matchers widen prevention and
  `ModifyDamageAmount` matching too, so the whole suite was the real check here)
- `just build` — BUILD SUCCESSFUL (all modules)
- `npm run typecheck` in `web-client` — clean
- Badge captured against the running stack via a throwaway Playwright scenario (deleted before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit: unrelated CI fix

`CardDefinitionSnapshotTest > WOE: card trees match golden` was failing on this PR and on **main**.
It isn't from this change — commit `547db4ac31` ("Charming scoundrel is rare") flipped
`CharmingScoundrel`'s rarity `COMMON → RARE` without re-blessing the card snapshot, and PR builds
merge against main's head so they inherit it.

Rebased onto main and ran `just rebless-cards`: it moves exactly one line (`COMMON` was the
serializer default and wasn't emitted; `RARE` is), and no other set's golden moves. Kept as its own
commit so it can be dropped or cherry-picked independently.
