### PR TITLE
Add Westvale Abbey, Archangel Avacyn and Altered Ego (INR)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8026,7 +8026,7 @@ The priority groups are (CR 616.1a–f):
   trigger itself. Used by Worldwalker Helm (`TokenCreationEvent(You, Artifact)`, add `Map`, `inheritTapped = true`)
   and Peregrin Took (`additionalTokenType = "Food"`, "those tokens plus an additional Food token are created instead")
   and Quina, Qu Gourmet (`additionalTokenType = "Frog"`, default `appliesTo` = any token you create, adds a 1/1 green Frog).
-- `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard, tappedIfCopied)` —
+- `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard, tappedIfCopied, additionalCounters)` —
   "enter as a copy of …". As the permanent enters, the controller picks an object matching
   `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides
   applied. `copyFromZone` selects the candidate pool: `Zone.BATTLEFIELD` (default — Clone, Clever
@@ -8039,7 +8039,16 @@ The priority groups are (CR 616.1a–f):
   value ≤ total mana spent (Mockingbird). `tappedIfCopied` makes the permanent enter **tapped** only
   when it actually enters as a copy — the "enter tapped as a copy" rider on the land-copy cycle
   (Echoing Deeps; Vesuva / Thespian's Stage copying a land on the battlefield); declining the copy
-  enters it untapped as its printed self. The copy snapshots a `CopyOfComponent` so it reverts to its
+  enters it untapped as its printed self. `additionalCounters: DynamicAmount?` is the sibling rider
+  "except it enters with N additional +1/+1 counters on it" — `DynamicAmount.XValue` for Altered
+  Ego, `Fixed(1)` for a Spark Double shape. It lives on the copy effect rather than on a separate
+  `EntersWithCounters`, because copying replaces the permanent's own copiable text: a self-targeted
+  enters-with-counters replacement would be gone by the time the copy applies. It follows the same
+  "only if a copy was actually made" rule as `tappedIfCopied`, which is the printed ruling
+  ("You can choose not to copy anything. … It won't have +1/+1 counters placed on it by its
+  ability."), and routes through `EntersWithReplacements.placeEntryCounters` so Hardened Scales-style
+  placement modifiers apply exactly as for printed enters-with counters. The copy snapshots a
+  `CopyOfComponent` so it reverts to its
   printed identity when it leaves the battlefield (CR 400.7 / 707.2). Works both when the source is
   cast as a spell (resolved off the stack) **and** when it enters the battlefield directly — a land
   played (Echoing Deeps) pauses via `PermanentEntryReplacements.pauseForEntersAsCopy`, its resumer

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1335,6 +1335,16 @@ data class LifeLossFloor(
  *                   copy — the "enter tapped as a copy" rider on the land-copy cycle (Vesuva,
  *                   Thespian's Stage, Echoing Deeps). If the copy is declined (or no candidate
  *                   exists) the permanent enters untapped as its printed self.
+ * @param additionalCounters When non-null, the permanent enters with this many **additional +1/+1
+ *                   counters** if (and only if) it enters as a copy — the "except it enters with N
+ *                   additional +1/+1 counters on it" rider (Altered Ego with
+ *                   [com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue], Spark Double with
+ *                   `Fixed(1)`). It belongs to the *copy* effect, not to a separate
+ *                   [EntersWithCounters]: copying replaces the permanent's own copiable text, so a
+ *                   self-targeted enters-with-counters replacement would be gone by the time the
+ *                   copy applies. Declining the copy therefore also declines the counters, which is
+ *                   the printed ruling ("You can choose not to copy anything. … It won't have +1/+1
+ *                   counters placed on it by its ability.").
  */
 @SerialName("EntersAsCopy")
 @Serializable
@@ -1350,6 +1360,7 @@ data class EntersAsCopy(
     val toughnessOverride: Int? = null,
     val exileCopiedCard: Boolean = false,
     val tappedIfCopied: Boolean = false,
+    val additionalCounters: DynamicAmount? = null,
     override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
         filter = GameObjectFilter.Any,
         to = Zone.BATTLEFIELD
@@ -1380,6 +1391,9 @@ data class EntersAsCopy(
                 }
                 if (additionalKeywords.isNotEmpty()) {
                     add("it has ${additionalKeywords.joinToString(", ") { it.name.lowercase() }}")
+                }
+                if (additionalCounters != null) {
+                    add("it enters with ${additionalCounters.description} additional +1/+1 counters on it")
                 }
             }
             if (exceptions.isNotEmpty()) append(", except ${exceptions.joinToString(" and ")}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AlteredEgoReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AlteredEgoReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val AlteredEgoReprint = Printing(
+    oracleId = "7c35f3fd-c64e-4944-a4d5-37ce916d23c3",
+    name = "Altered Ego",
+    setCode = "INR",
+    collectorNumber = "228",
+    scryfallId = "3b913b54-1a5c-4708-95c6-883c0f285d68",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b913b54-1a5c-4708-95c6-883c0f285d68.jpg?1783908083",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArchangelAvacynReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArchangelAvacynReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val ArchangelAvacynReprint = Printing(
+    oracleId = "432b37a5-d32a-4b78-91ab-860aa026b7cc",
+    name = "Archangel Avacyn",
+    setCode = "INR",
+    collectorNumber = "11",
+    scryfallId = "fe675f03-cbb5-4177-b7d7-64a30260ee2a",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe675f03-cbb5-4177-b7d7-64a30260ee2a.jpg?1783908191",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/f/e/fe675f03-cbb5-4177-b7d7-64a30260ee2a.jpg?1783908191",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WestvaleAbbeyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WestvaleAbbeyReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val WestvaleAbbeyReprint = Printing(
+    oracleId = "04eeb9ad-5c59-411b-8809-db8349838588",
+    name = "Westvale Abbey",
+    setCode = "INR",
+    collectorNumber = "287",
+    scryfallId = "5fbc6091-a161-45b0-9932-543b569caaee",
+    artist = "Min Yum",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fbc6091-a161-45b0-9932-543b569caaee.jpg?1783908059",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/5/f/5fbc6091-a161-45b0-9932-543b569caaee.jpg?1783908059",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AlteredEgo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AlteredEgo.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Altered Ego (Shadows over Innistrad #241 — the card's earliest printing; also reprinted in
+ * Shadows over Innistrad Remastered and Innistrad Remastered)
+ * {X}{2}{G}{U}
+ * Creature — Shapeshifter 0/0
+ *
+ * This spell can't be countered.
+ * You may have this creature enter as a copy of any creature on the battlefield, except it enters
+ * with X additional +1/+1 counters on it.
+ *
+ * Implementation:
+ *  - "This spell can't be countered" is the `cantBeCountered` card flag (stamped on the spell at
+ *    cast time), not a granted static — it protects only this spell.
+ *  - The copy is a plain [EntersAsCopy] over creatures on the battlefield, with the "except it
+ *    enters with X additional +1/+1 counters" rider carried by `additionalCounters` =
+ *    [DynamicAmount.XValue]. The rider belongs to the copy effect rather than a separate
+ *    enters-with-counters replacement, which is what makes the printed rulings fall out for free:
+ *    declining the copy also declines the counters ("It won't have +1/+1 counters placed on it by
+ *    its ability"), and X = 0 is simply a straight copy.
+ */
+val AlteredEgo = card("Altered Ego") {
+    manaCost = "{X}{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Shapeshifter"
+    power = 0
+    toughness = 0
+    oracleText = "This spell can't be countered.\n" +
+        "You may have this creature enter as a copy of any creature on the battlefield, except it " +
+        "enters with X additional +1/+1 counters on it."
+
+    cantBeCountered = true
+
+    replacementEffect(
+        EntersAsCopy(
+            optional = true,
+            copyFilter = GameObjectFilter.Creature,
+            additionalCounters = DynamicAmount.XValue,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "241"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg?1783937715"
+        ruling(
+            "2025-01-24",
+            "Altered Ego copies exactly what was printed on the original creature (unless that " +
+                "creature is copying something else or is a token; see below). It doesn't copy " +
+                "whether that creature is tapped or untapped, whether it has any counters on it or " +
+                "any Auras and Equipment attached to it, or any non-copy effects that have changed " +
+                "its power, toughness, types, color, or so on."
+        )
+        ruling(
+            "2025-01-24",
+            "Any \"enters\" abilities of the copied creature will trigger when Altered Ego enters " +
+                "the battlefield. Any \"as [this creature] enters\" or \"[this creature] enters " +
+                "with\" abilities of the chosen creature will also work."
+        )
+        ruling(
+            "2025-01-24",
+            "If the chosen creature is a token, Altered Ego copies the original characteristics of " +
+                "that token as stated by the effect that created that token. Altered Ego isn't a token."
+        )
+        ruling(
+            "2025-01-24",
+            "If Altered Ego somehow enters at the same time as another creature, Altered Ego can't " +
+                "become a copy of that creature. You may choose only a creature that's already on " +
+                "the battlefield."
+        )
+        ruling(
+            "2025-01-24",
+            "If the chosen creature has {X} in its mana cost, that X is considered to be 0. The " +
+                "value of X in Altered Ego's last ability will be whatever value was chosen for X " +
+                "while casting Altered Ego."
+        )
+        ruling(
+            "2025-01-24",
+            "You can choose not to copy anything. In that case, Altered Ego enters as a 0/0 " +
+                "creature and is probably put into the graveyard immediately. It won't have +1/+1 " +
+                "counters placed on it by its ability."
+        )
+        ruling(
+            "2025-01-24",
+            "X can be 0. Altered Ego won't enter with any additional +1/+1 counters, and it will " +
+                "just be a copy of the chosen creature."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ArchangelAvacyn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ArchangelAvacyn.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.core.Zone
+
+/**
+ * Archangel Avacyn // Avacyn, the Purifier (Shadows over Innistrad #5 — the card's earliest
+ * printing; also reprinted in Shadows over Innistrad Remastered and Innistrad Remastered)
+ * {3}{W}{W}
+ * Legendary Creature — Angel 4/4 // Legendary Creature — Angel 6/5
+ *
+ * Front — Archangel Avacyn ({3}{W}{W}, Legendary Creature — Angel, 4/4)
+ *   Flash
+ *   Flying, vigilance
+ *   When Archangel Avacyn enters, creatures you control gain indestructible until end of turn.
+ *   When a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of
+ *   the next upkeep.
+ *
+ * Back — Avacyn, the Purifier (Legendary Creature — Angel, 6/5, red)
+ *   Flying
+ *   When this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other
+ *   creature and each opponent.
+ *
+ * Implementation:
+ *  - The ETB grant is [Patterns.Group.grantKeywordToAll]`(INDESTRUCTIBLE, creaturesYouControl)`.
+ *    It is a one-shot until-end-of-turn grant over the creatures present as it resolves, which is
+ *    what the printed wording says — creatures entering later are not covered.
+ *  - "When a non-Angel creature you control dies" is a [Triggers.leavesBattlefield] factory trigger
+ *    with an ANY binding over `Creature.youControl().notSubtype(ANGEL)`. Avacyn herself is an Angel,
+ *    so she never triggers her own flip.
+ *  - "…transform Archangel Avacyn at the beginning of the next upkeep" is a step-based
+ *    [CreateDelayedTriggerEffect] on [Step.UPKEEP] with no `fireOnPlayer`, so it fires at the next
+ *    upkeep whatever turn that is (printed ruling).
+ *  - The delayed effect is gated on the permanent still being named `Archangel Avacyn`
+ *    ([Conditions.SourceMatches]). This is the second printed ruling: if several non-Angel creatures
+ *    died in one turn, each death queues its own delayed trigger, and the ones that resolve after
+ *    the first must **not** flip her back to the front face. Checking the face by name is exactly
+ *    "is she still Archangel Avacyn?".
+ *  - The back's trigger is [Triggers.TransformsToBack] — it fires only on the front→back flip, never
+ *    when some other effect turns her face up again. Its damage is
+ *    [Effects.ForEachInGroup]`(`[GroupFilter.AllOtherCreatures]`, …)` — `excludeSelf` keeps Avacyn
+ *    out of her own sweep — followed by 3 damage to [Player.EachOpponent]. Damage is sourced from
+ *    the ability's source, so it is Avacyn dealing it (lifelink/deathtouch grants, damage
+ *    redirection and "damage from a source you control" triggers all see her).
+ */
+
+private val NonAngelCreatureYouControl: GameObjectFilter =
+    GameObjectFilter.Creature.youControl().notSubtype(Subtype.ANGEL)
+
+private val ArchangelAvacynFront = card("Archangel Avacyn") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "RW" // Card-level identity: the red back face contributes (CR 903.4).
+    typeLine = "Legendary Creature — Angel"
+    power = 4
+    toughness = 4
+    oracleText = "Flash\n" +
+        "Flying, vigilance\n" +
+        "When Archangel Avacyn enters, creatures you control gain indestructible until end of turn.\n" +
+        "When a non-Angel creature you control dies, transform Archangel Avacyn at the beginning " +
+        "of the next upkeep."
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.INDESTRUCTIBLE,
+            Filters.Group.creaturesYouControl,
+        )
+        description = "Creatures you control gain indestructible until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = NonAngelCreatureYouControl,
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = CreateDelayedTriggerEffect(
+            step = Step.UPKEEP,
+            effect = ConditionalEffect(
+                condition = Conditions.SourceMatches(
+                    GameObjectFilter.Any.named("Archangel Avacyn"),
+                ),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+        description = "Transform Archangel Avacyn at the beginning of the next upkeep."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "5"
+        artist = "James Ryman"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1783937831"
+        ruling(
+            "2016-04-08",
+            "Archangel Avacyn's delayed triggered ability triggers at the beginning of the next " +
+                "upkeep regardless of whose turn it is."
+        )
+        ruling(
+            "2016-04-08",
+            "Archangel Avacyn's delayed triggered ability won't cause it to transform back into " +
+                "Archangel Avacyn if it has already transformed into Avacyn, the Purifier, perhaps " +
+                "because several creatures died in one turn."
+        )
+    }
+}
+
+private val AvacynThePurifier = card("Avacyn, the Purifier") {
+    manaCost = ""
+    colorIdentity = "RW"
+    colorIndicator = "R" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Legendary Creature — Angel"
+    power = 6
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature transforms into Avacyn, the Purifier, it deals 3 damage to each " +
+        "other creature and each opponent."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllOtherCreatures,
+            DealDamageEffect(3, EffectTarget.Self),
+        ) then Effects.DealDamage(3, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Avacyn, the Purifier deals 3 damage to each other creature and each opponent."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "5"
+        artist = "James Ryman"
+        flavorText = "\"Wings that once bore hope are now stained with blood. She is our guardian " +
+            "no longer.\"\n—Grete, cathar apostate"
+        imageUri = "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1783937831"
+    }
+}
+
+val ArchangelAvacyn: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ArchangelAvacynFront,
+    backFace = AvacynThePurifier,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WestvaleAbbey.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WestvaleAbbey.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Westvale Abbey // Ormendahl, Profane Prince (Shadows over Innistrad #281 — the card's earliest
+ * printing; also reprinted in Shadows over Innistrad Remastered and Innistrad Remastered)
+ * Land // Legendary Creature — Demon 9/7
+ *
+ * Front — Westvale Abbey (Land)
+ *   {T}: Add {C}.
+ *   {5}, {T}, Pay 1 life: Create a 1/1 white and black Human Cleric creature token.
+ *   {5}, {T}, Sacrifice five creatures: Transform this land, then untap it.
+ *
+ * Back — Ormendahl, Profane Prince (Legendary Creature — Demon, 9/7, black)
+ *   Flying, lifelink, indestructible, haste
+ *
+ * Implementation:
+ *  - A land TDFC via [CardDefinition.doubleFacedPermanent] — the same shape the Ixalan flip-lands
+ *    use, just with the land on the front. The back face is a creature, so the printed keywords are
+ *    plain [Keyword] grants; there is nothing to script on it.
+ *  - The Cleric ability's "Pay 1 life" is a real cost atom ([Costs.PayLife]), not a resolution
+ *    effect, so it composes into the activation cost alongside `{5}` and `{T}` and is checked (and
+ *    paid) before the ability goes on the stack.
+ *  - The flip ability's "Sacrifice five creatures" is [Costs.SacrificeMultiple]`(5, Creature)`.
+ *    Westvale Abbey itself is a land, never one of the five — the filter can't match it. The
+ *    sacrifices happen on activation, so the Clerics this land makes can pay for its own flip.
+ *  - "Transform this land, then untap it" is one composite effect: [TransformEffect] on
+ *    [EffectTarget.Self] followed by [Effects.Untap] on the same permanent. The untap matters
+ *    because `{T}` is part of the cost — Ormendahl arrives untapped and, having haste, can attack
+ *    the turn it flips.
+ */
+
+private val WestvaleAbbeyFront = card("Westvale Abbey") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{5}, {T}, Pay 1 life: Create a 1/1 white and black Human Cleric creature token.\n" +
+        "{5}, {T}, Sacrifice five creatures: Transform this land, then untap it."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.PayLife(1))
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE, Color.BLACK),
+            creatureTypes = setOf("Human", "Cleric"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg?1783937680",
+        )
+        description = "Create a 1/1 white and black Human Cleric creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{5}"),
+            Costs.Tap,
+            Costs.SacrificeMultiple(5, GameObjectFilter.Creature),
+        )
+        effect = Effects.Composite(
+            TransformEffect(EffectTarget.Self),
+            Effects.Untap(EffectTarget.Self),
+        )
+        description = "Transform this land, then untap it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "281"
+        artist = "Min Yum"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1783937703"
+        ruling(
+            "2016-07-13",
+            "For more information on double-faced cards, see the Shadows over Innistrad mechanics " +
+                "article (http://magic.wizards.com/en/articles/archive/feature/shadows-over-innistrad-mechanics)."
+        )
+    }
+}
+
+private val OrmendahlProfanePrince = card("Ormendahl, Profane Prince") {
+    manaCost = ""
+    colorIdentity = "B"
+    colorIndicator = "B" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Legendary Creature — Demon"
+    power = 9
+    toughness = 7
+    oracleText = "Flying, lifelink, indestructible, haste"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK, Keyword.INDESTRUCTIBLE, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "281"
+        artist = "Min Yum"
+        flavorText = "With Griselbrand gone, the Skirsdag eagerly awaited another demon to claim " +
+            "their devotion. Ormendahl did not make them wait long."
+        imageUri = "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1783937703"
+    }
+}
+
+val WestvaleAbbey: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = WestvaleAbbeyFront,
+    backFace = OrmendahlProfanePrince,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -179,6 +179,67 @@
     ]
 }
 
+// Altered Ego
+{
+    "name": "Altered Ego",
+    "manaCost": "{X}{2}{G}{U}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "This spell can't be countered.\nYou may have this creature enter as a copy of any creature on the battlefield, except it enters with X additional +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "additionalCounters": "XValue"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c05da08d-8fac-47bc-80d8-78a80d1463d2.jpg?1783937715",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "Altered Ego copies exactly what was printed on the original creature (unless that creature is copying something else or is a token; see below). It doesn't copy whether that creature is tapped or untapped, whether it has any counters on it or any Auras and Equipment attached to it, or any non-copy effects that have changed its power, toughness, types, color, or so on."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Any \"enters\" abilities of the copied creature will trigger when Altered Ego enters the battlefield. Any \"as [this creature] enters\" or \"[this creature] enters with\" abilities of the chosen creature will also work."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If the chosen creature is a token, Altered Ego copies the original characteristics of that token as stated by the effect that created that token. Altered Ego isn't a token."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If Altered Ego somehow enters at the same time as another creature, Altered Ego can't become a copy of that creature. You may choose only a creature that's already on the battlefield."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If the chosen creature has {X} in its mana cost, that X is considered to be 0. The value of X in Altered Ego's last ability will be whatever value was chosen for X while casting Altered Ego."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "You can choose not to copy anything. In that case, Altered Ego enters as a 0/0 creature and is probably put into the graveyard immediately. It won't have +1/+1 counters placed on it by its ability."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "X can be 0. Altered Ego won't enter with any additional +1/+1 counters, and it will just be a copy of the chosen creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Angelic Purge
 {
     "name": "Angelic Purge",
@@ -267,6 +328,179 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/7/37e2358c-211e-4d79-8120-88bb9e656cba.jpg"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Archangel Avacyn
+{
+    "name": "Archangel Avacyn",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flash\nFlying, vigilance\nWhen Archangel Avacyn enters, creatures you control gain indestructible until end of turn.\nWhen a non-Angel creature you control dies, transform Archangel Avacyn at the beginning of the next upkeep.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Creatures you control gain indestructible until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Angel"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "step": "UPKEEP",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "EntityMatches",
+                                "entity": "Self",
+                                "filter": "name:Archangel Avacyn"
+                            }
+                        },
+                        "then": "Transform"
+                    }
+                },
+                "descriptionOverride": "Transform Archangel Avacyn at the beginning of the next upkeep."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Avacyn, the Purifier",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Angel",
+        "oracleText": "Flying\nWhen this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 5
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "body": {
+                                    "type": "DealDamage",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Avacyn, the Purifier deals 3 damage to each other creature and each opponent."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "5",
+            "rarity": "MYTHIC",
+            "artist": "James Ryman",
+            "flavorText": "\"Wings that once bore hope are now stained with blood. She is our guardian no longer.\"\n—Grete, cathar apostate",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1783937831"
+        },
+        "colorIdentityOverride": [
+            "RED",
+            "WHITE"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "MYTHIC",
+        "artist": "James Ryman",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae155ee2-008f-4dc6-82bf-476be7baa224.jpg?1783937831",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "Archangel Avacyn's delayed triggered ability triggers at the beginning of the next upkeep regardless of whose turn it is."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "Archangel Avacyn's delayed triggered ability won't cause it to transform back into Archangel Avacyn if it has already transformed into Avacyn, the Purifier, perhaps because several creatures died in one turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
         "WHITE"
     ]
 }
@@ -2878,6 +3112,150 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Westvale Abbey
+{
+    "name": "Westvale Abbey",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{5}, {T}, Pay 1 life: Create a 1/1 white and black Human Cleric creature token.\n{5}, {T}, Sacrifice five creatures: Transform this land, then untap it.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Human",
+                        "Cleric"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/4/94ed2eca-1579-411d-af6f-c7359c65de30.jpg?1783937680"
+                },
+                "descriptionOverride": "Create a 1/1 white and black Human Cleric creature token."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "count": 5
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "Transform",
+                        {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        }
+                    ]
+                },
+                "descriptionOverride": "Transform this land, then untap it."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Ormendahl, Profane Prince",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Demon",
+        "oracleText": "Flying, lifelink, indestructible, haste",
+        "creatureStats": {
+            "power": 9,
+            "toughness": 7
+        },
+        "keywords": [
+            "FLYING",
+            "LIFELINK",
+            "INDESTRUCTIBLE",
+            "HASTE"
+        ],
+        "metadata": {
+            "collectorNumber": "281",
+            "rarity": "RARE",
+            "artist": "Min Yum",
+            "flavorText": "With Griselbrand gone, the Skirsdag eagerly awaited another demon to claim their devotion. Ormendahl did not make them wait long.",
+            "imageUri": "https://cards.scryfall.io/normal/back/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1783937703"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ],
+        "colorIndicator": [
+            "BLACK"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "281",
+        "rarity": "RARE",
+        "artist": "Min Yum",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1f53d7a-9dad-46e8-b686-cd1362867445.jpg?1783937703",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "For more information on double-faced cards, see the Shadows over Innistrad mechanics article (http://magic.wizards.com/en/articles/archive/feature/shadows-over-innistrad-mechanics)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.Serializable
 
 /**
@@ -198,6 +199,9 @@ data class ModalTargetContinuation(
  * @property toughnessOverride When non-null, overrides the copy's base toughness (Superior Spider-Man: 4)
  * @property exileCopiedCard When true, exile the copied card after copying it (Superior Spider-Man:
  *   "When you do, exile that card"). Used for graveyard copies.
+ * @property additionalCounters When non-null, the number of additional +1/+1 counters the copy
+ *   enters with (Altered Ego's "except it enters with X additional +1/+1 counters on it"). Applied
+ *   only when a copy was actually made — declining the copy declines the counters too.
  */
 @Serializable
 data class CloneEntersContinuation(
@@ -211,7 +215,8 @@ data class CloneEntersContinuation(
     val nameOverride: String? = null,
     val powerOverride: Int? = null,
     val toughnessOverride: Int? = null,
-    val exileCopiedCard: Boolean = false
+    val exileCopiedCard: Boolean = false,
+    val additionalCounters: DynamicAmount? = null
 ) : ContinuationFrame
 
 /**
@@ -232,6 +237,8 @@ data class CloneEntersContinuation(
  * @property controllerId Its controller (also the copy chooser).
  * @property fromZone The zone the permanent came from, used to synthesize the entry event.
  * @property tappedIfCopied Tap the permanent iff it entered as a copy ("enter tapped as a copy").
+ * @property additionalCounters Additional +1/+1 counters the permanent enters with iff it entered
+ *   as a copy. See [CloneEntersContinuation.additionalCounters].
  */
 @Serializable
 data class CloneEntersOnBattlefieldContinuation(
@@ -245,7 +252,8 @@ data class CloneEntersOnBattlefieldContinuation(
     val powerOverride: Int? = null,
     val toughnessOverride: Int? = null,
     val exileCopiedCard: Boolean = false,
-    val tappedIfCopied: Boolean = false
+    val tappedIfCopied: Boolean = false,
+    val additionalCounters: DynamicAmount? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -1,8 +1,10 @@
 package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -13,12 +15,16 @@ import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.targets.TargetOpponent
 import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 class ModalAndCloneContinuationResumer(
     private val services: com.wingedsheep.engine.core.EngineServices
 ) : ContinuationResumerModule {
+
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
 
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(ModalContinuation::class, ::resumeModal),
@@ -303,6 +309,32 @@ class ModalAndCloneContinuationResumer(
     }
 
     /**
+     * Apply an `EntersAsCopy.additionalCounters` rider — "except it enters with N additional +1/+1
+     * counters on it" (Altered Ego, Spark Double). Only ever called when a copy was actually made:
+     * the rider is part of the copy effect, so declining the copy declines the counters (printed
+     * ruling). Routes through [EntersWithReplacements.placeEntryCounters] so Hardened Scales-style
+     * counter-placement modifiers and the "counter placed this turn" tracker behave exactly as they
+     * do for a printed "enters with counters".
+     *
+     * @param xValue the value chosen for X while casting, for a [DynamicAmount.XValue] amount; null
+     *   on the non-spell entry path (a land/token copy has no cast X).
+     */
+    private fun applyCopyEntryCounters(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        amount: DynamicAmount,
+        xValue: Int?,
+    ): Pair<GameState, List<GameEvent>> {
+        val context = EffectContext(sourceId = entityId, controllerId = controllerId, xValue = xValue)
+        val count = dynamicAmountEvaluator.evaluate(state, amount, context)
+        val entityName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: ""
+        return EntersWithReplacements.placeEntryCounters(
+            state, entityId, CounterTypeFilter.PlusOnePlusOne, count, controllerId, entityName
+        )
+    }
+
+    /**
      * Resume after player selects a creature to copy for Clone-style effects.
      */
     fun resumeCloneEnters(
@@ -357,6 +389,19 @@ class ModalAndCloneContinuationResumer(
                     powerOverride = continuation.powerOverride,
                     toughnessOverride = continuation.toughnessOverride,
                 )
+
+                // "except it enters with X additional +1/+1 counters on it" (Altered Ego) — part of
+                // the copy effect, so it only applies when a copy was actually made. Stamped before
+                // the permanent enters so it is genuinely *entering* with them: state-based actions
+                // never see the 0/0, and enters-with-counters triggers read the final total.
+                val extraCounters = continuation.additionalCounters
+                if (extraCounters != null) {
+                    val (afterCounters, counterEvents) = applyCopyEntryCounters(
+                        newState, spellId, controllerId, extraCounters, spellComponent.xValue
+                    )
+                    newState = afterCounters
+                    events.addAll(counterEvents)
+                }
 
                 // Look up the card definition for the copied creature
                 copiedCardDef = services.cardRegistry.getCard(targetCardComponent.cardDefinitionId)
@@ -463,6 +508,17 @@ class ModalAndCloneContinuationResumer(
             newState = newState.updateEntity(entityId) { c ->
                 c.with(com.wingedsheep.engine.state.components.battlefield.TappedComponent)
             }
+        }
+
+        // "except it enters with N additional +1/+1 counters on it" — likewise only when a copy
+        // was actually made.
+        val bfExtraCounters = continuation.additionalCounters
+        if (copyApplied && bfExtraCounters != null) {
+            val (afterCounters, counterEvents) = applyCopyEntryCounters(
+                newState, entityId, continuation.controllerId, bfExtraCounters, xValue = null
+            )
+            newState = afterCounters
+            outEvents.addAll(counterEvents)
         }
 
         // "When you do, exile that card." (graveyard copies) — exile the copied card afterward.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -115,22 +115,15 @@ object EntersWithReplacements {
                         )
                         if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
                     }
-                    val counterType = resolveCounterType(effect.counterType)
-                    val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                        newState, entityId, counterType, effect.count, placerId = controllerId
+                    val (afterCounters, counterEvents) = placeEntryCounters(
+                        newState, entityId, effect.counterType, effect.count, controllerId, entityName
                     )
-                    val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
-                    newState = newState.updateEntity(entityId) { c ->
-                        c.with(current.withAdded(counterType, modifiedCount))
-                    }
-                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
-                    newState = afterMark
-                    events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
+                    newState = afterCounters
+                    events.addAll(counterEvents)
                 }
                 is EntersWithDynamicCounters -> {
                     // Skip "other only" effects when applying to self (e.g., Gev)
                     if (effect.otherOnly) continue
-                    val counterType = resolveCounterType(effect.counterType)
                     val context = EffectContext(
                         sourceId = entityId,
                         controllerId = controllerId,
@@ -138,18 +131,11 @@ object EntersWithReplacements {
                         totalManaSpent = totalManaSpent
                     )
                     val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
-                    if (count > 0) {
-                        val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                            newState, entityId, counterType, count, placerId = controllerId
-                        )
-                        val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
-                        newState = newState.updateEntity(entityId) { c ->
-                            c.with(current.withAdded(counterType, modifiedCount))
-                        }
-                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
-                        newState = afterMark
-                        events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
-                    }
+                    val (afterCounters, counterEvents) = placeEntryCounters(
+                        newState, entityId, effect.counterType, count, controllerId, entityName
+                    )
+                    newState = afterCounters
+                    events.addAll(counterEvents)
                 }
                 is EntersWithKeywords -> {
                     val context = EffectContext(
@@ -167,6 +153,44 @@ object EntersWithReplacements {
             }
         }
         return newState to events
+    }
+
+    /**
+     * Place [count] counters of [counterType] on [entityId] as it enters (CR 614.1c), honouring
+     * counter-placement modifiers (Hardened Scales, Solemnity) and recording the placement for
+     * "put a counter on a permanent this turn" trackers.
+     *
+     * Shared by the enters-with replacement branches above and by the copy path
+     * ([com.wingedsheep.engine.handlers.continuations.ModalAndCloneContinuationResumer]), where
+     * `EntersAsCopy.additionalCounters` carries the "except it enters with N additional +1/+1
+     * counters on it" rider — the copy replaces the permanent's own text, so those counters can't
+     * come from a self-targeted [EntersWithCounters]. A non-positive [count] is a no-op.
+     */
+    fun placeEntryCounters(
+        state: GameState,
+        entityId: EntityId,
+        counterType: CounterTypeFilter,
+        count: Int,
+        controllerId: EntityId,
+        entityName: String,
+    ): Pair<GameState, List<GameEvent>> {
+        if (count <= 0) return state to emptyList()
+        val resolved = resolveCounterType(counterType)
+        val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
+            state, entityId, resolved, count, placerId = controllerId
+        )
+        val current = state.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
+        var newState = state.updateEntity(entityId) { c ->
+            c.with(current.withAdded(resolved, modifiedCount))
+        }
+        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+        newState = afterMark
+        return newState to listOf(
+            CountersAddedEvent(
+                entityId, counterType.description, modifiedCount, entityName, firstThisTurn,
+                placedBy = controllerId
+            )
+        )
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -173,6 +173,7 @@ object PermanentEntryReplacements {
             toughnessOverride = effect.toughnessOverride,
             exileCopiedCard = effect.exileCopiedCard,
             tappedIfCopied = effect.tappedIfCopied,
+            additionalCounters = effect.additionalCounters,
         )
         val paused = state.pushContinuation(continuation).withPendingDecision(decision)
         return ExecutionResult.paused(paused, decision, carryEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -939,7 +939,8 @@ class StackResolver(
                         nameOverride = entersAsCopy.nameOverride,
                         powerOverride = entersAsCopy.powerOverride,
                         toughnessOverride = entersAsCopy.toughnessOverride,
-                        exileCopiedCard = entersAsCopy.exileCopiedCard
+                        exileCopiedCard = entersAsCopy.exileCopiedCard,
+                        additionalCounters = entersAsCopy.additionalCounters
                     )
 
                     val pausedState = state

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlteredEgoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlteredEgoScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.cards.AlteredEgo
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Altered Ego.
+ *
+ * Altered Ego {X}{2}{G}{U} — Creature — Shapeshifter 0/0
+ *   This spell can't be countered.
+ *   You may have this creature enter as a copy of any creature on the battlefield, except it
+ *   enters with X additional +1/+1 counters on it.
+ *
+ * These cover the `EntersAsCopy.additionalCounters` rider specifically — that the counters ride on
+ * the *copy* effect rather than on a separate enters-with-counters replacement. The three printed
+ * rulings that distinguishes: X counters land on top of the copied base P/T, X = 0 is a plain copy,
+ * and declining the copy also declines the counters.
+ */
+class AlteredEgoScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AlteredEgo)
+        return driver
+    }
+
+    test("copies a creature and enters with X additional +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Elvish Warrior is a 2/3; with X = 2 the copy should be a 4/5 carrying two counters.
+        val warrior = driver.putCreatureOnBattlefield(player, "Elvish Warrior")
+        val alteredEgo = driver.putCardInHand(player, "Altered Ego")
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.giveMana(player, Color.BLUE, 3)
+        driver.castXSpell(player, alteredEgo, xValue = 2).error shouldBe null
+        driver.bothPass()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options shouldContain warrior
+        driver.submitCardSelection(player, listOf(warrior))
+
+        val card = driver.state.getEntity(alteredEgo)?.get<CardComponent>()
+        card shouldNotBe null
+        card!!.name shouldBe "Elvish Warrior"
+
+        val counters = driver.state.getEntity(alteredEgo)?.get<CountersComponent>()
+        counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+
+        projector.getProjectedPower(driver.state, alteredEgo) shouldBe 4
+        projector.getProjectedToughness(driver.state, alteredEgo) shouldBe 5
+    }
+
+    test("X = 0 is a plain copy with no counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val warrior = driver.putCreatureOnBattlefield(player, "Elvish Warrior")
+        val alteredEgo = driver.putCardInHand(player, "Altered Ego")
+        driver.giveMana(player, Color.GREEN, 2)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castXSpell(player, alteredEgo, xValue = 0).error shouldBe null
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player, listOf(warrior))
+
+        val counters = driver.state.getEntity(alteredEgo)?.get<CountersComponent>()
+        (counters?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+        projector.getProjectedPower(driver.state, alteredEgo) shouldBe 2
+        projector.getProjectedToughness(driver.state, alteredEgo) shouldBe 3
+    }
+
+    test("declining the copy declines the counters too — it enters as a 0/0 and dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Elvish Warrior")
+        val alteredEgo = driver.putCardInHand(player, "Altered Ego")
+        driver.giveMana(player, Color.GREEN, 5)
+        driver.giveMana(player, Color.BLUE, 5)
+        driver.castXSpell(player, alteredEgo, xValue = 3).error shouldBe null
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        // "You can choose not to copy anything." — the copy is optional, so an empty selection is
+        // legal, and without the copy the +1/+1 counters never arrive to save the 0/0.
+        driver.submitCardSelection(player, emptyList())
+
+        driver.state.getBattlefield() shouldNotContain alteredEgo
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchangelAvacynScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchangelAvacynScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.cards.ArchangelAvacyn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Archangel Avacyn // Avacyn, the Purifier (SOI) — the delayed upkeep flip.
+ *
+ * Covers the two printed rulings that make this card awkward: the delayed trigger fires at the next
+ * upkeep whoever's turn it is, and a second queued flip must **not** turn her back over when several
+ * non-Angel creatures died in the same turn.
+ */
+class ArchangelAvacynScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ArchangelAvacyn)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Bolt [victim] and let the bolt (plus anything it triggers) finish resolving. */
+    fun bolt(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(victim)))
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty()) driver.bothPass()
+    }
+
+    /** Advance into the next upkeep (the opponent's) and drain whatever triggers there. */
+    fun advanceToNextUpkeep(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty()) driver.bothPass()
+    }
+
+    test("entering grants your creatures indestructible until end of turn") {
+        val (driver, you) = newGame()
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val avacyn = driver.putCardInHand(you, "Archangel Avacyn")
+        driver.giveMana(you, Color.WHITE, 5)
+        driver.castSpell(you, avacyn)
+        driver.bothPass() // Avacyn resolves; the ETB trigger goes on the stack
+        driver.bothPass() // the ETB trigger resolves
+
+        // 3 damage would normally kill a 2/2; indestructible keeps it around.
+        bolt(driver, you, bears)
+        driver.state.getBattlefield().contains(bears) shouldBe true
+    }
+
+    test("a non-Angel creature dying queues a flip that resolves at the next upkeep") {
+        val (driver, you) = newGame()
+        val avacyn = driver.putCreatureOnBattlefield(you, "Archangel Avacyn")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        bolt(driver, you, bears)
+
+        // Still front-face this turn — the flip is delayed to the next upkeep, not immediate.
+        faceName(driver, avacyn) shouldBe "Archangel Avacyn"
+
+        advanceToNextUpkeep(driver)
+
+        faceName(driver, avacyn) shouldBe "Avacyn, the Purifier"
+        val projected = projector.project(driver.state)
+        projected.getPower(avacyn) shouldBe 6
+        projected.getToughness(avacyn) shouldBe 5
+    }
+
+    test("transforming deals 3 damage to each other creature and each opponent") {
+        val (driver, you) = newGame()
+        val opponent = driver.getOpponent(you)
+        val avacyn = driver.putCreatureOnBattlefield(you, "Archangel Avacyn")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        bolt(driver, you, bears)
+        advanceToNextUpkeep(driver)
+
+        faceName(driver, avacyn) shouldBe "Avacyn, the Purifier"
+        // Every *other* creature took 3 — the opponent's 2/2 is gone, Avacyn herself is untouched.
+        driver.state.getBattlefield().contains(theirBears) shouldBe false
+        driver.state.getBattlefield().contains(avacyn) shouldBe true
+        driver.getLifeTotal(opponent) shouldBe 17
+        driver.getLifeTotal(you) shouldBe 20
+    }
+
+    test("two deaths in one turn flip her once, never back again") {
+        val (driver, you) = newGame()
+        val avacyn = driver.putCreatureOnBattlefield(you, "Archangel Avacyn")
+        val first = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val second = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        bolt(driver, you, first)
+        bolt(driver, you, second)
+
+        advanceToNextUpkeep(driver)
+
+        // Both delayed triggers fire in the same upkeep; the second finds her already flipped and
+        // does nothing (printed ruling), rather than turning her back to the front face.
+        faceName(driver, avacyn) shouldBe "Avacyn, the Purifier"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WestvaleAbbeyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WestvaleAbbeyScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.soi.cards.WestvaleAbbey
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Westvale Abbey // Ormendahl, Profane Prince (SOI) — the land that eats five creatures.
+ *
+ * The interesting seam is the flip ability's cost/effect pairing: `{T}` is part of the activation
+ * cost, so the land is tapped by the time the ability resolves, and "then untap it" has to leave
+ * Ormendahl untapped — which, with haste, is what lets him attack the turn he arrives.
+ */
+class WestvaleAbbeyScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WestvaleAbbey)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Activate one of the Abbey's abilities, auto-answering any cost decisions, then drain. */
+    fun activate(driver: GameTestDriver, player: EntityId, source: EntityId, abilityId: AbilityId) {
+        driver.submitSuccess(
+            ActivateAbility(playerId = player, sourceId = source, abilityId = abilityId)
+        )
+        var guard = 0
+        while (guard++ < 30 && (driver.state.stack.isNotEmpty() || driver.isPaused)) {
+            if (driver.isPaused) driver.autoResolveDecision() else driver.bothPass()
+        }
+    }
+
+    // [0] = {T}: Add {C}; [1] = the Cleric maker; [2] = the flip.
+    val abilities = WestvaleAbbey.activatedAbilities
+
+    test("the Cleric ability costs 1 life and makes a 1/1") {
+        val (driver, you) = newGame()
+        val abbey = driver.putPermanentOnBattlefield(you, "Westvale Abbey")
+        driver.giveColorlessMana(you, 5)
+
+        val before = driver.getCreatures(you).size
+        activate(driver, you, abbey, abilities[1].id)
+
+        driver.getCreatures(you).size shouldBe before + 1
+        driver.getLifeTotal(you) shouldBe 19
+    }
+
+    test("sacrificing five creatures transforms the land and untaps it") {
+        val (driver, you) = newGame()
+        val abbey = driver.putPermanentOnBattlefield(you, "Westvale Abbey")
+        repeat(5) { driver.putCreatureOnBattlefield(you, "Grizzly Bears") }
+        driver.giveColorlessMana(you, 5)
+
+        activate(driver, you, abbey, abilities[2].id)
+
+        faceName(driver, abbey) shouldBe "Ormendahl, Profane Prince"
+        driver.getCreatures(you).size shouldBe 1 // the five Bears are gone; Ormendahl is the creature
+        driver.isTapped(abbey) shouldBe false
+
+        val projected = projector.project(driver.state)
+        projected.getPower(abbey) shouldBe 9
+        projected.getToughness(abbey) shouldBe 7
+        projected.hasKeyword(abbey, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(abbey, Keyword.LIFELINK) shouldBe true
+        projected.hasKeyword(abbey, Keyword.INDESTRUCTIBLE) shouldBe true
+        projected.hasKeyword(abbey, Keyword.HASTE) shouldBe true
+    }
+
+    test("the flip ability isn't available without five creatures to sacrifice") {
+        val (driver, you) = newGame()
+        val abbey = driver.putPermanentOnBattlefield(you, "Westvale Abbey")
+        repeat(4) { driver.putCreatureOnBattlefield(you, "Grizzly Bears") }
+        driver.giveColorlessMana(you, 5)
+
+        driver.submit(
+            ActivateAbility(playerId = you, sourceId = abbey, abilityId = abilities[2].id)
+        ).error shouldNotBe null
+        faceName(driver, abbey) shouldBe "Westvale Abbey"
+    }
+})


### PR DESCRIPTION
Three cards from Innistrad Remastered. All three are reprints, so each canonical `CardDefinition` lands in **Shadows over Innistrad** (their earliest real printing) and INR gets a `Printing` row. `just check-card-printing` is clean for all three.

## Cards

**Westvale Abbey // Ormendahl, Profane Prince** — a land TDFC. "Sacrifice five creatures" is `Costs.SacrificeMultiple`, "Pay 1 life" a real cost atom, and "transform this land, then untap it" a `Composite` of `TransformEffect` + `Untap` on `Self`. The `{T}` in the cost is why the untap is load-bearing: with haste, Ormendahl attacks the turn he flips.

**Archangel Avacyn // Avacyn, the Purifier** — the delayed upkeep flip. Each non-Angel death queues a step-based `CreateDelayedTriggerEffect` on `UPKEEP` with no `fireOnPlayer`, so it fires at the next upkeep whoever's turn it is (printed ruling #1). The delayed effect is gated on the permanent still being named "Archangel Avacyn", which is printed ruling #2: several deaths in one turn must flip her *once*, not flip her back.

**Altered Ego** — needed one new SDK parameter (below).

## SDK change: `EntersAsCopy.additionalCounters`

Altered Ego's "except it enters with X additional +1/+1 counters on it" can't be a separate `EntersWithCounters`: copying replaces the permanent's own copiable text, so a self-targeted enters-with-counters replacement is gone by the time the copy applies. The rider has to live on the copy effect — which is also what makes the printed rulings fall out for free:

- declining the copy declines the counters ("It won't have +1/+1 counters placed on it by its ability"),
- X = 0 is a plain copy.

`additionalCounters: DynamicAmount?` threads through `CloneEntersContinuation` / `CloneEntersOnBattlefieldContinuation` and both resumer paths. Counter placement routes through a new `EntersWithReplacements.placeEntryCounters` — extracted from the two enters-with-counters branches that already duplicated it — so Hardened Scales-style placement modifiers and the "counter placed this turn" tracker behave exactly as for a printed "enters with counters". Next users of the parameter: Spark Double, Moritte of the Frost, Sakashima's Protégé.

`docs/card-sdk-language-reference.md` updated in the same change.

## Why only three

The INR tail is mostly blocked on unimplemented mechanics rather than card work — madness, disturb, soulbond, emerge, escalate, splice, battles/Sieges, triggered emblems (only static emblems exist), keyword-sharing (Odric), per-permanent untap restrictions on an unattach trigger (Stitcher's Graft), source-scoped sacrifice immunity (Sigarda), once-per-turn graveyard casting (Gisa and Geralf). Those are `add-feature` work, not `add-card`. These three were the ones that were genuinely card work.

## Verification

- `just test` (full suite) — green
- 10 new scenario tests: `ArchangelAvacynScenarioTest` (4), `WestvaleAbbeyScenarioTest` (3), `AlteredEgoScenarioTest` (3)
- card snapshot re-blessed; only these three cards move in `SOI.json`
- `just check-card-printing` clean for all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)