### PR TITLE
Add Captain Howler, Sea Scourge and Chandra, Spark Hunter to Aetherdrift

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CaptainHowlerSeaScourge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CaptainHowlerSeaScourge.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Captain Howler, Sea Scourge — Aetherdrift #194
+ * {2}{U}{R} · Legendary Creature — Shark Pirate · 5/4
+ *
+ * Ward—{2}, Pay 2 life.
+ * Whenever you discard one or more cards, target creature gets +2/+0 until end of turn for
+ * each card discarded this way. Whenever that creature deals combat damage to a player this
+ * turn, you draw a card.
+ *
+ * - Ward—{2}, Pay 2 life is one composite ward cost ([WardCost.Composite]); declining either
+ *   half counters the targeting spell or ability (CR 702.21a). Same shape as Gisa, the
+ *   Hellraiser.
+ * - The payoff is batch-worded (CR 603.2c), so it uses [Triggers.YouDiscardOneOrMore]: one
+ *   trigger per discard *event*, however many cards it contained. The pump reads the batch
+ *   size back through [ContextPropertyKey.TRIGGER_DISCARD_COUNT] and doubles it
+ *   ([DynamicAmount.Multiply]) for the printed "+2/+0 ... for each card". Discarding three
+ *   cards to one effect gives +6/+0; three sequential single discards fire three separate
+ *   triggers for +2/+0 each. The amount is evaluated once, as the ability resolves, and baked
+ *   into the layer-7c floating effect.
+ * - The second sentence is a delayed triggered ability (CR 603.7a) created by the same
+ *   resolution, not an ability granted to the creature: it is scoped to the pumped creature
+ *   via `watchedTarget`, expires at end of turn, and — crucially — is controlled by Captain
+ *   Howler's controller, so *you* draw even when the target is a creature you don't control.
+ *   `fireOnce` stays false because the printed wording is "Whenever", so a double strike
+ *   creature connecting twice draws two cards.
+ * - "target creature" is unrestricted ([Targets.Creature]) — any creature, not just yours.
+ */
+val CaptainHowlerSeaScourge = card("Captain Howler, Sea Scourge") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Shark Pirate"
+    power = 5
+    toughness = 4
+    oracleText = "Ward—{2}, Pay 2 life.\n" +
+        "Whenever you discard one or more cards, target creature gets +2/+0 until end of turn " +
+        "for each card discarded this way. Whenever that creature deals combat damage to a " +
+        "player this turn, you draw a card."
+
+    keywordAbility(
+        KeywordAbility.wardComposite(WardCost.Mana("{2}"), WardCost.Life(2))
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscardOneOrMore
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Composite(listOf(
+            Effects.ModifyStats(
+                power = DynamicAmount.Multiply(
+                    DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DISCARD_COUNT),
+                    2
+                ),
+                toughness = DynamicAmount.Fixed(0),
+                target = creature
+            ),
+            CreateDelayedTriggerEffect(
+                effect = Effects.DrawCards(1),
+                trigger = Triggers.dealsDamage(
+                    damageType = DamageType.Combat,
+                    recipient = RecipientFilter.AnyPlayer
+                ),
+                watchedTarget = creature,
+                expiry = DelayedTriggerExpiry.EndOfTurn
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "194"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg?1783907861"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ChandraSparkHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ChandraSparkHunter.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Chandra, Spark Hunter — Aetherdrift #116
+ * {3}{R} · Legendary Planeswalker — Chandra · Starting loyalty 4
+ *
+ * At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end
+ * of turn, it becomes an artifact creature and gains haste.
+ * +2: You may sacrifice an artifact or discard a card. If you do, draw a card.
+ * 0: Create a 3/2 colorless Vehicle artifact token with crew 1.
+ * −7: You get an emblem with "Whenever an artifact you control enters, this emblem deals 3 damage
+ *     to any target."
+ *
+ * Modeling notes:
+ *
+ *  - **The combat trigger** is a loyalty-independent triggered ability, not a loyalty ability, so
+ *    it lives in a plain `triggeredAbility { }` on [Triggers.BeginCombat] ("at the beginning of
+ *    combat on your turn"). "Up to one target" is `optional = true`; with no target chosen the
+ *    ability still resolves and simply does nothing. The Vehicle filter is a bare subtype filter
+ *    over `GameObjectFilter.Any`, not `Creature` — an uncrewed Vehicle is a *noncreature* artifact,
+ *    which is exactly the case this ability exists to fix.
+ *  - **The animation** is [Effects.AddCardType] "Creature" for the turn, the same Layer-4 grant
+ *    crew uses (Kolodin, Triumph Caster): a Vehicle is already an artifact (CR 301.7) and its
+ *    printed P/T and keywords apply the moment it is a creature, so the type grant is the whole
+ *    animation. Haste is a separate Layer-6 grant, and it matters — the animated Vehicle can attack
+ *    the turn Chandra points at it even though it has been a noncreature all along.
+ *  - **The +2** is a "you may" wrapped around a two-way choice, with the draw folded into each
+ *    branch. That is equivalent to the printed "If you do, draw a card" and avoids an
+ *    action-outcome gate: [com.wingedsheep.sdk.scripting.effects.SuccessCriterion] `Auto` can only
+ *    infer success from a terminal zone move, which a [Effects.ChooseAction] isn't. The
+ *    [FeasibilityCheck]s hide a branch the player can't actually take, and when neither is
+ *    available the choice resolves to nothing — so no draw, matching the printed gate.
+ *  - **The 0** makes the set's standard 3/2 crew-1 Vehicle, i.e. [Effects.CreateVehicleToken] —
+ *    the same predefined token Mu Yanling, Wind Rider creates.
+ *  - **The −7 emblem** is a *triggered* emblem, so it uses
+ *    [Effects.CreateGlobalTriggeredAbility] with [Duration.Permanent] (the Tezzeret, Cruel Captain
+ *    shape) rather than `CreatePermanentEmblem`, which only carries static P/T and keyword
+ *    modifications. Global grants aren't attached to an entity and aren't zone-checked, so the
+ *    emblem outlives Chandra. Emblems are colorless (printed ruling), so a permanent with
+ *    protection from red is still a legal target for its damage.
+ */
+val ChandraSparkHunter = card("Chandra, Spark Hunter") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Planeswalker — Chandra"
+    startingLoyalty = 4
+    oracleText = "At the beginning of combat on your turn, choose up to one target Vehicle you " +
+        "control. Until end of turn, it becomes an artifact creature and gains haste.\n" +
+        "+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n" +
+        "0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n" +
+        "−7: You get an emblem with \"Whenever an artifact you control enters, this emblem deals " +
+        "3 damage to any target.\""
+
+    // At the beginning of combat on your turn, choose up to one target Vehicle you control.
+    // Until end of turn, it becomes an artifact creature and gains haste.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val vehicle = target(
+            "up to one target Vehicle you control",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Any.withSubtype(Subtype.VEHICLE).youControl())
+            )
+        )
+        effect = Effects.AddCardType("Creature", vehicle, Duration.EndOfTurn) then
+            Effects.GrantKeyword(Keyword.HASTE, vehicle, Duration.EndOfTurn)
+    }
+
+    // +2: You may sacrifice an artifact or discard a card. If you do, draw a card.
+    loyaltyAbility(+2) {
+        effect = MayEffect(
+            effect = Effects.ChooseAction(
+                choices = listOf(
+                    EffectChoice(
+                        label = "Sacrifice an artifact",
+                        effect = Effects.Sacrifice(
+                            GameObjectFilter.Artifact,
+                            1,
+                            EffectTarget.Controller
+                        ) then Effects.DrawCards(1),
+                        feasibilityCheck = FeasibilityCheck.ControlsPermanentMatching(
+                            GameObjectFilter.Artifact
+                        )
+                    ),
+                    EffectChoice(
+                        label = "Discard a card",
+                        effect = Patterns.Hand.discardCards(1) then Effects.DrawCards(1),
+                        feasibilityCheck = FeasibilityCheck.HasCardsInZone(Zone.HAND)
+                    )
+                )
+            ),
+            descriptionOverride = "You may sacrifice an artifact or discard a card. If you do, " +
+                "draw a card."
+        )
+    }
+
+    // 0: Create a 3/2 colorless Vehicle artifact token with crew 1.
+    loyaltyAbility(0) {
+        effect = Effects.CreateVehicleToken()
+    }
+
+    // −7: You get an emblem with "Whenever an artifact you control enters, this emblem deals
+    //     3 damage to any target."
+    loyaltyAbility(-7) {
+        effect = Effects.CreateGlobalTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.entersBattlefield(
+                    filter = GameObjectFilter.Artifact.youControl(),
+                    binding = TriggerBinding.ANY
+                ).event,
+                binding = TriggerBinding.ANY,
+                effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0)),
+                targetRequirement = Targets.Any,
+                descriptionOverride = "Whenever an artifact you control enters, this emblem deals " +
+                    "3 damage to any target."
+            ),
+            descriptionOverride = "Whenever an artifact you control enters, this emblem deals 3 " +
+                "damage to any target."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "116"
+        artist = "Devin Elle Kurtz"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg?1783907885"
+
+        ruling("2025-02-07", "Emblems are colorless. This means that a permanent with protection from red can be the target of the emblem's triggered ability.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -2599,6 +2599,113 @@
     ]
 }
 
