### PR TITLE
Show the top library card face up on the Deck pile when you know it

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -194,6 +194,17 @@ decide what to hide. See `data-contracts.md` §B3 for the payload and its two ma
 particular that `remaining` means "copies you haven't seen", which is not always the same as
 "copies in your library".
 
+### Face-up top card
+
+The Deck pile itself renders its top card face up — with an amber ring, an 👁 badge and the normal
+hover preview — whenever the server sent details for entry **0** of that library's `cardIds`. The
+library zone is always transmitted in full (opaque ids for unknown cards), so position is all the
+client needs; the decision about *which* cards carry details is entirely the server's, and it makes
+it for a public reveal (Future Sight, Goblin Spy), a private peek ("you may look at the top card of
+your library any time"), and a scry/surveil the viewer just performed alike. `ZonePiles.tsx` never
+asks why. `TopOfLibraryClientViewTest` pins both halves of the contract: position 0 is the top, and
+the private peek stays out of an opponent's view.
+
 ## Battlefield card grouping (token quantity aggregation)
 
 Identical permanents on one player's board collapse into a single visual **stack**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TopOfLibraryClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TopOfLibraryClientViewTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * The client-view contract behind rendering the top library card face up on the Deck pile.
+ *
+ * The web client has no rules knowledge: it shows the top card face up exactly when the server
+ * sent details for the *first* entry of that library's `cardIds`. Two properties have to hold for
+ * that to be both correct and leak-free, and this test pins them:
+ *
+ *  - **Position 0 is the top of the library.** The library zone is always sent in full (opaque ids
+ *    for unknown cards), so the client identifies the top card purely by index.
+ *  - **[LookAtTopOfLibrary] is a private peek.** Unlike
+ *    [com.wingedsheep.sdk.scripting.RevealTopOfLibrary] (Goblin Spy, covered by [GoblinSpyTest]),
+ *    only the controller gets the card's details — an opponent's view must still be opaque.
+ */
+class TopOfLibraryClientViewTest : FunSpec({
+
+    val LensOfClarity = card("Lens of Clarity") {
+        manaCost = "{0}"
+        typeLine = "Artifact"
+
+        staticAbility {
+            ability = LookAtTopOfLibrary
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(LensOfClarity)
+        return driver
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("controller sees the top card of their own library, at position 0 of the library zone") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Lens of Clarity")
+        val topCard = driver.putCardOnTopOfLibrary(player, "Lightning Bolt")
+
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = player)
+
+        view.cards.keys shouldContain topCard
+        view.cards[topCard]!!.name shouldBe "Lightning Bolt"
+
+        val libraryZone = view.zones.first {
+            it.zoneId.ownerId == player && it.zoneId.zoneType == Zone.LIBRARY
+        }
+        libraryZone.cardIds.first() shouldBe topCard
+    }
+
+    test("the peek is private — an opponent's view of that library stays opaque") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Lens of Clarity")
+        val topCard = driver.putCardOnTopOfLibrary(player, "Lightning Bolt")
+
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = opponent)
+
+        view.cards.keys shouldNotContain topCard
+    }
+
+    test("without the ability the controller's own top card is hidden") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val topCard = driver.putCardOnTopOfLibrary(player, "Lightning Bolt")
+
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = player)
+
+        view.cards.keys shouldNotContain topCard
+    }
+
+    test("losing the source hides the top card again") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lens = driver.putPermanentOnBattlefield(player, "Lens of Clarity")
+        val topCard = driver.putCardOnTopOfLibrary(player, "Lightning Bolt")
+
+        transformer(driver).transform(driver.state, viewingPlayerId = player)
+            .cards.keys shouldContain topCard
+
+        driver.moveToGraveyard(lens)
+
+        transformer(driver).transform(driver.state, viewingPlayerId = player)
+            .cards.keys shouldNotContain topCard
+    }
+})

--- a/web-client/src/components/game/board/ZonePiles.tsx
+++ b/web-client/src/components/game/board/ZonePiles.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
-import { useZoneCards, useStackCards, useZone, selectGameState } from '@/store/selectors.ts'
+import { useZoneCards, useStackCards, useZone, useCard, selectGameState } from '@/store/selectors.ts'
 import { graveyard, exile, library } from '@/types'
 import type { ClientCard, ClientDeckCard, ClientPlayer } from '@/types'
 import { CARD_BACK_IMAGE_URL } from '@/utils/cardImages.ts'
