### PR TITLE
Add Yenna, Redtooth Regent (WOE) with name-uniqueness targeting and Aura token attachment

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1226,6 +1226,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `null` defaults to the effect's controller. Set it for "**Target player** creates a token that's a copy of
   target creature you control" (Echocasting Symposium): the chosen creature is copied but the token enters
   under the named player's control. Mirrors `CreateTokenEffect.controller`.
+  **Aura copies (CR 303.4h)** need no extra parameter — the executor handles them. A token copy of an Aura
+  is created rather than cast, so it never targets; instead its controller *chooses* what it enchants as it
+  enters, restricted to what the copied Aura could legally enchant (its `auraTarget`, with targeting
+  restrictions such as hexproof/shroud ignored per CR 303.4f). The choice is raised **before** the token
+  exists, so it enters already attached and its enters-the-battlefield triggers see the attachment; a
+  `PermanentAttachedEvent` fires so "becomes attached" triggers (Eriette, the Beguiler) work. With no legal
+  object to enchant the token isn't created at all (CR 303.4g). An effect making several Aura copies asks
+  once per token. Because the choice is a mid-resolution pause, `CREATED_TOKENS` is **not** populated on the
+  Aura path — branch a following step on the copied target instead (Yenna, Redtooth Regent's "if the token
+  is an Aura, untap Yenna, then scry 2").
   Like `CreateToken`, both `CreateTokenCopyOfTarget` and `CreateTokenCopyOfSource` publish their created token
   entity IDs to the `CREATED_TOKENS` pipeline collection, so a sibling effect in a `CompositeEffect` can address
   the new copy — e.g. Applied Geometry's "Create a token that's a copy … Put six +1/+1 counters on it" composes
@@ -2879,6 +2889,16 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   state-dependent battlefield target filter; compose it with the printed type/control/token restrictions.
   Used by The Apprentice's Folly
   (`Creature.youControl().nontoken().nameNotSharedWithControlledToken()`).
+- `.nameNotSharedWithAnotherControlledPermanent()` —
+  `CardPredicate.NameNotSharedWithAnotherControlledPermanent`: matches a permanent whose name isn't shared
+  with **any other** permanent the evaluating player controls. Broader than
+  `.nameNotSharedWithControlledToken()` on both sides: the compared set is every permanent the controller
+  has out (tokens *and* cards), and the candidate itself is excluded, so two same-named permanents
+  disqualify **each other**. Names are read through the projection, honoring Layer 3 name-changing effects
+  (Witness Protection). Keyed off the predicate context's `controllerId`; fails **open** with no controller
+  in scope. Used by Yenna, Redtooth Regent
+  (`Enchantment.youControl().nameNotSharedWithAnotherControlledPermanent()`) — the restriction is
+  self-limiting, since copying an enchantment makes it an illegal target from then on.
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -346,6 +346,16 @@ data class GameObjectFilter(
     )
 
     /**
+     * Match permanents whose name isn't shared with *another* permanent the evaluating player
+     * controls — "that doesn't have the same name as another permanent you control" (Yenna,
+     * Redtooth Regent). The candidate itself is excluded from the comparison; see
+     * [CardPredicate.NameNotSharedWithAnotherControlledPermanent].
+     */
+    fun nameNotSharedWithAnotherControlledPermanent() = copy(
+        cardPredicates = cardPredicates + CardPredicate.NameNotSharedWithAnotherControlledPermanent
+    )
+
+    /**
      * Match cards whose name equals the name durably chosen by the *source permanent* as it
      * entered (its [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under
      * [slot]). Static-projection / activation-legality safe — use this in static-ability filters

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -330,6 +330,27 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches a permanent whose name isn't shared with **any other** permanent the evaluating
+     * player controls — "that doesn't have the same name as another permanent you control"
+     * (Yenna, Redtooth Regent).
+     *
+     * Broader than [NameNotSharedWithControlledToken] in two ways: the compared set is every
+     * permanent the controller has on the battlefield (tokens *and* cards), and the candidate
+     * itself is excluded so a permanent never disqualifies itself ("**another** permanent").
+     * Two permanents sharing a name therefore disqualify each other, not just one of them.
+     *
+     * Names are read through the projection ([ProjectedState.getName]) so a name-changing
+     * Layer 3 effect (Witness Protection, Honest Work) is respected on both sides of the
+     * comparison. Fails open (matches) when no controller is in scope.
+     */
+    @SerialName("NameNotSharedWithAnotherControlledPermanent")
+    @Serializable
+    data object NameNotSharedWithAnotherControlledPermanent : CardPredicate {
+        override val description: String =
+            "that doesn't have the same name as another permanent you control"
+    }
+
+    /**
      * Matches cards *originally printed* in the given set — i.e. whose canonical
      * [com.wingedsheep.sdk.model.CardDefinition.setCode] equals [setCode] (case-insensitive),
      * regardless of which printing is actually in play. This is the card's first/canonical set, so

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/YennaRedtoothRegent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/YennaRedtoothRegent.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Yenna, Redtooth Regent
+ * {2}{G}{W}
+ * Legendary Creature — Elf Noble
+ * 4/4
+ *
+ * {2}, {T}: Choose target enchantment you control that doesn't have the same name as another
+ * permanent you control. Create a token that's a copy of it, except it isn't legendary. If the
+ * token is an Aura, untap Yenna, then scry 2. Activate only as a sorcery.
+ *
+ * Implementation notes:
+ *  - **The name restriction** is the target filter, not a resolution check: "doesn't have the same
+ *    name as another permanent you control" is
+ *    [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameNotSharedWithAnotherControlledPermanent].
+ *    It compares against every *other* permanent the controller has out — the token Yenna just
+ *    made included — so activating twice on the same enchantment is illegal the second time, which
+ *    is the card's whole design constraint.
+ *  - **"except it isn't legendary"** is `removedSupertypes = {LEGENDARY}` on
+ *    [Effects.CreateTokenCopyOfTarget]; the copy exception is baked into the token's own copiable
+ *    values, so anything that later copies the token also isn't legendary (printed ruling).
+ *  - **Aura copies** are handled generically by the token-copy executor: a token copy of an Aura
+ *    is created rather than cast, so its controller chooses what it enchants as it enters
+ *    (CR 303.4h), bound by the copied Aura's own enchant restriction. See
+ *    `AuraTokenHostChooser`.
+ *  - **The Aura rider** branches on the chosen target rather than on the created token. The two
+ *    coincide except when the Aura token can't be created for want of a legal host (CR 303.4g) —
+ *    a corner that can only arise if every object the Aura could enchant has left the battlefield
+ *    since activation, since the Aura's current host is itself always a legal choice.
+ */
+val YennaRedtoothRegent = card("Yenna, Redtooth Regent") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 4
+    toughness = 4
+    oracleText = "{2}, {T}: Choose target enchantment you control that doesn't have the same name " +
+        "as another permanent you control. Create a token that's a copy of it, except it isn't " +
+        "legendary. If the token is an Aura, untap Yenna, then scry 2. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        val enchantment = target(
+            "enchantment you control that doesn't have the same name as another permanent you control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Enchantment
+                        .youControl()
+                        .nameNotSharedWithAnotherControlledPermanent()
+                )
+            )
+        )
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = enchantment,
+            removedSupertypes = setOf(Supertype.LEGENDARY),
+        ) then ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Enchantment.withSubtype(Subtype.AURA)
+            ),
+            effect = Effects.Untap(EffectTarget.Self) then Effects.Scry(2),
+        )
+        description = "Choose target enchantment you control that doesn't have the same name as " +
+            "another permanent you control. Create a token that's a copy of it, except it isn't " +
+            "legendary. If the token is an Aura, untap Yenna, then scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "219"
+        artist = "Justyna Dura"
+        flavorText = "\"My people are both bloom and thorn.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg?1783915066"
+
+        ruling("2023-09-01", "Except for the listed exceptions, the token copies exactly what was printed on the original enchantment and nothing else (unless that enchantment is itself copying something else). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on.")
+        ruling("2023-09-01", "If the copied enchantment is copying something else, then the token enters the battlefield as whatever that enchantment copied, with the stated exceptions.")
+        ruling("2023-09-01", "If the copied enchantment has {X} in its mana cost, X is 0.")
+        ruling("2023-09-01", "Any enters-the-battlefield abilities of the copied enchantment will trigger when the token enters the battlefield. Any \"as [this enchantment] enters the battlefield\" or \"[this enchantment] enters the battlefield with\" abilities of the enchantment will also work.")
+        ruling("2023-09-01", "If something becomes a copy of the token, the copy also isn't legendary.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -20948,3 +20948,128 @@
         }
     ]
 }