+// Captain Howler, Sea Scourge
+{
+    "name": "Captain Howler, Sea Scourge",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Legendary Creature — Shark Pirate",
+    "oracleText": "Ward—{2}, Pay 2 life.\nWhenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Composite",
+                "parts": [
+                    {
+                        "type": "WardCost.Mana",
+                        "manaCost": "{2}"
+                    },
+                    {
+                        "type": "WardCost.Life",
+                        "amount": 2
+                    }
+                ]
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DiscardEvent",
+                    "batch": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Multiply",
+                                "amount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DISCARD_COUNT"
+                                },
+                                "multiplier": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "trigger": {
+                                "event": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat",
+                                    "recipient": "AnyPlayer"
+                                }
+                            },
+                            "watchedTarget": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "RARE",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/0957c90f-e10d-40f8-a4be-9e9ef623dd43.jpg?1783907861"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Caradora, Heart of Alacria
 {
     "name": "Caradora, Heart of Alacria",
@@ -2824,6 +2931,214 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Chandra, Spark Hunter
+{
+    "name": "Chandra, Spark Hunter",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Planeswalker — Chandra",
+    "oracleText": "At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.\n+2: You may sacrifice an artifact or discard a card. If you do, draw a card.\n0: Create a 3/2 colorless Vehicle artifact token with crew 1.\n−7: You get an emblem with \"Whenever an artifact you control enters, this emblem deals 3 damage to any target.\"",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCardType",
+                            "cardType": "Creature",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vehicle you control"
+                            },
+                            "duration": "EndOfTurn"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vehicle you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "Vehicle ctrl:you"
+                    },
+                    "id": "up to one target Vehicle you control"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 2
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ChooseAction",
+                        "choices": [
+                            {
+                                "label": "Sacrifice an artifact",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "ForceSacrifice",
+                                            "filter": "artifact",
+                                            "target": "Controller"
+                                        },
+                                        {
+                                            "type": "DrawCards",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "ControlsPermanentMatching",
+                                    "filter": "artifact"
+                                }
+                            },
+                            {
+                                "label": "Discard a card",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        },
+                                        {
+                                            "type": "DrawCards",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "HasCardsInZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may sacrifice an artifact or discard a card. If you do, draw a card."
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 0
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Vehicle"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -7
+                },
+                "effect": {
+                    "type": "CreateGlobalTriggeredAbility",
+                    "ability": {
+                        "id": "ability_5",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "artifact ctrl:you",
+                            "to": "Battlefield"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "targetRequirement": "AnyTarget",
+                        "descriptionOverride": "Whenever an artifact you control enters, this emblem deals 3 damage to any target."
+                    },
+                    "descriptionOverride": "Whenever an artifact you control enters, this emblem deals 3 damage to any target."
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "MYTHIC",
+        "artist": "Devin Elle Kurtz",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11f9b98e-48a1-491e-bdab-6e94e4ec747a.jpg?1783907885",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Emblems are colorless. This means that a permanent with protection from red can be the target of the emblem's triggered ability."
+            }
+        ]
+    },
+    "startingLoyalty": 4,
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainHowlerSeaScourgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainHowlerSeaScourgeScenarioTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Captain Howler, Sea Scourge (DFT #194) — {2}{U}{R} Legendary Creature — Shark Pirate, 5/4.
+ *
+ *   "Ward—{2}, Pay 2 life.
+ *    Whenever you discard one or more cards, target creature gets +2/+0 until end of turn for each
+ *    card discarded this way. Whenever that creature deals combat damage to a player this turn,
+ *    you draw a card."
+ *
+ * Two things are worth pinning. The pump doubles the *batch* size (CR 603.2c), so a single
+ * two-card discard event is +4/+0 rather than two separate +2/+0 triggers. And the follow-on
+ * sentence is a delayed triggered ability watching the pumped creature: it draws only on combat
+ * damage dealt **to a player**, and it keeps watching until end of turn rather than firing once.
+ */
+class CaptainHowlerSeaScourgeScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("the discard payoff scales with the batch") {
+
+            test("a two-card discard event gives +4/+0, not +2/+0") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Captain Howler, Sea Scourge", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardInHand(1, "Faithless Looting")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .stocked()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                // Faithless Looting: draw two, then discard two — one CardsDiscardedEvent.
+                val cast = game.castSpell(1, "Faithless Looting")
+                withClue("Faithless Looting cast should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // With exactly the two drawn cards in hand the discard may resolve without a
+                // prompt; when it does prompt, bin both Bears.
+                if (game.state.pendingDecision is SelectCardsDecision) {
+                    game.selectCards(game.findCardsInHand(1, "Grizzly Bears").take(2))
+                }
+
+                val targeting = game.state.pendingDecision as? ChooseTargetsDecision
+                withClue("The discard trigger pauses to choose target creature") {
+                    targeting shouldNotBe null
+                }
+                game.selectTargets(listOf(giant))
+                game.resolveStack()
+
+                withClue("Hill Giant is 3/3 pumped by +2/+0 per card in the two-card batch") {
+                    projector.getProjectedPower(game.state, giant) shouldBe 7
+                    projector.getProjectedToughness(game.state, giant) shouldBe 3
+                }
+            }
+        }
+
+        context("the delayed draw trigger") {
+
+            test("draws when the pumped creature connects with a player") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Captain Howler, Sea Scourge", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Chitin Gravestalker")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .stocked()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val libraryBefore = game.librarySize(1)
+
+                // Cycling {2} discards Chitin Gravestalker — a one-card discard event.
+                val cycle = game.cycleCard(1, "Chitin Gravestalker")
+                withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+
+                val targeting = game.state.pendingDecision as? ChooseTargetsDecision
+                withClue("The discard trigger pauses to choose target creature") {
+                    targeting shouldNotBe null
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears is 2/2 pumped to 4/2 by the one-card batch") {
+                    projector.getProjectedPower(game.state, bears) shouldBe 4
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("The unblocked 4/2 hit for 4") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+                withClue("Cycling drew one card, the delayed combat-damage trigger drew another") {
+                    game.librarySize(1) shouldBe libraryBefore - 2
+                }
+            }
+
+            test("does not draw when the pumped creature only damages a blocker") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Captain Howler, Sea Scourge", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withCardInHand(1, "Chitin Gravestalker")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .stocked()
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val libraryBefore = game.librarySize(1)
+
+                val cycle = game.cycleCard(1, "Chitin Gravestalker")
+                withClue("Cycling should succeed: ${cycle.error}") { cycle.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears"))).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("The blocked attacker dealt no damage to the player") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+                withClue("Only the cycling draw happened — combat damage to a creature doesn't draw") {
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                }
+            }
+        }
+    }
+
+    /** Both libraries stocked so nobody decks out on the draws these cases force. */
+    private fun ScenarioBuilder.stocked(): ScenarioBuilder = apply {
+        repeat(8) {
+            withCardInLibrary(1, "Grizzly Bears")
+            withCardInLibrary(2, "Grizzly Bears")
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraSparkHunterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChandraSparkHunterScenarioTest.kt
@@ -1,0 +1,224 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Chandra, Spark Hunter (DFT #116, {3}{R}, Loyalty 4).
+ *
+ *   At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end
+ *   of turn, it becomes an artifact creature and gains haste.
+ *   +2: You may sacrifice an artifact or discard a card. If you do, draw a card.
+ *   0: Create a 3/2 colorless Vehicle artifact token with crew 1.
+ *   −7: You get an emblem with "Whenever an artifact you control enters, this emblem deals 3 damage
+ *       to any target."
+ *
+ * Covers the three abilities whose composition could silently go wrong: the combat trigger's
+ * type-plus-haste animation (haste is what makes a freshly-cast Vehicle able to attack, so the test
+ * actually attacks with it), the +2's may-then-choose shape (declining must not draw), and the
+ * triggered emblem, which has to outlive Chandra dying to her own −7.
+ */
+class ChandraSparkHunterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the begin-combat animation") {
+
+            test("animates a Vehicle you control and hastes it into an attack") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Spark Hunter")
+                    .withCardOnBattlefield(1, "Adventurer's Airship", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val airship = game.findPermanent("Adventurer's Airship")!!
+
+                withClue("an uncrewed Vehicle is a noncreature artifact") {
+                    game.state.projectedState.isCreature(airship) shouldBe false
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(airship))
+                game.resolveStack()
+
+                withClue("the Vehicle is now an artifact creature with its printed 3/2") {
+                    val projected = game.state.projectedState
+                    projected.isCreature(airship) shouldBe true
+                    projected.getProjectedValues(airship)?.power shouldBe 3
+                    projected.getProjectedValues(airship)?.toughness shouldBe 2
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                withClue("haste lets it attack the turn it became a creature") {
+                    game.declareAttackers(mapOf("Adventurer's Airship" to 2)).error shouldBe null
+                }
+            }
+        }
+
+        context("the +2") {
+
+            test("discarding draws a replacement") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Spark Hunter")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Spark Hunter")!!
+                setLoyalty(game, chandra, 4)
+                val libraryBefore = game.librarySize(1)
+
+                activate(game, chandra, index = 0)
+                game.resolveStack()
+                game.answerYesNo(true)
+                // Chandra is the only permanent and she isn't an artifact, so "Sacrifice an
+                // artifact" is filtered out and the discard branch is auto-selected.
+                chooseIfOffered(game, "Discard a card")
+                if (game.state.pendingDecision is SelectCardsDecision) {
+                    game.selectCards(game.findCardsInHand(1, "Grizzly Bears"))
+                }
+                game.resolveStack()
+
+                withClue("the chosen card was discarded") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("and \"if you do\" drew one") {
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                    game.handSize(1) shouldBe 1
+                    game.isInHand(1, "Hill Giant") shouldBe true
+                }
+                withClue("+2 moved Chandra from 4 to 6 loyalty") {
+                    loyalty(game, chandra) shouldBe 6
+                }
+            }
+
+            test("declining draws nothing") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Spark Hunter")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Spark Hunter")!!
+                val libraryBefore = game.librarySize(1)
+
+                activate(game, chandra, index = 0)
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("no discard, no sacrifice, and therefore no draw") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.librarySize(1) shouldBe libraryBefore
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+
+        context("the 0") {
+
+            test("creates a 3/2 Vehicle token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Spark Hunter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Spark Hunter")!!
+                setLoyalty(game, chandra, 4)
+                activate(game, chandra, index = 1)
+                game.resolveStack()
+
+                val token = game.findPermanent("Vehicle")
+                withClue("a Vehicle token entered — noncreature until something crews it") {
+                    token shouldNotBe null
+                    game.state.projectedState.isCreature(token!!) shouldBe false
+                }
+                withClue("0 leaves loyalty where it was") {
+                    loyalty(game, chandra) shouldBe 4
+                }
+            }
+        }
+
+        context("the −7 emblem") {
+
+            test("outlives Chandra and burns for 3 when an artifact enters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Chandra, Spark Hunter")
+                    .withCardInHand(1, "Sol Ring")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val chandra = game.findPermanent("Chandra, Spark Hunter")!!
+                setLoyalty(game, chandra, 7)
+
+                activate(game, chandra, index = 2)
+                game.resolveStack()
+
+                withClue("Chandra died to the 0-loyalty state-based action; the emblem is global") {
+                    game.findPermanent("Chandra, Spark Hunter") shouldBe null
+                    game.state.globalGrantedTriggeredAbilities.size shouldBe 1
+                }
+
+                game.castSpell(1, "Sol Ring").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                withClue("the emblem's trigger dealt 3 to the chosen target") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+        }
+    }
+
+    private fun activate(game: TestGame, source: com.wingedsheep.sdk.model.EntityId, index: Int) {
+        val ability = cardRegistry.getCard("Chandra, Spark Hunter")!!.script.activatedAbilities[index]
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = source,
+                abilityId = ability.id
+            )
+        ).error shouldBe null
+    }
+
+    /** The choose-an-action prompt only appears when more than one branch is feasible. */
+    private fun chooseIfOffered(game: TestGame, label: String) {
+        val decision = game.state.pendingDecision as? ChooseOptionDecision ?: return
+        val index = decision.options.indexOfFirst { it.contains(label) }
+        if (index >= 0) game.submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    private fun loyalty(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun setLoyalty(game: TestGame, id: com.wingedsheep.sdk.model.EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+}


### PR DESCRIPTION
Two more cards from Aetherdrift's remaining tail (263 → 265 of 276). Both are built entirely from existing SDK primitives — no new engine vocabulary, no SDK reference changes.

## Captain Howler, Sea Scourge (#194) — {2}{U}{R} 5/4

> Ward—{2}, Pay 2 life.
> Whenever you discard one or more cards, target creature gets +2/+0 until end of turn for each card discarded this way. Whenever that creature deals combat damage to a player this turn, you draw a card.

- **Ward** is one composite cost (`WardCost.Composite`), the Gisa, the Hellraiser shape — declining either half counters the targeting spell (CR 702.21a).
- **The payoff is batch-worded** (CR 603.2c), so it's `Triggers.YouDiscardOneOrMore`: one trigger per discard *event*, and the pump doubles `TRIGGER_DISCARD_COUNT`. A two-card discard is +4/+0; three sequential one-card discards are three separate +2/+0 triggers.
- **The second sentence is a delayed triggered ability** (CR 603.7a) created by the same resolution — not an ability granted to the creature. It's scoped to the pumped creature via `watchedTarget` and controlled by Howler's controller, so *you* draw even when the target is a creature you don't control. `fireOnce` stays false to match "Whenever", so a double strike creature connecting twice draws twice.

## Chandra, Spark Hunter (#116) — {3}{R}, loyalty 4

> At the beginning of combat on your turn, choose up to one target Vehicle you control. Until end of turn, it becomes an artifact creature and gains haste.
> +2: You may sacrifice an artifact or discard a card. If you do, draw a card.
> 0: Create a 3/2 colorless Vehicle artifact token with crew 1.
> −7: You get an emblem with "Whenever an artifact you control enters, this emblem deals 3 damage to any target."

- **The combat trigger** is loyalty-independent, so it's a plain `triggeredAbility` on `Triggers.BeginCombat`. The animation is `AddCardType("Creature")` — the same Layer-4 grant crew uses (Kolodin, Triumph Caster) — plus a separate haste grant, which is what lets a Vehicle cast this turn attack. The filter is a bare Vehicle subtype over `GameObjectFilter.Any`, not `Creature`: an uncrewed Vehicle is a *noncreature* artifact, which is the case this ability exists to fix. "Up to one target" is `optional = true`, so it resolves fine with no target.
- **The +2** folds the draw into each branch of a two-way `ChooseAction` under a "you may" gate. That's equivalent to the printed "If you do, draw a card" and deliberately avoids an action-outcome gate: `SuccessCriterion.Auto` can only infer success from a terminal zone move, which a `ChooseAction` isn't. `FeasibilityCheck`s hide a branch the player can't take; when neither is available nothing happens and nothing is drawn.
- **The 0** is `Effects.CreateVehicleToken()`, the set's predefined 3/2 crew-1 token (same one Mu Yanling, Wind Rider makes).
- **The −7** is a *triggered* emblem, so `CreateGlobalTriggeredAbility` with `Duration.Permanent` (the Tezzeret, Cruel Captain shape) rather than `CreatePermanentEmblem`, which only carries static P/T and keywords. Global grants aren't attached to an entity, so the emblem outlives Chandra dying to her own −7.

## Tests

`CaptainHowlerSeaScourgeScenarioTest` (3) — two-card batch gives +4/+0 not +2/+0; the pumped attacker connecting draws; a blocked attacker damaging only a creature does not.

`ChandraSparkHunterScenarioTest` (5) — the animation plus haste actually attacking the same turn; the +2 accept path (discard, then draw a replacement) and decline path (no draw); the 0's token entering as a noncreature; the emblem surviving the −7 that killed Chandra and burning for 3 when an artifact enters.

## Verification

- `just build` — green (includes the mtg-sets card linter and snapshot suite)
- `just test-class CaptainHowlerSeaScourgeScenarioTest` — 3/3
- `just test-class ChandraSparkHunterScenarioTest` — 5/5
- `just check-card-printing` for both — canonical is DFT, the earliest real printing (the only other printings are `pdft` promos)
- `DFT.json` golden re-blessed; the diff is insertions only, both cards

Aetherdrift goes 263 → 265 of 276. The 11 still missing all need new engine capability (embalm as a keyword, X in a cycling cost, batched put-into-exile triggers, mana added to a *target player*, copying an activated ability, exhaust resets) — those are `add-feature` work, not card work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)