@@ -23,6 +23,16 @@ const BASE_PILE_COUNT = 3
 // Concede button so the top pile doesn't render under it.
 const OPPONENT_TOP_RESERVED = 52
 const MIN_PILE_WIDTH = 28
+
+/**
+ * Native tooltip for the Deck pile. When the top card is face up, lead with its name — that's
+ * the reason the pile looks different, and it doubles as the accessible label for the image.
+ */
+function deckPileTitle(canBrowseDeck: boolean, isOwnDeck: boolean, topCard: ClientCard | null): string | undefined {
+  if (!canBrowseDeck) return topCard ? `Top card: ${topCard.name}` : undefined
+  const browse = isOwnDeck ? 'Your deck list and library (D)' : 'Library'
+  return topCard ? `Top card: ${topCard.name} · ${browse}` : browse
+}
 
 /**
  * Deck, graveyard, exile — and, when present, a dedicated Plotted pile — display.
@@ -49,6 +59,13 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
   const topSuspendedCard = suspendedCards[suspendedCards.length - 1]
   const libraryZone = useZone(library(player.playerId))
   const libraryEntityIds = libraryZone?.cardIds ?? []
+  // A library card only carries details when the server decided its identity is legitimately
+  // known to this viewer: a public "play with the top card revealed" (Future Sight, Goblin Spy),
+  // a private "you may look at the top card of your library any time" (Glarb, Lens of Clarity),
+  // or a scry/surveil the viewer just performed. Whenever that holds for the *top* card, show it
+  // face up on the pile rather than making the player open the browser to read it. Index 0 is the
+  // top of the library — the same ordering the Library-order tab renders.
+  const topLibraryCard = useCard(libraryEntityIds[0] ?? null)
   // The server sends `deck` only for the viewing player, so this is empty on every other seat's
   // pile — which is exactly what suppresses the deck-list tab there.
   const ownDeck = useGameStore((state) => {
@@ -152,6 +169,7 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
   // The deck list is worth opening even on an empty library (you can still read what you played).
   const isOwnDeck = ownDeck.length > 0
   const canBrowseDeck = player.librarySize > 0 || isOwnDeck
+  const showsTopLibraryCard = player.librarySize > 0 && topLibraryCard !== null
 
   // `D` opens your own deck — the shortcut lives here rather than in a global handler because
   // exactly one ZonePile on the table is the viewer's, and `ownDeck` is how we know which.
@@ -175,19 +193,38 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
       <div style={styles.zoneStack}>
         <div
           data-zone={isOpponent ? 'opponent-library' : 'player-library'}
-          title={canBrowseDeck ? (isOwnDeck ? 'Your deck list and library (D)' : 'Library') : undefined}
-          style={{ ...styles.deckPile, ...pileStyle, cursor: canBrowseDeck ? 'pointer' : 'default' }}
+          title={deckPileTitle(canBrowseDeck, isOwnDeck, showsTopLibraryCard ? topLibraryCard : null)}
+          style={{
+            ...styles.deckPile,
+            ...pileStyle,
+            cursor: canBrowseDeck ? 'pointer' : 'default',
+            ...(showsTopLibraryCard ? styles.deckPileTopRevealed : null),
+          }}
           onClick={() => { if (canBrowseDeck) setBrowsingLibrary(true) }}
+          onMouseEnter={(e) => { if (showsTopLibraryCard) hoverCard(topLibraryCard.id, { x: e.clientX, y: e.clientY }) }}
+          onMouseLeave={() => hoverCard(null)}
         >
           {player.librarySize > 0 ? (
-            <img
-              src={CARD_BACK_IMAGE_URL}
-              alt="Library"
-              style={styles.pileImage}
-            />
+            showsTopLibraryCard ? (
+              <img
+                src={getCardImageUrl(topLibraryCard.name, topLibraryCard.imageUri, 'normal')}
+                alt={topLibraryCard.name}
+                style={styles.pileImage}
+                onError={(e) => handleImageError(e, topLibraryCard.name, 'normal')}
+              />
+            ) : (
+              <img
+                src={CARD_BACK_IMAGE_URL}
+                alt="Library"
+                style={styles.pileImage}
+              />
+            )
           ) : (
             <div style={styles.emptyPile} />
           )}
+          {/* Badge the face-up top card so it doesn't read as "the whole deck is public" — the
+              rest of the library is still a card back's worth of unknown. */}
+          {showsTopLibraryCard && <div style={styles.deckTopRevealedBadge}>👁</div>}
           <div style={{ ...styles.pileCount, fontSize: responsive.fontSize.small }}>{player.librarySize}</div>
         </div>
         <span style={{ ...styles.zoneLabel, fontSize: responsive.isMobile ? 8 : 10 }}>Deck</span>

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -160,6 +160,24 @@ export const styles: Record<string, React.CSSProperties> = {
     overflow: 'hidden',
     boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
   },