+
+// Yenna, Redtooth Regent
+{
+    "name": "Yenna, Redtooth Regent",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "{2}, {T}: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, then scry 2. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "enchantment you control that doesn't have the same name as another permanent you control"
+                            },
+                            "removedSupertypes": [
+                                "LEGENDARY"
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "enchantment Aura"
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "TapUntap",
+                                        "target": "Self",
+                                        "tap": false
+                                    },
+                                    {
+                                        "type": "Scry",
+                                        "count": 2
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsEnchantment",
+                                    "NameNotSharedWithAnotherControlledPermanent"
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "enchantment you control that doesn't have the same name as another permanent you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, then scry 2."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "RARE",
+        "artist": "Justyna Dura",
+        "flavorText": "\"My people are both bloom and thorn.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e635d461-254a-434e-8e5d-dea61dd8ca4f.jpg?1783915066",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Except for the listed exceptions, the token copies exactly what was printed on the original enchantment and nothing else (unless that enchantment is itself copying something else). It doesn't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If the copied enchantment is copying something else, then the token enters the battlefield as whatever that enchantment copied, with the stated exceptions."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If the copied enchantment has {X} in its mana cost, X is 0."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Any enters-the-battlefield abilities of the copied enchantment will trigger when the token enters the battlefield. Any \"as [this enchantment] enters the battlefield\" or \"[this enchantment] enters the battlefield with\" abilities of the enchantment will also work."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If something becomes a copy of the token, the copy also isn't legendary."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -475,6 +475,32 @@ data class CreateTokenCopyOfChosenContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller chooses what an Aura token copy will enchant (CR 303.4h).
+ *
+ * A token copy of an Aura is created on the battlefield rather than cast, so its controller
+ * picks a host instead of targeting one. The pick is raised *before* the token exists so it can
+ * enter already attached — see
+ * [com.wingedsheep.engine.handlers.effects.token.AuraTokenHostChooser].
+ *
+ * @property effect The original create-token-copy effect, re-executed for one token per pick
+ * @property context The resolution context, so the effect's target still resolves on resume
+ * @property controllerId The player creating (and choosing for) the token
+ * @property auraDefinitionId Card definition of the copied Aura, for re-deriving legal hosts
+ * @property auraName The copied Aura's name, for the next prompt
+ * @property remaining How many Aura tokens are still owed, including the one this pick creates
+ */
+@Serializable
+data class CreateTokenCopyAuraHostContinuation(
+    override val decisionId: String,
+    val effect: com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect,
+    val context: com.wingedsheep.engine.handlers.EffectContext,
+    val controllerId: EntityId,
+    val auraDefinitionId: String,
+    val auraName: String,
+    val remaining: Int
+) : ContinuationFrame
+
+/**
  * Resume after a player chooses an action from a list of labeled options.
  *
  * Used by [ChooseActionEffect] — the player is presented with feasible options

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -310,6 +310,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CounterUnlessPaysManaSelectionContinuation::class)
         subclass(WardTapPermanentsSubCostContinuation::class)
         subclass(CreateTokenCopyOfChosenContinuation::class)
+        subclass(CreateTokenCopyAuraHostContinuation::class)
         subclass(DistributeDamageContinuation::class)
         subclass(EachPlayerDiscardsOrLoseLifeContinuation::class)
         subclass(ManaSourceSelectionContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -350,6 +350,28 @@ class PredicateEvaluator {
                 }
             }
 
+            // "that doesn't have the same name as another permanent you control" (Yenna,
+            // Redtooth Regent). Compares against every *other* permanent the controller has on
+            // the battlefield — tokens and cards alike — so two same-named permanents disqualify
+            // each other. Names on both sides come from the projection, honoring Layer 3
+            // name-changing effects. Fails open with no controller in scope.
+            is CardPredicate.NameNotSharedWithAnotherControlledPermanent -> {
+                val controllerId = context?.controllerId
+                if (controllerId == null) {
+                    true
+                } else {
+                    val candidateName = projectedValues?.name ?: card.name
+                    state.getBattlefield().none { id ->
+                        id != entityId &&
+                            projected.getController(id) == controllerId &&
+                            (
+                                projected.getName(id)
+                                    ?: state.getEntity(id)?.get<CardComponent>()?.name
+                                ) == candidateName
+                    }
+                }
+            }
+
             // Keyword predicates - use projected keywords
             is CardPredicate.HasKeyword -> predicate.keyword.name in keywords
             is CardPredicate.NotKeyword -> predicate.keyword.name !in keywords
@@ -1504,6 +1526,7 @@ class PredicateEvaluator {
             is CardPredicate.NameEqualsChosen -> false
             CardPredicate.NameNotSharedWithControlledRoom -> false
             CardPredicate.NameNotSharedWithControlledToken -> false
+            CardPredicate.NameNotSharedWithAnotherControlledPermanent -> false
             is CardPredicate.OriginallyPrintedInSet -> false
 
             // Keyword predicates — not stored in record

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -829,6 +829,7 @@ class CastZoneResolver(
                 is CardPredicate.NameEqualsChosenComponent,
                 is CardPredicate.NameNotSharedWithControlledRoom,
                 is CardPredicate.NameNotSharedWithControlledToken,
+                is CardPredicate.NameNotSharedWithAnotherControlledPermanent,
                 is CardPredicate.ManaValueEqualsX,
                 is CardPredicate.ManaValueAtMostX,
                 is CardPredicate.ManaValueAtMostEntity,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -34,6 +34,7 @@ class ModalAndCloneContinuationResumer(
         resumer(CastWithCreatureTypeContinuation::class, ::resumeCastWithCreatureType),
         resumer(BudgetModalContinuation::class, ::resumeBudgetModal),
         resumer(CreateTokenCopyOfChosenContinuation::class, ::resumeCreateTokenCopyOfChosen),
+        resumer(CreateTokenCopyAuraHostContinuation::class, ::resumeCreateTokenCopyAuraHost),
         resumer(ChooseActionContinuation::class, ::resumeChooseAction)
     )
 
@@ -1261,6 +1262,63 @@ class ModalAndCloneContinuationResumer(
         ).toExecutionResult()
         if (result.isPaused) return result
         return checkForMore(result.state, result.events.toList())
+    }
+
+    /**
+     * Resume after the controller chose what an Aura token copy enchants (CR 303.4h).
+     *
+     * Creates exactly one token, already attached to the chosen host, then asks again for the
+     * next one when the effect owes more than one Aura copy. An empty pick (or a host that left
+     * the battlefield while the decision was outstanding) means no legal attachment, so that
+     * token isn't created — CR 303.4g.
+     */
+    fun resumeCreateTokenCopyAuraHost(
+        state: GameState,
+        continuation: CreateTokenCopyAuraHostContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is TargetsResponse) {
+            return ExecutionResult.error(state, "Expected targets response for Aura token host selection")
+        }
+
+        val hostId = response.selectedTargets[0]?.firstOrNull()
+        if (hostId == null || hostId !in state.getBattlefield()) {
+            return checkForMore(state, emptyList())
+        }
+
+        val executor = com.wingedsheep.engine.handlers.effects.token.CreateTokenCopyOfTargetExecutor(
+            staticAbilityHandler = com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler(services.cardRegistry),
+            cardRegistry = services.cardRegistry,
+        )
+        val created = executor.createTokens(
+            state = state,
+            effect = continuation.effect,
+            context = continuation.context,
+            controllerId = continuation.controllerId,
+            count = 1,
+            auraHostId = hostId,
+        )
+
+        val remaining = continuation.remaining - 1
+        if (remaining <= 0) {
+            return checkForMore(created.state, created.events.toList())
+        }
+
+        // More Aura copies owed — each gets its own host choice.
+        val next = com.wingedsheep.engine.handlers.effects.token.AuraTokenHostChooser.pause(
+            state = created.state,
+            effect = continuation.effect,
+            context = continuation.context,
+            auraDefinitionId = continuation.auraDefinitionId,
+            auraName = continuation.auraName,
+            controllerId = continuation.controllerId,
+            remaining = remaining,
+            cardRegistry = services.cardRegistry,
+        )
+        val nextDecision = next.pendingDecision
+            ?: return checkForMore(next.state, created.events.toList() + next.events.toList())
+        return ExecutionResult.paused(next.state, nextDecision, created.events.toList())
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/AuraTokenHostChooser.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/AuraTokenHostChooser.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.handlers.effects.token
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.CreateTokenCopyAuraHostContinuation
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.TargetRequirementInfo
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
+import java.util.UUID
+
+/**
+ * Raises the "what does this Aura token enchant?" choice (CR 303.4h).
+ *
+ * A token copy of an Aura is put onto the battlefield without being cast, so it never targets.
+ * Instead its controller chooses what it enchants as it enters, restricted to objects the copied
+ * Aura could legally enchant (CR 303.4f — its printed `enchant` restriction, with targeting
+ * restrictions such as hexproof and shroud ignored, since nothing is being targeted).
+ *
+ * The choice is raised *before* the token is created so it enters already attached: its
+ * enters-the-battlefield triggers and the first state-based check both see a properly attached
+ * Aura. If no legal object exists the token isn't created at all (CR 303.4g).
+ *
+ * Each token gets its own choice, so an effect creating several Aura copies asks once per token —
+ * the continuation carries how many are still owed.
+ */
+internal object AuraTokenHostChooser {
+
+    /**
+     * Pause for the controller to pick a host for the next Aura token, or return an unchanged
+     * state when there is nothing the Aura could legally enchant (no token is created).
+     */
+    fun pause(
+        state: GameState,
+        effect: CreateTokenCopyOfTargetEffect,
+        context: EffectContext,
+        auraDefinitionId: String,
+        auraName: String,
+        controllerId: EntityId,
+        remaining: Int,
+        cardRegistry: CardRegistry?,
+    ): EffectResult {
+        if (remaining <= 0) return EffectResult.success(state)
+
+        val hosts = legalHosts(state, auraDefinitionId, controllerId, cardRegistry)
+        if (hosts.isEmpty()) {
+            // Nothing legal to enchant — the Aura token can't enter (CR 303.4g), and neither can
+            // any of the ones still owed, since they would all copy the same Aura.
+            return EffectResult.success(state)
+        }
+
+        val decisionId = UUID.randomUUID().toString()
+        val decision = ChooseTargetsDecision(
+            id = decisionId,
+            playerId = controllerId,
+            prompt = "Choose what the $auraName token enchants",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name },
+                phase = DecisionPhase.RESOLUTION,
+            ),
+            targetRequirements = listOf(
+                TargetRequirementInfo(
+                    index = 0,
+                    description = "permanent for the $auraName token to enchant",
+                    minTargets = 1,
+                    maxTargets = 1,
+                )
+            ),
+            legalTargets = mapOf(0 to hosts),
+        )
+
+        val continuation = CreateTokenCopyAuraHostContinuation(
+            decisionId = decisionId,
+            effect = effect,
+            context = context,
+            controllerId = controllerId,
+            auraDefinitionId = auraDefinitionId,
+            auraName = auraName,
+            remaining = remaining,
+        )
+
+        return EffectResult(
+            state = state.withPendingDecision(decision).pushContinuation(continuation),
+            events = emptyList(),
+            pendingDecision = decision,
+        )
+    }
+
+    /**
+     * Objects the copied Aura could legally enchant. Derived from the Aura card definition's
+     * `auraTarget` — the token copies the printed enchant restriction along with everything else.
+     * An Aura whose definition declares no enchant restriction has no legal host.
+     */
+    private fun legalHosts(
+        state: GameState,
+        auraDefinitionId: String,
+        controllerId: EntityId,
+        cardRegistry: CardRegistry?,
+    ): List<EntityId> {
+        val auraTarget = cardRegistry?.getCard(auraDefinitionId)?.script?.auraTarget
+            ?: return emptyList()
+        return TargetFinder().findLegalTargets(
+            state = state,
+            requirement = auraTarget,
+            controllerId = controllerId,
+            sourceId = null,
+            ignoreTargetingRestrictions = true,
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -14,6 +14,8 @@ import com.wingedsheep.engine.event.GrantedTriggeredAbility
 import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -43,6 +45,14 @@ import kotlin.reflect.KClass
  *
  * Creates N token copies of a targeted permanent (resolved via EffectTarget).
  * Used for "Create X tokens that are copies of target token you control."
+ *
+ * **Aura copies (CR 303.4h).** A token copy of an Aura is put onto the battlefield without being
+ * cast, so it doesn't target — its controller instead *chooses* what it enchants as it enters,
+ * bound by the copied Aura's own enchant restriction (CR 303.4f; targeting restrictions such as
+ * hexproof and shroud are ignored). The choice is raised *before* the token exists, so the token
+ * enters already attached and its enters-the-battlefield triggers see the attachment. If there is
+ * no legal object to enchant, the token isn't created at all (CR 303.4g) — Yenna, Redtooth Regent
+ * copying an Aura whose only legal hosts have left the battlefield.
  */
 class CreateTokenCopyOfTargetExecutor(
     private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator(),
@@ -83,6 +93,46 @@ class CreateTokenCopyOfTargetExecutor(
             state, effect, context, count, controllerId, cardRegistry, staticAbilityHandler
         )
         if (replacementResult != null) return replacementResult
+
+        // An Aura token needs its host chosen before it can be created (CR 303.4h) — the copy's
+        // type line decides, so read it off the copied CardComponent (copiable values only).
+        if (auraTypeLineOf(effect, targetCard).isAura) {
+            return AuraTokenHostChooser.pause(
+                state = state,
+                effect = effect,
+                context = context,
+                auraDefinitionId = targetCard.cardDefinitionId,
+                auraName = targetCard.name,
+                controllerId = controllerId,
+                remaining = com.wingedsheep.engine.core.GameLimits
+                    .cappedTokenCount(count, "target-copy tokens"),
+                cardRegistry = cardRegistry,
+            )
+        }
+
+        return createTokens(state, effect, context, controllerId, count, auraHostId = null)
+    }
+
+    /**
+     * Create [count] token copies of the effect's target. When [auraHostId] is non-null every
+     * created token enters attached to it (the Aura path — see the class docs); otherwise the
+     * tokens enter unattached. Split out of [execute] so the Aura host-choice continuation can
+     * re-enter here once the controller has picked a host.
+     */
+    internal fun createTokens(
+        state: GameState,
+        effect: CreateTokenCopyOfTargetEffect,
+        context: EffectContext,
+        controllerId: EntityId,
+        count: Int,
+        auraHostId: EntityId?,
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state)
+        val targetContainer = state.getEntity(targetId)
+            ?: return EffectResult.success(state)
+        val targetCard = targetContainer.get<CardComponent>()
+            ?: return EffectResult.success(state)
 
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
@@ -150,6 +200,13 @@ class CreateTokenCopyOfTargetExecutor(
                 )
             }
 
