### PR TITLE
Add Ketramose, the New Dawn and Skyseer's Chariot to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3623,6 +3623,13 @@ in the repo today):
   **during your turn**" wording, add `triggerCondition = Conditions.IsYourTurn`; for "this
   ability triggers only once each turn", add `oncePerTurn = true`. (Attuned Hunter, Kishla
   Skimmer, Kheru Goldkeeper.)
+- `CardsPutIntoExile(fromZones?, filter?)` — batching trigger; fires once per event batch when one
+  or more matching **cards** are put into exile from any of `fromZones` (default: graveyard and
+  battlefield). Unlike the graveyard batches above it is **not** scoped to one player's zones —
+  "graveyards and/or the battlefield" means any graveyard and anyone's permanents, so every
+  controller of the trigger sees the same batch. Tokens never satisfy it (CR 111.6). Add
+  `triggerCondition = Conditions.IsYourTurn` for the "during your turn" wording.
+  (Ketramose, the New Dawn.)
 
 ### Discard
 
@@ -5093,6 +5100,14 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   Note that `GroupFilter.excludeSelf` (the printed "**other** permanents") is honored by this read
   site directly — the projection layer never sees this static — so a lord never discounts its own
   abilities.
+- `IncreaseActivatedAbilityCost(filter, amount)` — the taxing mirror of
+  `ReduceActivatedAbilityCost`: activated abilities of sources matching `filter` cost `amount`
+  generic mana **more** to activate. The two are summed into a single net delta before either is
+  applied, so a reduction and an increase on the same ability cancel (CR 601.2f). Unlike a
+  reduction, a tax also applies to abilities with **no mana in their cost** — a bare `{T}:` ability
+  taxed by {2} becomes `{2}, {T}:` — and there is no `manaFloor`, since costs only grow. Skyseer's
+  Chariot: "Activated abilities of sources with the chosen name cost {2} more to activate" →
+  `IncreaseActivatedAbilityCost(GroupFilter(GameObjectFilter.Any.namedFromChosenComponent()), DynamicAmount.Fixed(2))`.
 - `MayCastFromGraveyard(filter, lifeCost = 0, duringYourTurnOnly = false, entersWithCounter = null, addedSubtypeOnEntry = null)`
   — cast spells matching `filter` from your graveyard following normal timing, optionally paying
   `lifeCost` life. Free for Yawgmoth's Agenda (`MayCastFromGraveyard(Nonland)`); `lifeCost = 1,
