### PR TITLE
Add four Innistrad Remastered double-faced cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3863,6 +3863,12 @@ Triggers.youCastSpell(
 - `Transforms` — source transforms (either direction).
 - `TransformsToFront` — to front face.
 - `TransformsToBack` — to back face.
+- `transforms(binding, intoBackFace?)` — the factory behind the three SELF constants; reach for it to bind
+  the trigger elsewhere. `binding = TriggerBinding.ATTACHED` is "**when equipped/enchanted creature
+  transforms**" (Neglected Heirloom: "When equipped creature transforms, transform this Equipment"),
+  detected by `AttachmentTriggerDetector` like every other ATTACHED trigger — a transform flips the
+  permanent in place, so the Aura/Equipment is still attached when the event fires. `intoBackFace` filters
+  direction (`null` = either).
 - `YouCycleThis` — you cycle source.
 - `AnyPlayerCycles` — anyone cycles.
 - `AnyPlayerTapsLandForMana` — whenever any player taps a land for mana. Use
@@ -6378,6 +6384,13 @@ that works in both resolution and static-ability (projection) contexts.
   `ActivationRestriction.OnlyIfCondition(...)`, with `Counters.CHARGE`. Generic over counter type, reads counters live.
   Takes either a counter-type name (`Counters.CHARGE`) or a `CounterTypeFilter`; pass `CounterTypeFilter.Any` for
   "N or more counters **of any kind**" gates (Warden of the Inner Sky), which sums every counter kind on the source.
+- `SourceCounterCountAtMost(counterType, count)` — the downward-facing twin: a countdown gate rather than a
+  threshold (an `LTE` `Compare` on the same `EntityProperty(Source, CounterCount(filter))`). `count = 0` is the
+  "**if it has no [kind] counters on it**" clause that follows a remove-a-counter step — Thing in the Ice's
+  "remove an ice counter from this creature. Then if it has no ice counters on it, transform it" is
+  `Composite(RemoveCounters(Counters.ICE, 1, Self), ConditionalEffect(SourceCounterCountAtMost(Counters.ICE, 0),
+  TransformEffect(Self)))`. Reads the source live, so it sees the counter the same resolution just removed. Same
+  two overloads (name / `CounterTypeFilter`) as its `AtLeast` sibling.
 
 ### Turn / phase
 
@@ -8140,6 +8153,13 @@ substitution.
   `AddCounters(Counters.SKEWER, 1, EffectTarget.Self)`, and the optional self-sacrifice cashes the tally in
   for an impulse-exile sized by `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.SKEWER))`).
   A pure tally counter with no inherent rule.
