### PR TITLE
Add Redshift, Rocketeer Chief and Boom Scholar to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5024,7 +5024,8 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   equip ability's source. Because it is typically granted to a token (via
   `CreateTokenCopyOfTargetEffect.addedStaticAbilities`), the equip-cost reader unions
   `grantedStaticAbilities` with printed statics.
-- `ReduceActivatedAbilityCost(filter, amount, manaFloor = 0)` — the activated abilities of permanents
+- `ReduceActivatedAbilityCost(filter, amount, manaFloor = 0, exhaustOnly = false)` — the activated
+  abilities of permanents
   matching `filter` cost the dynamic `amount` of generic mana less to activate, with the mana in each
   cost floored
   at `manaFloor` *total* mana (generic + colored). The activated-ability sibling of `ReduceEquipCost`,
@@ -5041,6 +5042,14 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   from both the enumerator (displayed cost) and `ActivateAbilityHandler` (paid cost), keyed on the
   ability's source permanent; non-mana costs (`{T}`, sacrifice) and abilities with no mana cost are
   unaffected. Backed by `ManaCost.reduceGenericWithManaFloor(amount, minTotalMana)`.
+  `exhaustOnly = true` narrows the reduction to abilities marked `isExhaust` (CR 702.177) — it gates
+  on the **ability**, not the permanent, so a matching permanent's ordinary activated abilities stay
+  at full price while its exhaust ability is discounted. Boom Scholar: "Exhaust abilities of other
+  permanents you control cost {2} less to activate" →
+  `ReduceActivatedAbilityCost(GroupFilter(GameObjectFilter.Permanent.youControl(), excludeSelf = true), DynamicAmount.Fixed(2), exhaustOnly = true)`.
+  Note that `GroupFilter.excludeSelf` (the printed "**other** permanents") is honored by this read
+  site directly — the projection layer never sees this static — so a lord never discounts its own
+  abilities.
 - `MayCastFromGraveyard(filter, lifeCost = 0, duringYourTurnOnly = false, entersWithCounter = null, addedSubtypeOnEntry = null)`
   — cast spells matching `filter` from your graveyard following normal timing, optionally paying
   `lifeCost` life. Free for Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1,

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2166,11 +2166,15 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `conniveTargeting(requirement, storeAs?)` — connive whose +1/+1 counter lands on a *reflexively chosen* target: "draw a card, then discard a card. When you discard a nonland card this way, put a +1/+1 counter on target creature you control" (Teo, Spirited Glider). The recipient is selected at resolution via `SelectTargetEffect` *inside* the nonland gate — so the player never chooses up front or when the discard is a land. Pass the recipient's `TargetRequirement` (e.g. `Targets.CreatureYouControl`); do **not** also declare it as a cast-time `target(...)`. Exposed as `Effects.ConniveTargeting(requirement)`.
 - `readTheRunes()` — "draw X cards; for each, discard a card unless you sacrifice a permanent." Composes `RepeatDynamicTimesEffect(XValue, ChooseActionEffect(...))` with feasibility guards. Exposed as `Effects.ReadTheRunes()`.
 - `eachOpponentMayPutFromHand(filter?)` — each opponent may dump a matching card.
-- `putFromHand(filter?, count?, entersTapped?, entersAttacking?)` — you may put N from hand onto
-  battlefield. `entersAttacking = true` puts them in **tapped and attacking**
+- `putFromHand(filter?, count?, entersTapped?, entersAttacking?, anyNumber?, prompt?)` — you may put N
+  from hand onto battlefield. `entersAttacking = true` puts them in **tapped and attacking**
   (`ZonePlacement.TappedAndAttacking`; the engine adds an `AttackingComponent` against the defending
   player), e.g. Shadowfax, Lord of Horses ("put a creature card with lesser power from your hand onto
-  the battlefield tapped and attacking").
+  the battlefield tapped and attacking"). `anyNumber = true` swaps the default `ChooseUpTo(count)`
+  selection for `SelectionMode.ChooseAnyNumber`, i.e. the unbounded *"put **any number** of … cards
+  from your hand onto the battlefield"* wording (`count` is then ignored); zero is a legal choice, so
+  declining and an empty hand are both no-ops rather than stuck decisions. Redshift, Rocketeer Chief's
+  exhaust ability (`filter = Filters.Permanent, anyNumber = true`).
 - `incubate(n)` — make an Incubator token with N counters.
 - `impulse(count?, expiry?)` — impulse draw: exile the top N of your library, may play those cards until `expiry` (default end of turn); played cards still pay their mana. For the play-free variant compose with `GrantPlayWithoutPayingCostEffect` (cf. `shuffleAndExileTopPlayFree`). Irascible Wolverine (1), Annie Flash, the Veteran (2). `MayPlayExpiry` options: `EndOfTurn` (default), `Permanent` ("for as long as it remains exiled"), `UntilControllerStep(step, includeCurrentTurn?)` / the `UntilEndOfNextTurn` + `UntilNextEndStep` shorthands (turn-keyed, cleaned up at the matching cleanup), and `UntilSourceExilesAnother` — a **self-superseding** permission that persists across turns (and survives the granting source leaving play) but is revoked the moment that *same source* grants another such permission (exiles another card), so only the source's most-recently-exiled card stays playable and the earlier one remains in exile but unplayable. Requires the grant to carry a source id (falls back to `Permanent` behaviour without one); models "you may play that card until you exile another card with this creature" (**Superior Foes of Spider-Man**).
 - `returnLinkedExile(underOwnersControl?)` — bring back linked exile pile.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -315,11 +315,22 @@ object HandPatterns {
         )
     }
 
