### PR TITLE
Add Pit Automaton and Elvish Refueler to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3684,7 +3684,16 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
 - `YouActivateExhaustAbility` — you activate an ability marked `isExhaust`. Backed by
   `EventPattern.AbilityActivatedEvent(player = Player.You, requireExhaust = true)` and the activation event's
   `isExhaust` flag. The event is emitted as soon as the exhaust ability is put on the stack, so the triggered
-  ability is stacked above it and resolves first (Adrenaline Jockey, Rangers' Aetherhive).
+  ability is stacked above it and resolves first (Adrenaline Jockey, Rangers' Aetherhive). This is the plain
+  Aetherdrift wording, which counts an exhaust *mana* ability too.
+- `YouActivateNonManaExhaustAbility` — the same, but with the "that isn't a mana ability" clause
+  (`EventPattern.AbilityActivatedEvent(requireExhaust = true, excludeManaAbilities = true)`). Pit Automaton's
+  Oracle text was updated on release to add that clause so its copy payoff can't latch onto a mana ability;
+  the activated ability is exposed as `EffectTarget.TriggeringEntity`, so
+  `Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)` copies it. Usable as a **delayed** trigger
+  too (`CreateDelayedTriggerEffect(trigger = …, fireOnce = true)` = "when you next activate an exhaust ability
+  that isn't a mana ability this turn, …") — `AbilityActivatedEvent` is one of the filter-scoped patterns the
+  delayed-trigger matcher dispatches to the canonical `TriggerMatcher`.
 - `youActivateAbilityTargeting(targetMatch)` — you activate an ability whose **chosen targets** satisfy
   `targetMatch`. Backed by `EventPattern.AbilityActivatedEvent(player, targetMatch)`: when `targetMatch != null`, the
   activated ability on the stack must have at least one chosen target matching it, so a non-targeting ability (e.g.
@@ -4988,6 +4997,18 @@ staticAbility {
   condition = IsYourTurn)` ("During your turn, your opponents can't activate abilities of artifacts,
   creatures, or enchantments."); loyalty abilities and land mana abilities are unaffected because the
   filter only matches those three permanent types.
+- `IgnoreExhaustActivationLimit(condition = null)` — the *permission* mirror of the above: the controller
+  may activate exhaust abilities (CR 702.177) as though they hadn't been activated, i.e. the
+  `ActivationRestriction.Once` memory `isExhaust = true` installs is waived. Scoped to the activating player
+  being this permanent's controller (there is no "who" axis — you can only activate abilities of permanents
+  you control) and gated by `condition`, evaluated in the controller's context; `null` = always. Resolved by
+  `ExhaustActivationWaiver`, which all three activation-legality paths consult (the enumerators and the
+  activate handler via `CastPermissionUtils`, plus `ManaSolver`'s inlined check for auto-tapping) so they
+  can't drift. It never reaches a plain `Once`/`OncePerTurn` restriction on a *non*-exhaust ability.
+  Elvish Refueler = `IgnoreExhaustActivationLimit(condition = Conditions.All(Conditions.IsYourTurn,
+  Conditions.YouHaventActivatedAnExhaustAbilityThisTurn))` — the gate re-evaluates every frame, so the
+  permission evaporates the instant the turn's first exhaust ability is activated. Net effect: once per turn,
+  on your turn, you may re-use one already-spent exhaust ability of any permanent you control.
 
 **Tapped-for-mana mana statics** (extra mana / replaced mana when a land is tapped for mana — resolve
 inline as triggered mana abilities, off the stack per CR 605). These fire on the *manual* mana-ability
@@ -6550,6 +6571,12 @@ default to "you" so card authors don't need to pass it explicitly.
   `CardsDrawnThisTurnComponent` (reset for all players at turn start). Works in resolution and
   cost-reduction (projection) contexts. Used by Gwaihir the Windlord ("costs {2} less … as long as
   you've drawn two or more cards this turn") via `ModifySpellCost(..., gating = CostGating.OnlyIf(...))`.
+- `YouActivatedExhaustAbilitiesThisTurn(atLeast = 1)` / `YouHaventActivatedAnExhaustAbilityThisTurn` —
+  "as long as you've activated N or more exhaust abilities this turn" and its negation. Backed by
+  `PlayerActivatedExhaustAbilitiesThisTurn(Player.You, atLeast)`, reading the per-player
+  `ExhaustAbilitiesActivatedThisTurnComponent` (bumped at activation time, so a countered exhaust ability
+  still counts; reset for all players at turn start). Gates Elvish Refueler's
+  `IgnoreExhaustActivationLimit`.
 - `TriggeringSpellMatches(filter)` — intervening-if guard: the spell that triggered this ability
   matches `filter`. Reads the triggering entity's static card characteristics (so it stays correct
   after the spell leaves the stack). General "whenever you cast a spell, if it's a/an X ..." gate.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1269,6 +1269,20 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.PlayerDrewCardsThisTurn(Player.You, atLeast)
 
     /**
+     * As long as you've activated [atLeast] or more exhaust abilities this turn (CR 702.177),
+     * backed by the per-player `ExhaustAbilitiesActivatedThisTurnComponent`.
+     */
+    fun YouActivatedExhaustAbilitiesThisTurn(atLeast: Int = 1): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.PlayerActivatedExhaustAbilitiesThisTurn(Player.You, atLeast)
+
+    /**
+     * As long as you haven't activated an exhaust ability this turn — Elvish Refueler's gate on its
+     * "activate exhaust abilities as though they haven't been activated" permission.
+     */
+    val YouHaventActivatedAnExhaustAbilityThisTurn: ConditionInterface =
+        Not(com.wingedsheep.sdk.scripting.conditions.PlayerActivatedExhaustAbilitiesThisTurn(Player.You, 1))
+
+    /**
      * If you've committed a crime this turn (CR Outlaws of Thunder Junction). A crime is committed
      * when you cast a spell, activate an ability, or put a triggered ability on the stack that
      * targets an opponent, anything an opponent controls, and/or a card in an opponent's graveyard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1194,9 +1194,30 @@ object Triggers {
         binding = TriggerBinding.ANY
     )
 
-    /** Whenever you activate an exhaust ability. */
+    /**
+     * Whenever you activate an exhaust ability (CR 702.177). The plain Aetherdrift wording —
+     * Adrenaline Jockey, Rangers' Refueler, Rangers' Aetherhive, Afterburner Expert — which counts
+     * an exhaust *mana* ability as well. For the "that isn't a mana ability" variant see
+     * [YouActivateNonManaExhaustAbility].
+     */
     val YouActivateExhaustAbility: TriggerSpec = TriggerSpec(
         event = AbilityActivatedEvent(player = Player.You, requireExhaust = true),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever you activate an exhaust ability that isn't a mana ability — Pit Automaton, whose
+     * Oracle text was updated so its "copy it" payoff can never latch onto a mana ability. The
+     * activated ability is exposed as
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity], so
+     * [com.wingedsheep.sdk.dsl.Effects.CopyTargetSpellOrAbility] can copy it.
+     */
+    val YouActivateNonManaExhaustAbility: TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(
+            player = Player.You,
+            requireExhaust = true,
+            excludeManaAbilities = true
+        ),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1738,6 +1738,12 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * include the {T} symbol — and mana abilities without {T} *do* count, unlike the default
      * semantic. The engine emits an `AbilityActivatedEvent` for every activated ability whose cost
      * lacks {T} (mana or not); this flag is what tells the matcher to accept the mana-ability ones.
+     *
+     * [requireExhaust] narrows to exhaust abilities (CR 702.177). On its own it is the plain
+     * Aetherdrift wording — "Whenever you activate an exhaust ability" (Adrenaline Jockey, Rangers'
+     * Refueler) — which counts an exhaust *mana* ability too. [excludeManaAbilities] adds back the
+     * "isn't a mana ability" clause for Pit Automaton, whose Oracle text was updated to
+     * "an exhaust ability that isn't a mana ability" so its copy payoff can't grab a mana ability.
      */
     @SerialName("AbilityActivatedEvent")
     @Serializable
@@ -1747,6 +1753,7 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         val sourceFilter: GameObjectFilter? = null,
         val requireNoTapInCost: Boolean = false,
         val requireExhaust: Boolean = false,
+        val excludeManaAbilities: Boolean = false,
     ) : EventPattern {
         override val description: String = buildString {
             append(player.description)
@@ -1763,6 +1770,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
                     append("targets a ")
                     append(targetMatch.description)
                 }
+                requireExhaust && excludeManaAbilities ->
+                    append("is an exhaust ability that isn't a mana ability")
                 requireExhaust -> append("is an exhaust ability")
                 requireNoTapInCost -> append("doesn't have {T} in its activation cost")
                 else -> append("isn't a mana ability")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -656,3 +656,44 @@ data class PlayersCantActivateAbilities(
         else copy(permanentFilter = newFilter, condition = newCondition)
     }
 }
+
+/**
+ * The controller may activate exhaust abilities (CR 702.177) as though they hadn't been activated —
+ * i.e. the "activate only once" memory an exhaust ability carries
+ * ([com.wingedsheep.sdk.scripting.ActivationRestriction.Once]) is waived while this applies.
+ *
+ * The permission mirror of [PlayersCantActivateAbilities]: read at ability-activation-legality time
+ * on every battlefield permanent, scoped to the activating player being this permanent's controller
+ * (you can only activate abilities of permanents you control, so there is no separate "who" axis),
+ * and gated by [condition], evaluated in the controller's context — `null` = always.
+ *
+ * Elvish Refueler: "During your turn, as long as you haven't activated an exhaust ability this turn,
+ * you may activate exhaust abilities as though they haven't been activated." — the condition is
+ * `IsYourTurn AND NoExhaustAbilityActivatedThisTurn`, which makes the waiver evaporate the moment
+ * the first exhaust ability of the turn is activated. Non-exhaust abilities carrying a plain
+ * `Once`/`OncePerTurn` restriction are untouched.
+ *
+ * @property condition Optional timing/state gate, evaluated in the controller's context; null = always.
+ */
+@SerialName("IgnoreExhaustActivationLimit")
+@Serializable
+data class IgnoreExhaustActivationLimit(
+    val condition: Condition? = null
+) : StaticAbility {
+    override val description: String = buildString {
+        when (condition) {
+            is IsYourTurn -> append("During your turn, ")
+            is IsNotYourTurn -> append("During your opponents' turns, ")
+            else -> {}
+        }
+        append("you may activate exhaust abilities as though they haven't been activated")
+        when (condition) {
+            is IsYourTurn, is IsNotYourTurn, null -> {}
+            else -> append(" ${condition.description}")
+        }
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newCondition === condition) this else copy(condition = newCondition)
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -258,6 +258,26 @@ data class PlayerDrewCardsThisTurn(
 }
 
 /**
+ * Condition: "as long as [player] has activated [atLeast] or more exhaust abilities this turn"
+ * (CR 702.177).
+ *
+ * Backed by the per-player `ExhaustAbilitiesActivatedThisTurnComponent`, incremented as each exhaust
+ * ability is activated and cleared with the other per-turn trackers at cleanup. Elvish Refueler
+ * wants the *negation* — "as long as you haven't activated an exhaust ability this turn" — so it
+ * wraps this in `Conditions.Not`; the `Conditions.YouActivatedExhaustAbilitiesThisTurn` /
+ * `Conditions.YouHaventActivatedAnExhaustAbilityThisTurn` DSL helpers pass [Player.You].
+ */
+@SerialName("PlayerActivatedExhaustAbilitiesThisTurn")
+@Serializable
+data class PlayerActivatedExhaustAbilitiesThisTurn(
+    val player: Player = Player.You,
+    val atLeast: Int = 1
+) : Condition {
+    override val description: String =
+        "if ${player.description} activated $atLeast or more exhaust abilities this turn"
+}
+
+/**
  * Condition: "If [player] has committed a crime this turn" (CR Outlaws of Thunder Junction —
  * a player commits a crime as they cast a spell, activate an ability, or put a triggered ability
  * on the stack that targets one or more opponents, permanents/spells/abilities an opponent controls,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ElvishRefueler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/ElvishRefueler.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Elvish Refueler — Aetherdrift #161
+ * {2}{G} · Creature — Elf Druid · 2/3
+ *
+ * During your turn, as long as you haven't activated an exhaust ability this turn, you may activate
+ * exhaust abilities as though they haven't been activated.
+ * Exhaust — {1}{G}: Put a +1/+1 counter on this creature.
+ *
+ * Modeling notes:
+ *  - The permission is [IgnoreExhaustActivationLimit]: it waives the "activate only once" memory
+ *    (CR 702.177a) that `isExhaust = true` installs as an
+ *    [com.wingedsheep.sdk.scripting.ActivationRestriction.Once], and only for exhaust abilities — a
+ *    non-exhaust ability with a printed `Once`/`OncePerTurn` restriction is untouched.
+ *  - Its gate is the printed conjunction: [Conditions.IsYourTurn] AND
+ *    [Conditions.YouHaventActivatedAnExhaustAbilityThisTurn], the latter reading the per-player
+ *    `ExhaustAbilitiesActivatedThisTurnComponent` the engine bumps on every exhaust activation. The
+ *    count advances for the waived activation too, so the net effect is what the card means: once
+ *    per turn, on your turn, you get to re-use one already-spent exhaust ability — including the
+ *    Refueler's own, and including a *different* permanent's.
+ *  - The condition is re-evaluated at activation-legality time on every frame rather than projected
+ *    as a continuous effect, so the permission disappears mid-turn the instant the count moves,
+ *    and an opponent's turn never sees it.
+ */
+val ElvishRefueler = card("Elvish Refueler") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 2
+    toughness = 3
+    oracleText = "During your turn, as long as you haven't activated an exhaust ability this turn, " +
+        "you may activate exhaust abilities as though they haven't been activated.\n" +
+        "Exhaust — {1}{G}: Put a +1/+1 counter on this creature. " +
+        "(Activate each exhaust ability only once.)"
+
+    staticAbility {
+        ability = IgnoreExhaustActivationLimit(
+            condition = Conditions.All(
+                Conditions.IsYourTurn,
+                Conditions.YouHaventActivatedAnExhaustAbilityThisTurn
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        isExhaust = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Exhaust — {1}{G}: Put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Carly Milligan"
+        flavorText = "\"Anyone running low?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg?1783907872"
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PitAutomaton.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/PitAutomaton.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pit Automaton — Aetherdrift #238
+ * {2} · Artifact Creature — Construct · 0/4
+ *
+ * Defender
+ * {T}: Add {C}{C}. Spend this mana only to activate abilities.
+ * {2}, {T}: When you next activate an exhaust ability that isn't a mana ability this turn, copy it.
+ * You may choose new targets for the copy.
+ *
+ * Modeling notes:
+ *  - The mana ability is the unqualified "only to activate abilities" restriction
+ *    ([ManaRestriction.AbilityActivationOnly]) that Guidelight Optimizer and Redshift also use — it
+ *    constrains what each pip may pay for, not how many abilities it feeds, so the two {C} can be
+ *    split across activations and comfortably cover an exhaust ability's cost.
+ *  - "When you **next** … this turn" is a one-shot delayed triggered ability, so the payoff is
+ *    [CreateDelayedTriggerEffect] with `fireOnce = true` and [DelayedTriggerExpiry.EndOfTurn]: the
+ *    first matching activation consumes it, and an unfired one is swept at end of turn. Activating
+ *    this ability twice stacks two independent delayed triggers, so the next exhaust ability is
+ *    copied twice — matching the rules, since each resolution creates its own delayed ability.
+ *  - The trigger is [Triggers.YouActivateNonManaExhaustAbility], not the plain
+ *    [Triggers.YouActivateExhaustAbility] the other Aetherdrift exhaust payoffs use. Pit Automaton's
+ *    Oracle text was updated on release to add "that isn't a mana ability", so an exhaust *mana*
+ *    ability must not arm the copy.
+ *  - The copy itself reuses the shared [Effects.CopyTargetSpellOrAbility] against
+ *    [EffectTarget.TriggeringEntity] — the activated ability still on the stack beneath this delayed
+ *    trigger — which prompts for new targets per CR 707.10c. Per the printed ruling the triggered
+ *    ability resolves *before* the exhaust ability it copied, so the ability is guaranteed to still
+ *    be on the stack; that ordering is what makes `TriggeringEntity` resolvable at fire time (the
+ *    delayed-trigger executor deliberately leaves the copy effect's target unbaked).
+ */
+val PitAutomaton = card("Pit Automaton") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct"
+    power = 0
+    toughness = 4
+    oracleText = "Defender\n" +
+        "{T}: Add {C}{C}. Spend this mana only to activate abilities.\n" +
+        "{2}, {T}: When you next activate an exhaust ability that isn't a mana ability this turn, " +
+        "copy it. You may choose new targets for the copy."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2, ManaRestriction.AbilityActivationOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}{C}. Spend this mana only to activate abilities."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouActivateNonManaExhaustAbility,
+            effect = Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity),
+            fireOnce = true,
+            expiry = DelayedTriggerExpiry.EndOfTurn
+        )
+        description = "When you next activate an exhaust ability that isn't a mana ability this " +
+            "turn, copy it. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Villarrte"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg?1783907847"
+        ruling(
+            "2025-02-07",
+            "Pit Automaton has received an update to its Oracle text. Specifically, the delayed " +
+                "triggered ability doesn't trigger if you activate an exhaust ability that is also " +
+                "a mana ability."
+        )
+        ruling("2025-02-07", "Exhaust abilities can be activated any time you could normally activate an ability.")
+        ruling(
+            "2025-02-07",
+            "If an exhaust ability of a permanent is activated, and then that permanent leaves the " +
+                "battlefield and returns to the battlefield, it becomes a new object so its exhaust " +
+                "ability can be activated again."
+        )
+        ruling(
+            "2025-02-07",
+            "If an ability triggers whenever you activate an exhaust ability, that ability resolves " +
+                "before the exhaust ability resolves."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -5001,6 +5001,82 @@
     ]
 }
 
+// Elvish Refueler
+{
+    "name": "Elvish Refueler",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated.\nExhaust — {1}{G}: Put a +1/+1 counter on this creature. (Activate each exhaust ability only once.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "Exhaust — {1}{G}: Put a +1/+1 counter on this creature.",
+                "isExhaust": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "IgnoreExhaustActivationLimit",
+                "condition": {
+                    "type": "All",
+                    "conditions": [
+                        "IsYourTurn",
+                        {
+                            "type": "Not",
+                            "condition": "PlayerActivatedExhaustAbilitiesThisTurn"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Carly Milligan",
+        "flavorText": "\"Anyone running low?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/25dfbcb6-9b67-4151-b10f-dde70c5fd16d.jpg?1783907872",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Embalmed Ascendant
 {
     "name": "Embalmed Ascendant",
@@ -11703,6 +11779,97 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Pit Automaton
+{
+    "name": "Pit Automaton",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Defender\n{T}: Add {C}{C}. Spend this mana only to activate abilities.\n{2}, {T}: When you next activate an exhaust ability that isn't a mana ability this turn, copy it. You may choose new targets for the copy.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": "AbilityActivationOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}{C}. Spend this mana only to activate abilities."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "CopyTargetSpellOrAbility",
+                        "target": "TriggeringEntity"
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "AbilityActivatedEvent",
+                            "requireExhaust": true,
+                            "excludeManaAbilities": true
+                        },
+                        "binding": "ANY"
+                    },
+                    "fireOnce": true
+                },
+                "descriptionOverride": "When you next activate an exhaust ability that isn't a mana ability this turn, copy it. You may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Villarrte",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c72527ef-ac05-44c8-8c76-10532ce3da6e.jpg?1783907847",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "Pit Automaton has received an update to its Oracle text. Specifically, the delayed triggered ability doesn't trigger if you activate an exhaust ability that is also a mana ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "Exhaust abilities can be activated any time you could normally activate an ability."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an exhaust ability of a permanent is activated, and then that permanent leaves the battlefield and returns to the battlefield, it becomes a new object so its exhaust ability can be activated again."
+            },
+            {
+                "date": "2025-02-07",
+                "text": "If an ability triggers whenever you activate an exhaust ability, that ability resolves before the exhaust ability resolves."
+            }
+        ]
+    }
 }
 
 // Plow Through

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -512,6 +512,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CardsDrawnThisTurnComponent::class)
         subclass(BendsThisTurnComponent::class)
         subclass(EquipActivationsThisTurnComponent::class)
+        subclass(ExhaustAbilitiesActivatedThisTurnComponent::class)
         subclass(WasDealtCombatDamageThisTurnComponent::class)
         subclass(CombatDamageReceivedThisTurnComponent::class)
         subclass(WasDealtCombatDamageByLegendaryCreatureThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.player.LandsPlayedThisTurnCompone
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CardsPutIntoExileThisTurnComponent
 import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
+import com.wingedsheep.engine.state.components.player.ExhaustAbilitiesActivatedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.ManaSpentOnSpellsThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LoseAtEndStepComponent
 import com.wingedsheep.engine.state.components.player.LossReason
@@ -157,6 +158,9 @@ class TurnManager(
                     .with(CardsPutIntoExileThisTurnComponent(count = 0))
                     .with(ManaSpentOnSpellsThisTurnComponent(totalSpent = 0))
                     .with(EquipActivationsThisTurnComponent(count = 0))
+                    // Exhaust activations reset each turn (Elvish Refueler's "you haven't
+                    // activated an exhaust ability this turn" gate).
+                    .with(ExhaustAbilitiesActivatedThisTurnComponent(count = 0))
                     // Cards discarded this turn reset for every player (Mayhem gate + Green Goblin count).
                     .with(CardsDiscardedThisTurnComponent(cardIds = emptyList()))
                     // Lands played this turn (with zone-of-origin) reset (Spider-Man 2099).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -939,6 +939,13 @@ class TriggerDetector(
             // spell-cast matcher so the spell filter and casting-player predicate are honored.
             is com.wingedsheep.sdk.scripting.EventPattern.SpellCastEvent ->
                 matcher.matchesTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
+            // Ability-activation delayed triggers ("when you next activate an exhaust ability that
+            // isn't a mana ability this turn, …", Pit Automaton) are player-scoped, not
+            // entity-scoped: there is no watched permanent, so delegate to the canonical matcher so
+            // the player scope and the exhaust / mana-ability clauses behave identically to a
+            // battlefield-resident "whenever you activate …" trigger.
+            is com.wingedsheep.sdk.scripting.EventPattern.AbilityActivatedEvent ->
+                matcher.matchesTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
             is com.wingedsheep.sdk.scripting.EventPattern.DealsDamageEvent -> {
                 if (event !is com.wingedsheep.engine.core.DamageDealtEvent) return false
                 if (watchedEntityId != null && event.sourceId != watchedEntityId) return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -266,6 +266,9 @@ class TriggerMatcher(
                 if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
                 if (trigger.requireExhaust) {
                     if (!event.isExhaust) return false
+                    // Plain "whenever you activate an exhaust ability" counts an exhaust mana
+                    // ability too; only Pit Automaton's updated wording re-adds the exclusion.
+                    if (trigger.excludeManaAbilities && event.isManaAbility) return false
                 } else if (trigger.requireNoTapInCost) {
                     // Antiquities "activates an ability without {T} in its activation cost"
                     // (Haunting Wind / Powerleech / Artifact Possession). Match any activated

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -368,6 +368,18 @@ class ConditionEvaluator(
                     drawn >= condition.atLeast
                 }
             }
+            is com.wingedsheep.sdk.scripting.conditions.PlayerActivatedExhaustAbilitiesThisTurn -> {
+                if (condition.atLeast <= 0) true
+                else {
+                    val playerId = resolvePlayer(state, condition.player, ctx)
+                    val activated = playerId?.let {
+                        state.getEntity(it)
+                            ?.get<com.wingedsheep.engine.state.components.player.ExhaustAbilitiesActivatedThisTurnComponent>()
+                            ?.count
+                    } ?: 0
+                    activated >= condition.atLeast
+                }
+            }
             is PlayerCommittedCrimeThisTurn -> {
                 val playerId = resolvePlayer(state, condition.player, ctx)
                 playerId != null && playerId in state.playersWhoCommittedCrimeThisTurn

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -423,7 +423,9 @@ class ActivateAbilityHandler(
 
         // Check activation restrictions
         for (restriction in ability.restrictions) {
-            val error = checkActivationRestriction(state, action.playerId, action.sourceId, action.abilityId, restriction)
+            val error = checkActivationRestriction(
+                state, action.playerId, action.sourceId, action.abilityId, restriction, ability.isExhaust
+            )
             if (error != null) return error
         }
 
@@ -1399,6 +1401,18 @@ class ActivateAbilityHandler(
             }
         }
 
+        // Track exhaust activations this turn (CR 702.177). Elvish Refueler's waiver of the
+        // once-only memory holds only "as long as you haven't activated an exhaust ability this
+        // turn", so the count has to advance for the very activation that used the waiver too —
+        // which is why this is unconditional on whether the waiver applied.
+        if (ability.isExhaust) {
+            currentState = currentState.updateEntity(action.playerId) { c ->
+                val tracker = c.get<com.wingedsheep.engine.state.components.player.ExhaustAbilitiesActivatedThisTurnComponent>()
+                    ?: com.wingedsheep.engine.state.components.player.ExhaustAbilitiesActivatedThisTurnComponent()
+                c.with(tracker.copy(count = tracker.count + 1))
+            }
+        }
+
         // Apply text replacement if the source has a TextReplacementComponent
         var finalEffect = if (textReplacement != null) {
             ability.effect.applyTextReplacement(textReplacement)
@@ -2297,7 +2311,8 @@ class ActivateAbilityHandler(
         playerId: com.wingedsheep.sdk.model.EntityId,
         sourceId: com.wingedsheep.sdk.model.EntityId,
         abilityId: com.wingedsheep.sdk.scripting.AbilityId,
-        restriction: ActivationRestriction
+        restriction: ActivationRestriction,
+        isExhaustAbility: Boolean = false
     ): String? {
         return when (restriction) {
             is ActivationRestriction.AnyPlayerMay -> null // Not a restriction; handled in validate()
@@ -2346,7 +2361,11 @@ class ActivateAbilityHandler(
             }
             is ActivationRestriction.Once -> {
                 val tracker = state.getEntity(sourceId)?.get<AbilityActivatedEverComponent>()
-                if (tracker != null && tracker.hasActivated(abilityId)) {
+                // An exhaust ability's once-only memory can be waived (Elvish Refueler); a plain
+                // Once restriction on a non-exhaust ability never is.
+                if (tracker != null && tracker.hasActivated(abilityId) &&
+                    !(isExhaustAbility && castPermissionUtils.isExhaustActivationLimitWaived(state, playerId))
+                ) {
                     "This ability can only be activated once"
                 } else null
             }
@@ -2358,7 +2377,7 @@ class ActivateAbilityHandler(
             }
             is ActivationRestriction.All -> {
                 restriction.restrictions.firstNotNullOfOrNull {
-                    checkActivationRestriction(state, playerId, sourceId, abilityId, it)
+                    checkActivationRestriction(state, playerId, sourceId, abilityId, it, isExhaustAbility)
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -611,7 +611,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // Check activation restrictions
                 var restrictionsMet = true
                 for (restriction in ability.restrictions) {
-                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id)) {
+                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id, ability.isExhaust)) {
                         restrictionsMet = false
                         break
                     }
@@ -1027,7 +1027,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // Check activation restrictions
                 var restrictionsMet = true
                 for (restriction in ability.restrictions) {
-                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id)) {
+                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id, ability.isExhaust)) {
                         restrictionsMet = false
                         break
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CommandZoneAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CommandZoneAbilityEnumerator.kt
@@ -48,7 +48,7 @@ class CommandZoneAbilityEnumerator : ActionEnumerator {
 
                 // Activation restrictions (e.g. once each turn).
                 if (ability.restrictions.any {
-                        !context.castPermissionUtils.checkActivationRestriction(state, playerId, it, entityId, ability.id)
+                        !context.castPermissionUtils.checkActivationRestriction(state, playerId, it, entityId, ability.id, ability.isExhaust)
                     }
                 ) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -274,7 +274,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
                 // Check activation restrictions
                 var restrictionsMet = true
                 for (restriction in ability.restrictions) {
-                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id)) {
+                    if (!context.castPermissionUtils.checkActivationRestriction(state, playerId, restriction, entityId, ability.id, ability.isExhaust)) {
                         restrictionsMet = false
                         break
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -60,7 +60,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                 var restrictionsMet = true
                 for (restriction in ability.restrictions) {
                     if (!context.castPermissionUtils.checkActivationRestriction(
-                            state, playerId, restriction, entityId, ability.id
+                            state, playerId, restriction, entityId, ability.id, ability.isExhaust
                         )
                     ) {
                         restrictionsMet = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -41,6 +41,8 @@ import com.wingedsheep.sdk.scripting.MayPlayPermanentsFromGraveyard
 import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
+import com.wingedsheep.engine.mechanics.ExhaustActivationWaiver
+import com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit
 import com.wingedsheep.sdk.scripting.PlayersCantActivateAbilities
 import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
 import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
@@ -59,12 +61,20 @@ class CastPermissionUtils(
     private val predicateEvaluator: PredicateEvaluator,
     private val conditionEvaluator: ConditionEvaluator
 ) {
+    /**
+     * @param isExhaustAbility whether the ability being checked is an exhaust ability (CR 702.177).
+     *   Only [ActivationRestriction.Once] reads it: an exhaust ability's once-only memory can be
+     *   waived by [IgnoreExhaustActivationLimit] (Elvish Refueler), while a plain `Once` restriction
+     *   on a non-exhaust ability never is. Defaults to false, which is the restrictive answer — a
+     *   call site that forgets to pass it withholds a permission rather than granting one.
+     */
     fun checkActivationRestriction(
         state: GameState,
         playerId: EntityId,
         restriction: ActivationRestriction,
         sourceId: EntityId? = null,
-        abilityId: AbilityId? = null
+        abilityId: AbilityId? = null,
+        isExhaustAbility: Boolean = false
     ): Boolean {
         return when (restriction) {
             is ActivationRestriction.AnyPlayerMay -> true
@@ -99,7 +109,8 @@ class CastPermissionUtils(
                 if (sourceId == null || abilityId == null) true
                 else {
                     val tracker = state.getEntity(sourceId)?.get<AbilityActivatedEverComponent>()
-                    tracker == null || !tracker.hasActivated(abilityId)
+                    tracker == null || !tracker.hasActivated(abilityId) ||
+                        (isExhaustAbility && isExhaustActivationLimitWaived(state, playerId))
                 }
             }
             is ActivationRestriction.ControlledSinceYourMostRecentTurn -> {
@@ -112,7 +123,7 @@ class CastPermissionUtils(
                     ?.has<com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent>() != true
             }
             is ActivationRestriction.All -> restriction.restrictions.all {
-                checkActivationRestriction(state, playerId, it, sourceId, abilityId)
+                checkActivationRestriction(state, playerId, it, sourceId, abilityId, isExhaustAbility)
             }
         }
     }
@@ -627,6 +638,22 @@ class CastPermissionUtils(
         }
         return false
     }
+
+    /**
+     * True when some permanent [playerId] controls waives the "activate only once" memory that an
+     * exhaust ability carries (CR 702.177a) — Elvish Refueler's "you may activate exhaust abilities
+     * as though they haven't been activated".
+     *
+     * Scans printed and granted [IgnoreExhaustActivationLimit] statics on [playerId]'s battlefield
+     * and evaluates each one's condition in the granting permanent's controller's context, so
+     * Elvish Refueler's "During your turn, as long as you haven't activated an exhaust ability this
+     * turn" gate is re-checked every frame — the waiver disappears the moment the turn's first
+     * exhaust ability is activated. Consulted by both this class's restriction check (the
+     * enumerators' offered actions) and [ActivateAbilityHandler]'s (the executed action), so the
+     * two can't drift.
+     */
+    fun isExhaustActivationLimitWaived(state: GameState, playerId: EntityId): Boolean =
+        ExhaustActivationWaiver.isWaivedFor(state, playerId, cardRegistry, conditionEvaluator)
 
     /**
      * Sum the [ReduceEquipCost] amounts across [playerId]'s battlefield, unwrapping a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ExhaustActivationWaiver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ExhaustActivationWaiver.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit
+
+/**
+ * Whether a player currently has permission to activate exhaust abilities (CR 702.177) as though
+ * they hadn't been activated — i.e. whether the "activate only once" memory those abilities carry
+ * ([com.wingedsheep.sdk.scripting.ActivationRestriction.Once]) is waived.
+ *
+ * Lives here rather than in `CastPermissionUtils` because three independent activation-legality
+ * paths need the same answer and must not drift: the legal-action enumerators and
+ * `ActivateAbilityHandler` (both through `CastPermissionUtils`), and `ManaSolver`'s inlined
+ * restriction check for auto-tapping, which deliberately doesn't depend on the legalactions module.
+ */
+object ExhaustActivationWaiver {
+
+    /**
+     * True when some permanent [playerId] controls grants
+     * [IgnoreExhaustActivationLimit] and its condition currently holds.
+     *
+     * Both printed statics (from the card definition, honoring the permanent's current Class level)
+     * and statics granted at runtime are scanned. Each waiver's condition is evaluated in the
+     * granting permanent's controller's context and re-checked every call, so Elvish Refueler's
+     * "During your turn, as long as you haven't activated an exhaust ability this turn" gate stops
+     * applying the instant the turn's first exhaust ability is activated.
+     */
+    fun isWaivedFor(
+        state: GameState,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        conditionEvaluator: ConditionEvaluator
+    ): Boolean {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>()
+            val classLevel = state.getEntity(entityId)?.get<ClassLevelComponent>()?.currentLevel
+            val printed = card?.let { cardRegistry.getCard(it.cardDefinitionId) }
+                ?.script?.effectiveStaticAbilities(classLevel).orEmpty()
+            val granted = state.grantedStaticAbilities
+                .filter { it.entityId == entityId }
+                .map { it.ability }
+            for (ability in printed + granted) {
+                val waiver = ability as? IgnoreExhaustActivationLimit ?: continue
+                val condition = waiver.condition ?: return true
+                val context = EffectContext(sourceId = entityId, controllerId = playerId)
+                if (conditionEvaluator.evaluate(state, condition, context)) return true
+            }
+        }
+        return false
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -907,6 +907,7 @@ class StaticAbilityHandler(
             is SpendAnyManaTypeForActivatedAbilities,
             is PreventActivatedAbilities,
             is PlayersCantActivateAbilities,
+            is com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit,
             is PreventCycling,
 
             // Trigger detection (TriggerDetector.suppressEntersTriggers) — not a continuous

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1533,7 +1533,13 @@ class ManaSolver(
         }
         is ActivationRestriction.Once -> {
             val tracker = state.getEntity(sourceId)?.get<AbilityActivatedEverComponent>()
-            tracker == null || !tracker.hasActivated(ability.id)
+            tracker == null || !tracker.hasActivated(ability.id) ||
+                // An exhaust mana ability's once-only memory can be waived (Elvish Refueler), and
+                // auto-tap has to agree with the enumerator about whether it may be tapped again.
+                (
+                    ability.isExhaust && com.wingedsheep.engine.mechanics.ExhaustActivationWaiver
+                        .isWaivedFor(state, playerId, cardRegistry, conditionEvaluator)
+                    )
         }
         is ActivationRestriction.ControlledSinceYourMostRecentTurn ->
             state.getEntity(sourceId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -916,6 +916,21 @@ data class EquipActivationsThisTurnComponent(
 ) : Component
 
 /**
+ * Number of exhaust abilities (CR 702.177) this player has activated during the current turn. Reset
+ * to 0 at turn start by TurnManager, alongside the other per-turn player trackers.
+ *
+ * Read by [com.wingedsheep.sdk.scripting.conditions.PlayerActivatedExhaustAbilitiesThisTurn], whose
+ * negation gates Elvish Refueler's
+ * [com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit] permission — "as long as you haven't
+ * activated an exhaust ability this turn". Counted at activation time (CR 602.2), so it includes an
+ * exhaust ability that was later countered or whose source has left the battlefield.
+ */
+@Serializable
+data class ExhaustAbilitiesActivatedThisTurnComponent(
+    val count: Int = 0
+) : Component
+
+/**
  * Tracks the total damage dealt to a player during the current turn.
  * Includes both combat and non-combat damage. Prevented damage is not counted.
  * Cleared at end of turn by TurnManager.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElvishRefuelerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElvishRefuelerScenarioTest.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Elvish Refueler — "During your turn, as long as you haven't activated an
+ * exhaust ability this turn, you may activate exhaust abilities as though they haven't been
+ * activated."
+ *
+ * The net effect the claims below pin down: once per turn, on your own turn, you may re-use one
+ * already-spent exhaust ability — and the re-use itself burns the permission for the rest of that
+ * turn.
+ *
+ *  - the turn's first exhaust activation consumes the waiver, so a same-turn repeat is still illegal;
+ *  - on a later turn of yours the per-turn count has reset, so an already-spent exhaust ability of
+ *    *any* permanent you control is activatable again;
+ *  - the waiver never applies on an opponent's turn;
+ *  - it doesn't reach a plain [ActivationRestriction.Once] on a non-exhaust ability.
+ */
+class ElvishRefuelerScenarioTest : ScenarioTestBase() {
+
+    // A second exhaust body, so we can prove the waiver isn't scoped to the Refueler's own ability.
+    private val exhaustBuddy = card("Exhaust Buddy") {
+        manaCost = "{2}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            isExhaust = true
+            cost = Costs.Mana("{1}")
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // Non-exhaust, but printed "Activate only once" — the waiver must not reach it.
+    private val onceOnly = card("Once Only") {
+        manaCost = "{2}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Mana("{1}")
+            restrictions = listOf(ActivationRestriction.Once)
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    private val refuelerAbility
+        get() = cardRegistry.getCard("Elvish Refueler")!!.script.activatedAbilities.single { it.isExhaust }
+    private val buddyAbility get() = cardRegistry.getCard("Exhaust Buddy")!!.script.activatedAbilities.single()
+    private val onceOnlyAbility get() = cardRegistry.getCard("Once Only")!!.script.activatedAbilities.single()
+
+    private fun TestGame.activateAndResolve(permanent: EntityId, abilityId: com.wingedsheep.sdk.scripting.AbilityId) =
+        execute(ActivateAbility(player1Id, permanent, abilityId)).also { result ->
+            if (result.error == null) {
+                if (state.pendingDecision is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+            }
+        }
+
+    /** Pass priority through one whole turn, landing in the next turn's precombat main phase. */
+    private fun TestGame.advanceOneTurn() {
+        passUntilPhase(Phase.ENDING, Step.END)
+        passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+        resolveStack()
+        passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+    }
+
+    private fun TestGame.plusOneCounters(id: EntityId) =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun board(extraCard: String) = run {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Elvish Refueler", summoningSickness = false)
+            .withCardOnBattlefield(1, extraCard, summoningSickness = false)
+            .withLandsOnBattlefield(1, "Forest", 6)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(10) { builder = builder.withCardInLibrary(1, "Grizzly Bears") }
+        repeat(10) { builder = builder.withCardInLibrary(2, "Grizzly Bears") }
+        builder.build()
+    }
+
+    init {
+        cardRegistry.register(exhaustBuddy)
+        cardRegistry.register(onceOnly)
+
+        test("the turn's first exhaust activation consumes the waiver") {
+            val game = board("Exhaust Buddy")
+            val refueler = game.findPermanent("Elvish Refueler")!!
+
+            game.activateAndResolve(refueler, refuelerAbility.id).error shouldBe null
+            game.plusOneCounters(refueler) shouldBe 1
+
+            val second = game.execute(ActivateAbility(game.player1Id, refueler, refuelerAbility.id))
+            withClue("you have now activated an exhaust ability this turn, so the waiver is gone") {
+                (second.error != null) shouldBe true
+            }
+            game.plusOneCounters(refueler) shouldBe 1
+        }
+
+        test("on a later turn of yours, another permanent's spent exhaust ability is re-openable") {
+            val game = board("Exhaust Buddy")
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            game.activateAndResolve(buddy, buddyAbility.id).error shouldBe null
+            game.plusOneCounters(buddy) shouldBe 1
+            withClue("still the same turn — the waiver is already spent") {
+                (game.execute(ActivateAbility(game.player1Id, buddy, buddyAbility.id)).error != null) shouldBe true
+            }
+
+            // Opponent's turn, then back to ours: the per-turn exhaust count has reset.
+            game.advanceOneTurn()
+            game.advanceOneTurn()
+            game.state.activePlayerId shouldBe game.player1Id
+
+            val reactivate = game.activateAndResolve(buddy, buddyAbility.id)
+            withClue("Elvish Refueler should re-open the Buddy's exhaust ability: ${reactivate.error}") {
+                reactivate.error shouldBe null
+            }
+            game.plusOneCounters(buddy) shouldBe 2
+        }
+
+        test("the waiver does not apply on an opponent's turn") {
+            val game = board("Exhaust Buddy")
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            game.activateAndResolve(buddy, buddyAbility.id).error shouldBe null
+
+            // One turn on: the exhaust count has reset, but it is not our turn.
+            game.advanceOneTurn()
+            game.state.activePlayerId shouldBe game.player2Id
+
+            val onOpponentsTurn = game.execute(ActivateAbility(game.player1Id, buddy, buddyAbility.id))
+            withClue("the permission is limited to your own turn") {
+                (onOpponentsTurn.error != null) shouldBe true
+            }
+            game.plusOneCounters(buddy) shouldBe 1
+        }
+
+        test("a non-exhaust 'activate only once' ability is unaffected") {
+            val game = board("Once Only")
+            val once = game.findPermanent("Once Only")!!
+
+            game.activateAndResolve(once, onceOnlyAbility.id).error shouldBe null
+            game.plusOneCounters(once) shouldBe 1
+
+            // No exhaust ability has been activated this turn, so the waiver is fully in force —
+            // it still must not reach a plain Once restriction on a non-exhaust ability.
+            val second = game.execute(ActivateAbility(game.player1Id, once, onceOnlyAbility.id))
+            withClue("the waiver is scoped to exhaust abilities only") {
+                (second.error != null) shouldBe true
+            }
+            game.plusOneCounters(once) shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitAutomatonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PitAutomatonScenarioTest.kt
@@ -1,0 +1,208 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Pit Automaton — "{2}, {T}: When you next activate an exhaust ability that
+ * isn't a mana ability this turn, copy it. You may choose new targets for the copy."
+ *
+ * The claims under test:
+ *  - the ability arms a one-shot delayed trigger that copies the next qualifying exhaust activation
+ *    (observed as a doubled effect), and is consumed by it;
+ *  - a *non*-exhaust activated ability leaves it armed;
+ *  - an exhaust **mana** ability leaves it armed — the "that isn't a mana ability" clause Pit
+ *    Automaton's Oracle text was updated to add, and the reason it can't reuse the plain
+ *    `Triggers.YouActivateExhaustAbility` the set's other exhaust payoffs use;
+ *  - the mana ability produces two colorless restricted to activating abilities.
+ */
+class PitAutomatonScenarioTest : ScenarioTestBase() {
+
+    // "Exhaust — {1}: Put a +1/+1 counter on this creature." Copying it yields two counters.
+    private val exhaustBuddy = card("Exhaust Buddy") {
+        manaCost = "{2}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            isExhaust = true
+            cost = Costs.Mana("{1}")
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // A plain (non-exhaust) activated ability — must not consume the armed trigger.
+    private val plainActivator = card("Plain Activator") {
+        manaCost = "{2}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Mana("{1}")
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        }
+    }
+
+    // An exhaust MANA ability with no {T} in its cost, so the engine still emits an
+    // AbilityActivatedEvent for it (a {T} mana ability never reaches the stack at all).
+    private val exhaustManaSource = card("Exhaust Mana Source") {
+        manaCost = "{2}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            isExhaust = true
+            cost = Costs.Mana("{0}")
+            effect = Effects.AddMana(Color.GREEN, 1)
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    private val armAbility
+        get() = cardRegistry.getCard("Pit Automaton")!!.script.activatedAbilities.single { !it.isManaAbility }
+    private val pitManaAbility
+        get() = cardRegistry.getCard("Pit Automaton")!!.script.activatedAbilities.single { it.isManaAbility }
+    private val buddyAbility get() = cardRegistry.getCard("Exhaust Buddy")!!.script.activatedAbilities.single()
+    private val plainAbility get() = cardRegistry.getCard("Plain Activator")!!.script.activatedAbilities.single()
+    private val manaSourceAbility
+        get() = cardRegistry.getCard("Exhaust Mana Source")!!.script.activatedAbilities.single()
+
+    private fun TestGame.activateAndResolve(permanent: EntityId, abilityId: AbilityId) =
+        execute(ActivateAbility(player1Id, permanent, abilityId)).also { result ->
+            if (result.error == null) {
+                if (state.pendingDecision is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+            }
+        }
+
+    private fun TestGame.plusOneCounters(id: EntityId) =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun board(vararg extraCards: String) = run {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Pit Automaton", summoningSickness = false)
+            .withLandsOnBattlefield(1, "Forest", 8)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        for (name in extraCards) builder = builder.withCardOnBattlefield(1, name, summoningSickness = false)
+        // Enough library for the turn-passing tests so nobody decks out mid-scenario.
+        repeat(10) { builder = builder.withCardInLibrary(1, "Grizzly Bears") }
+        repeat(10) { builder = builder.withCardInLibrary(2, "Grizzly Bears") }
+        builder.build()
+    }
+
+    init {
+        cardRegistry.register(exhaustBuddy)
+        cardRegistry.register(plainActivator)
+        cardRegistry.register(exhaustManaSource)
+
+        test("the next exhaust ability activated is copied, and the trigger is spent") {
+            val game = board("Exhaust Buddy")
+            val automaton = game.findPermanent("Pit Automaton")!!
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            val arm = game.activateAndResolve(automaton, armAbility.id)
+            withClue("arming should be legal: ${arm.error}") { arm.error shouldBe null }
+            withClue("a one-shot delayed trigger is now watching for an exhaust activation") {
+                game.state.delayedTriggers.size shouldBe 1
+            }
+
+            game.activateAndResolve(buddy, buddyAbility.id).error shouldBe null
+            withClue("the exhaust ability resolved once, and its copy resolved once more") {
+                game.plusOneCounters(buddy) shouldBe 2
+            }
+            withClue("a 'when you next …' trigger is consumed by the activation that fired it") {
+                game.state.delayedTriggers.size shouldBe 0
+            }
+        }
+
+        test("a non-exhaust activated ability leaves the trigger armed") {
+            val game = board("Plain Activator", "Exhaust Buddy")
+            val automaton = game.findPermanent("Pit Automaton")!!
+            val plain = game.findPermanent("Plain Activator")!!
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            game.activateAndResolve(automaton, armAbility.id).error shouldBe null
+            game.activateAndResolve(plain, plainAbility.id).error shouldBe null
+
+            withClue("an ordinary ability isn't an exhaust ability, so nothing was copied") {
+                game.plusOneCounters(plain) shouldBe 1
+            }
+            game.state.delayedTriggers.size shouldBe 1
+
+            // Still armed: the next real exhaust activation gets doubled.
+            game.activateAndResolve(buddy, buddyAbility.id).error shouldBe null
+            game.plusOneCounters(buddy) shouldBe 2
+        }
+
+        test("an exhaust mana ability does not fire it (Oracle update)") {
+            val game = board("Exhaust Mana Source", "Exhaust Buddy")
+            val automaton = game.findPermanent("Pit Automaton")!!
+            val manaSource = game.findPermanent("Exhaust Mana Source")!!
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            game.activateAndResolve(automaton, armAbility.id).error shouldBe null
+            game.activateAndResolve(manaSource, manaSourceAbility.id).error shouldBe null
+
+            withClue("'an exhaust ability that isn't a mana ability' excludes this one") {
+                game.state.delayedTriggers.size shouldBe 1
+            }
+
+            game.activateAndResolve(buddy, buddyAbility.id).error shouldBe null
+            withClue("the still-armed trigger copies the first non-mana exhaust ability instead") {
+                game.plusOneCounters(buddy) shouldBe 2
+            }
+        }
+
+        test("an unfired trigger expires at end of turn ('this turn')") {
+            val game = board("Exhaust Buddy")
+            val automaton = game.findPermanent("Pit Automaton")!!
+            val buddy = game.findPermanent("Exhaust Buddy")!!
+
+            game.activateAndResolve(automaton, armAbility.id).error shouldBe null
+            game.state.delayedTriggers.size shouldBe 1
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.resolveStack()
+
+            withClue("the delayed trigger is scoped to the turn it was created on") {
+                game.state.delayedTriggers.size shouldBe 0
+            }
+            withClue("and the exhaust ability it was watching for was never copied") {
+                game.plusOneCounters(buddy) shouldBe 0
+            }
+        }
+
+        test("the mana ability adds two colorless spendable only on activated abilities") {
+            val game = board()
+            val automaton = game.findPermanent("Pit Automaton")!!
+
+            game.execute(ActivateAbility(game.player1Id, automaton, pitManaAbility.id)).error shouldBe null
+
+            val pool = game.state.getEntity(game.player1Id)!!.get<ManaPoolComponent>()!!
+            withClue("both pips are stored as restricted mana carrying the activation-only rider") {
+                pool.restrictedMana.size shouldBe 2
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two more Aetherdrift cards, both from the set's remaining tail. Each needed a small piece of engine vocabulary around the **Exhaust** keyword (CR 702.177); everything else composes from existing primitives.

Aetherdrift goes **269/276 → 271/276**.

## Pit Automaton (#238)

> Defender
> `{T}`: Add `{C}{C}`. Spend this mana only to activate abilities.
> `{2}`, `{T}`: When you next activate an exhaust ability that isn't a mana ability this turn, copy it. You may choose new targets for the copy.

- **`EventPattern.AbilityActivatedEvent.excludeManaAbilities`** + a `Triggers.YouActivateNonManaExhaustAbility` facade. The plain *"whenever you activate an exhaust ability"* wording the set's other payoffs use (Adrenaline Jockey, Rangers' Refueler, Rangers' Aetherhive, Afterburner Expert) does count an exhaust *mana* ability — Pit Automaton's Oracle text was updated on release to exclude it, so it gets the narrower spec and the existing shared one is left untouched.
- **`TriggerDetector.matchesEventForWatchedEntity`** now dispatches `AbilityActivatedEvent` to the canonical `TriggerMatcher`, exactly as `SpellCastEvent` already does. That `when` was fail-closed (`else -> false`), which is why the pattern couldn't previously be used as a *delayed* trigger.

With those two, the card is pure composition: `CreateDelayedTriggerEffect(trigger = …, fireOnce = true, expiry = EndOfTurn)` wrapping the existing `Effects.CopyTargetSpellOrAbility(EffectTarget.TriggeringEntity)`. Per the printed ruling the trigger resolves *before* the exhaust ability it copied, so the ability is still on the stack when `TriggeringEntity` resolves — the delayed-trigger executor deliberately leaves that target unbaked.

## Elvish Refueler (#161)

> During your turn, as long as you haven't activated an exhaust ability this turn, you may activate exhaust abilities as though they haven't been activated.
> Exhaust — `{1}{G}`: Put a +1/+1 counter on this creature.

- **`IgnoreExhaustActivationLimit(condition)`** — the permission mirror of `PlayersCantActivateAbilities`. It waives the `ActivationRestriction.Once` memory that `isExhaust = true` installs, and *only* for exhaust abilities; a plain `Once`/`OncePerTurn` on a non-exhaust ability is untouched.
- **`ExhaustActivationWaiver`** resolves it for all three activation-legality paths that must agree: the legal-action enumerators and `ActivateAbilityHandler` (both via `CastPermissionUtils`), plus `ManaSolver`'s inlined restriction check for auto-tapping, which deliberately doesn't depend on the legalactions module.
- **`ExhaustAbilitiesActivatedThisTurnComponent`** — a new per-player tracker reset alongside the other per-turn ones, read by the new `Conditions.YouHaventActivatedAnExhaustAbilityThisTurn`. The count advances for the *waived* activation too, so the net effect is the printed one: once per turn, on your turn, you may re-use one already-spent exhaust ability of any permanent you control.

The condition is re-evaluated at activation-legality time rather than projected as a continuous effect, so the permission evaporates mid-turn the instant the count moves, and an opponent's turn never sees it.

## Tests

Nine scenario tests, one file per card:

**`PitAutomatonScenarioTest`** — the next exhaust ability is copied and the trigger is spent; a non-exhaust ability leaves it armed; an exhaust *mana* ability leaves it armed (the Oracle-update clause); an unfired trigger expires at end of turn; the mana ability yields two activation-restricted pips.

**`ElvishRefuelerScenarioTest`** — the turn's first exhaust activation consumes the waiver; on a later turn of yours another permanent's spent exhaust ability is re-openable; the waiver never applies on an opponent's turn; a non-exhaust "activate only once" ability is unaffected.

## Verification

`just build`, `just test`, and `just check` all pass. `CardDefinitionSnapshotTest` was re-blessed — the golden diff is exactly the two new cards and nothing else. `just check-card-printing` confirms DFT is the canonical (and only) printing for both.

## Why only two cards

All seven cards Aetherdrift was missing are the hard tail — every one needs engine capability, so I scoped to the two whose engine work was genuinely bounded. The five left each need a whole subsystem rather than a primitive:

| Card | Blocker |
|---|---|
| Cursecloth Wrappings | Embalm doesn't exist as a keyword at all, plus granting it dynamically to a graveyard card with a computed cost |
| Gonti, Night Minister | Cross-player impulse exile off an opponent's library, playable with mana of any type |
| Radiant Lotus | Variable-count *sacrifice* cost (the `ExilePermanents` shape, but X = count) **and** mana paid into a target player's pool |
| Mimeoplasm, Revered One | As-enters X-exile from the graveyard linked to a later become-a-copy-of-an-exiled-card ability |
| The Aetherspark | Planeswalker–Equipment hybrid: loyalty abilities, attach, "can't be attacked", a granted damage trigger |

Radiant Lotus is the closest of the five — it mirrors the existing `CostAtom.ExilePermanents` machinery — and is the natural next pick if you want the set finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)