+  `ice` (`Counters.ICE`): SOI — Thing in the Ice (enters with four via an `EntersWithCounters(
+  CounterTypeFilter.Named(Counters.ICE), count = 4, selfOnly = true)` replacement; its
+  `Triggers.YouCastInstantOrSorcery` trigger removes one and then flips the permanent through a
+  `ConditionalEffect(Conditions.SourceCounterCountAtMost(Counters.ICE, 0), TransformEffect(Self))`).
+  A "countdown to zero" counter with no inherent rule — the inverse of the `wish`/`film` "uses left" shape:
+  read down rather than spent as a cost. Gating the flip on the live count *inside the ability's resolution*
+  is what makes the printed ruling hold — removing the last counter any other way never transforms it.
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -79,7 +79,8 @@ enum class CounterType {
     INGENUITY,
     FILM,
     SKEWER,
-    ENERGY;
+    ENERGY,
+    ICE;
 
     companion object {
         /**
@@ -394,6 +395,18 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val ENERGY = "energy"
+
+    /**
+     * Ice counter (SOI — Thing in the Ice). Passive "thaw countdown" counter with no inherent rule
+     * of its own — Thing in the Ice enters with four (`EntersWithCounters(CounterTypeFilter.Named(
+     * Counters.ICE), count = 4, selfOnly = true)`) and its instant/sorcery cast trigger removes one,
+     * then transforms the permanent once the tally reaches zero (a `Gate.WhenCondition` on
+     * `Conditions.SourceCounterCountAtMost(Counters.ICE, 0)`). Same countdown shape as
+     * `Counters.WISH` / `Counters.FILM`, but read down to zero rather than spent as a cost — and
+     * per the printed ruling, removing the last counter *any other way* does not transform it.
+     * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val ICE = "ice"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1116,6 +1116,34 @@ object Conditions {
         )
 
     /**
+     * While this permanent has at most [count] counters of [counterType] on it.
+     *
+     * The downward-facing twin of [SourceCounterCountAtLeast] — a countdown gate rather than a
+     * threshold. `count = 0` is the "if it has no [kind] counters on it" clause that follows a
+     * remove-a-counter step (Thing in the Ice: "remove an ice counter from this creature. Then if
+     * it has no ice counters on it, transform it"), which is why it reads the source live rather
+     * than off the entry state.
+     */
+    fun SourceCounterCountAtMost(counterType: String, count: Int): ConditionInterface =
+        SourceCounterCountAtMost(CounterTypeFilter.Named(counterType), count)
+
+    /**
+     * While this permanent has at most [count] counters matching [counterType] on it.
+     *
+     * The [CounterTypeFilter] form of [SourceCounterCountAtMost]; pass [CounterTypeFilter.Any] to
+     * total every kind.
+     */
+    fun SourceCounterCountAtMost(counterType: CounterTypeFilter, count: Int): ConditionInterface =
+        Compare(
+            DynamicAmount.EntityProperty(
+                EntityReference.Source,
+                EntityNumericProperty.CounterCount(counterType)
+            ),
+            ComparisonOperator.LTE,
+            DynamicAmount.Fixed(count)
+        )
+
+    /**
      * If a permanent with the given subtype was sacrificed as part of the cost.
      * Used for cards like Thallid Omnivore: "If a Saproling was sacrificed this way, you gain 2 life."
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1654,6 +1654,23 @@ object Triggers {
         binding = TriggerBinding.SELF
     )
 
+    /**
+     * Generic "transforms" factory — use [Transforms] / [TransformsToBack] / [TransformsToFront]
+     * for the SELF forms; reach for this factory to bind the trigger elsewhere.
+     *
+     * `binding = TriggerBinding.ATTACHED` is "when **equipped/enchanted** creature transforms"
+     * (Neglected Heirloom: "When equipped creature transforms, transform this Equipment"), routed
+     * through `AttachmentTriggerDetector` like every other ATTACHED trigger. [intoBackFace] filters
+     * direction: `true` = to back, `false` = to front, `null` = either.
+     */
+    fun transforms(
+        binding: TriggerBinding = TriggerBinding.SELF,
+        intoBackFace: Boolean? = null
+    ): TriggerSpec = TriggerSpec(
+        event = TransformEvent(intoBackFace = intoBackFace),
+        binding = binding
+    )
+
     // =========================================================================
     // Targeting Triggers
     // =========================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DocentOfPerfection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DocentOfPerfection.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Docent of Perfection // Final Iteration (Eldritch Moon #56 — the card's earliest printing; also
+ * reprinted in Shadows of the Past and Innistrad Remastered)
+ * {3}{U}{U}
+ * Creature — Insect Horror 5/4 // Creature — Eldrazi Insect 6/5
+ *
+ * Front — Docent of Perfection ({3}{U}{U}, Creature — Insect Horror, 5/4)
+ *   Flying
+ *   Whenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature token.
+ *   Then if you control three or more Wizards, transform this creature.
+ *
+ * Back — Final Iteration (Creature — Eldrazi Insect, 6/5, colorless)
+ *   Flying
+ *   Wizards you control get +2/+1 and have flying.
+ *   Whenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature token.
+ *
+ * Implementation:
+ *  - Both faces share the same [Triggers.YouCastInstantOrSorcery] → [Effects.CreateToken] trigger;
+ *    the front adds a [ConditionalEffect] on [Conditions.YouControlAtLeast]`(3, Wizard)` that flips
+ *    it. The token is made *before* the count, so the Wizard it just created counts toward the
+ *    three, and the flip only happens while this ability resolves (printed ruling: already
+ *    controlling three Wizards doesn't transform it on its own).
+ *  - The token's art comes from Eldritch Moon's synced token set (the 1/1 blue Human Wizard), so no
+ *    explicit `imageUri` is needed.
+ *  - The back's anthem is two static rows over the same [GroupFilter] — [ModifyStats]`(2, 1)` in
+ *    Layer 7c and [GrantKeyword]`(FLYING)` in Layer 6 — which the engine ties together with a shared
+ *    `groupId` so both halves see the same affected set (CR 613.6). It covers *every* Wizard you
+ *    control, not just the tokens; Final Iteration is an Eldrazi Insect, so it never pumps itself.
+ */
+
+private val WizardsYouControl: GroupFilter =
+    GroupFilter(GameObjectFilter.Creature.youControl().withSubtype("Wizard"))
+
+private val HumanWizardToken = Effects.CreateToken(
+    power = 1,
+    toughness = 1,
+    colors = setOf(Color.BLUE),
+    creatureTypes = setOf("Human", "Wizard"),
+)
+
+private val DocentOfPerfectionFront = card("Docent of Perfection") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Insect Horror"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature " +
+        "token. Then if you control three or more Wizards, transform this creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.Composite(
+            HumanWizardToken,
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(
+                    3,
+                    GameObjectFilter.Creature.withSubtype("Wizard"),
+                ),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "Create a 1/1 blue Human Wizard creature token. Then if you control three " +
+            "or more Wizards, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Nils Hamm"
+        flavorText = "The time had come for him to share his findings."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1783937509"
+        ruling(
+            "2025-01-24",
+            "An ability that triggers when a player casts a spell resolves before the spell that " +
+                "caused it to trigger. It resolves even if that spell is countered or otherwise " +
+                "leaves the stack without resolving."
+        )
+        ruling(
+            "2025-01-24",
+            "If you control three or more Wizards while you control Docent of Perfection, it won't " +
+                "transform yet. It only transforms while its triggered ability is resolving after " +
+                "you cast an instant or sorcery spell."
+        )
+        ruling(
+            "2025-01-24",
+            "When Docent of Perfection transforms into Final Iteration, the instant or sorcery " +
+                "spell that's on the stack doesn't cause Final Iteration's triggered ability to " +
+                "trigger."
+        )
+        ruling(
+            "2025-01-24",
+            "All Wizards you control get +2/+1 and have flying, not just those created by Docent " +
+                "of Perfection or Final Iteration."
+        )
+    }
+}
+
+private val FinalIteration = card("Final Iteration") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Creature — Eldrazi Insect"
+    power = 6
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Wizards you control get +2/+1 and have flying.\n" +
+        "Whenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature token."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = 2, toughnessBonus = 1, filter = WizardsYouControl)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, WizardsYouControl)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = HumanWizardToken
+        description = "Create a 1/1 blue Human Wizard creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1783937509"
+    }
+}
+
+val DocentOfPerfection: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = DocentOfPerfectionFront,
+    backFace = FinalIteration,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrizzledAngler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrizzledAngler.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grizzled Angler // Grisly Anglerfish (Eldritch Moon #63 — the card's earliest printing; also
+ * reprinted in Innistrad Remastered)
+ * {2}{U}
+ * Creature — Human 2/3 // Creature — Eldrazi Fish 4/5
+ *
+ * Front — Grizzled Angler ({2}{U}, Creature — Human, 2/3)
+ *   {T}: Mill two cards. Then if there is a colorless creature card in your graveyard,
+ *   transform this creature.
+ *
+ * Back — Grisly Anglerfish (Creature — Eldrazi Fish, 4/5, colorless)
+ *   {6}: Creatures your opponents control attack this turn if able.
+ *
+ * Implementation:
+ *  - The front's tap ability is [Patterns.Library.mill] (2) followed by a [ConditionalEffect] on
+ *    [Conditions.CardsInGraveyardMatchingAtLeast]`(1, colorless creature)` that flips the permanent
+ *    with [TransformEffect] — the Treasure Map "do a thing, then conditionally transform" shape. The
+ *    condition is re-read *after* the mill, so cards milled by this very activation count, and the
+ *    flip only happens while the ability resolves (printed ruling: an already-present colorless
+ *    creature card doesn't transform it on its own).
+ *  - "Colorless creature card" is `GameObjectFilter.Creature` plus [CardPredicate.IsColorless] —
+ *    a graveyard-zone read, so base characteristics are the right source (no projection needed).
+ *  - The back's {6} ability marks every creature your opponents control with
+ *    [Effects.MarkMustAttackThisTurn] via [Effects.ForEachInGroup] over
+ *    [GroupFilter.AllCreaturesOpponentsControl] — `EffectTarget.Self` inside the ForEach body is
+ *    the iterated creature. The marker is per-creature and this-turn only, and the engine's
+ *    attack-requirement check already honours the printed rulings: a creature that can't attack
+ *    (summoning sick, tapped, an attack restriction) doesn't, a cost to attack is never forced,
+ *    and each controller still picks what their creature attacks.
+ */
+
+private val ColorlessCreatureCard: GameObjectFilter =
+    GameObjectFilter.Creature.withCardPredicate(CardPredicate.IsColorless)
+
+private val GrizzledAnglerFront = card("Grizzled Angler") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human"
+    power = 2
+    toughness = 3
+    oracleText = "{T}: Mill two cards. Then if there is a colorless creature card in your " +
+        "graveyard, transform this creature. (To mill two cards, put the top two cards of your " +
+        "library into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Patterns.Library.mill(2),
+            ConditionalEffect(
+                condition = Conditions.CardsInGraveyardMatchingAtLeast(1, ColorlessCreatureCard),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "Mill two cards. Then if there is a colorless creature card in your " +
+            "graveyard, transform this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Kev Walker"
+        flavorText = "\"There's no question that these waters are treacherous, but if there's one " +
+            "thing I've learned in all my years of sailing . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1783937503"
+        ruling(
+            "2025-01-24",
+            "If you have a colorless creature card in your graveyard while you control Grizzled " +
+                "Angler, it won't transform yet. It only transforms while its activated ability is " +
+                "resolving."
+        )
+        ruling(
+            "2025-01-24",
+            "If a creature affected by Grisly Anglerfish's effect hasn't been under its " +
+                "controller's control since the turn began, is tapped, or is affected by a spell or " +
+                "ability that says it can't attack, then it doesn't attack. If there's a cost " +
+                "associated with having that creature attack, its controller isn't forced to pay " +
+                "that cost, so it doesn't have to attack in that case either."
+        )
+        ruling(
+            "2025-01-24",
+            "Each creature's controller still chooses the player, planeswalker, or battle it " +
+                "attacks. The creatures that have to attack don't necessarily have to attack you if " +
+                "there are other options."
+        )
+    }
+}
+
+private val GrislyAnglerfish = card("Grisly Anglerfish") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Creature — Eldrazi Fish"
+    power = 4
+    toughness = 5
+    oracleText = "{6}: Creatures your opponents control attack this turn if able."
+
+    activatedAbility {
+        cost = Costs.Mana("{6}")
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreaturesOpponentsControl,
+            effect = Effects.MarkMustAttackThisTurn(EffectTarget.Self),
+        )
+        description = "Creatures your opponents control attack this turn if able."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Kev Walker"
+        flavorText = "\". . . it's that the lure of the sea is impossible to ignore.\""
+        imageUri = "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1783937503"
+    }
+}
+
+val GrizzledAngler: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = GrizzledAnglerFront,
+    backFace = GrislyAnglerfish,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DocentOfPerfectionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DocentOfPerfectionReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val DocentOfPerfectionReprint = Printing(
+    oracleId = "85e797de-da27-4cd5-8fa4-4aef948988b2",
+    name = "Docent of Perfection",
+    setCode = "INR",
+    collectorNumber = "62",
+    scryfallId = "96658239-3169-42ef-9983-cd4da24e0f4c",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96658239-3169-42ef-9983-cd4da24e0f4c.jpg?1783908169",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/9/6/96658239-3169-42ef-9983-cd4da24e0f4c.jpg?1783908169",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrizzledAnglerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GrizzledAnglerReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val GrizzledAnglerReprint = Printing(
+    oracleId = "d37effd3-d194-4609-9994-6d70038a68f9",
+    name = "Grizzled Angler",
+    setCode = "INR",
+    collectorNumber = "67",
+    scryfallId = "16c0bb08-36b3-41e2-a5a9-2fcd6bb49beb",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16c0bb08-36b3-41e2-a5a9-2fcd6bb49beb.jpg?1783908168",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/1/6/16c0bb08-36b3-41e2-a5a9-2fcd6bb49beb.jpg?1783908168",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/NeglectedHeirloomReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/NeglectedHeirloomReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val NeglectedHeirloomReprint = Printing(
+    oracleId = "1374498c-58fd-40b9-b63b-f87fedc42e58",
+    name = "Neglected Heirloom",
+    setCode = "INR",
+    collectorNumber = "269",
+    scryfallId = "7813cd70-bb60-4953-a35d-9876f5230c42",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/7813cd70-bb60-4953-a35d-9876f5230c42.jpg?1783908071",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/7/8/7813cd70-bb60-4953-a35d-9876f5230c42.jpg?1783908071",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ThingInTheIceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ThingInTheIceReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val ThingInTheIceReprint = Printing(
+    oracleId = "f2c10591-4c0c-4286-af91-e8d8d10a4c9d",
+    name = "Thing in the Ice",
+    setCode = "INR",
+    collectorNumber = "91",
+    scryfallId = "7269d533-cb3f-498e-b97f-eb6c49e170c3",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/7269d533-cb3f-498e-b97f-eb6c49e170c3.jpg?1783908158",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/7/2/7269d533-cb3f-498e-b97f-eb6c49e170c3.jpg?1783908158",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NeglectedHeirloom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/NeglectedHeirloom.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Neglected Heirloom // Ashmouth Blade (Shadows over Innistrad #260 — the card's earliest printing;
+ * also reprinted in Innistrad Remastered)
+ * {1}
+ * Artifact — Equipment // Artifact — Equipment
+ *
+ * Front — Neglected Heirloom ({1}, Artifact — Equipment)
+ *   Equipped creature gets +1/+1.
+ *   When equipped creature transforms, transform this Equipment.
+ *   Equip {1}
+ *
+ * Back — Ashmouth Blade (Artifact — Equipment)
+ *   Equipped creature gets +3/+3 and has first strike.
+ *   Equip {3}
+ *
+ * Implementation:
+ *  - Both faces are plain Equipment: [ModifyStats] and [GrantKeyword] default to
+ *    `GroupFilter.attachedCreature()`, and `equipAbility(...)` wires the equip cost per face.
+ *  - "When **equipped creature** transforms" is `Triggers.transforms(binding =
+ *    `[TriggerBinding.ATTACHED]`)` — the Equipment watches the permanent it's attached to, the same
+ *    binding behind "whenever equipped creature deals combat damage" (Goldvein Pick) and "becomes
+ *    untapped" (Fishing Pole). A [TransformEffect] flips the permanent in place, so the Equipment is
+ *    still attached when the event fires. The trigger takes no direction filter: it fires on a flip
+ *    either way, which matches the werewolf pairs this Equipment was printed for.
+ *  - Per the printed ruling, nothing card-specific handles the "equipped creature transforms into a
+ *    *noncreature* permanent" case — the attachment state-based action unattaches the Equipment
+ *    before this trigger resolves, and it still transforms.
+ */
+
+private val NeglectedHeirloomFront = card("Neglected Heirloom") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "When equipped creature transforms, transform this Equipment.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = 1, toughnessBonus = 1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.transforms(binding = TriggerBinding.ATTACHED)
+        effect = TransformEffect(EffectTarget.Self)
+        description = "Transform this Equipment."
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "260"
+        artist = "Volkan Baǵa"
+        flavorText = "\"There is a rich history in a blade like this.\"\n—Old Rutstein"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1783937716"
+        ruling(
+            "2016-04-08",
+            "When Neglected Heirloom transforms, it remains attached to the creature it's attached " +
+                "to. If the equipped creature transforms into a noncreature permanent, Neglected " +
+                "Heirloom will become unattached before it transforms into Ashmouth Blade."
+        )
+    }
+}
+
+private val AshmouthBlade = card("Ashmouth Blade") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +3/+3 and has first strike.\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = 3, toughnessBonus = 3)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "260"
+        artist = "Volkan Baǵa"
+        flavorText = "\"Its previous owners had some stories to share, I'm certain.\"\n—Old Rutstein"
+        imageUri = "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1783937716"
+    }
+}
+
+val NeglectedHeirloom: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = NeglectedHeirloomFront,
+    backFace = AshmouthBlade,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ThingInTheIce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ThingInTheIce.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thing in the Ice // Awoken Horror (Shadows over Innistrad #92 — the card's earliest printing;
+ * also reprinted in Shadows of the Past and Innistrad Remastered)
+ * {1}{U}
+ * Creature — Horror 0/4 // Creature — Kraken Horror 7/8
+ *
+ * Front — Thing in the Ice ({1}{U}, Creature — Horror, 0/4)
+ *   Defender
+ *   This creature enters with four ice counters on it.
+ *   Whenever you cast an instant or sorcery spell, remove an ice counter from this creature.
+ *   Then if it has no ice counters on it, transform it.
+ *
+ * Back — Awoken Horror (Creature — Kraken Horror, 7/8, blue)
+ *   When this creature transforms into Awoken Horror, return all non-Horror creatures to their
+ *   owners' hands.
+ *
+ * Implementation:
+ *  - "Enters with four ice counters" is a replacement effect (CR 614.1c), not an ETB trigger:
+ *    [EntersWithCounters] over the new [Counters.ICE] counter, `selfOnly`.
+ *  - The cast trigger is [Triggers.YouCastInstantOrSorcery] → [Effects.RemoveCounters] of one ice
+ *    counter, then a [ConditionalEffect] on [Conditions.SourceCounterCountAtMost]`(ice, 0)` that
+ *    flips it. Gating the transform on the *live* count after the removal is what makes the printed
+ *    ruling hold: taking the last counter off any other way never transforms it, because only this
+ *    ability's resolution runs the check.
+ *  - The back's trigger is [Triggers.TransformsToBack] (the ability lives on the face that ends up
+ *    up), returning every creature that isn't a Horror — both players' — via
+ *    [Patterns.Group.returnAllToHand]. Awoken Horror is itself a Horror, so it never bounces
+ *    itself; a *front-face* Thing in the Ice on the battlefield is a Horror too and also stays.
+ */
+
+private val NonHorrorCreatures: GroupFilter =
+    GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype("Horror")))
+
+private val ThingInTheIceFront = card("Thing in the Ice") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Horror"
+    power = 0
+    toughness = 4
+    oracleText = "Defender\n" +
+        "This creature enters with four ice counters on it.\n" +
+        "Whenever you cast an instant or sorcery spell, remove an ice counter from this creature. " +
+        "Then if it has no ice counters on it, transform it."
+
+    keywords(Keyword.DEFENDER)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.ICE),
+            count = 4,
+            selfOnly = true,
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.Composite(
+            Effects.RemoveCounters(Counters.ICE, 1, EffectTarget.Self),
+            ConditionalEffect(
+                condition = Conditions.SourceCounterCountAtMost(Counters.ICE, 0),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "Remove an ice counter from this creature. Then if it has no ice counters " +
+            "on it, transform it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1783937788"
+        ruling(
+            "2025-01-24",
+            "An ability that triggers when a player casts a spell resolves before the spell that " +
+                "caused it to trigger. It resolves even if that spell is countered or otherwise " +
+                "leaves the stack without resolving."
+        )
+        ruling(
+            "2025-01-24",
+            "When Thing in the Ice's triggered ability transforms it, Awoken Horror's ability will " +
+                "trigger and resolve before the spell that caused Thing in the Ice's last ability " +
+                "to trigger."
+        )
+        ruling(
+            "2025-01-24",
+            "Removing all ice counters from Thing in the Ice some other way will not cause it to " +
+                "transform. You'll need to cast an instant or sorcery spell and cause its last " +
+                "ability to trigger."
+        )
+    }
+}
+
+private val AwokenHorror = card("Awoken Horror") {
+    manaCost = ""
+    colorIdentity = "U"
+    colorIndicator = "U" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Creature — Kraken Horror"
+    power = 7
+    toughness = 8
+    oracleText = "When this creature transforms into Awoken Horror, return all non-Horror " +
+        "creatures to their owners' hands."
+
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Patterns.Group.returnAllToHand(NonHorrorCreatures)
+        description = "Return all non-Horror creatures to their owners' hands."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Svetlin Velinov"
+        flavorText = "\"It serves as evidence of the ancient power of the deep, a reminder that " +
+            "the sea is the only thing worthy of reverence.\"\n—Runo Stromkirk"
+        imageUri = "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1783937788"
+    }
+}
+
+val ThingInTheIce: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ThingInTheIceFront,
+    backFace = AwokenHorror,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -662,6 +662,184 @@
     }
 }
 