@@ -7689,8 +7704,10 @@ the `CastChoicesComponent` under `ChoiceSlot.CARD_NAME` as a `ChoiceValue.TextCh
 `chosenCardName()` or, for name-keyed static-ability filters,
 `GameObjectFilter.namedFromChosenComponent()` (→ `CardPredicate.NameEqualsChosenComponent`, see §7).
 The offered pool is controlled by `cardNamePool: CardNamePool` — `CardNamePool.LAND` (default) offers
-every registered land name (Petrified Hamlet's "choose a land card name"); `CardNamePool.ANY` offers
-every registered card name (Sorcerous Spyglass / Pithing Needle's "choose any card name"). Set
+every registered land name (Petrified Hamlet's "choose a land card name"); `CardNamePool.NONLAND`
+offers every registered nonland name (Skyseer's Chariot's "choose a nonland card name");
+`CardNamePool.ANY` offers every registered card name (Sorcerous Spyglass / Pithing Needle's "choose
+any card name"). Set
 `lookAtOpponentHand = true` to first reveal an opponent's hand to the controller as the permanent
 enters, immediately before the choice (durable reveal via `RevealedToComponent`, correctly masked to
 show only to the controller; purely informational — it never restricts the name chosen, so an empty

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
@@ -58,6 +58,18 @@ data class ManaCost(val symbols: List<ManaSymbol>) {
     }
 
     /**
+     * Increase the generic mana portion of this cost by [amount] (CR 601.2f / 602.2b — cost
+     * increases are applied to the mana part of the cost). Colored/hybrid/Phyrexian symbols are
+     * untouched, and a cost with no mana at all (`{T}:` abilities) gains the generic outright:
+     * `{}` → `{2}`, `{1}{U}` → `{3}{U}`.
+     */
+    fun increaseGeneric(amount: Int): ManaCost {
+        if (amount <= 0) return this
+        val nonGeneric = symbols.filter { it !is ManaSymbol.Generic }
+        return ManaCost(listOf(ManaSymbol.Generic(genericAmount + amount)) + nonGeneric)
+    }
+
+    /**
      * Reduce the generic portion by [amount], but never below a *total* of [minTotalMana] mana
      * (generic + every other mana symbol). Colored/hybrid/phyrexian/colorless symbols are never
      * removed; only generic mana is reduced, and only down to the point where the whole cost still

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -827,6 +827,27 @@ object Triggers {
     )
 
     // =========================================================================
+    // Exile Batching Triggers
+    // =========================================================================
+
+    /**
+     * Whenever one or more cards matching [filter] are put into exile from [fromZones].
+     * Batching trigger — fires at most once per event batch regardless of how many cards were
+     * exiled or which of the watched zones each came from, and it is *not* scoped to one player's
+     * zones ("graveyards", plural, and anyone's battlefield permanents).
+     *
+     * Pair with `triggerCondition = Conditions.IsYourTurn` for the common "during your turn"
+     * wording (Ketramose, the New Dawn).
+     */
+    fun CardsPutIntoExile(
+        fromZones: Set<Zone> = setOf(Zone.GRAVEYARD, Zone.BATTLEFIELD),
+        filter: GameObjectFilter = GameObjectFilter.Any
+    ): TriggerSpec = TriggerSpec(
+        event = CardsPutIntoExileEvent(fromZones = fromZones, filter = filter),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Card Drawing Triggers
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -869,3 +869,43 @@ data class ReduceActivatedAbilityCost(
         return if (newFilter !== filter || newAmount !== amount) copy(filter = newFilter, amount = newAmount) else this
     }
 }
+
+/**
+ * The activated abilities of sources matching [filter] cost [amount] generic mana **more** to
+ * activate — the taxing mirror of [ReduceActivatedAbilityCost], summed against it into a single
+ * net delta so a reduction and an increase on the same ability cancel (CR 601.2f: increases and
+ * reductions are applied to the mana part of the cost, and the two are netted before payment).
+ *
+ * Unlike a reduction, an increase applies even when the ability has *no* mana in its cost — a bare
+ * `{T}:` ability taxed by {2} becomes `{2}, {T}:`. There is no floor parameter: costs only grow.
+ *
+ * Used by Skyseer's Chariot — "Activated abilities of sources with the chosen name cost {2} more to
+ * activate", where [filter] is the bare chosen-name predicate
+ * ([com.wingedsheep.sdk.scripting.GameObjectFilter.namedFromChosenComponent]) so the tax keys off
+ * the Vehicle's durable as-enters card-name choice.
+ *
+ * @property filter Which sources' activated abilities are taxed (matched via projected state; use
+ *   [com.wingedsheep.sdk.scripting.filters.unified.GroupFilter.source] for "this permanent's
+ *   abilities" or a battlefield filter for a group).
+ * @property amount Dynamic generic-mana increase applied to each matching ability's cost.
+ */
+@SerialName("IncreaseActivatedAbilityCost")
+@Serializable
+data class IncreaseActivatedAbilityCost(
+    val filter: GroupFilter,
+    val amount: DynamicAmount
+) : StaticAbility {
+    override val description: String = buildString {
+        append(filter.description.replaceFirstChar { it.uppercase() })
+        when (amount) {
+            is DynamicAmount.Fixed -> append("'s activated abilities cost {${amount.amount}} more to activate")
+            else -> append("'s activated abilities cost {X} more to activate, where X is ${amount.description}")
+        }
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newFilter !== filter || newAmount !== amount) copy(filter = newFilter, amount = newAmount) else this
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1985,6 +1985,63 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     // =========================================================================
+    // Exile Batching Triggers
+    // =========================================================================
+
+    /**
+     * Whenever one or more cards matching [filter] are put into exile from any of [fromZones].
+     *
+     * This is a **batching trigger** (CR 603.2c) — it fires at most once per event batch,
+     * regardless of how many cards were exiled or which of the watched zones each came from.
+     * Unlike [CardsPutIntoYourGraveyardEvent] / [CardsLeftYourGraveyardEvent] it is **not** scoped
+     * to a single player's zone: "from graveyards and/or the battlefield" means *any* graveyard and
+     * *any* player's permanents, so every controller with this trigger sees the same batch.
+     *
+     * Only cards fire it — tokens are not cards (CR 111.6), so a token exiled from the battlefield
+     * never satisfies it even though it briefly occupies the exile zone before CR 111.7 sweeps it.
+     *
+     * The common "during your turn" timing restriction is expressed on the card via
+     * `triggerCondition = Conditions.IsYourTurn` rather than baked into the event.
+     *
+     * Examples:
+     * - "Whenever one or more cards are put into exile from graveyards and/or the battlefield
+     *   during your turn, …" → `CardsPutIntoExileEvent()` + `triggerCondition = Conditions.IsYourTurn`
+     *   (Ketramose, the New Dawn)
+     */
+    @SerialName("CardsPutIntoExileEvent")
+    @Serializable
+    data class CardsPutIntoExileEvent(
+        val fromZones: Set<Zone> = setOf(Zone.GRAVEYARD, Zone.BATTLEFIELD),
+        val filter: GameObjectFilter = GameObjectFilter.Any
+    ) : EventPattern {
+        override val description: String = buildString {
+            append("one or more ")
+            if (filter != GameObjectFilter.Any) {
+                append(filter.cardPredicates.joinToString(" ") { it.description })
+                append(" ")
+            }
+            append("cards are put into exile from ")
+            append(
+                fromZones.sortedBy { it.ordinal }.joinToString(" and/or ") { zone ->
+                    when (zone) {
+                        Zone.GRAVEYARD -> "graveyards"
+                        Zone.BATTLEFIELD -> "the battlefield"
+                        Zone.HAND -> "hands"
+                        Zone.LIBRARY -> "libraries"
+                        Zone.STACK -> "the stack"
+                        else -> zone.displayName
+                    }
+                }
+            )
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    // =========================================================================
     // Sacrifice Triggers
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1477,13 +1477,24 @@ enum class ChoiceType {
  * The pool of card names offered by a [ChoiceType.CARD_NAME] [EntersWithChoice].
  *
  * - [LAND] — only registered *land* card names (Petrified Hamlet: "choose a land card name").
+ * - [NONLAND] — every registered card name that isn't a land (Skyseer's Chariot: "choose a nonland
+ *   card name").
  * - [ANY] — every registered card name (Sorcerous Spyglass / Pithing Needle: "choose any card
  *   name"). The chosen name is still stored under [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_NAME]
  *   and read the same way; only the offered option set differs.
  */
 enum class CardNamePool {
     LAND,
-    ANY
+    NONLAND,
+    ANY;
+
+    /** The decision prompt shown when naming a card from this pool. */
+    val prompt: String
+        get() = when (this) {
+            LAND -> "Choose a land card name"
+            NONLAND -> "Choose a nonland card name"
+            ANY -> "Choose a card name"
+        }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KetramoseTheNewDawn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/KetramoseTheNewDawn.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ketramose, the New Dawn — Aetherdrift #209.
+ *
+ * The attack/block gate counts *every* card in exile, whoever owns it and however it got there
+ * (Scryfall ruling 2025-02-07) — hence `Count(Player.Each, Zone.EXILE)` rather than a
+ * controller-scoped count. `CantAttackUnless` / `CantBlockUnless` are checked at declaration time
+ * only, which is also what the second ruling wants: once Ketramose has been declared, it keeps
+ * attacking or blocking even if exile shrinks below seven.
+ *
+ * The draw trigger is a CR 603.2c batch — one exile event fires it once no matter how many cards
+ * moved, and "graveyards and/or the battlefield" is unscoped (any graveyard, anyone's permanents),
+ * so it uses [Triggers.CardsPutIntoExile] rather than the controller-scoped graveyard batches.
+ * "During your turn" is the trigger condition.
+ */
+val KetramoseTheNewDawn = card("Ketramose, the New Dawn") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — God"
+    power = 4
+    toughness = 4
+    oracleText = "Menace, lifelink, indestructible\n" +
+        "Ketramose can't attack or block unless there are seven or more cards in exile.\n" +
+        "Whenever one or more cards are put into exile from graveyards and/or the battlefield " +
+        "during your turn, you draw a card and lose 1 life."
+
+    keywords(Keyword.MENACE, Keyword.LIFELINK, Keyword.INDESTRUCTIBLE)
+
+    val sevenOrMoreCardsInExile = Compare(
+        DynamicAmount.Count(Player.Each, Zone.EXILE),
+        ComparisonOperator.GTE,
+        DynamicAmount.Fixed(7)
+    )
+
+    staticAbility {
+        ability = CantAttackUnless(sevenOrMoreCardsInExile)
+    }
+    staticAbility {
+        ability = CantBlockUnless(sevenOrMoreCardsInExile)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsPutIntoExile()
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.LoseLife(1, EffectTarget.Controller)
+        )
+        description = "Whenever one or more cards are put into exile from graveyards and/or the " +
+            "battlefield during your turn, you draw a card and lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "209"
+        artist = "Maaz Ali Khan"
+        flavorText = "Let the past die so the future might live."
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg?1783907856"
+        ruling(
+            "2025-02-07",
+            "The ability that prevents Ketramose from attacking or blocking counts the total " +
+                "number of cards in exile, regardless of who owns them or how they were exiled."
+        )
+        ruling(
+            "2025-02-07",
+            "Once Ketramose has been declared as an attacker or blocker, it will continue to " +
+                "attack or block that combat even if the number of cards in exile falls below seven."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SkyseersChariot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/SkyseersChariot.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CardNamePool
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Skyseer's Chariot — Aetherdrift #28.
+ *
+ * {1}{W} · Artifact — Vehicle · 3/3
+ *   Flying
+ *   As this Vehicle enters, choose a nonland card name.
+ *   Activated abilities of sources with the chosen name cost {2} more to activate.
+ *   Crew 2
+ *
+ * The naming clause is the standard as-enters replacement (CR 614.12) — [EntersWithChoice] with
+ * [ChoiceType.CARD_NAME] and the [CardNamePool.NONLAND] pool, storing the pick durably on the
+ * permanent's `CastChoicesComponent` under `ChoiceSlot.CARD_NAME`. The tax then reads that slot
+ * through `GameObjectFilter.namedFromChosenComponent()`, the same chosen-name predicate Sorcerous
+ * Spyglass locks abilities with — so the two cards agree on what "sources with the chosen name"
+ * means, and control changes / copies follow the permanent's own choice.
+ *
+ * "Cost {2} more to activate" taxes *every* activated ability of a matching source, mana abilities
+ * and crew included, and applies even to abilities with no mana in their cost ("{T}:" becomes
+ * "{2}, {T}:") — see [IncreaseActivatedAbilityCost].
+ */
+val SkyseersChariot = card("Skyseer's Chariot") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Vehicle"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "As this Vehicle enters, choose a nonland card name.\n" +
+        "Activated abilities of sources with the chosen name cost {2} more to activate.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This " +
+        "Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.FLYING)
+
+    // As this Vehicle enters, choose a nonland card name.
+    replacementEffect(
+        EntersWithChoice(
+            choiceType = ChoiceType.CARD_NAME,
+            cardNamePool = CardNamePool.NONLAND,
+        )
+    )
+
+    staticAbility {
+        ability = IncreaseActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Any.namedFromChosenComponent()),
+            amount = DynamicAmount.Fixed(2),
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "28"
+        artist = "Carl Critchlow"
+        flavorText = "\"It's the dawn of a new era, and we shall rise like the suns to greet it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg?1783907914"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -8530,6 +8530,109 @@
     ]
 }
 
+// Ketramose, the New Dawn
+{
+    "name": "Ketramose, the New Dawn",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Menace, lifelink, indestructible\nKetramose can't attack or block unless there are seven or more cards in exile.\nWhenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE",
+        "LIFELINK",
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CardsPutIntoExileEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "triggerCondition": "IsYourTurn",
+                "descriptionOverride": "Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "Each",
+                        "zone": "Exile"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "Each",
+                        "zone": "Exile"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "MYTHIC",
+        "artist": "Maaz Ali Khan",
+        "flavorText": "Let the past die so the future might live.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cffae8d0-7b4e-42ed-8124-24a86b38f490.jpg?1783907856",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "The ability that prevents Ketramose from attacking or blocking counts the total number of cards in exile, regardless of who owns them or how they were exiled."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Once Ketramose has been declared as an attacker or blocker, it will continue to attack or block that combat even if the number of cards in exile falls below seven."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Kickoff Celebrations
 {
     "name": "Kickoff Celebrations",
@@ -14847,6 +14950,64 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Skyseer's Chariot
+{
+    "name": "Skyseer's Chariot",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Flying\nAs this Vehicle enters, choose a nonland card name.\nActivated abilities of sources with the chosen name cost {2} more to activate.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "IncreaseActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "NameEqualsChosenComponent"
+                        ]
+                    }
+                },
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CARD_NAME",
+                "cardNamePool": "NONLAND"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "RARE",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"It's the dawn of a new era, and we shall rise like the suns to greet it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96ed5b66-8e74-4a90-ad4e-c39d15993994.jpg?1783907914"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -264,6 +264,11 @@ class TriggerDetector(
         // "during your turn" restriction is a triggerCondition (Conditions.IsYourTurn) on the card.
         detectCardsLeftGraveyardBatchTriggers(state, events, triggers, index)
 
+        // Detect "whenever one or more cards are put into exile from graveyards and/or the
+        // battlefield" batching triggers (Ketramose, the New Dawn). Unlike the graveyard batches
+        // this is not scoped to one player's zones, so it fires once per qualifying source.
+        detectCardsPutIntoExileBatchTriggers(state, events, triggers, index)
+
         // Detect "whenever you sacrifice one or more [permanents]" batching triggers
         // (e.g., Camellia, the Seedmiser). Groups sacrifice events per controller
         // and fires the trigger at most once per controller.
@@ -1883,6 +1888,53 @@ class TriggerDetector(
                         )
                     )
                 }
+            }
+        }
+    }
+
+    /**
+     * Detect "whenever one or more cards are put into exile from graveyards and/or the
+     * battlefield" batching triggers (Ketramose, the New Dawn).
+     *
+     * Unlike the graveyard batch passes this is **not** scoped to one player's zone — the printed
+     * text says "graveyards" (plural) and doesn't restrict whose battlefield the permanent left,
+     * so every exile out of a watched zone counts for every controller with the trigger. The batch
+     * fires at most once per detection pass (CR 603.2c), no matter how many cards moved or which
+     * of the watched zones they came from.
+     *
+     * The "during your turn" restriction is expressed on the card as
+     * `triggerCondition = Conditions.IsYourTurn` and applied later in detectTriggers.
+     */
+    private fun detectCardsPutIntoExileBatchTriggers(
+        state: GameState,
+        events: List<EngineGameEvent>,
+        triggers: MutableList<PendingTrigger>,
+        index: TriggerIndex
+    ) {
+        val exiled = events.filterIsInstance<ZoneChangeEvent>()
+            .filter { it.toZone == Zone.EXILE && it.fromZone != Zone.EXILE }
+        if (exiled.isEmpty()) return
+
+        for (entry in index.getEntitiesForCategory(TriggerCategory.CARDS_EXILED_BATCH)) {
+            for (ability in entry.abilities) {
+                val trigger = ability.trigger
+                if (trigger !is EventPattern.CardsPutIntoExileEvent) continue
+
+                val hasMatch = exiled.any { event ->
+                    event.fromZone in trigger.fromZones &&
+                        cardMatchesGraveyardBatchFilter(state, event.entityId, trigger.filter)
+                }
+                if (!hasMatch) continue
+
+                triggers.add(
+                    PendingTrigger(
+                        ability = ability,
+                        sourceId = entry.entityId,
+                        sourceName = entry.cardComponent.name,
+                        controllerId = entry.controllerId,
+                        triggerContext = TriggerContext()
+                    )
+                )
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -63,6 +63,7 @@ enum class TriggerCategory {
     LIBRARY_TO_GRAVEYARD,
     ANY_TO_GRAVEYARD,
     CARDS_LEFT_GRAVEYARD,
+    CARDS_EXILED_BATCH,
     SACRIFICE,
     COMBAT_DAMAGE_BATCH,
     LEAVE_WITHOUT_DYING,
@@ -252,6 +253,7 @@ class TriggerIndex(
                 is SdkGameEvent.CardsPutIntoGraveyardFromLibraryEvent -> listOf(TriggerCategory.LIBRARY_TO_GRAVEYARD)
                 is SdkGameEvent.CardsPutIntoYourGraveyardEvent -> listOf(TriggerCategory.ANY_TO_GRAVEYARD)
                 is SdkGameEvent.CardsLeftYourGraveyardEvent -> listOf(TriggerCategory.CARDS_LEFT_GRAVEYARD)
+                is SdkGameEvent.CardsPutIntoExileEvent -> listOf(TriggerCategory.CARDS_EXILED_BATCH)
                 is SdkGameEvent.PermanentsSacrificedEvent -> listOf(TriggerCategory.SACRIFICE)
                 is SdkGameEvent.OneOrMoreDealCombatDamageToPlayerEvent -> listOf(TriggerCategory.COMBAT_DAMAGE_BATCH)
                 is SdkGameEvent.OneOrMoreDealCombatDamageToYouEvent -> listOf(TriggerCategory.COMBAT_DAMAGE_BATCH)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -640,6 +640,8 @@ class TriggerMatcher(
             is EventPattern.CardsPutIntoYourGraveyardEvent -> false
             // Leave-graveyard batch triggers are handled by detectCardsLeftGraveyardBatchTriggers
             is EventPattern.CardsLeftYourGraveyardEvent -> false
+            // Exile batch triggers are handled by detectCardsPutIntoExileBatchTriggers
+            is EventPattern.CardsPutIntoExileEvent -> false
             // Sacrifice batch triggers are handled by detectSacrificeBatchTriggers
             is EventPattern.PermanentsSacrificedEvent -> false
             // Combat damage batch triggers are handled by detectCombatDamageBatchTriggers

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -490,9 +490,7 @@ class PlayLandHandler(
                         fromZone = fromZone,
                         carryEvents = events,
                         cardNameOptions = if (firstChoice.choiceType == ChoiceType.CARD_NAME) {
-                            if (firstChoice.cardNamePool == com.wingedsheep.sdk.scripting.CardNamePool.ANY) {
-                                cardRegistry.allCardNames().toList()
-                            } else cardRegistry.landCardNames().toList()
+                            cardRegistry.cardNamesIn(firstChoice.cardNamePool).toList()
                         } else emptyList(),
                     )
                 if (result != null) return result

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LeylineContinuationResumer.kt
@@ -147,9 +147,7 @@ class LeylineContinuationResumer(
                 it is ZoneChangeEvent && it.entityId == leylineCardId
             },
             cardNameOptions = if (firstChoice.choiceType == ChoiceType.CARD_NAME) {
-                if (firstChoice.cardNamePool == CardNamePool.ANY) {
-                    services.cardRegistry.allCardNames().toList()
-                } else services.cardRegistry.landCardNames().toList()
+                services.cardRegistry.cardNamesIn(firstChoice.cardNamePool).toList()
             } else emptyList(),
         )
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -375,9 +375,7 @@ object PermanentEntryReplacements {
                     revealOpponentHandForEntersChoice(state, controllerId)
                 } else state to emptyList()
                 val id = "choose-card-name-enters-${entityId.value}"
-                val prompt = if (choice.cardNamePool == CardNamePool.ANY) {
-                    "Choose a card name"
-                } else "Choose a land card name"
+                val prompt = choice.cardNamePool.prompt
                 val decision = ChooseOptionDecision(
                     id = id,
                     playerId = chooserId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -722,60 +722,89 @@ class CastPermissionUtils(
         isExhaustAbility: Boolean = false
     ): AbilityCost {
         if (sourceId == null) return cost
-        val (amount, manaFloor) = sumActivatedAbilityCostReductions(state, sourceId, isExhaustAbility)
-        if (amount <= 0) return cost
+        val (net, manaFloor) = sumActivatedAbilityCostModifications(state, sourceId, isExhaustAbility)
+        if (net == 0) return cost
+        // net > 0 reduces (floored), net < 0 taxes. A reduction can only shrink mana that is
+        // already there; a tax applies to *every* activated ability, so a cost with no mana part
+        // (`{T}:`, sacrifice, crew) gains one — "{T}:" taxed by {2} becomes "{2}, {T}:".
+        val modify: (ManaCost) -> ManaCost =
+            if (net > 0) { mana -> mana.reduceGenericWithManaFloor(net, manaFloor) }
+            else { mana -> mana.increaseGeneric(-net) }
+        val taxAtom = { AbilityCost.Atom(CostAtom.Mana(modify(ManaCost.ZERO))) }
         return when (cost) {
             is AbilityCost.Atom -> cost.manaCostOrNull
-                ?.let { AbilityCost.Atom(CostAtom.Mana(it.reduceGenericWithManaFloor(amount, manaFloor))) } ?: cost
+                ?.let { AbilityCost.Atom(CostAtom.Mana(modify(it))) }
+                ?: if (net < 0) AbilityCost.Composite(listOf(taxAtom(), cost)) else cost
             is AbilityCost.Composite -> {
                 var applied = false
-                AbilityCost.Composite(cost.costs.map { sub ->
+                val modified = AbilityCost.Composite(cost.costs.map { sub ->
                     val subMana = sub.manaCostOrNull
                     if (!applied && subMana != null) {
                         applied = true
-                        AbilityCost.Atom(CostAtom.Mana(subMana.reduceGenericWithManaFloor(amount, manaFloor)))
+                        AbilityCost.Atom(CostAtom.Mana(modify(subMana)))
                     } else sub
                 })
+                if (!applied && net < 0) AbilityCost.Composite(listOf(taxAtom()) + cost.costs) else modified
             }
-            else -> cost
+            // Every other shape (Tap, TapAttachedCreature, Loyalty, Craft, …) carries no mana part:
+            // a reduction is a no-op, a tax prepends the mana the player must now also pay.
+            else -> if (net < 0) AbilityCost.Composite(listOf(taxAtom(), cost)) else cost
         }
     }
 
     /**
-     * Sum the generic reduction (and take the most restrictive mana floor) from every
-     * [ReduceActivatedAbilityCost] static on the battlefield whose [ReduceActivatedAbilityCost.filter]
-     * matches the ability source [sourceId]. The filter scope is resolved directly:
-     * `Scope.Self` → the static's own source; `Scope.AttachedTo` → the permanent the static's
-     * source (an Aura/Equipment) is attached to; any other (battlefield) scope → the source's
-     * base filter matched against [sourceId] under projected state.
+     * Net the generic cost modification (and take the most restrictive mana floor) from every
+     * [ReduceActivatedAbilityCost] / [com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost]
+     * static on the battlefield whose filter matches the ability source [sourceId]. The returned
+     * delta is **positive for a net reduction** and negative for a net tax — reductions and
+     * increases on the same ability cancel before either is applied to the cost.
      *
-     * An `exhaustOnly` static contributes nothing unless [isExhaustAbility] is set.
+     * The filter scope is resolved directly: `Scope.Self` → the static's own source;
+     * `Scope.AttachedTo` → the permanent the static's source (an Aura/Equipment) is attached to;
+     * any other (battlefield) scope → the source's base filter matched against [sourceId] under
+     * projected state.
+     *
+     * An `exhaustOnly` reduction contributes nothing unless [isExhaustAbility] is set.
      */
-    private fun sumActivatedAbilityCostReductions(
+    private fun sumActivatedAbilityCostModifications(
         state: GameState,
         sourceId: EntityId,
         isExhaustAbility: Boolean
     ): Pair<Int, Int> {
-        var totalAmount = 0
+        var net = 0
         var floor = 0
+        val evaluator = DynamicAmountEvaluator()
         for (entityId in state.getBattlefield()) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            val controllerId by lazy { state.getEntity(entityId)?.get<ControllerComponent>()?.playerId }
             for (ability in cardDef.script.staticAbilities) {
-                val reduce = ability as? com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost ?: continue
-                if (reduce.exhaustOnly && !isExhaustAbility) continue
-                if (activatedAbilityReductionApplies(state, entityId, reduce.filter, sourceId)) {
-                    val controllerId = state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: continue
-                    totalAmount += DynamicAmountEvaluator().evaluate(
-                        state,
-                        reduce.amount,
-                        EffectContext(sourceId = entityId, controllerId = controllerId)
-                    ).coerceAtLeast(0)
-                    floor = maxOf(floor, reduce.manaFloor)
+                when (ability) {
+                    is com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost -> {
+                        if (ability.exhaustOnly && !isExhaustAbility) continue
+                        if (!activatedAbilityReductionApplies(state, entityId, ability.filter, sourceId)) continue
+                        val owner = controllerId ?: continue
+                        net += evaluator.evaluate(
+                            state,
+                            ability.amount,
+                            EffectContext(sourceId = entityId, controllerId = owner)
+                        ).coerceAtLeast(0)
+                        floor = maxOf(floor, ability.manaFloor)
+                    }
+                    is com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost -> {
+                        if (!activatedAbilityReductionApplies(state, entityId, ability.filter, sourceId)) continue
+                        val owner = controllerId ?: continue
+                        net -= evaluator.evaluate(
+                            state,
+                            ability.amount,
+                            EffectContext(sourceId = entityId, controllerId = owner)
+                        ).coerceAtLeast(0)
+                    }
+                    else -> continue
                 }
             }
         }
-        return totalAmount to floor
+        return net to floor
     }
 
     /**
@@ -801,7 +830,13 @@ class CastPermissionUtils(
             val projected = state.projectedState
             predicateEvaluator.matches(
                 state, projected, sourceId, filter.baseFilter,
-                PredicateContext(controllerId = state.getEntity(staticSourceId)?.get<ControllerComponent>()?.playerId ?: staticSourceId)
+                // sourceId = the *static's* permanent, not the ability's: name-keyed predicates
+                // (`NameEqualsChosenComponent`, Skyseer's Chariot) read the chosen name off the
+                // permanent that carries the static.
+                PredicateContext(
+                    sourceId = staticSourceId,
+                    controllerId = state.getEntity(staticSourceId)?.get<ControllerComponent>()?.playerId ?: staticSourceId
+                )
             )
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -876,6 +876,7 @@ class StaticAbilityHandler(
             is FreeFirstEquipEachTurn,
             is ReduceEquipCost,
             is ReduceActivatedAbilityCost,
+            is com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost,
             is PlayFromTopOfLibrary,
             is PlayLandsAndCastFilteredFromTopOfLibrary,
             is PlotFromTopOfLibrary,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3557,10 +3557,7 @@ class StackResolver(
                 // (Sorcerous Spyglass / Pithing Needle) as the permanent spell resolves. The pool
                 // is land names or every registered card name per [EntersWithChoice.cardNamePool];
                 // the chosen name is stored durably under [ChoiceSlot.CARD_NAME] by the resumer.
-                val cardNames = when (choice.cardNamePool) {
-                    com.wingedsheep.sdk.scripting.CardNamePool.ANY -> cardRegistry.allCardNames()
-                    com.wingedsheep.sdk.scripting.CardNamePool.LAND -> cardRegistry.landCardNames()
-                }.sorted()
+                val cardNames = cardRegistry.cardNamesIn(choice.cardNamePool).sorted()
                 if (cardNames.isEmpty()) return null
                 // "As this enters, look at an opponent's hand, then …": reveal the opponent's hand
                 // to the controller before presenting the name choice.
@@ -3568,9 +3565,7 @@ class StackResolver(
                     com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
                         .revealOpponentHandForEntersChoice(state, controllerId)
                 } else state to emptyList()
-                val prompt = if (choice.cardNamePool == com.wingedsheep.sdk.scripting.CardNamePool.ANY) {
-                    "Choose a card name"
-                } else "Choose a land card name"
+                val prompt = choice.cardNamePool.prompt
                 val decisionId = "choose-card-name-enters-${spellId.value}"
                 val decision = ChooseOptionDecision(
                     id = decisionId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/CardRegistry.kt
@@ -121,6 +121,26 @@ class CardRegistry(private val parent: CardRegistry? = null) {
     }
 
     /**
+     * Get the names of every registered card whose type line does *not* include Land (Skyseer's
+     * Chariot's "choose a nonland card name"). Unique names only; the mirror of [landCardNames].
+     */
+    fun nonlandCardNames(): Set<String> {
+        val own = cardsByName.values.filter { !it.isLand }.map { it.name }.toSet()
+        return if (parent == null) own else own + parent.nonlandCardNames().filter { it !in cardsByName }
+    }
+
+    /**
+     * The names offered by an `EntersWithChoice(ChoiceType.CARD_NAME)` drawing from [pool] — the
+     * single place the pool-to-registry mapping lives, so every naming path (spell resolution,
+     * land drop, leyline opening) offers the same option set.
+     */
+    fun cardNamesIn(pool: com.wingedsheep.sdk.scripting.CardNamePool): Set<String> = when (pool) {
+        com.wingedsheep.sdk.scripting.CardNamePool.ANY -> allCardNames()
+        com.wingedsheep.sdk.scripting.CardNamePool.LAND -> landCardNames()
+        com.wingedsheep.sdk.scripting.CardNamePool.NONLAND -> nonlandCardNames()
+    }
+
+    /**
      * Get all cards with a given name (useful for basic lands with multiple variants).
      *
      * @param name The card name (e.g., "Plains")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KetramoseTheNewDawnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KetramoseTheNewDawnScenarioTest.kt
@@ -1,0 +1,223 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ketramose, the New Dawn (DFT #209) — {1}{W}{B} Legendary Creature — God, 4/4.
+ *
+ *   Menace, lifelink, indestructible
+ *   Ketramose can't attack or block unless there are seven or more cards in exile.
+ *   Whenever one or more cards are put into exile from graveyards and/or the battlefield during
+ *   your turn, you draw a card and lose 1 life.
+ *
+ * Two things are worth proving beyond the happy path:
+ *  - the exile count is **global** (Scryfall ruling 2025-02-07 — "regardless of who owns them"),
+ *    so seven cards in the *opponent's* exile enable the attack just as well as your own; and
+ *  - the draw trigger is a CR 603.2c **batch** — Rest in Peace sweeping several graveyard cards
+ *    into exile at once must draw one card and cost one life, not one per card.
+ */
+class KetramoseTheNewDawnScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Ketramose, the New Dawn — attack/block gate on seven cards in exile") {
+
+            test("cannot attack with only six cards in exile") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .apply { repeat(6) { withCardInExile(1, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("six cards in exile is one short — the attack must be rejected") {
+                    game.declareAttackers(mapOf("Ketramose, the New Dawn" to 2)).error shouldNotBe null
+                }
+            }
+
+            test("can attack with seven cards in exile") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .apply { repeat(7) { withCardInExile(1, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("seven cards in exile satisfies the restriction") {
+                    game.declareAttackers(mapOf("Ketramose, the New Dawn" to 2)).error shouldBe null
+                }
+            }
+
+            test("the opponent's exile counts too — the tally is global") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .apply { repeat(7) { withCardInExile(2, "Grizzly Bears") } }
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                withClue("cards in Bob's exile count toward Ketramose's seven (2025-02-07 ruling)") {
+                    game.declareAttackers(mapOf("Ketramose, the New Dawn" to 2)).error shouldBe null
+                }
+            }
+
+            test("cannot block with only six cards in exile") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .apply { repeat(6) { withCardInExile(1, "Hill Giant") } }
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("six cards in exile — the block must be rejected") {
+                    game.declareBlockers(
+                        mapOf("Ketramose, the New Dawn" to listOf("Grizzly Bears"))
+                    ).error shouldNotBe null
+                }
+            }
+
+            test("can block with seven cards in exile") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(2, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .apply { repeat(7) { withCardInExile(1, "Hill Giant") } }
+                    .withActivePlayer(1)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("seven cards in exile satisfies the restriction") {
+                    game.declareBlockers(
+                        mapOf("Ketramose, the New Dawn" to listOf("Grizzly Bears"))
+                    ).error shouldBe null
+                }
+            }
+        }
+
+        context("Ketramose, the New Dawn — exile batch trigger") {
+
+            test("exiling a card from a graveyard during your turn draws a card and loses 1 life") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(1, "Coffin Purge")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpellTargetingGraveyardCard(1, "Coffin Purge", 2, "Grizzly Bears")
+                    .error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Ketramose sees the graveyard→exile move and drains one life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore - 1
+                }
+                withClue("the drawn card comes off the library") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("exiling a permanent from the battlefield also fires the trigger") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(1, "Wander Off")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Wander Off", bears).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("battlefield→exile is one of the watched source zones") {
+                    game.getLifeTotal(1) shouldBe lifeBefore - 1
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("a multi-card exile fires the trigger only once (CR 603.2c batching)") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardInHand(1, "Rest in Peace")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Rest in Peace").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("four cards left graveyards in one event — that is one trigger, not four") {
+                    game.getLifeTotal(1) shouldBe lifeBefore - 1
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("does not trigger during the opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Ketramose, the New Dawn", summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Swamp", 1)
+                    .withCardInHand(2, "Coffin Purge")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpellTargetingGraveyardCard(2, "Coffin Purge", 1, "Grizzly Bears")
+                    .error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the trigger is gated on 'during your turn'") {
+                    game.getLifeTotal(1) shouldBe lifeBefore
+                    game.handSize(1) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkyseersChariotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkyseersChariotScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.chosenCardName
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Skyseer's Chariot (DFT #28) — {1}{W} Artifact — Vehicle, 3/3.
+ *
+ *   Flying
+ *   As this Vehicle enters, choose a nonland card name.
+ *   Activated abilities of sources with the chosen name cost {2} more to activate.
+ *   Crew 2
+ *
+ * Two things worth proving: the as-enters choice draws from the **nonland** pool (lands must not be
+ * offered — the Petrified Hamlet / Sorcerous Spyglass pools are the land-only and everything
+ * variants), and the tax is a real {2}, not a lock. Prodigal Sorcerer's ping costs a bare `{T}`, so
+ * with no mana available naming it turns the ability off entirely, and adding exactly two untapped
+ * lands turns it back on.
+ */
+class SkyseersChariotScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.castChariotToChoice(): ChooseOptionDecision {
+        castSpell(1, "Skyseer's Chariot")
+        if (hasPendingDecision()) submitManaSourcesAutoPay()
+        resolveStack()
+        val decision = getPendingDecision()
+        withClue("Skyseer's Chariot must present an as-enters card-name choice on resolution") {
+            (decision is ChooseOptionDecision) shouldBe true
+        }
+        return decision as ChooseOptionDecision
+    }
+
+    private fun TestGame.chooseName(decision: ChooseOptionDecision, name: String) {
+        withClue("The chosen name must be offered by the nonland pool") {
+            decision.options shouldContain name
+        }
+        submitDecision(OptionChosenResponse(decision.id, decision.options.indexOf(name)))
+    }
+
+    /**
+     * Whether the ability is offered as *payable*. The enumerator still lists an unaffordable
+     * ability (greyed out in the client), so the tax shows up as `affordable = false`, not as a
+     * missing action.
+     */
+    private fun TestGame.canActivate(sourceId: EntityId): Boolean =
+        getLegalActions(1).any { (it.action as? ActivateAbility)?.sourceId == sourceId && it.isAffordable }
+
+    private fun TestGame.abilityCostText(sourceId: EntityId): String =
+        getLegalActions(1).first { (it.action as? ActivateAbility)?.sourceId == sourceId }.description
+
+    init {
+        context("Skyseer's Chariot — as-enters nonland card name") {
+
+            test("offers nonland names and withholds land names") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skyseer's Chariot")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val decision = game.castChariotToChoice()
+
+                withClue("the NONLAND pool offers nonland card names") {
+                    decision.options shouldContain "Grizzly Bears"
+                }
+                withClue("lands are excluded — that is what separates this pool from ANY") {
+                    decision.options shouldNotContain "Plains"
+                    decision.options shouldNotContain "Forest"
+                }
+
+                game.chooseName(decision, "Grizzly Bears")
+
+                val chariot = game.findPermanent("Skyseer's Chariot")!!
+                withClue("the pick is stored durably under ChoiceSlot.CARD_NAME") {
+                    game.state.getEntity(chariot)?.chosenCardName() shouldBe "Grizzly Bears"
+                }
+            }
+        }
+
+        context("Skyseer's Chariot — activated abilities of the named source cost {2} more") {
+
+            test("naming a source taxes its {T} ability out of reach with no mana available") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skyseer's Chariot")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                withClue("before the Chariot lands, the bare {T} ping is activatable") {
+                    game.canActivate(tim) shouldBe true
+                }
+
+                val decision = game.castChariotToChoice()
+                game.chooseName(decision, "Prodigal Sorcerer")
+
+                withClue("the offered cost is rebuilt from the taxed cost") {
+                    game.abilityCostText(tim) shouldBe "{2}, {T}: Deal 1 damage to target"
+                }
+                withClue("both Plains paid for the Chariot — a {2}-taxed {T} ability is unaffordable") {
+                    game.canActivate(tim) shouldBe false
+                }
+            }
+
+            test("the tax is exactly {2} — two spare lands make the ability affordable again") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skyseer's Chariot")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                val decision = game.castChariotToChoice()
+                game.chooseName(decision, "Prodigal Sorcerer")
+
+                withClue("two Plains remain untapped — exactly the {2} the tax adds") {
+                    game.canActivate(tim) shouldBe true
+                }
+            }
+
+            test("an unnamed source keeps its ability at printed cost") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Skyseer's Chariot")
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                val decision = game.castChariotToChoice()
+                game.chooseName(decision, "Grizzly Bears")
+
+                withClue("the tax keys off the chosen name — a different name leaves Tim untouched") {
+                    game.canActivate(tim) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two cards from Aetherdrift's remaining tail (11 unimplemented, all of which need engine capability). Each needed one small piece of new engine vocabulary.

## Ketramose, the New Dawn (DFT #209)

> Menace, lifelink, indestructible
> Ketramose can't attack or block unless there are seven or more cards in exile.
> Whenever one or more cards are put into exile from graveyards and/or the battlefield during your turn, you draw a card and lose 1 life.

- **New `EventPattern.CardsPutIntoExileEvent` / `Triggers.CardsPutIntoExile`** — a CR 603.2c batching trigger. Unlike `CardsPutIntoYourGraveyardEvent` / `CardsLeftYourGraveyardEvent` it is *not* scoped to one player's zones ("graveyards", plural, and anyone's permanents), so it gets its own detector pass and `CARDS_EXILED_BATCH` category rather than reusing an owner-grouped one. Tokens never satisfy it (CR 111.6).
- The attack/block gate is `CantAttackUnless` / `CantBlockUnless` over `Count(Player.Each, Zone.EXILE) >= 7`, matching the 2025-02-07 ruling that the tally counts every card in exile regardless of owner. Both restrictions are declaration-time only, which is also what the second ruling wants.

## Skyseer's Chariot (DFT #28)

> Flying
> As this Vehicle enters, choose a nonland card name.
> Activated abilities of sources with the chosen name cost {2} more to activate.
> Crew 2

- **New `IncreaseActivatedAbilityCost` static** — the taxing mirror of `ReduceActivatedAbilityCost`. The two are summed into a single net delta before either is applied, so a reduction and an increase on the same ability cancel (CR 601.2f). Unlike a reduction, a tax also applies to abilities with **no mana part**: a bare `{T}:` ability taxed by {2} becomes `{2}, {T}:`.
- **New `CardNamePool.NONLAND`.** While adding it, the pool-to-registry mapping moved into `CardRegistry.cardNamesIn` and the prompt onto `CardNamePool.prompt` — there were three `if (pool == ANY) … else land` copies that would each have silently fallen through to the land pool for any new variant.
- **Bug fix:** the activated-ability cost-modification filter never set `PredicateContext.sourceId`, so name-keyed predicates (`NameEqualsChosenComponent`) could not read the static's own chosen name. It now passes the static's permanent.

## Not included

Radiant Lotus was scoped and dropped: it needs three separate engine features (a variable-count sacrifice *cost*, a recipient on `AddManaEffect` for "target player adds…", and a resolution-time color choice feeding that mana). The rest of the DFT tail is similar — X in a cycling cost (Webstrike Elite, Valor's Flagship), granting embalm to a graveyard card (Cursecloth Wrappings), copying exhaust abilities (Pit Automaton, Elvish Refueler), planeswalker-Equipment (The Aetherspark).

## Verification

- `just test` — green.
- `KetramoseTheNewDawnScenarioTest` (9 tests): both combat restrictions incl. the opponent-exile case, graveyard-source and battlefield-source triggers, one-trigger-per-batch via Rest in Peace, and no trigger on the opponent's turn.
- `SkyseersChariotScenarioTest` (4 tests): the nonland pool offers nonlands and withholds lands, the tax renders as `{2}, {T}` and makes a bare `{T}` ability unaffordable, two spare lands make it affordable again, and an unnamed source is untouched.
- `just check-card-printing` ok for both; only these two cards moved in the DFT golden.
- `docs/card-sdk-language-reference.md` updated for the new trigger, static, and name pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)