+    /**
+     * "Put up to [count] cards from your hand onto the battlefield" — Gather (hand, matching
+     * [filter]) → Select up to [count] → Move to the battlefield. The `ChooseUpTo` selection models
+     * the "you may" (Elvish Pioneer, Kaalia of the Vast, Spelunking).
+     *
+     * [anyNumber] swaps the selection for [SelectionMode.ChooseAnyNumber], i.e. the unbounded
+     * "put **any number** of … cards from your hand onto the battlefield" wording (Redshift,
+     * Rocketeer Chief's exhaust ability) — [count] is then ignored.
+     */
     fun putFromHand(
         filter: GameObjectFilter = GameObjectFilter.Any,
         count: Int = 1,
         entersTapped: Boolean = false,
-        entersAttacking: Boolean = false
+        entersAttacking: Boolean = false,
+        anyNumber: Boolean = false,
+        prompt: String? = null
     ): CompositeEffect = CompositeEffect(
         listOf(
             GatherCardsEffect(
@@ -328,8 +339,13 @@ object HandPatterns {
             ),
             SelectFromCollectionEffect(
                 from = "put_candidates",
-                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(count)),
-                storeSelected = "putting"
+                selection = if (anyNumber) {
+                    SelectionMode.ChooseAnyNumber
+                } else {
+                    SelectionMode.ChooseUpTo(DynamicAmount.Fixed(count))
+                },
+                storeSelected = "putting",
+                prompt = prompt
             ),
             MoveCollectionEffect(
                 from = "putting",

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -830,24 +830,32 @@ sealed interface UnlockCostTarget {
  * an ordinary reduction. Non-mana costs (`{T}`, sacrifice) and abilities with no mana cost are
  * unaffected. Multiple sources stack additively before the floor is applied.
  *
+ * [exhaustOnly] narrows the reduction to abilities marked `isExhaust` (CR 702.177) — Boom Scholar's
+ * "Exhaust abilities of other permanents you control cost {2} less to activate." It gates on the
+ * *ability*, not the permanent, so a matching permanent's ordinary activated abilities cost full
+ * price while its exhaust ability is discounted.
+ *
  * @property filter Which permanents' activated abilities are cheaper (matched via projected state;
  *   use [GroupFilter.attachedCreature] for an Aura's enchanted permanent, [GroupFilter.source] for
  *   "this permanent's abilities", or a battlefield filter for a group).
  * @property amount Dynamic generic-mana reduction applied to each matching ability's cost.
  * @property manaFloor Minimum total mana the cost may be reduced to (default 0).
+ * @property exhaustOnly When true, only exhaust abilities (`ActivatedAbility.isExhaust`) are reduced.
  */
 @SerialName("ReduceActivatedAbilityCost")
 @Serializable
 data class ReduceActivatedAbilityCost(
     val filter: GroupFilter,
     val amount: DynamicAmount,
-    val manaFloor: Int = 0
+    val manaFloor: Int = 0,
+    val exhaustOnly: Boolean = false
 ) : StaticAbility {
     override val description: String = buildString {
+        val abilities = if (exhaustOnly) "exhaust abilities" else "activated abilities"
         append(filter.description.replaceFirstChar { it.uppercase() })
         when (amount) {
-            is DynamicAmount.Fixed -> append("'s activated abilities cost {${amount.amount}} less to activate")
-            else -> append("'s activated abilities cost {X} less to activate, where X is ${amount.description}")
+            is DynamicAmount.Fixed -> append("'s $abilities cost {${amount.amount}} less to activate")
+            else -> append("'s $abilities cost {X} less to activate, where X is ${amount.description}")
         }
         if (manaFloor > 0) {
             append(". This effect can't reduce the mana in that cost to less than ")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BoomScholar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BoomScholar.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Boom Scholar — Aetherdrift #189
+ * {1}{R}{G} · Creature — Goblin Advisor · 3/3
+ *
+ * Exhaust abilities of other permanents you control cost {2} less to activate.
+ * Exhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two
+ * +1/+1 counters on this creature.
+ *
+ * The discount is [ReduceActivatedAbilityCost] with `exhaustOnly = true` — the qualifier gates on the
+ * *ability* (`isExhaust`, CR 702.177), not the permanent, so a matching permanent's ordinary
+ * activated abilities stay at full price while its exhaust ability is {2} cheaper. `excludeSelf`
+ * carries the printed "**other** permanents", so Boom Scholar's own {4}{R}{G} is never discounted.
+ * `manaFloor` stays 0 per the 2025-02-07 ruling that the reduction *can* take the mana component
+ * down to {0}; generic-only, so a `{R}{R}` exhaust cost is untouched (CR 118.7).
+ *
+ * "Creatures and Vehicles you control" is one union filter rather than two grants, and — as on its
+ * set-mate Kickoff Celebrations — it is deliberately not narrowed to creatures: an uncrewed Vehicle
+ * is a noncreature artifact that still picks up trample here, so crewing it later this turn yields a
+ * trampler. Boom Scholar is itself a creature you control, so it gains trample from its own ability.
+ */
+val BoomScholar = card("Boom Scholar") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Goblin Advisor"
+    power = 3
+    toughness = 3
+    oracleText = "Exhaust abilities of other permanents you control cost {2} less to activate.\n" +
+        "Exhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. " +
+        "Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)"
+
+    staticAbility {
+        ability = ReduceActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Permanent.youControl(), excludeSelf = true),
+            amount = DynamicAmount.Fixed(2),
+            exhaustOnly = true
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{R}{G}")
+        isExhaust = true
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(
+                    (GameObjectFilter.Creature or GameObjectFilter.Any.withSubtype("Vehicle")).youControl()
+                ),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+            ),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        )
+        description = "Creatures and Vehicles you control gain trample until end of turn. Put two " +
+            "+1/+1 counters on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "189"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg?1783907862"
+        ruling(
+            "2025-02-07",
+            "Boom Scholar's first ability can cause the mana component of the cost to activate an " +
+                "ability to be {0}."
+        )
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RedshiftRocketeerChief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RedshiftRocketeerChief.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Redshift, Rocketeer Chief — Aetherdrift #218
+ * {R}{G} · Legendary Creature — Goblin Pilot · 2/3
+ *
+ * Vigilance
+ * {T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate
+ * abilities.
+ * Exhaust — {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.
+ *
+ * The mana ability is [Effects.AddAnyColorMana] — *one* chosen color, X of it, not X mana in any
+ * combination — with X read as [DynamicAmounts.sourcePower] so it tracks Redshift's **projected**
+ * power (counters, lords, and any pump applied before the ability resolves all count). Tagged
+ * [ManaRestriction.AbilityActivationOnly], the unqualified "only to activate abilities" restriction
+ * (any activated ability of any source, matching Boommobile and Guidelight Optimizer) rather than an
+ * artifact- or type-scoped one. That pool-level restriction constrains what each pip may pay for, not
+ * how many abilities it feeds, so the mana may be split across several activations — and it
+ * comfortably covers Redshift's own exhaust ability.
+ *
+ * The payoff is [Patterns.Hand.putFromHand] with `anyNumber = true`: Gather (hand, permanent cards) →
+ * Select any number → Move to the battlefield. "Any number" includes zero, so declining is legal and
+ * an empty hand is a no-op rather than a stuck decision. `isExhaust = true` makes the DSL add
+ * [com.wingedsheep.sdk.scripting.ActivationRestriction.Once], which is per-object — a Redshift that
+ * leaves and returns is a new object and may activate it again.
+ */
+val RedshiftRocketeerChief = card("Redshift, Rocketeer Chief") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Goblin Pilot"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to " +
+        "activate abilities.\n" +
+        "Exhaust — {10}{R}{G}: Put any number of permanent cards from your hand onto the " +
+        "battlefield. (Activate each exhaust ability only once.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            DynamicAmounts.sourcePower(),
+            ManaRestriction.AbilityActivationOnly
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add X mana of any one color, where X is Redshift's power. Spend this " +
+            "mana only to activate abilities."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{10}{R}{G}")
+        isExhaust = true
+        effect = Patterns.Hand.putFromHand(
+            filter = Filters.Permanent,
+            anyNumber = true,
+            prompt = "Choose any number of permanent cards to put onto the battlefield"
+        )
+        description = "Put any number of permanent cards from your hand onto the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "218"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg?1783907854"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -1466,6 +1466,104 @@
     ]
 }
 
+// Boom Scholar
+{
+    "name": "Boom Scholar",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Goblin Advisor",
+    "oracleText": "Exhaust abilities of other permanents you control cost {2} less to activate.\nExhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature|Vehicle ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature.",
+                "isExhaust": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": "permanent ctrl:you",
+                    "excludeSelf": true
+                },
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "exhaustOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2b84684-10c9-4635-a922-620f04809bb1.jpg?1783907862",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Boom Scholar's first ability can cause the mana component of the cost to activate an ability to be {0}."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Boommobile
 {
     "name": "Boommobile",

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -12229,6 +12229,109 @@
     ]
 }
 
+// Redshift, Rocketeer Chief
+{
+    "name": "Redshift, Rocketeer Chief",
+    "manaCost": "{R}{G}",
+    "typeLine": "Legendary Creature — Goblin Pilot",
+    "oracleText": "Vigilance\n{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.\nExhaust — {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "restriction": "AbilityActivationOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{10}{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "permanent"
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "putting",
+                            "prompt": "Choose any number of permanent cards to put onto the battlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Put any number of permanent cards from your hand onto the battlefield.",
+                "isExhaust": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fba3820-32ba-47e9-9fa8-f985ff471b3f.jpg?1783907854",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Reef Roads
 {
     "name": "Reef Roads",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3091,6 +3091,7 @@
     },
     "metadata": {
         "collectorNumber": "124",
+        "rarity": "RARE",
         "artist": "Caroline Gariba",
         "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8090bcf-e17a-4110-a518-77ccd045b18f.jpg?1783915097"
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -249,7 +249,7 @@ class ActivateAbilityHandler(
                 castPermissionUtils.applyEquipCostReduction(
                     castPermissionUtils.applyActivatedAbilityCostReduction(
                         applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets),
-                        state, action.sourceId
+                        state, action.sourceId, ability.isExhaust
                     ),
                     ability, state, action.playerId, equipTargetIdForCost,
                     abilitySourceId = action.sourceId
@@ -592,7 +592,7 @@ class ActivateAbilityHandler(
                 castPermissionUtils.applyEquipCostReduction(
                     castPermissionUtils.applyActivatedAbilityCostReduction(
                         applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets),
-                        state, action.sourceId
+                        state, action.sourceId, ability.isExhaust
                     ),
                     ability, state, action.playerId, equipTargetIdForCost,
                     abilitySourceId = action.sourceId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -135,7 +135,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         context.castPermissionUtils.applyEquipCostReduction(
                             context.castPermissionUtils.applyActivatedAbilityCostReduction(
                                 applyAbilityGenericCostReduction(rawCost, ability, state, entityId, playerId, context),
-                                state, entityId
+                                state, entityId, ability.isExhaust
                             ),
                             ability, state, playerId, abilitySourceId = entityId
                         ),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -709,14 +709,20 @@ class CastPermissionUtils(
      *
      * Generic-only (colored pips untouched, CR 118.7); reductions stack additively and the most
      * restrictive (largest) [ReduceActivatedAbilityCost.manaFloor] is applied as the floor.
+     *
+     * [isExhaustAbility] is the activated ability's `isExhaust` flag (CR 702.177). A static with
+     * [ReduceActivatedAbilityCost.exhaustOnly] applies only when it is true — Boom Scholar's "Exhaust
+     * abilities of other permanents you control cost {2} less to activate" leaves those permanents'
+     * ordinary activated abilities at full price.
      */
     fun applyActivatedAbilityCostReduction(
         cost: AbilityCost,
         state: GameState,
-        sourceId: EntityId?
+        sourceId: EntityId?,
+        isExhaustAbility: Boolean = false
     ): AbilityCost {
         if (sourceId == null) return cost
-        val (amount, manaFloor) = sumActivatedAbilityCostReductions(state, sourceId)
+        val (amount, manaFloor) = sumActivatedAbilityCostReductions(state, sourceId, isExhaustAbility)
         if (amount <= 0) return cost
         return when (cost) {
             is AbilityCost.Atom -> cost.manaCostOrNull
@@ -742,8 +748,14 @@ class CastPermissionUtils(
      * `Scope.Self` → the static's own source; `Scope.AttachedTo` → the permanent the static's
      * source (an Aura/Equipment) is attached to; any other (battlefield) scope → the source's
      * base filter matched against [sourceId] under projected state.
+     *
+     * An `exhaustOnly` static contributes nothing unless [isExhaustAbility] is set.
      */
-    private fun sumActivatedAbilityCostReductions(state: GameState, sourceId: EntityId): Pair<Int, Int> {
+    private fun sumActivatedAbilityCostReductions(
+        state: GameState,
+        sourceId: EntityId,
+        isExhaustAbility: Boolean
+    ): Pair<Int, Int> {
         var totalAmount = 0
         var floor = 0
         for (entityId in state.getBattlefield()) {
@@ -751,6 +763,7 @@ class CastPermissionUtils(
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
                 val reduce = ability as? com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost ?: continue
+                if (reduce.exhaustOnly && !isExhaustAbility) continue
                 if (activatedAbilityReductionApplies(state, entityId, reduce.filter, sourceId)) {
                     val controllerId = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: continue
                     totalAmount += DynamicAmountEvaluator().evaluate(
@@ -765,13 +778,20 @@ class CastPermissionUtils(
         return totalAmount to floor
     }
 
-    /** Whether a [ReduceActivatedAbilityCost] on [staticSourceId] reaches the ability source [sourceId]. */
+    /**
+     * Whether a [ReduceActivatedAbilityCost] on [staticSourceId] reaches the ability source [sourceId].
+     *
+     * `filter.excludeSelf` is honored here rather than left to the projection layer (which never sees
+     * this static): a `GroupFilter(..., excludeSelf = true)` is the "**other** permanents you control"
+     * wording, so the static's own source must not discount its own abilities (Boom Scholar's own
+     * exhaust ability costs full price).
+     */
     private fun activatedAbilityReductionApplies(
         state: GameState,
         staticSourceId: EntityId,
         filter: com.wingedsheep.sdk.scripting.filters.unified.GroupFilter,
         sourceId: EntityId
-    ): Boolean = when (filter.scope) {
+    ): Boolean = if (filter.excludeSelf && staticSourceId == sourceId) false else when (filter.scope) {
         is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self -> staticSourceId == sourceId
         is com.wingedsheep.sdk.scripting.filters.unified.Scope.AttachedTo ->
             state.getEntity(staticSourceId)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoomScholarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoomScholarScenarioTest.kt
@@ -1,0 +1,296 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dft.cards.BoomScholar
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Boom Scholar (DFT #189) — {1}{R}{G} Goblin Advisor, 3/3.
+ *
+ * "Exhaust abilities of other permanents you control cost {2} less to activate." — the new
+ * `ReduceActivatedAbilityCost(exhaustOnly = true)` qualifier, which gates on the *ability*
+ * (`isExhaust`, CR 702.177) rather than the permanent. Asserted behaviourally: each board is given
+ * *exactly* the mana the reduced (or unreduced) cost needs, so "is this activation affordable" is the
+ * assertion — no reliance on a displayed cost string.
+ *  - another permanent's exhaust ability is {2} cheaper, and its ordinary activated ability is not,
+ *  - Boom Scholar's own exhaust ability is not ("**other** permanents", via `excludeSelf`),
+ *  - an opponent's exhaust ability is not ("you control"),
+ *  - only generic pips are reduced (CR 118.7),
+ *  - two Scholars stack additively down to {0} (2025-02-07 ruling).
+ *
+ * "Exhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two
+ * +1/+1 counters on this creature." — the union filter reaches an uncrewed Vehicle (a noncreature
+ * artifact) as well as creatures, and does not touch an opponent's creature.
+ */
+class BoomScholarScenarioTest : ScenarioTestBase() {
+
+    private val exhaustAbilityId = BoomScholar.activatedAbilities.single { it.isExhaust }.id
+
+    init {
+        // A permanent with BOTH an exhaust ability and an ordinary activated ability at the same
+        // printed {3} cost, so one card proves the qualifier discriminates by ability, not by source.
+        cardRegistry.register(
+            card("Boom Test Rig") {
+                manaCost = "{2}"
+                typeLine = "Artifact"
+                oracleText = "Exhaust — {3}: You gain 1 life.\n{3}: You gain 2 life."
+                activatedAbility {
+                    cost = Costs.Mana("{3}")
+                    isExhaust = true
+                    effect = Effects.GainLife(1)
+                    description = "You gain 1 life."
+                }
+                activatedAbility {
+                    cost = Costs.Mana("{3}")
+                    effect = Effects.GainLife(2)
+                    timing = TimingRule.InstantSpeed
+                    description = "{3}: You gain 2 life."
+                }
+            }
+        )
+        // A colored exhaust cost, to prove only the generic portion is reduced (CR 118.7).
+        cardRegistry.register(
+            card("Boom Test Colored Rig") {
+                manaCost = "{2}"
+                typeLine = "Artifact"
+                oracleText = "Exhaust — {2}{R}{R}: You gain 1 life."
+                activatedAbility {
+                    cost = Costs.Mana("{2}{R}{R}")
+                    isExhaust = true
+                    effect = Effects.GainLife(1)
+                    description = "You gain 1 life."
+                }
+            }
+        )
+
+        // A plain Vehicle — no abilities beyond crew, so activating Boom Scholar's exhaust doesn't
+        // set off anything else (Rangers' Refueler, for instance, draws on every exhaust activation).
+        cardRegistry.register(
+            card("Boom Test Wagon") {
+                manaCost = "{2}"
+                typeLine = "Artifact — Vehicle"
+                power = 4
+                toughness = 4
+                oracleText = "Crew 2"
+                keywordAbility(KeywordAbility.crew(2))
+            }
+        )
+
+        fun rigExhaustId(): AbilityId =
+            cardRegistry.getCard("Boom Test Rig")!!.activatedAbilities.single { it.isExhaust }.id
+
+        fun rigPlainId(): AbilityId =
+            cardRegistry.getCard("Boom Test Rig")!!.activatedAbilities.single { !it.isExhaust }.id
+
+        /** Whether the engine currently offers [abilityId] on [source] as an affordable activation. */
+        fun TestGame.canActivate(playerNumber: Int, source: EntityId, abilityId: AbilityId): Boolean =
+            getLegalActions(playerNumber).any { info ->
+                info.isAffordable &&
+                    (info.action as? ActivateAbility)?.let { it.sourceId == source && it.abilityId == abilityId } == true
+            }
+
+        /**
+         * A board with [scholars] Boom Scholars, a Boom Test Rig, and exactly [mountains] Mountains —
+         * so affordability alone reports how far the discount reached.
+         */
+        fun rigBoard(scholars: Int, mountains: Int): TestGame {
+            var builder = scenario().withPlayers("Alice", "Bob")
+            repeat(scholars) {
+                builder = builder.withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+            }
+            builder = builder.withCardOnBattlefield(1, "Boom Test Rig")
+            if (mountains > 0) builder = builder.withLandsOnBattlefield(1, "Mountain", mountains)
+            return builder
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+        }
+
+        context("Boom Scholar") {
+
+            test("another permanent's exhaust ability costs {2} less — {3} becomes payable with {1}") {
+                val game = rigBoard(scholars = 1, mountains = 1)
+                val rig = game.findPermanent("Boom Test Rig")!!
+
+                withClue("one mana covers the reduced {3} exhaust cost") {
+                    game.canActivate(1, rig, rigExhaustId()) shouldBe true
+                }
+
+                val lifeBefore = game.getLifeTotal(1)
+                game.execute(ActivateAbility(game.player1Id, rig, rigExhaustId())).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                withClue("and it really resolves") { game.getLifeTotal(1) shouldBe lifeBefore + 1 }
+            }
+
+            test("the SAME permanent's ordinary activated ability is not reduced") {
+                val game = rigBoard(scholars = 1, mountains = 1)
+                val rig = game.findPermanent("Boom Test Rig")!!
+
+                withClue("the non-exhaust {3} ability is unaffordable with one mana") {
+                    game.canActivate(1, rig, rigPlainId()) shouldBe false
+                }
+                withClue("with three mana it becomes affordable — proving nothing else blocks it") {
+                    rigBoard(scholars = 1, mountains = 3).let { g ->
+                        g.canActivate(1, g.findPermanent("Boom Test Rig")!!, rigPlainId()) shouldBe true
+                    }
+                }
+            }
+
+            test("Boom Scholar's own exhaust ability is not discounted (\"other permanents\")") {
+                fun board(mountains: Int, forests: Int): TestGame = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", mountains)
+                    .withLandsOnBattlefield(1, "Forest", forests)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // A self-discount would make {4}{R}{G} cost {2}{R}{G} — four mana.
+                val four = board(mountains = 3, forests = 1)
+                withClue("four mana must NOT be enough: the Scholar can't discount itself") {
+                    four.canActivate(1, four.findPermanent("Boom Scholar")!!, exhaustAbilityId) shouldBe false
+                }
+                val six = board(mountains = 5, forests = 1)
+                withClue("the full {4}{R}{G} — six mana — is affordable") {
+                    six.canActivate(1, six.findPermanent("Boom Scholar")!!, exhaustAbilityId) shouldBe true
+                }
+            }
+
+            test("an opponent's exhaust ability is not discounted (\"you control\")") {
+                fun board(mountains: Int): TestGame = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Boom Test Rig")
+                    .withLandsOnBattlefield(2, "Mountain", mountains)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val one = board(1)
+                withClue("Alice's Scholar must not subsidise Bob's exhaust ability") {
+                    one.canActivate(2, one.findPermanent("Boom Test Rig")!!, rigExhaustId()) shouldBe false
+                }
+                val three = board(3)
+                withClue("Bob pays the printed {3} himself") {
+                    three.canActivate(2, three.findPermanent("Boom Test Rig")!!, rigExhaustId()) shouldBe true
+                }
+            }
+
+            test("only the generic portion is reduced (CR 118.7)") {
+                fun board(mountains: Int): TestGame = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Boom Test Colored Rig")
+                    .withLandsOnBattlefield(1, "Mountain", mountains)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val id = cardRegistry.getCard("Boom Test Colored Rig")!!.activatedAbilities.single().id
+                // {2}{R}{R} loses its two generic pips → {R}{R}, so two Mountains suffice…
+                val two = board(2)
+                withClue("{2}{R}{R} reduces to {R}{R}") {
+                    two.canActivate(1, two.findPermanent("Boom Test Colored Rig")!!, id) shouldBe true
+                }
+                // …but not one: the two red pips survive the reduction.
+                val one = board(1)
+                withClue("the two colored pips are untouched, so one mana is not enough") {
+                    one.canActivate(1, one.findPermanent("Boom Test Colored Rig")!!, id) shouldBe false
+                }
+            }
+
+            test("two Scholars stack additively and can take the cost to {0} (2025-02-07 ruling)") {
+                val one = rigBoard(scholars = 1, mountains = 0)
+                withClue("one Scholar leaves {1}, unaffordable with no mana sources") {
+                    one.canActivate(1, one.findPermanent("Boom Test Rig")!!, rigExhaustId()) shouldBe false
+                }
+                val two = rigBoard(scholars = 2, mountains = 0)
+                withClue("two Scholars reduce {3} past zero — the ability is free") {
+                    two.canActivate(1, two.findPermanent("Boom Test Rig")!!, rigExhaustId()) shouldBe true
+                }
+            }
+
+            test("exhaust grants trample to creatures and Vehicles you control, and adds two counters") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // An uncrewed Vehicle: a noncreature artifact that must still gain trample.
+                    .withCardOnBattlefield(1, "Boom Test Wagon")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scholar = game.findPermanent("Boom Scholar")!!
+                game.execute(ActivateAbility(game.player1Id, scholar, exhaustAbilityId)).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val projected = StateProjector().project(game.state)
+                val myBear = game.findAllPermanents("Grizzly Bears")
+                    .first { projected.getController(it) == game.player1Id }
+                val theirBear = game.findAllPermanents("Grizzly Bears")
+                    .first { projected.getController(it) == game.player2Id }
+                val vehicle = game.findPermanent("Boom Test Wagon")!!
+
+                withClue("your creature gains trample") {
+                    projected.hasKeyword(myBear, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("your uncrewed Vehicle gains trample too") {
+                    projected.hasKeyword(vehicle, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Boom Scholar is itself a creature you control") {
+                    projected.hasKeyword(scholar, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("the opponent's creature does not") {
+                    projected.hasKeyword(theirBear, Keyword.TRAMPLE) shouldBe false
+                }
+                withClue("two +1/+1 counters land on Boom Scholar: a 3/3 becomes a 5/5") {
+                    projected.getPower(scholar) shouldBe 5
+                    projected.getToughness(scholar) shouldBe 5
+                }
+            }
+
+            test("the exhaust ability may be activated only once") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Boom Scholar", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 10)
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scholar = game.findPermanent("Boom Scholar")!!
+                game.execute(ActivateAbility(game.player1Id, scholar, exhaustAbilityId)).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("a second activation is rejected even with mana to spare") {
+                    game.execute(
+                        ActivateAbility(game.player1Id, scholar, exhaustAbilityId)
+                    ).error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RedshiftRocketeerChiefScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RedshiftRocketeerChiefScenarioTest.kt
@@ -1,0 +1,252 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dft.cards.RedshiftRocketeerChief
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Redshift, Rocketeer Chief (DFT #218) — {R}{G} Legendary Goblin Pilot, 2/3.
+ *
+ * Every printed clause has a paired test:
+ *  - "Vigilance" — snapshot/keyword net; not re-tested here.
+ *  - "{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to
+ *    activate abilities." — one *chosen* color, X of it, X read from **projected** power (so +1/+1
+ *    counters raise it), tagged [ManaRestriction.AbilityActivationOnly], and it really does fund
+ *    another source's activated ability.
+ *  - "Exhaust — {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield."
+ *    — the unbounded `ChooseAnyNumber` selection over permanent cards only (an instant in hand is
+ *    not an option), zero is a legal choice, and the exhaust ability is spent after one activation.
+ */
+class RedshiftRocketeerChiefScenarioTest : ScenarioTestBase() {
+
+    private val manaAbilityId = RedshiftRocketeerChief.activatedAbilities.single { it.isManaAbility }.id
+    private val exhaustAbilityId = RedshiftRocketeerChief.activatedAbilities.single { it.isExhaust }.id
+
+    init {
+        // A sink for the restricted mana: an activated ability with a plain {2} mana cost, so we can
+        // prove Redshift's mana pays for an *ability* of another source.
+        cardRegistry.register(
+            card("Redshift Test Cache") {
+                manaCost = "{0}"
+                typeLine = "Artifact"
+                oracleText = "{2}: You gain 3 life."
+                activatedAbility {
+                    cost = Costs.Mana("{2}")
+                    effect = Effects.GainLife(3)
+                    timing = TimingRule.InstantSpeed
+                }
+            }
+        )
+
+        /** Tap Redshift for mana, choosing [color]; returns the resulting pool. */
+        fun TestGame.tapForMana(redshift: EntityId, color: Color): ManaPoolComponent {
+            execute(ActivateAbility(player1Id, redshift, manaAbilityId)).error shouldBe null
+            val decision = getPendingDecision()
+            decision.shouldBeInstanceOf<ChooseColorDecision>()
+            submitDecision(ColorChosenResponse(decision.id, color)).error shouldBe null
+            return state.getEntity(player1Id)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        }
+
+        context("Redshift, Rocketeer Chief") {
+
+            test("{T} adds power-many mana of one chosen color, restricted to ability activation") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                val pool = game.tapForMana(redshift, Color.RED)
+
+                withClue("Redshift is a 2/3, so X = 2 — all of the one chosen color") {
+                    pool.restrictedMana.size shouldBe 2
+                    pool.restrictedMana.all { it.color == Color.RED } shouldBe true
+                }
+                withClue("the mana is spendable only on ability activations") {
+                    pool.restrictedMana.all {
+                        it.restriction == ManaRestriction.AbilityActivationOnly
+                    } shouldBe true
+                }
+                withClue("nothing unrestricted was added") {
+                    pool.red shouldBe 0
+                    pool.green shouldBe 0
+                    pool.colorless shouldBe 0
+                }
+                withClue("{T} taps Redshift") {
+                    game.state.getEntity(redshift)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("X tracks Redshift's projected power, not its printed power") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                // Two +1/+1 counters — a 2/3 becomes a projected 4/5.
+                game.state = game.state.updateEntity(redshift) { container ->
+                    container.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, 2))
+                }
+
+                val pool = game.tapForMana(redshift, Color.GREEN)
+
+                withClue("a 4/5 Redshift adds four mana") {
+                    pool.restrictedMana.size shouldBe 4
+                    pool.restrictedMana.all { it.color == Color.GREEN } shouldBe true
+                }
+            }
+
+            test("the restricted mana pays for another source's activated ability") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Redshift Test Cache")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                game.tapForMana(redshift, Color.RED).restrictedMana.size shouldBe 2
+
+                val cache = game.findPermanent("Redshift Test Cache")!!
+                val gainId = cardRegistry.getCard("Redshift Test Cache")!!.activatedAbilities.single().id
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.execute(ActivateAbility(game.player1Id, cache, gainId)).error shouldBe null
+                withClue("the two restricted mana paid the {2} activation cost") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                        ?.restrictedMana?.size shouldBe 0
+                }
+                game.resolveStack()
+                game.getLifeTotal(1) shouldBe lifeBefore + 3
+            }
+
+            test("exhaust puts any number of permanent cards from hand onto the battlefield") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    // {10}{R}{G}: eleven Mountains cover {10}{R}, the Forest covers {G}.
+                    .withLandsOnBattlefield(1, "Mountain", 11)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Grizzly Bears")   // permanent card
+                    .withCardInHand(1, "Island")          // permanent card (land)
+                    .withCardInHand(1, "Lightning Bolt")  // NOT a permanent card
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                game.execute(
+                    ActivateAbility(game.player1Id, redshift, exhaustAbilityId)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("only the two permanent cards are selectable — Lightning Bolt is not") {
+                    decision.options.size shouldBe 2
+                }
+
+                // "Any number" means both at once, not one at a time.
+                game.selectCards(decision.options).error shouldBe null
+                game.resolveStack()
+
+                withClue("both permanent cards entered the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Island") shouldBe true
+                }
+                withClue("the instant stayed in hand") {
+                    game.isInHand(1, "Lightning Bolt") shouldBe true
+                }
+            }
+
+            test("exhaust may be declined — any number includes zero") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 11)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                game.execute(
+                    ActivateAbility(game.player1Id, redshift, exhaustAbilityId)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                game.selectCards(emptyList()).error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing was put onto the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("the card is still in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("the exhaust ability may be activated only once") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Redshift, Rocketeer Chief", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 22)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardsInHand(1, "Grizzly Bears", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val redshift = game.findPermanent("Redshift, Rocketeer Chief")!!
+                game.execute(
+                    ActivateAbility(game.player1Id, redshift, exhaustAbilityId)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                game.selectCards(emptyList())
+                game.resolveStack()
+
+                withClue("mana is still available, but the exhaust ability is spent for this object") {
+                    game.execute(
+                        ActivateAbility(game.player1Id, redshift, exhaustAbilityId)
+                    ).error shouldNotBe null
+                }
+                withClue("and it is no longer offered as a legal action") {
+                    game.getLegalActions(1).none { info ->
+                        (info.action as? ActivateAbility)?.abilityId == exhaustAbilityId
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements two of the fifteen remaining Aetherdrift cards. Each needed one small, generalized SDK addition — no card-specific engine code.

## Cards

**Redshift, Rocketeer Chief** (#218, rare) — `mtg-sets/.../dft/cards/RedshiftRocketeerChief.kt`
- Vigilance.
- `{T}: Add X mana of any one color, where X is Redshift's power. Spend this mana only to activate abilities.` → `Effects.AddAnyColorMana(DynamicAmounts.sourcePower(), ManaRestriction.AbilityActivationOnly)`. X reads **projected** power, so counters and lords count. The restriction is the unqualified "only to activate abilities", matching set-mates Boommobile and Guidelight Optimizer — a pool-level restriction constrains what each pip may pay for, not how many abilities it feeds, so the mana can be split across activations and comfortably covers Redshift's own exhaust ability.
- `Exhaust — {10}{R}{G}: Put any number of permanent cards from your hand onto the battlefield.`

**Boom Scholar** (#189, uncommon) — `mtg-sets/.../dft/cards/BoomScholar.kt`
- `Exhaust abilities of other permanents you control cost {2} less to activate.`
- `Exhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature.` Reuses the "Creatures and Vehicles you control" union filter from set-mate Kickoff Celebrations, deliberately not narrowed to creatures so an uncrewed Vehicle picks up trample and can attack once crewed.

## SDK / engine additions

**`Patterns.Hand.putFromHand(anyNumber = true)`** (plus a `prompt` passthrough) swaps the existing `ChooseUpTo(count)` selection for `SelectionMode.ChooseAnyNumber` — the unbounded *"put any number of … cards from your hand onto the battlefield"* wording. Zero stays a legal choice, so declining and an empty hand are no-ops rather than stuck decisions.

**`ReduceActivatedAbilityCost(exhaustOnly = true)`** narrows the reduction to abilities marked `isExhaust` (CR 702.177). It gates on the **ability**, not the permanent, so a matching permanent's ordinary activated abilities stay at full price. `CastPermissionUtils.applyActivatedAbilityCostReduction` now takes the ability's `isExhaust` flag, threaded from both existing callers — the enumerator's displayed cost and `ActivateAbilityHandler`'s paid cost — so the two still agree.

**Latent gap fixed:** `GroupFilter.excludeSelf` was ignored at that read site. It is normally honored by the projection layer, which never sees this static, so an "other permanents you control" reduction would have discounted the lord's own abilities. Boom Scholar's own `{4}{R}{G}` is the first card to depend on it, and it now stays at full price.

`docs/card-sdk-language-reference.md` updated for both additions.

## Tests

`RedshiftRocketeerChiefScenarioTest` (6) — power-many mana of one chosen color; X tracking projected power via +1/+1 counters; the restricted mana funding another source's activated ability; any-number selection filtered to permanent cards only (an instant in hand is not an option); declining with zero; exhaust spent after one activation.

`BoomScholarScenarioTest` (8) — the discount reaching another permanent's exhaust ability but **not** its ordinary ability, **not** the Scholar's own, and **not** an opponent's; generic-only reduction (`{2}{R}{R}` → `{R}{R}`); two Scholars stacking additively to `{0}` per the 2025-02-07 ruling; the trample grant hitting creatures and an uncrewed Vehicle but not the opponent's creature, plus the two counters; the once-only exhaust cap. The cost assertions are behavioural — each board gets *exactly* the mana the reduced or unreduced cost needs, so affordability is the assertion rather than a displayed cost string.

## Unrelated fix carried here

`CardDefinitionSnapshotTest > WOE` was already failing on `main`: commit 547db4ac31 ("Charming scoundrel is rare") changed that card's rarity from COMMON to RARE without re-blessing `snapshots/cards/WOE.json`. COMMON is the golden's omitted default, so RARE needs the field written out. This branch merges `main` and adds that one line, which is what turned the `test (content)` / `backend` jobs red here. Nothing to do with the two cards above — it just unblocks CI on this PR.

## Verification

`just test` (full suite) green · `just check` green · `just rebless-cards` — only these two cards move in `snapshots/cards/DFT.json` · `just check-card-printing` clean for both (DFT is the earliest real printing for each).

Aetherdrift goes from 261/276 to 263/276.

## Not implemented, and why

The user asked for a handful, fewer if complex. The remaining thirteen Aetherdrift cards are the hard tail — each needs engine capability beyond a card. The one I got furthest into:

**Captain Howler, Sea Scourge** — the first two clauses are ready today (composite `WardCost` for "Ward—{2}, Pay 2 life"; `Triggers.YouDiscardOneOrMore` with `TRIGGER_DISCARD_COUNT` for the per-card pump). The blocker is the third: *"Whenever that creature deals combat damage to a player this turn, **you** draw a card."* Effect-path granted triggered abilities (`GameState.grantedTriggeredAbilities`) carry no granter, so `TriggerAbilityResolver` merges them into the **holder's** ability list and the draw would resolve for the pumped creature's controller. Since the target is unrestricted, pumping an opponent's creature would let *them* draw. Making this correct means attributing a granter to effect-path grants (`granterId` on `GrantedTriggeredAbility`, recorded by `GrantTriggeredAbilityExecutor`, surfaced through `resolveGranterIds` — which today only covers attachment-scoped static grants) so `EffectTarget.GrantingSource` resolves. That is `add-feature` scope and would also fix the same latent misresolution on the existing Vigorous Charge, so it deserves its own PR rather than being smuggled in here.

The others need larger features: an activated-ability cost **increase** keyed to a chosen card name (Skyseer's Chariot), mana added to a *target player* (Radiant Lotus), exhaust-reset permission (Elvish Refueler), a self-removing one-shot global trigger that copies the next exhaust ability (Pit Automaton), granting embalm at a computed cost (Cursecloth Wrappings), an exile-count attack/block restriction plus an exile-from-graveyard-or-battlefield trigger (Ketramose), and copy-a-linked-exiled-creature-card (Mimeoplasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
