### PR TITLE
Add X-cost cycling support, with Webstrike Elite and Valor's Flagship

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5895,7 +5895,15 @@ composite abilities).
   Boosters. Author the per-card equip cost and equipped-creature bonus alongside the `jobSelect()` call (e.g. Monk's
   Fist: `jobSelect()` + `ModifyStats(1, 0)` + `GrantSubtype("Monk", Filters.EquippedCreature)` + `equipAbility("{2}")`).
 - `Toxic(n)` — adds poison counters on combat damage.
-- `Cycling(cost)` — pay cost, discard, draw a card.
+- `Cycling(cost)` — pay cost, discard, draw a card. The cost may contain `{X}`
+  (`KeywordAbility.cycling("{X}{G}{G}")`, Webstrike Elite): cycling is an activated ability (CR 702.29a), so X is
+  announced as it's activated (CR 107.3a). The legal action carries `hasXCost` / `maxAffordableX` so the client's
+  xSelection phase asks for X and submits it on `CycleCard.xValue`; a bare submission instead pauses on an engine
+  `ChooseNumberDecision` (`CycleCardChooseXContinuation`) rather than silently defaulting X to 0. The announced X
+  rides `CardCycledEvent.xValue` into the cycling trigger's context, so a `Triggers.YouCycleThis` payoff reads it as
+  `DynamicAmount.XValue` (Valor's Flagship's "create X Pilot tokens") or via `manaValueEqualsX()` /
+  `manaValueAtMostX()` in a target filter (Webstrike Elite's "artifact or enchantment with mana value X").
+  X-cost **typecycling** is not wired — no such card is printed.
 - `BasicLandcycling(cost)` — cycling that fetches a basic land type.
 - `Typecycling(type, cost)` — cycling that fetches a card type.
 - `Plot(cost)` — `KeywordAbility.plot(cost)`. Special action available during your main phase while the stack is empty: pay [cost] and exile the card from your hand. It becomes plotted (stamped with a `PlottedComponent`). On a later turn you may cast it from exile without paying its mana cost, as a sorcery (CR 718). Cast permission is granted via the engine's standard `MayPlayPermission` + `PlayWithoutPayingCostComponent`, gated by `Conditions.SourcePlottedOnPriorTurn`. No card-side wiring needed — declare the keyword ability on the card and the engine handles the rest.
@@ -8436,6 +8444,9 @@ Card authors rarely reference these directly; they are created/updated by the ma
 
 - **Cycling / Typecycling / Basic landcycling** — `KeywordAbility.Cycling(cost)`, `Typecycling(type, cost)`,
   `BasicLandcycling(cost)`; unified via `TypecyclingVariant(cost, searchFilter, description)` in `TypecycleCardHandler`.
+  A plain cycling cost may contain `{X}`; `CycleCardHandler` announces it (CR 107.3a), resolves the cost via
+  `ManaCost.withXAs(x)` so the ordinary payment path sees no X, and stamps it on `CardCycledEvent.xValue` for the
+  cycling trigger. See the `Cycling(cost)` entry in §Keyword abilities for the full flow.
 - **Plot (CR 718)** — `KeywordAbility.plot(cost)`. Engine wires a sorcery-speed `PlotEnumerator` + `PlotCardHandler`
   that pays the plot cost, exiles the card face-up from hand, stamps `PlottedComponent(controllerId, turnPlotted)` +
   `PlayWithoutPayingCostComponent`, and adds a permanent `MayPlayPermission` gated by `SourcePlottedOnPriorTurn`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
@@ -43,6 +43,27 @@ data class ManaCost(val symbols: List<ManaSymbol>) {
     fun isEmpty(): Boolean = symbols.isEmpty()
 
     /**
+     * Substitute an announced value of X into this cost (CR 107.3a), turning each `{X}` symbol into
+     * that much generic mana: `{X}{G}{G}` with X=2 becomes `{2}{G}{G}`, and `{X}{X}{R}` with X=3
+     * becomes `{6}{R}`. A cost with no `{X}` is returned unchanged.
+     *
+     * The point is to hand downstream payment code a cost with no X left in it, so the ordinary
+     * pool/solver path pays it without a separate X-spending pass.
+     */
+    fun withXAs(x: Int): ManaCost {
+        if (!hasX) return this
+        val xGeneric = x.coerceAtLeast(0) * xCount
+        val withoutX = symbols.filterNot { it is ManaSymbol.X }
+        val newGenericAmount = genericAmount + xGeneric
+        val nonGeneric = withoutX.filterNot { it is ManaSymbol.Generic }
+        return if (newGenericAmount > 0) {
+            ManaCost(listOf(ManaSymbol.Generic(newGenericAmount)) + nonGeneric)
+        } else {
+            ManaCost(nonGeneric)
+        }
+    }
+
+    /**
      * Reduce the generic mana portion of this cost by [amount].
      * Colored/hybrid/phyrexian symbols are unaffected.
      */

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/ManaCostWithXAsTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/ManaCostWithXAsTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.sdk.core
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [ManaCost.withXAs] — substituting an announced X (CR 107.3a) into a cost, so downstream payment
+ * code never has to special-case an `{X}` symbol. Driven by X-cost cycling (Webstrike Elite's
+ * "Cycling {X}{G}{G}"), where the handler resolves the cost once and then pays it like any other.
+ */
+class ManaCostWithXAsTest : StringSpec({
+
+    fun sub(cost: String, x: Int) = ManaCost.parse(cost).withXAs(x)
+
+    "{X}{G}{G} with X=2 becomes {2}{G}{G}" {
+        sub("{X}{G}{G}", 2) shouldBe ManaCost.parse("{2}{G}{G}")
+    }
+    "{X}{2}{W} with X=3 folds into the printed generic as {5}{W}" {
+        sub("{X}{2}{W}", 3) shouldBe ManaCost.parse("{5}{W}")
+    }
+    "X=0 drops the symbol entirely rather than leaving {0}" {
+        sub("{X}{G}{G}", 0) shouldBe ManaCost.parse("{G}{G}")
+    }
+    "a bare {X} with X=0 is the empty cost" {
+        sub("{X}", 0) shouldBe ManaCost.ZERO
+    }
+    "each X symbol is charged separately — {X}{X}{R} with X=3 is {6}{R}" {
+        sub("{X}{X}{R}", 3) shouldBe ManaCost.parse("{6}{R}")
+    }
+    "a cost with no X is returned unchanged" {
+        sub("{2}{G}", 4) shouldBe ManaCost.parse("{2}{G}")
+    }
+    "a negative X is clamped to 0 rather than underflowing the generic" {
+        sub("{X}{G}{G}", -1) shouldBe ManaCost.parse("{G}{G}")
+    }
+    "the substituted cost carries no X left for downstream payment" {
+        sub("{X}{2}{W}", 3).hasX shouldBe false
+    }
+    "mana value reflects the announced X" {
+        sub("{X}{G}{G}", 4).cmc shouldBe 6
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ValorsFlagship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ValorsFlagship.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Valor's Flagship — Aetherdrift #35
+ * {4}{W}{W}{W} · Legendary Artifact — Vehicle · 7/7
+ *
+ * Flying, first strike, lifelink
+ * Crew 3
+ * Cycling {X}{2}{W}
+ * When you cycle this card, create X 1/1 colorless Pilot creature tokens with "This token saddles
+ * Mounts and crews Vehicles as though its power were 2 greater."
+ *
+ * Cycling is an activated ability (CR 702.29a), so X is announced as it's activated (CR 107.3a).
+ * The engine carries that announced X on `CardCycledEvent` into the trigger's context, where
+ * [DynamicAmount.XValue] reads it — cycling for X=0 legally creates no tokens.
+ */
+val ValorsFlagship = card("Valor's Flagship") {
+    manaCost = "{4}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Artifact — Vehicle"
+    power = 7
+    toughness = 7
+    oracleText = "Flying, first strike, lifelink\n" +
+        "Crew 3 (Tap any number of creatures you control with total power 3 or more: This " +
+        "Vehicle becomes an artifact creature until end of turn.)\n" +
+        "Cycling {X}{2}{W} ({X}{2}{W}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token " +
+        "saddles Mounts and crews Vehicles as though its power were 2 greater.\""
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE, Keyword.LIFELINK)
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    keywordAbility(KeywordAbility.cycling("{X}{2}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        effect = Effects.CreateToken(
+            count = DynamicAmount.XValue,
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Pilot"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+            staticAbilities = listOf(CrewSaddleContribution(modifier = 2))
+        )
+        description = "When you cycle this card, create X 1/1 colorless Pilot creature tokens " +
+            "with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\""
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "35"
+        artist = "Stephan Martiniere"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg?1783907911"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WebstrikeElite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/WebstrikeElite.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Webstrike Elite — Aetherdrift #186
+ * {G}{G} · Creature — Insect Archer · 3/3
+ *
+ * Reach
+ * Cycling {X}{G}{G}
+ * When you cycle this card, destroy up to one target artifact or enchantment with mana value X.
+ *
+ * Cycling is an activated ability (CR 702.29a), so X is announced as it's activated (CR 107.3a).
+ * The engine carries that announced X on `CardCycledEvent` into the trigger's context, where
+ * `manaValueEqualsX()` reads it — so cycling for X=3 can only destroy a mana-value-3 permanent.
+ *
+ * The cycle payoff is a separate ability from cycling itself (CR 702.29c and the card's rulings):
+ * it's legal to cycle with nothing of that mana value on the battlefield, because the target is
+ * "up to one" (`optional = true`), and countering one ability leaves the other to resolve.
+ */
+val WebstrikeElite = card("Webstrike Elite") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect Archer"
+    power = 3
+    toughness = 3
+    oracleText = "Reach\n" +
+        "Cycling {X}{G}{G} ({X}{G}{G}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, destroy up to one target artifact or enchantment with mana value X."
+
+    keywords(Keyword.REACH)
+
+    keywordAbility(KeywordAbility.cycling("{X}{G}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target(
+            "up to one target artifact or enchantment with mana value X",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.ArtifactOrEnchantment.manaValueEqualsX())
+            )
+        )
+        effect = Effects.Destroy(t)
+        description = "When you cycle this card, destroy up to one target artifact or " +
+            "enchantment with mana value X."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "186"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg?1783907863"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -17019,6 +17019,70 @@
     ]
 }
 
+// Valor's Flagship
+{
+    "name": "Valor's Flagship",
+    "manaCost": "{4}{W}{W}{W}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Flying, first strike, lifelink\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)\nCycling {X}{2}{W} ({X}{2}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\"",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE",
+        "LIFELINK",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        },
+        {
+            "type": "Cycling",
+            "cost": "{X}{2}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": "XValue",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Pilot"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/6/8672d795-04f9-4089-9c92-6d6ff628da12.jpg?1783907682",
+                    "staticAbilities": [
+                        {
+                            "type": "CrewSaddleContribution",
+                            "modifier": 2
+                        }
+                    ]
+                },
+                "descriptionOverride": "When you cycle this card, create X 1/1 colorless Pilot creature tokens with \"This token saddles Mounts and crews Vehicles as though its power were 2 greater.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "MYTHIC",
+        "artist": "Stephan Martiniere",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8af1dddf-6c95-448b-acc8-df5a99202e9a.jpg?1783907911"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Veloheart Bike
 {
     "name": "Veloheart Bike",
@@ -17621,6 +17685,73 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Webstrike Elite
+{
+    "name": "Webstrike Elite",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Insect Archer",
+    "oracleText": "Reach\nCycling {X}{G}{G} ({X}{G}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, destroy up to one target artifact or enchantment with mana value X.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{X}{G}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target artifact or enchantment with mana value X"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsArtifact",
+                                        "IsEnchantment"
+                                    ]
+                                },
+                                "ManaValueEqualsX"
+                            ]
+                        }
+                    },
+                    "id": "up to one target artifact or enchantment with mana value X"
+                },
+                "descriptionOverride": "When you cycle this card, destroy up to one target artifact or enchantment with mana value X."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "RARE",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/064cc22d-d424-4bc9-b8f0-88b170fd6c28.jpg?1783907863"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -95,6 +95,12 @@ data class TriggeredAbilityContinuation(
     /** Value chosen for {X} on the spell that fired this trigger (Geometer's Arthropod). Read via
      *  `ContextPropertyKey.X_VALUE_OF_TRIGGERING_SPELL`. Null for non-cast / no-{X} triggers. */
     val triggerXValueOfTriggeringSpell: Int? = null,