+  // Applied on top of `deckPile` when the top library card is face up (Future Sight, Goblin Spy,
+  // "you may look at the top card of your library any time", or a fresh scry/surveil). The amber
+  // ring is the same accent the Library-order browser puts on position 0, so "top card" reads the
+  // same in both places.
+  deckPileTopRevealed: {
+    boxShadow: '0 0 0 2px #fde68a, 0 0 14px rgba(253, 230, 138, 0.45)',
+  },
+  deckTopRevealedBadge: {
+    position: 'absolute',
+    top: 2,
+    left: 2,
+    backgroundColor: 'rgba(40, 32, 8, 0.9)',
+    border: '1px solid rgba(253, 230, 138, 0.7)',
+    borderRadius: 4,
+    padding: '0 3px',
+    fontSize: 9,
+    lineHeight: '13px',
+  },
   graveyardPile: {
     position: 'relative',
     overflow: 'hidden',


### PR DESCRIPTION
## Why

Cards granting *"You may look at the top card of your library any time"* — Glarb, Calamity's Augur; Glowcap Lantern; Madame Web, Clairvoyant; The Lunar Whale; The Belligerent — already had a working engine half. `ClientStateTransformer` sends details for that card to its controller, and the Deck browser's **Library order** tab renders it face up.

The pile itself still drew a card back, so actually using the ability meant opening an overlay every time you wanted to remember what was on top.

## What

`ZonePiles.tsx` now renders entry **0** of the library zone face up whenever the server sent details for it — amber ring, 👁 badge, and the standard hover preview.

The library zone is always transmitted in full (opaque ids for unknown cards), so position is all the client needs, and the rule is simply *"whatever the server revealed"*. That keeps the client rules-free and picks up three cases at once:

- private peek — `LookAtTopOfLibrary` (the ask)
- public reveal — `PlayFromTopOfLibrary` / `RevealTopOfLibrary` (Future Sight, Goblin Spy), including on an opponent's pile, which is correct for those cards
- a scry/surveil the viewer just performed — the same knowledge the Library-order tab already shows, and cleared on shuffle by `LibraryRevealUtils`

No engine or protocol change: the masking decision stays entirely server-side.

## Screenshots

Deck pile, same scenario (Glarb on the battlefield, Lightning Bolt on top), before → after:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/top-card-deck-pile-screenshots/crop-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/top-card-deck-pile-screenshots/crop-after.png) |

Hover preview on the pile:

![hover](https://raw.githubusercontent.com/wingedsheep/argentum-engine/top-card-deck-pile-screenshots/after-hover.png)

*(`top-card-deck-pile-screenshots` is a throwaway image-only branch — delete it after merge.)*

## Tests

New `TopOfLibraryClientViewTest` pins the two properties the UI leans on, neither of which was covered before:

- position 0 of a library's `cardIds` is the top card
- `LookAtTopOfLibrary` is **private** — absent from an opponent's view, absent without the ability, and gone again when the source leaves the battlefield

Verification run: `just test-class TopOfLibraryClientViewTest` (4/4 pass), `npm run typecheck`, `npm run build`, `npx vitest run` (387 pass). E2E suite not run, per standing preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)