+            // CR 303.4h: an Aura token enters already attached to the host its controller chose
+            // before it was created, so the attachment is in place for any enters-the-battlefield
+            // trigger and for the very first state-based check.
+            if (auraHostId != null) {
+                components.add(AttachedToComponent(auraHostId))
+            }
+
             var container = ComponentContainer.of(*components.toTypedArray())
 
             if (staticAbilityHandler != null) {
@@ -166,6 +223,25 @@ class CreateTokenCopyOfTargetExecutor(
                 .applyCreatedTokenEntryTap(
                     newState, tokenId, controllerId, definedTapped = effect.tapped,
                 )
+            // Wire the host side of the attachment and announce it, so "becomes attached"
+            // triggers (Eriette, the Beguiler) fire for an Aura token the same way they do when
+            // an Aura card is put onto the battlefield attached (CR 603.2e).
+            if (auraHostId != null) {
+                newState = newState.updateEntity(auraHostId) { hostContainer ->
+                    val existing = hostContainer.get<AttachmentsComponent>()
+                    hostContainer.with(
+                        AttachmentsComponent((existing?.attachedIds ?: emptyList()) + tokenId)
+                    )
+                }
+                events.add(
+                    com.wingedsheep.engine.core.PermanentAttachedEvent(
+                        attachmentId = tokenId,
+                        attachmentName = tokenCard.name,
+                        attachedToId = auraHostId,
+                        controllerId = controllerId,
+                    )
+                )
+            }
             createdTokens.add(tokenId)
 
             for (ability in effect.triggeredAbilities) {
@@ -297,4 +373,17 @@ class CreateTokenCopyOfTargetExecutor(
             updatedCollections = mapOf(com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS to createdTokens.toList())
         )
     }
+
+    /**
+     * The type line the copy will actually have, after the effect's `override*` clauses. Read to
+     * decide whether the Aura host choice applies — "except it's a creature" turns an Aura copy
+     * into something that isn't an Aura and needs no host.
+     */
+    private fun auraTypeLineOf(
+        effect: CreateTokenCopyOfTargetEffect,
+        targetCard: CardComponent,
+    ) = targetCard.typeLine.copy(
+        cardTypes = effect.overrideCardTypes ?: targetCard.typeLine.cardTypes,
+        subtypes = effect.overrideSubtypes ?: (targetCard.typeLine.subtypes + effect.addedSubtypes),
+    )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -743,6 +743,9 @@ internal class AffectsFilterResolver {
         // affects-filter concern.
         CardPredicate.NameNotSharedWithControlledRoom -> false
         CardPredicate.NameNotSharedWithControlledToken -> false
+        // Likewise "no other permanent you control shares this name" — a targeting restriction
+        // evaluated against live battlefield state, not a static affects-filter.
+        CardPredicate.NameNotSharedWithAnotherControlledPermanent -> false
         is CardPredicate.OriginallyPrintedInSet ->
             card.originalSetCode?.equals(predicate.setCode, ignoreCase = true) == true
         is CardPredicate.HasBasicLandType -> if (isFaceDown) false else subtypes.any { it.equals(predicate.landType, ignoreCase = true) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -995,6 +995,9 @@ class CostCalculator(
             // Room-name distinctness is a resolution-time search filter, not a cost concern.
             CardPredicate.NameNotSharedWithControlledRoom -> false
             CardPredicate.NameNotSharedWithControlledToken -> false
+            // Same for "no other permanent you control shares this name" — a targeting
+            // restriction, never a cost-reduction condition.
+            CardPredicate.NameNotSharedWithAnotherControlledPermanent -> false
 
             is CardPredicate.OriginallyPrintedInSet ->
                 cardDef.setCode?.equals(predicate.setCode, ignoreCase = true) == true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YennaRedtoothRegentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YennaRedtoothRegentScenarioTest.kt
@@ -1,0 +1,228 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.woe.cards.YennaRedtoothRegent
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Yenna, Redtooth Regent — "{2}, {T}: Choose target enchantment you control that doesn't have the
+ * same name as another permanent you control. Create a token that's a copy of it, except it isn't
+ * legendary. If the token is an Aura, untap Yenna, then scry 2. Activate only as a sorcery."
+ *
+ * Covers the two capabilities this card introduced:
+ *  - `CardPredicate.NameNotSharedWithAnotherControlledPermanent` — the target restriction, which is
+ *    self-limiting: copying an enchantment makes it an illegal target from then on.
+ *  - The Aura branch of `CreateTokenCopyOfTargetExecutor` — a token copy of an Aura is created, not
+ *    cast, so its controller chooses what it enchants as it enters (CR 303.4h).
+ */
+class YennaRedtoothRegentScenarioTest : ScenarioTestBase() {
+
+    private val copyAbilityId = YennaRedtoothRegent.activatedAbilities.first { !it.isManaAbility }.id
+
+    init {
+
+        test("copies a non-Aura enchantment; Yenna stays tapped and there is no scry") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Yenna, Redtooth Regent")
+                .withCardOnBattlefield(1, "A Tale for the Ages")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val yenna = game.findPermanent("Yenna, Redtooth Regent")!!
+            val tale = game.findPermanent("A Tale for the Ages")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = yenna,
+                    abilityId = copyAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(tale)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("a token copy of the enchantment now shares the battlefield with the original") {
+                game.findAllPermanents("A Tale for the Ages").size shouldBe 2
+            }
+            withClue("the copy is a token; the original is not") {
+                val token = game.findAllPermanents("A Tale for the Ages").single { it != tale }
+                game.state.getEntity(token)?.has<TokenComponent>() shouldBe true
+            }
+            withClue("the copied enchantment isn't an Aura, so Yenna is not untapped") {
+                game.state.getEntity(yenna)?.has<TappedComponent>() shouldBe true
+            }
+            withClue("and no scry is offered") {
+                game.hasPendingDecision() shouldBe false
+            }
+        }
+
+        test("the token copy of a legendary enchantment isn't legendary, so both survive") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Yenna, Redtooth Regent")
+                .withCardOnBattlefield(1, "Mornsong Aria")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val yenna = game.findPermanent("Yenna, Redtooth Regent")!!
+            val aria = game.findPermanent("Mornsong Aria")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = yenna,
+                    abilityId = copyAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(aria)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            val copies = game.findAllPermanents("Mornsong Aria")
+            withClue("the legend rule (CR 704.5j) doesn't fire — the token isn't legendary") {
+                copies.size shouldBe 2
+            }
+            val token = copies.single { it != aria }
+            withClue("the token's projected types omit LEGENDARY") {
+                game.state.projectedState.getProjectedValues(token)?.types shouldNotBe null
+                game.state.projectedState.getProjectedValues(token)!!.types.contains("LEGENDARY") shouldBe false
+            }
+            withClue("the original keeps its own legendary supertype") {
+                game.state.projectedState.getProjectedValues(aria)!!.types shouldContain "LEGENDARY"
+            }
+        }
+
+        test("an enchantment sharing a name with another permanent you control isn't a legal target") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Yenna, Redtooth Regent")
+                .withCardOnBattlefield(1, "A Tale for the Ages")
+                .withCardOnBattlefield(1, "A Tale for the Ages")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val yenna = game.findPermanent("Yenna, Redtooth Regent")!!
+            val tales = game.findAllPermanents("A Tale for the Ages")
+            tales.size shouldBe 2
+
+            withClue("both copies disqualify each other — 'another permanent you control'") {
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = yenna,
+                        abilityId = copyAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(tales.first())),
+                    )
+                ).error shouldNotBe null
+            }
+        }
+
+        test("copying an enchantment makes it an illegal target for the next activation") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Yenna, Redtooth Regent")
+                .withCardOnBattlefield(1, "A Tale for the Ages")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val yenna = game.findPermanent("Yenna, Redtooth Regent")!!
+            val tale = game.findPermanent("A Tale for the Ages")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = yenna,
+                    abilityId = copyAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(tale)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+            game.findAllPermanents("A Tale for the Ages").size shouldBe 2
+
+            // Untap Yenna by hand so the second attempt fails on the target restriction rather
+            // than on the {T} cost.
+            game.state = game.state.updateEntity(yenna) { it.without<TappedComponent>() }
+
+            withClue("the original now shares its name with the token it produced") {
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = yenna,
+                        abilityId = copyAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(tale)),
+                    )
+                ).error shouldNotBe null
+            }
+        }
+
+        test("copying an Aura asks what the token enchants, then untaps Yenna and scries") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Yenna, Redtooth Regent")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardAttachedTo(1, "Charmed Sleep", "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val yenna = game.findPermanent("Yenna, Redtooth Regent")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val sleep = game.findPermanent("Charmed Sleep")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = yenna,
+                    abilityId = copyAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(sleep)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("CR 303.4h — the controller chooses what the Aura token enchants") {
+                val decision = game.getPendingDecision()
+                (decision is ChooseTargetsDecision) shouldBe true
+                (decision as ChooseTargetsDecision).legalTargets[0]!! shouldContain bears
+            }
+            game.selectTargets(listOf(bears))
+
+            val copies = game.findAllPermanents("Charmed Sleep")
+            withClue("the Aura token was created") {
+                copies.size shouldBe 2
+            }
+            val token: EntityId = copies.single { it != sleep }
+            withClue("and it entered already attached to the chosen host") {
+                game.state.getEntity(token)?.get<AttachedToComponent>()?.targetId shouldBe bears
+            }
+            withClue("the token is an Aura, so Yenna untaps") {
+                game.state.getEntity(yenna)?.has<TappedComponent>() shouldBe false
+            }
+            withClue("and the controller scries 2") {
+                game.hasPendingDecision() shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Wilds of Eldraine had **4 cards left** unimplemented (262/266). They're the last four because each needs *engine capability*, not just a card definition. Per "pick fewer cards if they are complex", this PR implements the one whose new vocabulary is most self-contained and reusable: **Yenna, Redtooth Regent**.

The other three and their concrete blockers are listed at the bottom.

## Yenna, Redtooth Regent

> `{2}`, `{T}`: Choose target enchantment you control that doesn't have the same name as another permanent you control. Create a token that's a copy of it, except it isn't legendary. If the token is an Aura, untap Yenna, then scry 2. Activate only as a sorcery.

Two new generic capabilities:

### 1. `CardPredicate.NameNotSharedWithAnotherControlledPermanent`

The target restriction, as a filter rather than a resolution check. Broader than the existing `NameNotSharedWithControlledToken` on both sides:

- the compared set is **every** permanent the controller has out — tokens *and* cards;
- the candidate itself is excluded ("**another** permanent"), so two same-named permanents disqualify **each other**, not just one of them.

Names on both sides read through the projection, so a Layer 3 name-changing effect (Witness Protection, Honest Work) is honored. Fails open with no controller in scope, matching its siblings.

The restriction is self-limiting by design: copying an enchantment makes it an illegal target from then on. That's the card's whole balancing constraint, and it's pinned by a test.

### 2. Aura token attachment — CR 303.4h

A token copy of an Aura is *created*, not cast, so it never targets. Instead its controller **chooses** what it enchants as it enters, restricted to what the copied Aura could legally enchant (its `auraTarget`, with targeting restrictions such as hexproof/shroud ignored per CR 303.4f).

- The choice is raised **before** the token exists, so it enters already attached — ETB triggers and the first state-based check both see a properly attached Aura.
- A `PermanentAttachedEvent` fires, so "becomes attached" triggers (Eriette, the Beguiler) work on this path too (CR 603.2e).
- With no legal object to enchant, the token isn't created at all (CR 303.4g).
- An effect making several Aura copies asks once per token.

This is a rules-correctness fix for the executor generally, not a Yenna special case — any future "token that's a copy of target Aura" gets it.

## UX / client

The host choice reuses the existing `ChooseTargetsDecision`, so it renders through the same battlefield-targeting UI as every other "choose what this attaches to" prompt (One Last Job). **No new decision type and no client change.**

## Known divergence (documented on the card)

The host choice is a mid-resolution pause, and pipeline collections don't survive one, so `CREATED_TOKENS` is not populated on the Aura path. Yenna's "if the token is an Aura" rider therefore branches on the **copied target** rather than the created token. The two coincide except when the Aura token can't be created for want of a legal host — a corner that can only arise if every object the Aura could enchant left the battlefield since activation, since the Aura's *current* host is itself always a legal choice. Threading collections through continuations would be a much larger engine change; it's called out in the card's KDoc.

## Tests

`YennaRedtoothRegentScenarioTest` — 5 cases:

1. non-Aura copy: token created, Yenna stays tapped, no scry;
2. copying a **legendary** enchantment (Mornsong Aria): both survive, the token's projected types omit `LEGENDARY`, the original keeps it;
3. two same-named enchantments disqualify each other → activation rejected;
4. after copying, the original is no longer a legal target;
5. full Aura flow: host decision raised with the right legal targets → token enters attached to the chosen host → Yenna untaps → scry pending.

## Verification

- `just test` — full suite green
- `just check-card-printing "Yenna, Redtooth Regent"` — ok, canonical in WOE (its only real printing)
- `just rebless-cards` — only `snapshots/cards/WOE.json` moved, +125 lines, all Yenna
- `docs/card-sdk-language-reference.md` updated for both the new predicate and the Aura-copy behavior

## The three WOE cards still missing, and why

| Card | Blocker |
|---|---|
| **Likeness Looter** | Three separate features: (a) X-gated target selection — its `{X}` target filter is "creature card with mana value X", but `ManaValueEqualsX` matches nothing until X is bound, and the mana-`{X}` activation path has no target pause (only the `ExilePermanents` cost path does); (b) `addedKeywords` on the become-a-copy effect ("except it has flying"); (c) a **self-perpetuating retained ability** ("and this ability") — it can't be a plain data field because it would recurse infinitely, so it needs the resolving `ActivatedAbility` plumbed onto the stack component and into `EffectContext`. |
| **The Irencrag** | `BecomeArtifactEffect` needs a `name` clause (the Layer 3 `SetName` modification exists, so this part is cheap) **and** granted static abilities that actually project. `GameState.grantedStaticAbilities` is read only by point-of-use checks (combat, equip-cost, cast permissions) — the layer projector never consults it, so "Equipped creature gets +3/+3" would silently do nothing. |
| **Ashiok, Wicked Manipulator** | Three features: a replacement effect over *paying life* (touches every cost-payment path), a `DynamicAmount` for "total mana value of cards you own in exile", and a turn-scoped "a card was put into exile this turn" tracker for its Nightmare tokens. |

Each is `add-feature` work rather than a card change; happy to take any of them on as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)