### PR TITLE
Add Vexing Devil and Killing Wave (AVR canonical, INR reprints)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KillingWave.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KillingWave.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Killing Wave
+ * {X}{B}
+ * Sorcery
+ * For each creature, its controller sacrifices it unless they pay X life.
+ *
+ * The 2012-05-01 ruling fixes the shape: the active player decides for all of their creatures
+ * first, then each other player in turn order — hence `ForEachPlayer(ActivePlayerFirst)` (APNAP
+ * order) wrapping a per-creature `ForEachInGroup` over the creatures *that* player controls. Each
+ * iteration rebinds the resolution controller, so both `youControl()` and the pay-or-suffer
+ * prompt land on the player whose creatures are being resolved.
+ *
+ * Paying is a cost, not a loss the player can decline to be able to afford: `Gate.MayPay` checks
+ * affordability first, so a player with less life than X is never offered the choice and simply
+ * sacrifices (CR 119.4). X = 0 costs nothing to pay, but the choice is still offered — a player
+ * may decline and sacrifice anyway, which is what the rules allow.
+ *
+ * Known deviation: the ruling has every player *decide* first and then pay/sacrifice
+ * simultaneously; here each player's payments and sacrifices resolve before the next player is
+ * asked. Only observable through death triggers that would otherwise all see the same board.
+ */
+val KillingWave = card("Killing Wave") {
+    manaCost = "{X}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "For each creature, its controller sacrifices it unless they pay X life."
+
+    spell {
+        effect = Effects.ForEachPlayer(
+            Player.ActivePlayerFirst,
+            listOf(
+                Effects.ForEachInGroup(
+                    filter = GroupFilter.AllCreaturesYouControl,
+                    effect = OptionalCostEffect(
+                        cost = PayDynamicLifeEffect(DynamicAmount.XValue),
+                        ifPaid = Effects.Composite(emptyList()),
+                        ifNotPaid = Effects.SacrificeTarget(EffectTarget.Self),
+                        // The gate labels its own "yes" button with the computed cost ("Pay 2
+                        // life") and its "no" with "Don't pay", so the prompt only has to state
+                        // the stakes. It can't name *which* creature is being asked about — the
+                        // decision's source is the spell, not the iteration entity — so a board
+                        // with several creatures shows one identical prompt per creature.
+                        descriptionOverride = "Pay life for this creature, or sacrifice it.",
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "111"
+        artist = "Steve Argyle"
+        flavorText = "\"I come looking for demons and I find a plane full of angels. " +
+            "I hate angels.\"\n—Liliana Vess"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg?1783940697"
+
+        ruling(
+            "2012-05-01",
+            "First, the active player chooses whether to pay X life for each creature they " +
+                "control. Then each other player in turn order chooses for their creatures. Then " +
+                "each player pays life and sacrifices creatures at the same time. Players will " +
+                "know the decisions of players who chose before them.",
+        )
+        ruling(
+            "2012-05-01",
+            "A player may choose to pay life for some creatures and sacrifice the rest. " +
+                "It's not an all-or-nothing decision.",
+        )
+        ruling("2012-05-01", "You can't pay more life than you have.")
+        ruling(
+            "2012-05-01",
+            "If you can't sacrifice a creature (perhaps because of Sigarda, Host of Herons), " +
+                "you can choose not to pay life and nothing will happen.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VexingDevil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VexingDevil.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vexing Devil
+ * {R}
+ * Creature — Devil
+ * 4/3
+ * When this creature enters, any opponent may have it deal 4 damage to them.
+ * If a player does, sacrifice this creature.
+ *
+ * Per the 2018-12-07 ruling, each opponent in turn order chooses independently, so the ability is
+ * modelled as `ForEachPlayer(EachOpponent)` with the yes/no delegated to the opponent being asked
+ * (`decisionMaker`). Accepting deals the damage and sacrifices the Devil in the same, uninterruptible
+ * step — no player gets priority in between, which is exactly what the second ruling requires. A
+ * second opponent accepting after the Devil is already gone still takes 4 (last-known information);
+ * the redundant sacrifice is a no-op.
+ *
+ * Known deviation: `Player.EachOpponent` iterates opponents in seat order rather than APNAP order.
+ * Identical in a two-player game; in multiplayer the *order* of the prompts can differ from the
+ * ruling, though every opponent is still asked and every acceptance still resolves.
+ */
+val VexingDevil = card("Vexing Devil") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, any opponent may have it deal 4 damage to them. " +
+        "If a player does, sacrifice this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachPlayer(
+            Player.EachOpponent,
+            listOf(
+                MayEffect(
+                    effect = Effects.Composite(
+                        Effects.DealDamage(
+                            amount = 4,
+                            target = EffectTarget.PlayerRef(Player.You),
+                            damageSource = EffectTarget.Self,
+                        ),
+                        // `ForEachPlayer` rebinds the resolving controller to the opponent being
+                        // asked, so the sacrifice has to name the Devil's *own* controller as the
+                        // actor — otherwise the control mismatch silently skips it.
+                        SacrificeTargetEffect(
+                            target = EffectTarget.Self,
+                            sacrificedByItsController = true,
+                        ),
+                    ),
+                    decisionMaker = EffectTarget.PlayerRef(Player.You),
+                    // Shown to the opponent being asked, so it reads from their perspective.
+                    descriptionOverride = "Have Vexing Devil deal 4 damage to you? " +
+                        "If you do, its controller sacrifices it.",
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Lucas Graciano"
+        flavorText = "It's not any fun until someone loses an eye."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg?1783940672"
+
+        ruling(
+            "2018-12-07",
+            "As Vexing Devil's ability resolves, the next opponent in turn order (or, if it's an " +
+                "opponent's turn, that opponent) chooses whether to be dealt 4 damage, then each " +
+                "other opponent in turn order does the same. If any of them do, you sacrifice " +
+                "Vexing Devil.",
+        )
+        ruling(
+            "2018-12-07",
+            "No player may take actions between the time an opponent chooses to be dealt damage " +
+                "by Vexing Devil and the time you sacrifice Vexing Devil.",
+        )
+        ruling(
+            "2012-05-01",
+            "If a player chooses to have Vexing Devil deal 4 damage to them, but some or all of " +
+                "that damage is prevented or redirected, Vexing Devil will still be sacrificed.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KillingWaveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KillingWaveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Killing Wave reprint in INR. Canonical CardDefinition lives in AVR (its earliest printing).
+ */
+val KillingWaveReprint = Printing(
+    oracleId = "69d6b906-5461-4eba-8667-dbb8c0ce3fcb",
+    name = "Killing Wave",
+    setCode = "INR",
+    collectorNumber = "121",
+    scryfallId = "d412f946-9063-49da-adb8-1248b828b286",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d412f946-9063-49da-adb8-1248b828b286.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VexingDevilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VexingDevilReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vexing Devil reprint in INR. Canonical CardDefinition lives in AVR (its earliest printing).
+ */
+val VexingDevilReprint = Printing(
+    oracleId = "b582e485-c024-47f0-ad6f-b918d32288ba",
+    name = "Vexing Devil",
+    setCode = "INR",
+    collectorNumber = "178",
+    scryfallId = "ba50e7df-9dec-4df8-94a5-5883bbedf0cb",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba50e7df-9dec-4df8-94a5-5883bbedf0cb.jpg",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -717,6 +717,79 @@
     ]
 }
 
+// Killing Wave
+{
+    "name": "Killing Wave",
+    "manaCost": "{X}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "For each creature, its controller sacrifices it unless they pay X life.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Players",
+                "players": "ActivePlayerFirst"
+            },
+            "body": {
+                "type": "ForEach",
+                "space": {
+                    "type": "IterationSpace.Group",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "body": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayDynamicLife",
+                            "amount": "XValue"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": []
+                    },
+                    "otherwise": {
+                        "type": "SacrificeTarget",
+                        "target": "Self"
+                    },
+                    "descriptionOverride": "Pay life for this creature, or sacrifice it."
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "RARE",
+        "artist": "Steve Argyle",
+        "flavorText": "\"I come looking for demons and I find a plane full of angels. I hate angels.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33de2371-175e-4f8a-9636-35f996e3cf24.jpg?1783940697",
+        "rulings": [
+            {
+                "date": "2012-05-01",
+                "text": "First, the active player chooses whether to pay X life for each creature they control. Then each other player in turn order chooses for their creatures. Then each player pays life and sacrifices creatures at the same time. Players will know the decisions of players who chose before them."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "A player may choose to pay life for some creatures and sacrifice the rest. It's not an all-or-nothing decision."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "You can't pay more life than you have."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "If you can't sacrifice a creature (perhaps because of Sigarda, Host of Herons), you can choose not to pay life and nothing will happen."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Maalfeld Twins
 {
     "name": "Maalfeld Twins",
@@ -1151,6 +1224,91 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Vexing Devil
+{
+    "name": "Vexing Devil",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "When this creature enters, any opponent may have it deal 4 damage to them. If a player does, sacrifice this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "DealDamage",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    },
+                                    "target": {
+                                        "type": "PlayerRef",
+                                        "player": "You"
+                                    },
+                                    "damageSource": "Self"
+                                },
+                                {
+                                    "type": "SacrificeTarget",
+                                    "target": "Self",
+                                    "sacrificedByItsController": true
+                                }
+                            ]
+                        },
+                        "decisionMaker": {
+                            "type": "PlayerRef",
+                            "player": "You"
+                        },
+                        "descriptionOverride": "Have Vexing Devil deal 4 damage to you? If you do, its controller sacrifices it."
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Lucas Graciano",
+        "flavorText": "It's not any fun until someone loses an eye.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbbefd98-4b17-4cc2-9ef9-8807f594cb16.jpg?1783940672",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "As Vexing Devil's ability resolves, the next opponent in turn order (or, if it's an opponent's turn, that opponent) chooses whether to be dealt 4 damage, then each other opponent in turn order does the same. If any of them do, you sacrifice Vexing Devil."
+            },
+            {
+                "date": "2018-12-07",
+                "text": "No player may take actions between the time an opponent chooses to be dealt damage by Vexing Devil and the time you sacrifice Vexing Devil."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "If a player chooses to have Vexing Devil deal 4 damage to them, but some or all of that damage is prevented or redirected, Vexing Devil will still be sacrificed."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillingWaveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillingWaveScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.KillingWave
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Killing Wave — {X}{B} Sorcery
+ * "For each creature, its controller sacrifices it unless they pay X life."
+ *
+ * Covers the three things that make this more than a plain edict: the choice is per creature and
+ * per controller (not the caster), paying is a *cost* so a player who can't afford X is never
+ * offered it, and it sweeps both sides of the board.
+ */
+class KillingWaveScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(KillingWave)
+        return driver
+    }
+
+    test("each controller chooses per creature: pay X life to keep it, or sacrifice it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val wave = driver.putCardInHand(caster, "Killing Wave")
+        driver.giveMana(caster, Color.BLACK, 3)
+        driver.castXSpell(caster, wave, xValue = 2).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Active player first (APNAP): the caster is asked about their own Bears.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>().playerId shouldBe caster
+        // Still paused afterwards (the opponent has yet to choose), so assert on `error`, not
+        // `isSuccess` — the latter is false whenever a decision is still pending.
+        driver.submitYesNo(caster, true).error shouldBe null
+
+        // Then the opponent, for theirs.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>().playerId shouldBe opponent
+        driver.submitYesNo(opponent, false).error shouldBe null
+
+        driver.getLifeTotal(caster) shouldBe 18
+        driver.getLifeTotal(opponent) shouldBe 20
+        driver.findPermanent(caster, "Grizzly Bears") shouldNotBe null
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        driver.getGraveyardCardNames(opponent) shouldBe listOf("Grizzly Bears")
+    }
+
+    test("a player who cannot pay X life is never offered the choice and just sacrifices") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.setLifeTotal(opponent, 2)
+
+        val wave = driver.putCardInHand(caster, "Killing Wave")
+        driver.giveMana(caster, Color.BLACK, 6)
+        driver.castXSpell(caster, wave, xValue = 5).isSuccess shouldBe true
+        driver.bothPass()
+
+        // The caster controls no creatures, and the opponent cannot afford 5 life — no prompt at all.
+        driver.pendingDecision shouldBe null
+        driver.getLifeTotal(opponent) shouldBe 2
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        driver.getGraveyardCardNames(opponent) shouldBe listOf("Grizzly Bears")
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VexingDevilScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VexingDevilScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.VexingDevil
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Vexing Devil — {R} 4/3 Creature — Devil
+ * "When this creature enters, any opponent may have it deal 4 damage to them.
+ *  If a player does, sacrifice this creature."
+ *
+ * The choice belongs to the *opponent*, not the Devil's controller, and accepting must both deal
+ * the damage and sacrifice the Devil in one uninterruptible step (2018-12-07 ruling).
+ */
+class VexingDevilScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(VexingDevil)
+        return driver
+    }
+
+    fun castDevil(driver: GameTestDriver) {
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val devil = driver.putCardInHand(caster, "Vexing Devil")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpell(caster, devil).isSuccess shouldBe true
+        // Resolve the creature spell, then the ETB trigger it puts on the stack.
+        driver.bothPass()
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+    }
+
+    test("the opponent — not the controller — is asked, and accepting deals 4 and sacrifices the Devil") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        castDevil(driver)
+
+        val decision = driver.pendingDecision
+        decision shouldNotBe null
+        decision.shouldBeInstanceOf<YesNoDecision>().playerId shouldBe opponent
+
+        driver.submitYesNo(opponent, true).isSuccess shouldBe true
+
+        driver.getLifeTotal(opponent) shouldBe 16
+        driver.getLifeTotal(caster) shouldBe 20
+        driver.findPermanent(caster, "Vexing Devil") shouldBe null
+        driver.getGraveyardCardNames(caster) shouldBe listOf("Vexing Devil")
+    }
+
+    test("declining leaves the Devil on the battlefield and the opponent at full life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        castDevil(driver)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>().playerId shouldBe opponent
+        driver.submitYesNo(opponent, false).isSuccess shouldBe true
+
+        driver.getLifeTotal(opponent) shouldBe 20
+        driver.findPermanent(caster, "Vexing Devil") shouldNotBe null
+        driver.getGraveyardCardNames(caster) shouldBe emptyList()
+    }
+})


### PR DESCRIPTION
Two more Innistrad Remastered cards. Both were first printed in Avacyn Restored, so the canonical `CardDefinition`s live in AVR and INR gets `Printing` rows (`just check-card-printing` is clean for both).

## Vexing Devil — {R} 4/3 Creature — Devil

> When this creature enters, any opponent may have it deal 4 damage to them. If a player does, sacrifice this creature.

`ForEachPlayer(Player.EachOpponent)` with the yes/no delegated to the opponent being asked via `MayEffect(decisionMaker = PlayerRef(Player.You))` — the 2018-12-07 ruling has each opponent choose in turn order, not just the first one. Accepting deals the damage and sacrifices the Devil inside the same gate, so no player gets priority in between (second ruling). The sacrifice needs `sacrificedByItsController = true`: `ForEachPlayer` rebinds the resolving controller to the opponent, and a plain "sacrifice it" is silently skipped on that control mismatch.

Known deviation, documented on the card: `Player.EachOpponent` iterates in seat order rather than APNAP order. Identical in two-player; in multiplayer every opponent is still asked, only the prompt order can differ.

## Killing Wave — {X}{B} Sorcery

> For each creature, its controller sacrifices it unless they pay X life.

`ForEachPlayer(Player.ActivePlayerFirst)` (APNAP, matching the ruling that the active player decides for all their creatures first) wrapping a per-creature `ForEachInGroup(AllCreaturesYouControl)`, gated by `OptionalCostEffect(cost = PayDynamicLifeEffect(DynamicAmount.XValue), ifNotPaid = SacrificeTarget(Self))`. Because paying life is a real cost, `Gate.MayPay`'s affordability pre-pass means a player with less life than X is never offered the choice and simply sacrifices (CR 119.4). X = 0 still prompts, which is correct — a player may decline to pay 0.

Known deviation, documented on the card: the ruling has everyone decide first and then pay/sacrifice simultaneously; here each player's payments and sacrifices resolve before the next player is asked. Only observable through death triggers.

## Notes

- **Pure composition** — no new SDK vocabulary, so no `card-sdk-language-reference.md` change.
- **UX**: both use the existing `YesNoDecision` flow. Killing Wave's gate labels its buttons with the computed cost ("Pay 2 life" / "Don't pay"); the prompt can't name *which* creature is being asked about, since the decision's source is the spell rather than the iteration entity, so a wide board shows one identical prompt per creature. Called out in the card's KDoc.
- **Why only two cards**: of INR's 56 missing cards, the rest are gated on engine capabilities we don't have — madness (11 cards), emerge (5), escalate (4), disturb (4), splice onto Arcane, soulbond, eminence, battles, the original-Innistrad werewolf "no spells were cast last turn" transform (8 DFCs — `previousTurnActiveTeamSpellCounts` exists in `GameState` but has no SDK-level `Condition`), skulk (Odric), a once-per-turn cap on `MayCastFromGraveyard` (Gisa and Geralf), a linked exile that can hold a spell (Spell Queller), and a controller-scoped `CantBeSacrificed` (Sigarda). Each of those is `add-feature` work, not `add-card`.

## Verification

- `just build` — green (AVR card snapshot re-blessed; diff is insertions only, both new cards).
- `just test-class VexingDevilScenarioTest` — 2/2 passing (opponent is the one asked; accept deals 4 + sacrifices; decline leaves it in play).
- `just test-class KillingWaveScenarioTest` — 2/2 passing (per-controller prompts in APNAP order, pay-vs-sacrifice split, unaffordable-cost path prompts nobody).
- `just check-card-printing "Vexing Devil"` / `"Killing Wave"` — both ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)