+// Docent of Perfection
+{
+    "name": "Docent of Perfection",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Insect Horror",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature token. Then if you control three or more Wizards, transform this creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Human",
+                                "Wizard"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Wizard"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Create a 1/1 blue Human Wizard creature token. Then if you control three or more Wizards, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Final Iteration",
+        "manaCost": "",
+        "typeLine": "Creature — Eldrazi Insect",
+        "oracleText": "Flying\nWizards you control get +2/+1 and have flying.\nWhenever you cast an instant or sorcery spell, create a 1/1 blue Human Wizard creature token.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 5
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "SpellCastEvent",
+                        "spellFilter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsInstant",
+                                        "IsSorcery"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Human",
+                            "Wizard"
+                        ]
+                    },
+                    "descriptionOverride": "Create a 1/1 blue Human Wizard creature token."
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "creature Wizard ctrl:you"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "creature Wizard ctrl:you"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "56",
+            "rarity": "RARE",
+            "artist": "Nils Hamm",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1783937509"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Nils Hamm",
+        "flavorText": "The time had come for him to share his findings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30c3d4c1-dc3d-4529-9d6e-8c16149cf6da.jpg?1783937509",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If you control three or more Wizards while you control Docent of Perfection, it won't transform yet. It only transforms while its triggered ability is resolving after you cast an instant or sorcery spell."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "When Docent of Perfection transforms into Final Iteration, the instant or sorcery spell that's on the stack doesn't cause Final Iteration's triggered ability to trigger."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "All Wizards you control get +2/+1 and have flying, not just those created by Docent of Perfection or Final Iteration."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Drogskol Shieldmate
 {
     "name": "Drogskol Shieldmate",
@@ -1105,6 +1283,153 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Grizzled Angler
+{
+    "name": "Grizzled Angler",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human",
+    "oracleText": "{T}: Mill two cards. Then if there is a colorless creature card in your graveyard, transform this creature. (To mill two cards, put the top two cards of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "Count",
+                                        "player": "You",
+                                        "zone": "Graveyard",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsCreature",
+                                                "IsColorless"
+                                            ]
+                                        }
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Mill two cards. Then if there is a colorless creature card in your graveyard, transform this creature."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Grisly Anglerfish",
+        "manaCost": "",
+        "typeLine": "Creature — Eldrazi Fish",
+        "oracleText": "{6}: Creatures your opponents control attack this turn if able.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 5
+        },
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{6}"
+                        }
+                    },
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        },
+                        "body": "MarkMustAttackThisTurn"
+                    },
+                    "descriptionOverride": "Creatures your opponents control attack this turn if able."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "63",
+            "rarity": "UNCOMMON",
+            "artist": "Kev Walker",
+            "flavorText": "\". . . it's that the lure of the sea is impossible to ignore.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1783937503"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "\"There's no question that these waters are treacherous, but if there's one thing I've learned in all my years of sailing . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eb4ddf4-f695-412d-be80-b93392432498.jpg?1783937503",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "If you have a colorless creature card in your graveyard while you control Grizzled Angler, it won't transform yet. It only transforms while its activated ability is resolving."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If a creature affected by Grisly Anglerfish's effect hasn't been under its controller's control since the turn began, is tapped, or is affected by a spell or ability that says it can't attack, then it doesn't attack. If there's a cost associated with having that creature attack, its controller isn't forced to pay that cost, so it doesn't have to attack in that case either."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Each creature's controller still chooses the player, planeswalker, or battle it attacks. The creatures that have to attack don't necessarily have to attack you if there are other options."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1265,6 +1265,136 @@
     ]
 }
 