+    /** The trigger's own X — the value announced for an `{X}` cost on the *action that fired it*
+     *  (an `{X}` cycling cost, a megamorph turn-up), as opposed to
+     *  [triggerXValueOfTriggeringSpell], which is a *cast spell's* X. Read as
+     *  `DynamicAmount.XValue` and by X-relative target filters (`manaValueEqualsX()`), so it must
+     *  survive target selection or the ability fizzles its own legal target on resolution. */
+    val xValue: Int? = null,
     /** Pipeline state carried from a `ReflexiveTriggerEffect`'s action half, preserved across target
      *  selection so the stack object built on resume carries it (CR 603.12). Null otherwise. */
     val carriedPipeline: com.wingedsheep.engine.handlers.PipelineState? = null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DiscardAndDrawContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/DiscardAndDrawContinuations.kt
@@ -142,6 +142,24 @@ data class CycleDrawContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume a cycling action after the player announces X for an `{X}` cycling cost (CR 107.3a) —
+ * Webstrike Elite's "Cycling {X}{G}{G}".
+ *
+ * The legal-actions submission path sends a bare [CycleCard] with `xValue == null`; the handler
+ * raises a ChooseNumberDecision and stores this frame. On resume the handler is re-entered with
+ * `xValue` bound, and the cost is paid for that amount. Mirrors
+ * [ActivateAbilityChooseManaXContinuation] — paying the mana is automatic, so there is no follow-up
+ * decision.
+ *
+ * @property action The original [CycleCard] (its `xValue` is still null on the stored copy).
+ */
+@Serializable
+data class CycleCardChooseXContinuation(
+    override val decisionId: String,
+    val action: CycleCard
+) : ContinuationFrame
+
+/**
  * Resume the search step of a typecycling action after cycling triggers have resolved.
  *
  * Same issue as CycleDrawContinuation but for typecycling, which searches the library

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -349,13 +349,18 @@ data class ActivateAbility(
  *
  * @property playerId The player cycling the card
  * @property cardId The card being cycled
+ * @property xValue The announced value of X for a cycling cost containing `{X}` (Webstrike Elite's
+ *   "Cycling {X}{G}{G}"), chosen as the ability is activated (CR 107.3a). Null on the legal-actions
+ *   submission path — the handler then raises a ChooseNumberDecision and re-enters with it bound.
+ *   Ignored for cycling costs without `{X}`.
  */
 @Serializable
 @SerialName("CycleCard")
 data class CycleCard(
     override val playerId: EntityId,
     val cardId: EntityId,
-    val paymentStrategy: PaymentStrategy = PaymentStrategy.AutoPay
+    val paymentStrategy: PaymentStrategy = PaymentStrategy.AutoPay,
+    val xValue: Int? = null
 ) : GameAction
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1611,13 +1611,19 @@ data class BecomesTargetEvent(
 
 /**
  * A player cycled a card.
+ *
+ * @property xValue The value announced for `{X}` in the cycling cost, for cards with an X cycling
+ *   cost (Webstrike Elite's "Cycling {X}{G}{G}"). A "when you cycle this card" trigger reads it as
+ *   `DynamicAmount.XValue` via `TriggerContext.xValue`, so "destroy … with mana value X" and
+ *   "create X tokens" resolve against the X that was actually paid. Null for ordinary cycling.
  */
 @Serializable
 @SerialName("CardCycledEvent")
 data class CardCycledEvent(
     val playerId: EntityId,
     val cardId: EntityId,
-    val cardName: String
+    val cardName: String,
+    val xValue: Int? = null
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -283,6 +283,7 @@ val engineSerializersModule = SerializersModule {
         subclass(GuessTopCardKindContinuation::class)
         subclass(SelectTargetPipelineContinuation::class)
         subclass(CycleDrawContinuation::class)
+        subclass(CycleCardChooseXContinuation::class)
         subclass(TypecycleSearchContinuation::class)
         subclass(DistributeCountersContinuation::class)
         subclass(RemoveAnyNumberOfCountersContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -279,7 +279,13 @@ data class TriggerContext(
                     triggeringEntityId = event.cardEntityId,
                     triggeringPlayerId = event.playerId
                 )
-                is CardCycledEvent -> TriggerContext(triggeringPlayerId = event.playerId)
+                // xValue carries the X announced for an `{X}` cycling cost (CR 107.3a) so a
+                // "when you cycle this card" trigger can read it as DynamicAmount.XValue —
+                // Webstrike Elite's "with mana value X", Valor's Flagship's "create X tokens".
+                is CardCycledEvent -> TriggerContext(
+                    triggeringPlayerId = event.playerId,
+                    xValue = event.xValue
+                )
                 is com.wingedsheep.engine.core.CrewOrSaddleContributionEvent -> TriggerContext(
                     triggeringEntityId = event.permanentId,
                     triggeringPlayerId = event.controllerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1681,7 +1681,10 @@ class TriggerDetector(
                         sourceId = entityId,
                         sourceName = cardComponent.name,
                         controllerId = event.playerId,
-                        triggerContext = TriggerContext(triggeringPlayerId = event.playerId)
+                        // fromEvent, not a hand-built context: it also carries the X announced for
+                        // an `{X}` cycling cost, which the payoff reads (Webstrike Elite's "mana
+                        // value X" target filter, Valor's Flagship's "create X tokens").
+                        triggerContext = TriggerContext.fromEvent(event)
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -183,6 +183,11 @@ class TriggerProcessor(
                 controllerId = trigger.controllerId,
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                 triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+                // The X carried by the triggering event (an {X} cycling cost, a megamorph turn-up)
+                // so an X-relative target filter — `manaValueEqualsX()` on Webstrike Elite's
+                // "artifact or enchantment with mana value X" — finds targets at legality time.
+                // Without it those predicates read an unbound X and match nothing.
+                xValue = trigger.triggerContext.xValue,
                 storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
                 chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
                 storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
@@ -384,6 +389,11 @@ class TriggerProcessor(
                 controllerId = trigger.controllerId,
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                 triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+                // The X carried by the triggering event (an {X} cycling cost, a megamorph turn-up)
+                // so an X-relative target filter — `manaValueEqualsX()` on Webstrike Elite's
+                // "artifact or enchantment with mana value X" — finds targets at legality time.
+                // Without it those predicates read an unbound X and match nothing.
+                xValue = trigger.triggerContext.xValue,
                 storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
                 chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
                 storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
@@ -494,6 +504,11 @@ class TriggerProcessor(
                 controllerId = trigger.controllerId,
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                 triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+                // The X carried by the triggering event (an {X} cycling cost, a megamorph turn-up)
+                // so an X-relative target filter — `manaValueEqualsX()` on Webstrike Elite's
+                // "artifact or enchantment with mana value X" — finds targets at legality time.
+                // Without it those predicates read an unbound X and match nothing.
+                xValue = trigger.triggerContext.xValue,
                 storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
                 chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
                 storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
@@ -586,6 +601,9 @@ class TriggerProcessor(
                     controllerId = trigger.controllerId,
                     triggeringEntityId = trigger.triggerContext.triggeringEntityId,
                     triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
+                    // See the note on the other findLegalTargets call sites: an X-relative target
+                    // filter needs the triggering event's X bound to match anything.
+                    xValue = trigger.triggerContext.xValue,
                     storedCollections = trigger.carriedPipeline?.storedCollections ?: emptyMap(),
                     chosenValues = trigger.carriedPipeline?.chosenValues ?: emptyMap(),
                     storedStringLists = trigger.carriedPipeline?.storedStringLists ?: emptyMap(),
@@ -738,6 +756,7 @@ class TriggerProcessor(
             triggerColorsSpentOnTriggeringSpell = trigger.triggerContext.colorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = trigger.triggerContext.manaValueOfTriggeringSpell,
             triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell,
+            xValue = trigger.triggerContext.xValue,
             carriedPipeline = trigger.carriedPipeline
         )
 
@@ -1114,6 +1133,9 @@ class TriggerProcessor(
             controllerId = ability.controllerId,
             triggeringEntityId = ability.triggeringEntityId,
             triggeringPlayerId = ability.triggeringPlayerId,
+            // Same reason as the pending-trigger call sites: an X-relative target filter must see
+            // the X the ability went on the stack with, or it re-checks as having no legal targets.
+            xValue = ability.xValue,
             storedCollections = ability.carriedPipeline?.storedCollections ?: emptyMap(),
             chosenValues = ability.carriedPipeline?.chosenValues ?: emptyMap(),
             storedStringLists = ability.carriedPipeline?.storedStringLists ?: emptyMap(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/CycleCardHandler.kt
@@ -79,6 +79,15 @@ class CycleCardHandler(
             .firstOrNull { it.searchFilter == null }
             ?: return "This card doesn't have cycling"
 
+        // The action is client-supplied: a negative X would underflow the cost substitution.
+        if (action.xValue != null && action.xValue < 0) {
+            return "X can't be negative"
+        }
+
+        // Affordability is judged against X=0 when the player hasn't announced X yet — the
+        // handler raises the choice, and X=0 is always a legal announcement (CR 107.3a).
+        val effectiveCost = cyclingAbility.cost.withXAs(action.xValue ?: 0)
+
         if (action.paymentStrategy is PaymentStrategy.Explicit) {
             for (sourceId in action.paymentStrategy.manaAbilitiesToActivate) {
                 val sourceContainer = state.getEntity(sourceId)
@@ -87,7 +96,7 @@ class CycleCardHandler(
                     return "Mana source is already tapped: $sourceId"
                 }
             }
-        } else if (!manaSolver.canPay(state, action.playerId, cyclingAbility.cost)) {
+        } else if (!manaSolver.canPay(state, action.playerId, effectiveCost)) {
             return "Not enough mana to cycle this card"
         }
 
@@ -108,6 +117,54 @@ class CycleCardHandler(
             .firstOrNull { it.searchFilter == null }
             ?: return ExecutionResult.error(state, "This card doesn't have cycling")
 
+        // ---------------------------------------------------------------------
+        // {X} cycling cost — announce X (CR 107.3a).
+        //
+        // Cycling is an activated ability (CR 702.29a), so its `{X}` is chosen as the ability is
+        // activated. The legal-actions submission path sends a bare CycleCard with no xValue; pause
+        // for the choice and re-enter with it bound. The engine-direct path (xValue pre-filled,
+        // as scenario tests and the AI use) skips this. Mirrors the mana-X pause in
+        // ActivateAbilityHandler.
+        // ---------------------------------------------------------------------
+        if (cyclingAbility.cost.hasX && action.xValue == null) {
+            val fixedMana = cyclingAbility.cost.withXAs(0).cmc
+            val maxX = ((manaSolver.getAvailableManaCount(state, action.playerId) - fixedMana) /
+                cyclingAbility.cost.xCount.coerceAtLeast(1)).coerceAtLeast(0)
+            val decisionId = java.util.UUID.randomUUID().toString()
+            val decision = com.wingedsheep.engine.core.ChooseNumberDecision(
+                id = decisionId,
+                playerId = action.playerId,
+                prompt = "Choose X for cycling ${cardComponent.name} (0-$maxX)",
+                context = com.wingedsheep.engine.core.DecisionContext(
+                    sourceId = action.cardId,
+                    sourceName = cardComponent.name,
+                    phase = com.wingedsheep.engine.core.DecisionPhase.CASTING
+                ),
+                minValue = 0,
+                maxValue = maxX
+            )
+            val pausedState = state
+                .withPendingDecision(decision)
+                .pushContinuation(
+                    com.wingedsheep.engine.core.CycleCardChooseXContinuation(
+                        decisionId = decisionId,
+                        action = action
+                    )
+                )
+            val event = com.wingedsheep.engine.core.DecisionRequestedEvent(
+                decisionId = decisionId,
+                playerId = action.playerId,
+                decisionType = "CHOOSE_NUMBER",
+                prompt = decision.prompt
+            )
+            return ExecutionResult.paused(pausedState, decision, listOf(event))
+        }
+
+        // X is settled from here on. Substituting it into the cost leaves an ordinary X-free cost,
+        // so every payment path below (pool, auto-tap, explicit taps) works unchanged.
+        val announcedX = action.xValue?.takeIf { cyclingAbility.cost.hasX }
+        val cyclingCost = cyclingAbility.cost.withXAs(announcedX ?: 0)
+
         var currentState = state
         val events = mutableListOf<GameEvent>()
         val ownerId = cardComponent.ownerId ?: action.playerId
@@ -124,7 +181,7 @@ class CycleCardHandler(
             colorless = poolComponent.colorless
         )
 
-        val partialResult = pool.payPartial(cyclingAbility.cost)
+        val partialResult = pool.payPartial(cyclingCost)
         val poolAfterPayment = partialResult.newPool
         val remainingCost = partialResult.remainingCost
         val manaSpentFromPool = partialResult.manaSpent
@@ -225,7 +282,7 @@ class CycleCardHandler(
         )
 
         // Emit cycling event (for cycling triggers like Astral Slide)
-        events.add(CardCycledEvent(action.playerId, action.cardId, cardComponent.name))
+        events.add(CardCycledEvent(action.playerId, action.cardId, cardComponent.name, announcedX))
 
         currentState = currentState.tick()
 
@@ -242,11 +299,15 @@ class CycleCardHandler(
             val triggerResult = triggerProcessor.processTriggers(stateWithDrawContinuation, preTriggers)
 
             if (triggerResult.isPaused) {
+                // triggersAlreadyProcessed: the cycling events above have been through
+                // detectTriggers here. Without the flag, SubmitDecisionHandler re-scans this
+                // result's events when the cycle was resumed from a decision (an {X} cycling
+                // cost's ChooseNumber) and queues the cycling trigger a second time.
                 return ExecutionResult.paused(
                     triggerResult.state,
                     triggerResult.pendingDecision!!,
                     events + triggerResult.events
-                )
+                ).copy(triggersAlreadyProcessed = true)
             }
 
             // Triggers resolved synchronously — pop the draw continuation and draw inline
@@ -269,13 +330,14 @@ class CycleCardHandler(
                 drawResult.state,
                 drawResult.pendingDecision!!,
                 events + drawResult.events
-            )
+            ).copy(triggersAlreadyProcessed = true)
         }
         currentState = drawResult.newState
         events.addAll(drawResult.events)
 
         // Cycling doesn't change priority
         return ExecutionResult.success(currentState, events)
+            .copy(triggersAlreadyProcessed = true)
     }
 
     private fun isCyclingPrevented(state: GameState): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
@@ -13,10 +13,37 @@ class DiscardAndDrawContinuationResumer(
     private val services: com.wingedsheep.engine.core.EngineServices
 ) : ContinuationResumerModule {
 
+    private val cycleCardHandler:
+        com.wingedsheep.engine.handlers.actions.ability.CycleCardHandler by lazy {
+            com.wingedsheep.engine.handlers.actions.ability.CycleCardHandler.create(services)
+        }
+
     override fun resumers(): List<ContinuationResumer<*>> = listOf(
         resumer(HandSizeDiscardContinuation::class, ::resumeHandSizeDiscard),
-        resumer(EachPlayerDiscardsOrLoseLifeContinuation::class, ::resumeEachPlayerDiscardsOrLoseLife)
+        resumer(EachPlayerDiscardsOrLoseLifeContinuation::class, ::resumeEachPlayerDiscardsOrLoseLife),
+        resumer(CycleCardChooseXContinuation::class, ::resumeCycleCardChooseX)
     )
+
+    /**
+     * Resume a cycling action once the player has announced X for an `{X}` cycling cost
+     * (CR 107.3a) — Webstrike Elite's "Cycling {X}{G}{G}". Re-enter the handler with X bound; the
+     * cost is then paid for that amount and the cycle proceeds normally. No follow-up decision —
+     * paying the mana is automatic.
+     */
+    fun resumeCycleCardChooseX(
+        state: GameState,
+        continuation: CycleCardChooseXContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is NumberChosenResponse) {
+            return ExecutionResult.error(state, "Expected number response for cycling X choice")
+        }
+        val chosenX = response.number.coerceAtLeast(0)
+        val result = cycleCardHandler.execute(state, continuation.action.copy(xValue = chosenX))
+        return if (result.isPaused || result.error != null) result
+        else checkForMore(result.newState, result.events)
+    }
 
     fun resumeHandSizeDiscard(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -128,6 +128,7 @@ class EffectAndTriggerContinuationResumer(
                 triggerColorsSpentOnTriggeringSpell = continuation.triggerColorsSpentOnTriggeringSpell,
                 triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell,
                 triggerXValueOfTriggeringSpell = continuation.triggerXValueOfTriggeringSpell,
+                xValue = continuation.xValue,
                 carriedPipeline = continuation.carriedPipeline
             )
             val stackResult = services.stackResolver.putTriggeredAbility(state, elseComponent, emptyList())
@@ -184,6 +185,7 @@ class EffectAndTriggerContinuationResumer(
             triggerColorsSpentOnTriggeringSpell = continuation.triggerColorsSpentOnTriggeringSpell,
             triggerManaValueOfTriggeringSpell = continuation.triggerManaValueOfTriggeringSpell,
             triggerXValueOfTriggeringSpell = continuation.triggerXValueOfTriggeringSpell,
+            xValue = continuation.xValue,
             carriedPipeline = continuation.carriedPipeline
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CyclingEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CyclingEnumerator.kt
@@ -33,17 +33,30 @@ class CyclingEnumerator : ActionEnumerator {
             val typedCycling = cyclingAbilities.firstOrNull { it.searchFilter != null }
 
             if (plainCycling != null) {
-                val canAfford = context.manaSolver.canPay(state, playerId, plainCycling.cost, precomputedSources = context.availableManaSources)
+                // An `{X}` cycling cost (Webstrike Elite's "Cycling {X}{G}{G}") is affordable as
+                // soon as its fixed part is payable — X = 0 is always a legal announcement (CR
+                // 107.3a). Substituting X = 0 gives that baseline for both the check and the
+                // auto-tap preview; the displayed cost string keeps the `{X}` so the player sees
+                // the real cost, and hasXCost/maxAffordableX drive the client's X chooser.
+                val hasXCost = plainCycling.cost.hasX
+                val baseCost = plainCycling.cost.withXAs(0)
+                val canAfford = context.manaSolver.canPay(state, playerId, baseCost, precomputedSources = context.availableManaSources)
                 val autoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, plainCycling.cost, precomputedSources = context.availableManaSources)
+                    context.manaSolver.solve(state, playerId, baseCost, precomputedSources = context.availableManaSources)
                         ?.sources?.map { it.entityId }
                 }
+                val maxAffordableX = if (hasXCost) {
+                    val available = context.manaSolver.getAvailableManaCount(state, playerId, context.availableManaSources)
+                    ((available - baseCost.cmc).coerceAtLeast(0)) / plainCycling.cost.xCount.coerceAtLeast(1)
+                } else null
                 result.add(
                     LegalAction(
                         actionType = "CycleCard",
                         description = "Cycle ${cardComponent.name}",
                         action = CycleCard(playerId, cardId),
                         affordable = canAfford,
+                        hasXCost = hasXCost,
+                        maxAffordableX = maxAffordableX,
                         manaCostString = plainCycling.cost.toString(),
                         autoTapPreview = autoTapPreview
                     )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValorsFlagshipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValorsFlagshipScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Valor's Flagship — a 7/7 Vehicle with flying, first strike, lifelink and Crew 3, plus
+ * Cycling {X}{2}{W} and "When you cycle this card, create X 1/1 colorless Pilot creature tokens
+ * with 'This token saddles Mounts and crews Vehicles as though its power were 2 greater.'"
+ *
+ * The X announced for the cycling cost (CR 107.3a) is what the trigger's token count reads, so
+ * these cases pin the count against the announcement — including X = 0, which legally creates
+ * nothing. The token's crew rider matters as much as the count: a lone 1/1 Pilot could never crew
+ * a Crew 3 Vehicle on its printed power, but crews as though its power were 3.
+ */
+class ValorsFlagshipScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cycling for X=3 creates three Pilot tokens") {
+            val game = flagshipGame(plains = 6)
+
+            val cycle = game.cycleCard(1, "Valor's Flagship", xValue = 3)
+            withClue("Cycling for X=3 should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            game.resolveStack()
+
+            withClue("X = 3 tokens") { game.findPermanents("Pilot Token").size shouldBe 3 }
+            withClue("The Flagship itself was discarded to pay the cycling cost") {
+                game.isInGraveyard(1, "Valor's Flagship") shouldBe true
+            }
+        }
+
+        test("X=0 creates no tokens but still cycles and draws") {
+            // Three Plains pay {0}{2}{W} exactly — proof the {X} was charged as 0, not skipped.
+            val game = flagshipGame(plains = 3)
+            val handBefore = game.handSize(1)
+
+            val cycle = game.cycleCard(1, "Valor's Flagship", xValue = 0)
+            withClue("Cycling for X=0 should succeed on three Plains: ${cycle.error}") {
+                cycle.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("X = 0 tokens") { game.findPermanents("Pilot Token").size shouldBe 0 }
+            withClue("Cycling still drew a card, replacing the discarded Flagship") {
+                game.handSize(1) shouldBe handBefore
+                game.isInGraveyard(1, "Valor's Flagship") shouldBe true
+            }
+        }
+
+        test("the Pilot tokens carry the crew rider — one alone crews a Crew 3 Vehicle") {
+            val game = flagshipGame(plains = 6, extraVehicle = "Detention Chariot")
+            val vehicle = game.findPermanent("Detention Chariot")!!
+
+            val cycle = game.cycleCard(1, "Valor's Flagship", xValue = 1)
+            withClue("Cycling for X=1 should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            game.resolveStack()
+
+            val pilots = game.findPermanents("Pilot Token")
+            withClue("X = 1 token") { pilots.size shouldBe 1 }
+
+            val crew = game.execute(CrewVehicle(game.player1Id, vehicle, pilots))
+            withClue("Crewing should be paid by the lone Pilot: ${crew.error}") {
+                crew.error shouldBe null
+            }
+            game.resolveStack()
+            withClue("A lone 1/1 Pilot crews for 3 thanks to the +2 rider") {
+                game.state.projectedState.isCreature(vehicle) shouldBe true
+            }
+        }
+
+        test("the Flagship on the battlefield is a 7/7 Vehicle with its three keywords") {
+            val game = flagshipGame(plains = 6, flagshipInPlay = true)
+            val flagship = game.findPermanent("Valor's Flagship")!!
+            val projected = game.state.projectedState
+
+            withClue("A Vehicle is not a creature until crewed, but its P/T is printed 7/7") {
+                projected.getPower(flagship) shouldBe 7
+                projected.getToughness(flagship) shouldBe 7
+            }
+            withClue("Flying, first strike and lifelink are printed on the Vehicle") {
+                projected.hasKeyword(flagship, Keyword.FLYING) shouldBe true
+                projected.hasKeyword(flagship, Keyword.FIRST_STRIKE) shouldBe true
+                projected.hasKeyword(flagship, Keyword.LIFELINK) shouldBe true
+            }
+        }
+    }
+
+    /** The Flagship in hand (or in play), and [plains] Plains to cycle it with. */
+    private fun flagshipGame(
+        plains: Int,
+        extraVehicle: String? = null,
+        flagshipInPlay: Boolean = false
+    ): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withLandsOnBattlefield(1, "Plains", plains)
+        if (flagshipInPlay) {
+            builder.withCardOnBattlefield(1, "Valor's Flagship", summoningSickness = false)
+        } else {
+            builder.withCardInHand(1, "Valor's Flagship")
+        }
+        if (extraVehicle != null) {
+            builder.withCardOnBattlefield(1, extraVehicle, summoningSickness = false)
+        }
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WebstrikeEliteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WebstrikeEliteScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Webstrike Elite — Reach, Cycling {X}{G}{G}, and "When you cycle this card, destroy up to one
+ * target artifact or enchantment with mana value X."
+ *
+ * Cycling is an activated ability (CR 702.29a), so X is announced as the ability is activated
+ * (CR 107.3a). These cases pin that the announced X reaches the trigger: it gates which permanents
+ * are legal targets (`manaValueEqualsX()` is *equals*, not "or less"), X = 0 is a legal
+ * announcement that simply finds nothing, and — per the card's rulings — cycling is legal with no
+ * matching permanent at all because the two abilities are independent.
+ */
+class WebstrikeEliteScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cycling for X=3 destroys a mana-value-3 artifact") {
+            // Bottle Gnomes is a {3} artifact, so cycling for X=3 must find it.
+            val game = eliteGame(opposing = listOf("Bottle Gnomes"), forests = 5)
+            val gnomes = game.findPermanent("Bottle Gnomes")!!
+
+            val cycle = game.cycleCard(1, "Webstrike Elite", xValue = 3)
+            withClue("Cycling for X=3 should succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.selectTargets(listOf(gnomes))
+            game.resolveStack()
+
+            withClue("The mana-value-3 artifact was destroyed") {
+                game.findPermanent("Bottle Gnomes") shouldBe null
+                game.isInGraveyard(2, "Bottle Gnomes") shouldBe true
+            }
+            withClue("The Elite itself was discarded to pay the cycling cost") {
+                game.isInGraveyard(1, "Webstrike Elite") shouldBe true
+            }
+        }
+
+        test("the announced X gates targeting — a mana value 3 artifact is no target for X=2") {
+            val game = eliteGame(opposing = listOf("Bottle Gnomes"), forests = 5)
+
+            val cycle = game.cycleCard(1, "Webstrike Elite", xValue = 2)
+            withClue("Cycling for X=2 should still succeed: ${cycle.error}") { cycle.error shouldBe null }
+            if (game.hasPendingDecision()) game.skipTargets()
+            game.resolveStack()
+
+            withClue("\"mana value X\" is an exact match, so the {3} artifact survives X=2") {
+                (game.findPermanent("Bottle Gnomes") != null) shouldBe true
+                game.isInGraveyard(2, "Bottle Gnomes") shouldBe false
+            }
+        }
+
+        test("cycling with no matching permanent still draws — the two abilities are independent") {
+            val game = eliteGame(opposing = emptyList(), forests = 5)
+            val handBefore = game.handSize(1)
+
+            val cycle = game.cycleCard(1, "Webstrike Elite", xValue = 2)
+            withClue("Cycling is legal with nothing to destroy: ${cycle.error}") {
+                cycle.error shouldBe null
+            }
+            if (game.hasPendingDecision()) game.skipTargets()
+            game.resolveStack()
+
+            withClue("The cycling ability drew a card, replacing the discarded Elite") {
+                game.handSize(1) shouldBe handBefore
+                game.isInGraveyard(1, "Webstrike Elite") shouldBe true
+            }
+        }
+
+        test("X=0 is a legal announcement and costs only the coloured part of the cycling cost") {
+            // Two Forests pay {0}{G}{G} exactly — proof the {X} was charged as 0, not skipped.
+            val game = eliteGame(opposing = listOf("Bottle Gnomes"), forests = 2)
+
+            val cycle = game.cycleCard(1, "Webstrike Elite", xValue = 0)
+            withClue("Cycling for X=0 should succeed on two Forests: ${cycle.error}") {
+                cycle.error shouldBe null
+            }
+            if (game.hasPendingDecision()) game.skipTargets()
+            game.resolveStack()
+
+            withClue("Nothing has mana value 0, so the Gnomes survive") {
+                game.isInGraveyard(2, "Bottle Gnomes") shouldBe false
+            }
+            withClue("The Elite was still cycled") {
+                game.isInGraveyard(1, "Webstrike Elite") shouldBe true
+            }
+        }
+
+        test("submitting no X raises a ChooseNumber decision — the client's path") {
+            val game = eliteGame(opposing = listOf("Bottle Gnomes"), forests = 5)
+            val gnomes = game.findPermanent("Bottle Gnomes")!!
+
+            val cycle = game.cycleCard(1, "Webstrike Elite")
+            withClue("A bare CycleCard on an {X} cost pauses instead of defaulting X to 0") {
+                cycle.error shouldBe null
+                game.hasPendingDecision() shouldBe true
+            }
+
+            game.chooseNumber(3)
+            if (game.hasPendingDecision()) game.selectTargets(listOf(gnomes))
+            game.resolveStack()
+
+            withClue("The X answered at the decision reached the trigger") {
+                game.isInGraveyard(2, "Bottle Gnomes") shouldBe true
+            }
+        }
+    }
+
+    /** The Elite in hand, [forests] Forests to cycle it with, and the opponent's permanents. */
+    private fun eliteGame(opposing: List<String>, forests: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Webstrike Elite")
+            .withLandsOnBattlefield(1, "Forest", forests)
+        opposing.forEach { builder.withCardOnBattlefield(2, it, summoningSickness = false) }
+        repeat(8) {
+            builder.withCardInLibrary(1, "Grizzly Bears")
+            builder.withCardInLibrary(2, "Grizzly Bears")
+        }
+        return builder
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -860,15 +860,19 @@ abstract class ScenarioTestBase : FunSpec() {
         /**
          * Cycle a card by name from a player's hand.
          * The player pays the cycling cost, discards the card, and draws a card.
+         *
+         * [xValue] announces X for an `{X}` cycling cost (Webstrike Elite's "Cycling {X}{G}{G}").
+         * Leaving it null on such a card exercises the client's path instead: the engine raises a
+         * ChooseNumberDecision for X and resumes once it's answered.
          */
-        fun cycleCard(playerNumber: Int, cardName: String): ExecutionResult {
+        fun cycleCard(playerNumber: Int, cardName: String, xValue: Int? = null): ExecutionResult {
             val playerId = if (playerNumber == 1) player1Id else player2Id
             val hand = state.getHand(playerId)
             val cardId = hand.find { entityId ->
                 state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
             } ?: error("Card '$cardName' not found in player $playerNumber's hand")
 
-            return execute(CycleCard(playerId, cardId))
+            return execute(CycleCard(playerId, cardId, xValue = xValue))
         }
 
         /**

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -286,7 +286,8 @@ export function mergeResult(
       if (
         action.type === 'CastSpell' ||
         action.type === 'ActivateAbility' ||
-        action.type === 'TurnFaceUp'
+        action.type === 'TurnFaceUp' ||
+        action.type === 'CycleCard'
       ) {
         return { ...action, xValue: result.xValue }
       }

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -195,6 +195,12 @@ export interface CycleCardAction {
   readonly playerId: EntityId
   readonly cardId: EntityId
   readonly paymentStrategy?: PaymentStrategy
+  /**
+   * Chosen X for an `{X}` cycling cost (Webstrike Elite's "Cycling {X}{G}{G}"), set by the
+   * xSelection pipeline phase. Omitted for ordinary cycling — and if omitted on an X cost, the
+   * engine raises its own ChooseNumber decision rather than defaulting X to 0.
+   */
+  readonly xValue?: number
 }
 
 export interface TypecycleCardAction {


### PR DESCRIPTION
Two Aetherdrift cards from the set's remaining tail, plus the one engine capability both needed.

## Why a feature was needed

All 9 cards left in DFT need engine capability. Both cycling ones need the same thing: an `{X}` in a cycling cost. Cycling is an activated ability (CR 702.29a), so X is announced as the ability is activated (CR 107.3a) — and the announced value has to reach the "when you cycle this card" trigger.

## Engine

- **`ManaCost.withXAs(x)`** substitutes the announced X into a cost (`{X}{G}{G}` + X=2 → `{2}{G}{G}`), so every downstream payment path sees an ordinary X-free cost instead of each one re-implementing the X-spending dance.
- **`CycleCard.xValue`** carries the announcement. A bare submission pauses on a `ChooseNumberDecision` (`CycleCardChooseXContinuation`) rather than silently defaulting X to 0 — mirroring `ActivateAbilityHandler`'s mana-X pause. `CyclingEnumerator` also exposes `hasXCost` / `maxAffordableX`, so the client picks X up front through its existing `xSelection` pipeline phase instead.
- **`CardCycledEvent.xValue`** carries the announced X into the trigger's context, where a payoff reads it as `DynamicAmount.XValue` or through an X-relative target filter.

### Three places dropped X on the way to the trigger

Each was found by a failing scenario test, and each has one pinning it:

1. `detectCyclingCardTriggers` hand-built its `TriggerContext` instead of using `TriggerContext.fromEvent`.
2. `TriggerProcessor`'s `findLegalTargets` contexts carried no `xValue`, so `manaValueEqualsX()` matched nothing at legality time.
3. `TriggeredAbilityContinuation` had no `xValue` slot, so a trigger that paused for target selection fizzled its own legal target on resolution.

`CycleCardHandler` now marks its results `triggersAlreadyProcessed`, so `SubmitDecisionHandler` doesn't re-scan already-detected cycling events and queue the trigger a second time when the cycle resumed from the X decision. (This is why the action path and the decision path behaved differently.)

## Cards

Both are DFT-canonical — the only earlier printings are `pdft` promos.

| Card | |
|---|---|
| **Webstrike Elite** `{G}{G}` 3/3 | Reach · Cycling `{X}{G}{G}` · destroy up to one target artifact or enchantment with mana value X |
| **Valor's Flagship** `{4}{W}{W}{W}` 7/7 | Legendary Vehicle · flying, first strike, lifelink · Crew 3 · Cycling `{X}{2}{W}` · create X Pilot tokens |

## Scope note

X-cost **typecycling** is deliberately not wired — no such card is printed. Called out in the SDK reference rather than left as a silent gap.

## Verification

- `just test` — green (9192 rules-engine tests, 0 failures).
- 9 new scenario tests across the two cards: X gating targets (`manaValueEqualsX` is *equals*, not "or less"), X=0 as a legal announcement that pays only the coloured part, cycling legally with nothing to hit, the token count tracking X, the Pilot token's crew rider, and the bare-submit ChooseNumber path.
- 9 new SDK tests for `ManaCost.withXAs` (multi-X costs, X=0, negative clamp, no-X passthrough).
- `just rebless-cards` — DFT golden shows **only** the two new cards (131 added, 0 removed).
- `just check-card-printing` clean for both; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)