### PR TITLE
Add selectable Limited products with printing-safe pools

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -208,7 +208,7 @@ private fun MtgSet.boosterCardPool(
     registry: CardRegistry,
     limitedCardNames: Set<String>?,
 ): List<CardDefinition> {
-    val eligibleOwnCards = cards
+    val eligibleOwnCards = cards.stamp(this)
         .asSequence()
         .filter { limitedCardNames == null || it.name in limitedCardNames }
         .map { card ->

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
@@ -40,6 +40,17 @@ class GameBeansConfigBoosterPoolTest : FunSpec({
         rarities shouldContain Rarity.RARE
     }
 
+    test("own cards are stamped with their Limited set printing identity") {
+        val por = boosterGenerator.availableSets["POR"].shouldNotBeNull()
+        val ragingGoblin = por.cards.first { it.name == "Raging Goblin" }
+
+        ragingGoblin.setCode shouldBe "POR"
+        ragingGoblin.metadata.collectorNumber shouldBe "145"
+        com.wingedsheep.engine.limited.BoosterGenerator.withCardArt(
+            mapOf("Raging Goblin" to 1), listOf(ragingGoblin),
+        ) shouldBe mapOf("Raging Goblin#POR-145" to 1)
+    }
+
     test("Foundations includes its own cards and its reprints in the booster pool") {
         val fdn = boosterGenerator.availableSets["FDN"].shouldNotBeNull()
         val names = fdn.cards.map { it.name }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -150,15 +150,9 @@ class BoosterGenerator(
          * Counts are merged rather than replaced, so a deck list that already names the printing it
          * gets stamped with (premade lists may carry `Name#SET-CN` entries) keeps all its copies.
          *
-         * The identifiers are `Name#SetCode-CollectorNumber` strings that resolve via
-         * [com.wingedsheep.engine.registry.CardRegistry]'s secondary index — predating the
-         * multi-printing system. This works correctly under multi-printing because the resolved
-         * [CardDefinition.metadata.imageUri] is stamped onto each entity's
-         * [com.wingedsheep.engine.state.components.identity.CardComponent.imageUri] at game-init,
-         * which then beats the canonical metadata via the precedence flip in
-         * `ClientStateTransformer`. The rich `cardEntries` channel (Phase 4 of the multi-printing
-         * plan) is not used here — switching is part of the Phase 6.5 cleanup that retires the
-         * `Name#SET-CN` secondary index. See `backlog/multi-printing-system.md`.
+         * The identifiers are `Name#SetCode-CollectorNumber` strings. The server session converts them
+         * into rich `CardEntry` printing references at game start, so the printing registry can
+         * overlay the correct art without changing the card's canonical rules identity.
          *
          * @param deckList The submitted deck list, keyed by card name
          * @param basics Land name to the printing that deck building offered, from [getBasicLands]
@@ -184,12 +178,12 @@ class BoosterGenerator(
         }
 
         /**
-         * The `Name#SetCode-CollectorNumber` identifier for [land], degrading to `Name#Number` and
-         * then to the bare name as the printing loses the coordinates to address it by.
+         * The `Name#SetCode-CollectorNumber` identifier for [land]. Both coordinates are required:
+         * a collector number without a set code cannot address a unique printing.
          */
         private fun printingIdentifier(cardName: String, land: CardDefinition): String {
             val collectorNumber = land.metadata.collectorNumber ?: return cardName
-            val setCode = land.setCode ?: return "$cardName#$collectorNumber"
+            val setCode = land.setCode ?: return cardName
             return "$cardName#$setCode-$collectorNumber"
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBasicLandArtTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorBasicLandArtTest.kt
@@ -127,6 +127,12 @@ class BoosterGeneratorBasicLandArtTest : DescribeSpec({
                 .shouldContainExactly(mapOf("Plains" to 8))
         }
 
+        it("degrades to the bare name when the printing has no set code to address") {
+            val setless = mapOf("Plains" to regular262.copy(setCode = null))
+            BoosterGenerator.withBasicLandArt(mapOf("Plains" to 8), setless)
+                .shouldContainExactly(mapOf("Plains" to 8))
+        }
+
         it("keeps every copy when the deck already names the printing it gets stamped with") {
             // Premade tournament lists may carry Name#SET-CN entries; merging (not replacing) keeps
             // the 4 plain Plains from being swallowed by the 4 already-stamped ones.


### PR DESCRIPTION
## Summary

- keep paper booster pools as the default and allow hosts to select catalogued per-set additions
- preserve each selected set's printing and artwork through Limited deckbuilding and gameplay
- stamp own cards with their Limited set identity and avoid ambiguous collector-only printing pins
- show selected additions with a compact hoverable `+` indicator on lobby set chips

Supersedes #1617 and includes the fix for the deterministic sealed FFA initialization failure (`Raging Goblin#145`).

## Verification

- `just test` — passed
- `npm run typecheck` — passed
- `git diff --check` — passed