+// Neglected Heirloom
+{
+    "name": "Neglected Heirloom",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nWhen equipped creature transforms, transform this Equipment.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TransformEvent",
+                "binding": "ATTACHED",
+                "effect": "Transform",
+                "descriptionOverride": "Transform this Equipment."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "backFace": {
+        "name": "Ashmouth Blade",
+        "manaCost": "",
+        "typeLine": "Artifact — Equipment",
+        "oracleText": "Equipped creature gets +3/+3 and has first strike.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{3}"
+                        }
+                    },
+                    "effect": {
+                        "type": "AttachEquipment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "creature you control"
+                        }
+                    ],
+                    "timing": "SorcerySpeed",
+                    "isEquipAbility": true
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 3,
+                    "toughnessBonus": 3
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE"
+                }
+            ]
+        },
+        "equipCost": "{3}",
+        "metadata": {
+            "collectorNumber": "260",
+            "rarity": "UNCOMMON",
+            "artist": "Volkan Baǵa",
+            "flavorText": "\"Its previous owners had some stories to share, I'm certain.\"\n—Old Rutstein",
+            "imageUri": "https://cards.scryfall.io/normal/back/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1783937716"
+        },
+        "colorIdentityOverride": [],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"There is a rich history in a blade like this.\"\n—Old Rutstein",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cc2ac21-d31f-4a0d-956a-dabb6e1f3b5a.jpg?1783937716",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "When Neglected Heirloom transforms, it remains attached to the creature it's attached to. If the equipped creature transforms into a noncreature permanent, Neglected Heirloom will become unattached before it transforms into Ashmouth Blade."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Open the Armory
 {
     "name": "Open the Armory",
@@ -1879,6 +2009,180 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Thing in the Ice
+{
+    "name": "Thing in the Ice",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Defender\nThis creature enters with four ice counters on it.\nWhenever you cast an instant or sorcery spell, remove an ice counter from this creature. Then if it has no ice counters on it, transform it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RemoveCounters",
+                            "counterType": "ice",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": {
+                                                "type": "Named",
+                                                "name": "ice"
+                                            }
+                                        }
+                                    },
+                                    "operator": "LTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Remove an ice counter from this creature. Then if it has no ice counters on it, transform it."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "ice"
+                },
+                "count": 4,
+                "selfOnly": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Awoken Horror",
+        "manaCost": "",
+        "typeLine": "Creature — Kraken Horror",
+        "oracleText": "When this creature transforms into Awoken Horror, return all non-Horror creatures to their owners' hands.",
+        "creatureStats": {
+            "power": 7,
+            "toughness": 8
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "NotSubtype",
+                                                "subtype": "Horror"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "returnAllToHand_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "returnAllToHand_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Return all non-Horror creatures to their owners' hands."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "92",
+            "rarity": "RARE",
+            "artist": "Svetlin Velinov",
+            "flavorText": "\"It serves as evidence of the ancient power of the deep, a reminder that the sea is the only thing worthy of reverence.\"\n—Runo Stromkirk",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1783937788"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "BLUE"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/359d1b13-6156-43b0-a9a7-6bfff36c1a91.jpg?1783937788",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "When Thing in the Ice's triggered ability transforms it, Awoken Horror's ability will trigger and resolve before the spell that caused Thing in the Ice's last ability to trigger."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Removing all ice counters from Thing in the Ice some other way will not cause it to transform. You'll need to cast an instant or sorcery spell and cause its last ability to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.AttackersDeclaredEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
 import com.wingedsheep.engine.core.TappedEvent
+import com.wingedsheep.engine.core.TransformedEvent
 import com.wingedsheep.engine.core.TurnFaceUpEvent
 import com.wingedsheep.engine.core.UntappedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
@@ -84,6 +85,9 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             is TurnFaceUpEvent -> listOf(event.entityId)
             is TappedEvent -> listOf(event.entityId)
             is UntappedEvent -> listOf(event.entityId)
+            // "When equipped creature transforms" (Neglected Heirloom). A transform flips the
+            // permanent in place, so the Equipment is still attached when the event fires.
+            is TransformedEvent -> listOf(event.entityId)
             // "an ability of enchanted artifact … was activated" (Artifact Possession) — the
             // activated ability's source is the enchanted permanent.
             is AbilityActivatedEvent -> listOf(event.sourceId)
@@ -148,6 +152,13 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
             }
             is EventPattern.TurnFaceUpEvent -> {
                 event is TurnFaceUpEvent && event.entityId == attachedEntityId
+            }
+            // "When equipped creature transforms" (Neglected Heirloom). Identity with the attached
+            // permanent plus the pattern's direction filter is the whole match — the same two checks
+            // TriggerMatcher applies on the SELF path.
+            is EventPattern.TransformEvent -> {
+                if (event !is TransformedEvent || event.entityId != attachedEntityId) return false
+                trigger.intoBackFace == null || trigger.intoBackFace == event.intoBackFace
             }
             is EventPattern.ZoneChangeEvent -> {
                 if (event !is ZoneChangeEvent) return false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DocentOfPerfectionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DocentOfPerfectionScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Docent of Perfection // Final Iteration (EMN) — Wizard tokens, the three-Wizard flip, and the
+ * back face's two-row anthem.
+ *
+ * The flip condition is checked *after* the token is created, so the third cast is the one that
+ * transforms it (the token it just made is the third Wizard), and only while the ability resolves.
+ */
+class DocentOfPerfectionScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun boltOpponent(driver: GameTestDriver, player: EntityId) {
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpellWithTargets(
+            player, bolt, listOf(ChosenTarget.Player(driver.getOpponent(player)))
+        )
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty()) driver.bothPass()
+    }
+
+    fun wizardTokens(driver: GameTestDriver, player: EntityId): List<EntityId> =
+        driver.getCreatures(player).filter {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Human Wizard Token"
+        }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    test("each instant or sorcery makes a 1/1 blue Human Wizard token") {
+        val (driver, you) = newGame()
+        val docent = driver.putCreatureOnBattlefield(you, "Docent of Perfection")
+
+        boltOpponent(driver, you)
+
+        val tokens = wizardTokens(driver, you)
+        tokens.size shouldBe 1
+        val projected = projector.project(driver.state)
+        projected.getPower(tokens.single()) shouldBe 1
+        projected.getToughness(tokens.single()) shouldBe 1
+        faceName(driver, docent) shouldBe "Docent of Perfection"
+    }
+
+    test("two Wizards is not enough to flip it") {
+        val (driver, you) = newGame()
+        val docent = driver.putCreatureOnBattlefield(you, "Docent of Perfection")
+
+        repeat(2) { boltOpponent(driver, you) }
+
+        wizardTokens(driver, you).size shouldBe 2
+        faceName(driver, docent) shouldBe "Docent of Perfection"
+    }
+
+    test("the third Wizard transforms it into Final Iteration, which anthems every Wizard") {
+        val (driver, you) = newGame()
+        val docent = driver.putCreatureOnBattlefield(you, "Docent of Perfection")
+
+        repeat(3) { boltOpponent(driver, you) }
+
+        wizardTokens(driver, you).size shouldBe 3
+        faceName(driver, docent) shouldBe "Final Iteration"
+
+        val projected = projector.project(driver.state)
+        projected.getPower(docent) shouldBe 6
+        projected.getToughness(docent) shouldBe 5
+        projected.hasKeyword(docent, Keyword.FLYING) shouldBe true
+
+        // "Wizards you control get +2/+1 and have flying" — both static rows, over every Wizard.
+        wizardTokens(driver, you).forEach { token ->
+            projected.getPower(token) shouldBe 3
+            projected.getToughness(token) shouldBe 2
+            projected.hasKeyword(token, Keyword.FLYING) shouldBe true
+        }
+    }
+
+    test("the anthem reaches Wizards the Docent didn't make, and not the opponent's") {
+        val (driver, you) = newGame()
+        val opponent = driver.getOpponent(you)
+        val docent = driver.putCreatureOnBattlefield(you, "Docent of Perfection")
+
+        // A printed Wizard on each side. Bog Initiate is a 1/1 Human Wizard.
+        val yourWizard = driver.putCreatureOnBattlefield(you, "Bog Initiate")
+        val theirWizard = driver.putCreatureOnBattlefield(opponent, "Bog Initiate")
+
+        // Your Bog Initiate already counts, so the second cast is the one that hits three Wizards.
+        repeat(2) { boltOpponent(driver, you) }
+        faceName(driver, docent) shouldBe "Final Iteration"
+
+        val projected = projector.project(driver.state)
+        projected.getPower(yourWizard) shouldBe 3
+        projected.getToughness(yourWizard) shouldBe 2
+        projected.hasKeyword(yourWizard, Keyword.FLYING) shouldBe true
+        projected.getPower(theirWizard) shouldBe 1
+        projected.getToughness(theirWizard) shouldBe 1
+        projected.hasKeyword(theirWizard, Keyword.FLYING) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrizzledAnglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrizzledAnglerScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.combat.MustAttackThisTurnComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.emn.cards.GrizzledAngler
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Grizzled Angler // Grisly Anglerfish (EMN) — the mill-then-conditionally-transform tap ability,
+ * and the back face's "creatures your opponents control attack this turn if able".
+ *
+ * The graveyard check runs *after* the mill, so a colorless creature card milled by this very
+ * activation is what flips it; a graveyard with no colorless creature leaves it front face up.
+ */
+class GrizzledAnglerScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Activate the named face's sole activated ability and drain the stack. */
+    fun activate(driver: GameTestDriver, player: EntityId, source: EntityId, abilityId: AbilityId) {
+        driver.submitSuccess(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = abilityId)
+        )
+        var guard = 0
+        while (guard++ < 20 && (driver.state.stack.isNotEmpty() || driver.isPaused)) {
+            if (driver.isPaused) driver.autoResolveDecision() else driver.bothPass()
+        }
+    }
+
+    test("milling no colorless creature card leaves it front face up") {
+        val (driver, you) = newGame()
+        val angler = driver.putCreatureOnBattlefield(you, "Grizzled Angler")
+        driver.removeSummoningSickness(angler)
+
+        activate(driver, you, angler, GrizzledAngler.activatedAbilities.first().id)
+
+        driver.getGraveyard(you).size shouldBe 2 // two Islands
+        faceName(driver, angler) shouldBe "Grizzled Angler"
+    }
+
+    test("milling a colorless creature card transforms it into Grisly Anglerfish") {
+        val (driver, you) = newGame()
+        val angler = driver.putCreatureOnBattlefield(you, "Grizzled Angler")
+        driver.removeSummoningSickness(angler)
+
+        // Juggernaut is a colorless artifact creature — put it where the mill will find it.
+        driver.putCardOnTopOfLibrary(you, "Juggernaut")
+
+        activate(driver, you, angler, GrizzledAngler.activatedAbilities.first().id)
+
+        driver.getGraveyardCardNames(you).contains("Juggernaut") shouldBe true
+        faceName(driver, angler) shouldBe "Grisly Anglerfish"
+
+        val projected = projector.project(driver.state)
+        projected.getPower(angler) shouldBe 4
+        projected.getToughness(angler) shouldBe 5
+    }
+
+    test("a colorless creature already in the graveyard doesn't flip it on its own") {
+        val (driver, you) = newGame()
+        val angler = driver.putCreatureOnBattlefield(you, "Grizzled Angler")
+        driver.putCardInGraveyard(you, "Juggernaut")
+
+        // No activation, no flip — the transform only happens while the ability resolves.
+        faceName(driver, angler) shouldBe "Grizzled Angler"
+    }
+
+    test("the back face's {6} ability forces the opponent's creatures to attack, not yours") {
+        val (driver, you) = newGame()
+        val opponent = driver.getOpponent(you)
+        val angler = driver.putCreatureOnBattlefield(you, "Grizzled Angler")
+        driver.removeSummoningSickness(angler)
+        driver.putCardOnTopOfLibrary(you, "Juggernaut")
+        activate(driver, you, angler, GrizzledAngler.activatedAbilities.first().id)
+        faceName(driver, angler) shouldBe "Grisly Anglerfish"
+
+        val theirCourser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val yourCourser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        driver.giveColorlessMana(you, 6)
+        val backAbility = GrizzledAngler.backFace!!.activatedAbilities.first().id
+        activate(driver, you, angler, backAbility)
+
+        driver.state.getEntity(theirCourser)?.get<MustAttackThisTurnComponent>() shouldBe
+            MustAttackThisTurnComponent
+        driver.state.getEntity(yourCourser)?.get<MustAttackThisTurnComponent>() shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeglectedHeirloomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeglectedHeirloomScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.cards.NeglectedHeirloom
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Neglected Heirloom // Ashmouth Blade (SOI) — "When **equipped creature** transforms, transform
+ * this Equipment."
+ *
+ * Exercises the new `Triggers.transforms(binding = TriggerBinding.ATTACHED)` shape end to end: the
+ * Equipment watches the permanent it's attached to, and a transform of that permanent flips the
+ * Equipment. A transform happens in place, so the Equipment is still attached when the event fires.
+ */
+class NeglectedHeirloomScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    fun attachedTo(driver: GameTestDriver, id: EntityId): EntityId? =
+        driver.state.getEntity(id)?.get<AttachedToComponent>()?.targetId
+
+    fun drain(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 20 && (driver.state.stack.isNotEmpty() || driver.isPaused)) {
+            if (driver.isPaused) driver.autoResolveDecision() else driver.bothPass()
+        }
+    }
+
+    /** Put the Heirloom onto the battlefield and equip it to [creature]. */
+    fun equipTo(driver: GameTestDriver, player: EntityId, creature: EntityId): EntityId {
+        val heirloom = driver.putPermanentOnBattlefield(player, "Neglected Heirloom")
+        driver.giveColorlessMana(player, 1)
+        val equipId = NeglectedHeirloom.activatedAbilities.first { it.isEquipAbility }.id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = heirloom,
+                abilityId = equipId,
+                targets = listOf(ChosenTarget.Permanent(creature)),
+            )
+        )
+        drain(driver)
+        return heirloom
+    }
+
+    test("equipped creature gets +1/+1 from the front face") {
+        val (driver, you) = newGame()
+        val creature = driver.putCreatureOnBattlefield(you, "Test DFC Front")
+        val heirloom = equipTo(driver, you, creature)
+
+        attachedTo(driver, heirloom) shouldBe creature
+        val projected = projector.project(driver.state)
+        projected.getPower(creature) shouldBe 3 // 2/2 + 1/+1
+        projected.getToughness(creature) shouldBe 3
+    }
+
+    test("the equipped creature transforming flips the Equipment into Ashmouth Blade") {
+        val (driver, you) = newGame()
+        val creature = driver.putCreatureOnBattlefield(you, "Test DFC Front")
+        val heirloom = equipTo(driver, you, creature)
+
+        // Transform the equipped creature (2/2 Human -> 4/4 Werewolf back face).
+        val spell = driver.putCardInHand(you, "Transform Target Creature")
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpellWithTargets(you, spell, listOf(ChosenTarget.Permanent(creature)))
+        drain(driver)
+
+        faceName(driver, creature) shouldBe "Test DFC Back"
+        faceName(driver, heirloom) shouldBe "Ashmouth Blade"
+
+        // Still attached, now granting +3/+3 and first strike.
+        attachedTo(driver, heirloom) shouldBe creature
+        val projected = projector.project(driver.state)
+        projected.getPower(creature) shouldBe 7 // 4/4 + 3/+3
+        projected.getToughness(creature) shouldBe 7
+        projected.hasKeyword(creature, Keyword.FIRST_STRIKE) shouldBe true
+    }
+
+    test("an unequipped Heirloom is not flipped when some other permanent transforms") {
+        val (driver, you) = newGame()
+        val creature = driver.putCreatureOnBattlefield(you, "Test DFC Front")
+        val heirloom = driver.putPermanentOnBattlefield(you, "Neglected Heirloom")
+
+        val spell = driver.putCardInHand(you, "Transform Target Creature")
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpellWithTargets(you, spell, listOf(ChosenTarget.Permanent(creature)))
+        drain(driver)
+
+        faceName(driver, creature) shouldBe "Test DFC Back"
+        faceName(driver, heirloom) shouldBe "Neglected Heirloom"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThingInTheIceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThingInTheIceScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thing in the Ice // Awoken Horror (SOI) — the ice-counter countdown.
+ *
+ * Covers the new `Counters.ICE` counter, the `Conditions.SourceCounterCountAtMost(ice, 0)` gate that
+ * only flips the permanent on the resolution that removed the last counter, and the back face's
+ * transforms-into trigger bouncing every non-Horror creature.
+ */
+class ThingInTheIceScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    /** Cast Thing in the Ice for real so the enters-with-counters replacement actually applies. */
+    fun castThing(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Thing in the Ice")
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, card)
+        driver.bothPass()
+        return driver.findPermanent(player, "Thing in the Ice")!!
+    }
+
+    /** Cast a Lightning Bolt at the opponent and let the cast trigger + the bolt both resolve. */
+    fun boltOpponent(driver: GameTestDriver, player: EntityId) {
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpellWithTargets(
+            player, bolt, listOf(ChosenTarget.Player(driver.getOpponent(player)))
+        )
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty()) driver.bothPass()
+    }
+
+    fun iceCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.ICE) ?: 0
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    test("enters with four ice counters and has defender") {
+        val (driver, you) = newGame()
+        val thing = castThing(driver, you)
+
+        iceCounters(driver, thing) shouldBe 4
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(thing, Keyword.DEFENDER) shouldBe true
+        projected.getPower(thing) shouldBe 0
+        projected.getToughness(thing) shouldBe 4
+    }
+
+    test("each instant or sorcery you cast removes one ice counter, without flipping early") {
+        val (driver, you) = newGame()
+        val thing = castThing(driver, you)
+
+        repeat(3) { boltOpponent(driver, you) }
+
+        iceCounters(driver, thing) shouldBe 1
+        faceName(driver, thing) shouldBe "Thing in the Ice"
+    }
+
+    test("removing the last ice counter transforms it and bounces all non-Horror creatures") {
+        val (driver, you) = newGame()
+        val opponent = driver.getOpponent(you)
+        val thing = castThing(driver, you)
+
+        // A non-Horror creature on each side — both should end up back in their owners' hands.
+        driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val handBefore = driver.getHandSize(you)
+        val opponentHandBefore = driver.getHandSize(opponent)
+
+        repeat(4) { boltOpponent(driver, you) }
+
+        iceCounters(driver, thing) shouldBe 0
+        faceName(driver, thing) shouldBe "Awoken Horror"
+        projector.project(driver.state).getPower(thing) shouldBe 7
+        projector.project(driver.state).getToughness(thing) shouldBe 8
+
+        // Awoken Horror is a Horror, so it stays; both Coursers went home.
+        driver.findPermanent(you, "Centaur Courser") shouldBe null
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+        driver.getHandSize(you) shouldBe handBefore + 1
+        driver.getHandSize(opponent) shouldBe opponentHandBefore + 1
+        driver.findPermanent(you, "Awoken Horror") shouldBe thing
+    }
+
+    test("removing the last ice counter another way does not transform it (printed ruling)") {
+        val (driver, you) = newGame()
+        val thing = castThing(driver, you)
+
+        // Strip every ice counter directly — no cast trigger resolves, so nothing flips.
+        val container = driver.state.getEntity(thing)!!
+        driver.replaceState(
+            driver.state.withEntity(
+                thing,
+                container.with(CountersComponent(emptyMap()))
+            )
+        )
+
+        iceCounters(driver, thing) shouldBe 0
+        faceName(driver, thing) shouldBe "Thing in the Ice"
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -131,4 +131,5 @@ export const counterManaClass: Record<string, string> = {
   REVIVAL: 'counter-charge',
   INGENUITY: 'counter-charge',
   FILM: 'counter-charge',
+  ICE: 'counter-flood',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -785,6 +785,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.REVIVAL,
   CounterType.INGENUITY,
   CounterType.FILM,
+  CounterType.ICE,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2012,6 +2012,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   WISH: { bg: 'rgba(35, 22, 48, 0.95)', border: 'rgba(170, 130, 210, 0.7)', color: '#c8a8e0', glow: 'rgba(170, 130, 210, 0.55)' },
   REVIVAL: { bg: 'rgba(22, 34, 30, 0.95)', border: 'rgba(120, 205, 165, 0.7)', color: '#9ee0c0', glow: 'rgba(120, 205, 165, 0.55)' },
   FILM: { bg: 'rgba(28, 28, 32, 0.95)', border: 'rgba(180, 185, 195, 0.7)', color: '#d0d4dc', glow: 'rgba(180, 185, 195, 0.5)' },
+  ICE: { bg: 'rgba(18, 42, 58, 0.95)', border: 'rgba(140, 210, 240, 0.7)', color: '#b8e4f5', glow: 'rgba(140, 210, 240, 0.55)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -448,6 +448,7 @@ export enum CounterType {
   FILM = 'FILM',
   SKEWER = 'SKEWER',
   ENERGY = 'ENERGY',
+  ICE = 'ICE',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -517,6 +518,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.FILM]: 'Film',
   [CounterType.SKEWER]: 'Skewer',
   [CounterType.ENERGY]: 'Energy',
+  [CounterType.ICE]: 'Ice',
 }
 
 /**


### PR DESCRIPTION
Implements four cards from Innistrad Remastered's missing list. All four are reprints, so each canonical `CardDefinition` lives in the card's **earliest real printing** (EMN / SOI) with a `Printing` row in INR — `just check-card-printing` is clean for all four.

## Cards

| Card | Canonical | INR |
|---|---|---|
| Grizzled Angler // Grisly Anglerfish | EMN #63 | #67 |
| Thing in the Ice // Awoken Horror | SOI #92 | #91 |
| Docent of Perfection // Final Iteration | EMN #56 | #62 |
| Neglected Heirloom // Ashmouth Blade | SOI #260 | #269 |

- **Grizzled Angler** — `{T}`: mill two, then transform if there's a colorless creature card in your graveyard. The back's `{6}` ability marks every creature your opponents control with `MarkMustAttackThisTurn` through a `ForEachInGroup`, so the engine's existing attack-requirement checks already give the printed rulings (a creature that can't attack doesn't; a cost to attack is never forced; each controller still picks what it attacks).
- **Thing in the Ice** — enters with four ice counters; each instant/sorcery you cast removes one and flips it at zero. The back's transforms-into trigger returns every non-Horror creature (both players') to its owner's hand; Awoken Horror is a Horror, so it stays.
- **Docent of Perfection** — a 1/1 blue Human Wizard token on each instant/sorcery, then flips at three or more Wizards. The token is created *before* the count, so the Wizard it just made is the third. The back is a two-row static anthem (`ModifyStats(2, 1)` + `GrantKeyword(FLYING)`) over every Wizard you control, not just its own tokens.
- **Neglected Heirloom** — Equipment that flips itself when the equipped creature transforms; the back is +3/+3 and first strike for equip `{3}`.

## New SDK / engine vocabulary

All three additions are general primitives, not card-specific escape hatches:

- **`Counters.ICE`** — a countdown counter, the inverse of the `wish`/`film` "uses left" shape (read down to zero rather than spent as a cost). Wired through the client's counter enum, display names, passive-badge list, palette and icon so the tally actually renders on the card.
- **`Conditions.SourceCounterCountAtMost(counterType, count)`** — the downward-facing twin of `SourceCounterCountAtLeast`: the "if it has no [kind] counters on it" clause that follows a remove-a-counter step. Reads the source live, so it sees the counter the same resolution just removed.
- **`Triggers.transforms(binding, intoBackFace?)`** — the factory behind the three existing SELF constants, so a transform trigger can bind to the *attached* permanent ("when equipped creature transforms"). `TransformedEvent` is now routed through `AttachmentTriggerDetector` alongside the other `ATTACHED` triggers; a transform flips the permanent in place, so the Equipment is still attached when the event fires.

Gating each flip on the live state *inside the ability's resolution* is what makes the printed rulings hold — an already-satisfied condition never transforms these cards on its own, and each test covers that case explicitly (removing the last ice counter another way, a colorless creature already sitting in the graveyard, an unequipped Heirloom watching some other permanent flip).

`docs/card-sdk-language-reference.md` is updated for all three additions in the same change.

## Considered and dropped

Vexing Devil and Killing Wave were on the shortlist and pulled out rather than approximated: the first needs an APNAP "any opponent may *choose*" loop (today's `AnyPlayerMayPayEffect` only takes pay-costs, and life payment isn't damage), the second a dynamic-amount life payment (`CostAtom.PayLife` is a fixed `Int`). Both are `add-feature` work, not add-card.

## Verification

- `just build` — green (9101 rules-engine tests)
- Four new scenario tests, one per card, all passing
- `just check-card-printing` clean for all four
- `just client-typecheck` clean
- Card snapshots re-blessed: EMN + SOI only, additions only, no removals
- All 12 image URIs verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)