### PR TITLE
Add Ashiok, Wicked Manipulator — completes Wilds of Eldraine (266/266)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8207,6 +8207,17 @@ The priority groups are (CR 616.1a–f):
   and damage-dealt triggers see the full damage. Multiple instances pick the strictest floor. Used by
   Ali from Cairo (`LifeLossFloor(floor = 1, appliesTo = LifeLossEvent(Player.You))`); Worship adds a
   `restrictions = listOf(YouControlACreature)` gate.
+- `ReplaceLifePaymentWithLibraryExile(appliesTo)` — a life **payment** becomes an exile of that many cards
+  off the top of the payer's library, when the library is at least that deep (Ashiok, Wicked Manipulator).
+  `appliesTo` is a `LifePaymentEvent` whose `player` filter picks whose payments are replaced (default
+  `Player.You`). **Scope:** payments only (CR 118.8) — life *loss* from damage or a "you lose N life"
+  effect keeps its own path, which is exactly the printed reminder text "Damage and unpayable costs still
+  cause you to lose life". Mandatory and unsplittable, and a library shallower than the payment simply
+  falls through to paying life normally. It does not raise what you're allowed to pay: CR 118.5 still
+  requires a life total at least equal to the payment, so cost legality is unchanged.
+  Applied by `LifePaymentService`, the engine choke point every life payment funnels through — cost
+  atoms, additional casting costs, ward and Phyrexian-style payments, pain-cost mana abilities and the
+  `PayLife` / `PayDynamicLife` resolution effects alike.
 - `PreventLifeGain(appliesTo)` — life gain matching the event is fully prevented (Sulfuric Vortex, Erebos).
   The `LifeGainEvent.player` scope can be `You` / `EachOpponent` / `Each` (resolved relative to the
   source's controller) or `EnchantedPlayer` for an "enchant player" Aura whose locked player is its

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -387,6 +387,24 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * When a player would **pay** life — life spent to satisfy a cost (CR 118.8), as opposed to
+     * life lost to damage or to a "loses N life" effect. Distinct from [LifeLossEvent]: every life
+     * payment reduces a life total, but only a payment is a cost the player chose to pay, and only
+     * payments are replaceable by effects worded "if you would pay life" (Ashiok, Wicked
+     * Manipulator). Damage and unpayable costs are never this event.
+     *
+     * Replacement-effect only — a payment surfaces to triggered abilities as the `LifeChangedEvent`
+     * it produces, so this pattern never matches as a trigger.
+     */
+    @SerialName("LifePaymentEvent")
+    @Serializable
+    data class LifePaymentEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} would pay life"
+    }
+
+    /**
      * When a player would gain or lose life.
      * Used for cards like Moonstone Harbinger: "Whenever you gain or lose life during your turn".
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1300,6 +1300,44 @@ data class LifeLossFloor(
     }
 }
 
+/**
+ * A life *payment* becomes an exile of that many cards off the top of the payer's library, so long
+ * as the library is deep enough to cover it. Ashiok, Wicked Manipulator: "If you would pay life
+ * while your library has at least that many cards in it, exile that many cards from the top of your
+ * library instead."
+ *
+ * Applies only to [EventPattern.LifePaymentEvent] — life spent on a cost (CR 118.8). Damage and
+ * "you lose N life" effects are life *loss*, not payment, and are untouched; that is exactly the
+ * card's reminder text ("Damage and unpayable costs still cause you to lose life").
+ *
+ * Three consequences of it being a mandatory replacement, all per the printed rulings:
+ * - **Not optional, not splittable.** With the library deep enough, every point is exiled instead;
+ *   the payer cannot choose to pay some in life and some in cards.
+ * - **Shallow library falls through.** With fewer cards in the library than the payment, the
+ *   replacement simply doesn't apply and life is paid normally — this is a condition on the
+ *   replacement, not a choice.
+ * - **It doesn't raise what you can pay.** CR 118.5 still requires a life total at least equal to
+ *   the payment, so cost legality is unchanged; only how the payment is made changes.
+ *
+ * @param appliesTo Which player's life payments are replaced (default: the source's controller).
+ */
+@SerialName("ReplaceLifePaymentWithLibraryExile")
+@Serializable
+data class ReplaceLifePaymentWithLibraryExile(
+    override val appliesTo: EventPattern = EventPattern.LifePaymentEvent()
+) : ReplacementEffect {
+    override val description: String = "If ${appliesTo.description} while " +
+        "${(appliesTo as? EventPattern.LifePaymentEvent)?.player?.possessive ?: "their"} library " +
+        "has at least that many cards in it, exile that many cards from the top of " +
+        "${(appliesTo as? EventPattern.LifePaymentEvent)?.player?.possessive ?: "their"} " +
+        "library instead"
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+    }
+}
+
 // =============================================================================
 // Copy Replacement Effects
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/WildsOfEldrainSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/WildsOfEldrainSet.kt
@@ -16,7 +16,6 @@ object WildsOfEldrainSet : MtgSet {
     override val code = "WOE"
     override val displayName = "Wilds of Eldraine"
     override val releaseDate = "2023-09-08"
-    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshiokWickedManipulator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AshiokWickedManipulator.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ReplaceLifePaymentWithLibraryExile
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ashiok, Wicked Manipulator
+ * {3}{B}{B}
+ * Legendary Planeswalker — Ashiok
+ * Loyalty 5
+ *
+ * If you would pay life while your library has at least that many cards in it, exile that many
+ * cards from the top of your library instead.
+ * +1: Look at the top two cards of your library. Exile one of them and put the other into your hand.
+ * −2: Create two 1/1 black Nightmare creature tokens with "At the beginning of combat on your turn,
+ *     if a card was put into exile this turn, put a +1/+1 counter on this token."
+ * −7: Target player exiles the top X cards of their library, where X is the total mana value of
+ *     cards you own in exile.
+ *
+ * Modeling notes:
+ *  - The static ability is a genuine replacement effect, not a triggered one, so it uses the
+ *    [ReplaceLifePaymentWithLibraryExile] replacement on the new `LifePaymentEvent` pattern. Every
+ *    life *payment* in the engine funnels through `LifePaymentService`, which consults this before
+ *    deducting life — so it covers cost atoms, additional casting costs, ward and Phyrexian-style
+ *    payments, pain-cost mana abilities and the `PayLife` resolution effects alike. Life *loss*
+ *    (damage, "you lose N life") keeps its own path untouched, which is exactly the printed
+ *    reminder text: damage and unpayable costs still cause you to lose life.
+ *  - The +1 is the Gather → Select → Move pipeline with the two destinations swapped relative to
+ *    a normal impulse-draw: the *selected* card goes to hand and the remainder is exiled. That is
+ *    the same choice the oracle text asks for ("exile one of them and put the other into your
+ *    hand") — with two cards, choosing which to keep and choosing which to exile are the same
+ *    decision. A library with only one card left still works: you look at what's there and keep it.
+ *  - The −2 tokens carry a triggered ability whose intervening "if" (CR 603.4) reuses
+ *    [Conditions.CardsPutIntoExileThisTurn], the game-wide `CARDS_PUT_INTO_EXILE` turn tracker
+ *    built for Ennis, Debate Moderator. Ashiok's own static ability and +1 both feed it, and so
+ *    does an opponent's exiling. `Triggers.BeginCombat` is already "at the beginning of combat on
+ *    your turn" (a `StepEvent(BEGIN_COMBAT, Player.You)`), so the tokens only check on your turn.
+ *  - The −7's X is the total mana value of cards *you own* in exile — the engine keys the exile
+ *    zone by owner, so `DynamicAmounts.zone(Player.You, Zone.EXILE).sumManaValue()` is exactly
+ *    that, and it is evaluated against Ashiok's controller even though the exiling player is the
+ *    target.
+ */
+val AshiokWickedManipulator = card("Ashiok, Wicked Manipulator") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Planeswalker — Ashiok"
+    startingLoyalty = 5
+    oracleText = "If you would pay life while your library has at least that many cards in it, " +
+        "exile that many cards from the top of your library instead.\n" +
+        "+1: Look at the top two cards of your library. Exile one of them and put the other into " +
+        "your hand.\n" +
+        "−2: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on " +
+        "your turn, if a card was put into exile this turn, put a +1/+1 counter on this token.\"\n" +
+        "−7: Target player exiles the top X cards of their library, where X is the total mana " +
+        "value of cards you own in exile."
+
+    // If you would pay life while your library has at least that many cards in it, exile that
+    // many cards from the top of your library instead.
+    replacementEffect(ReplaceLifePaymentWithLibraryExile())
+
+    // +1: Look at the top two cards of your library. Exile one of them and put the other into
+    //     your hand.
+    loyaltyAbility(+1) {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 2,
+            keepCount = 1,
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.EXILE),
+        )
+    }
+
+    // −2: Create two 1/1 black Nightmare creature tokens with "At the beginning of combat on your
+    //     turn, if a card was put into exile this turn, put a +1/+1 counter on this token."
+    loyaltyAbility(-2) {
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(2),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Nightmare"),
+            triggeredAbilities = listOf(
+                TriggeredAbility.create(
+                    trigger = Triggers.BeginCombat.event,
+                    binding = Triggers.BeginCombat.binding,
+                    triggerCondition = Conditions.CardsPutIntoExileThisTurn(),
+                    effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                    descriptionOverride = "At the beginning of combat on your turn, if a card was " +
+                        "put into exile this turn, put a +1/+1 counter on this token.",
+                ),
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg?1783914991",
+        )
+    }
+
+    // −7: Target player exiles the top X cards of their library, where X is the total mana value
+    //     of cards you own in exile.
+    loyaltyAbility(-7) {
+        target("target player", Targets.Player)
+        effect = Patterns.Library.exileTop(
+            count = DynamicAmounts.zone(Player.You, Zone.EXILE).sumManaValue(),
+            target = EffectTarget.ContextTarget(0),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "78"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg?1783915111"
+
+        ruling("2023-09-01", "Ashiok, Wicked Nightmare's first ability isn't optional. You can't choose to pay life instead of exiling cards from the top of your library while you control Ashiok, and you can't split the payment between life and cards.")
+        ruling("2023-09-01", "If you would pay life while you control Ashiok and your library does not have at least that many cards in it, you'll just pay life as normal.")
+        ruling("2023-09-01", "Ashiok's first ability doesn't allow you to attempt to pay an amount of life greater than your current life total.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -833,6 +833,206 @@
     ]
 }
 
+// Ashiok, Wicked Manipulator
+{
+    "name": "Ashiok, Wicked Manipulator",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Planeswalker — Ashiok",
+    "oracleText": "If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.\n+1: Look at the top two cards of your library. Exile one of them and put the other into your hand.\n−2: Create two 1/1 black Nightmare creature tokens with \"At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this token.\"\n−7: Target player exiles the top X cards of their library, where X is the total mana value of cards you own in exile.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Nightmare"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/5/858428ee-3a9c-4dfc-84c2-751e59df2ed7.jpg?1783914991",
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_3",
+                            "trigger": {
+                                "type": "StepEvent",
+                                "step": "BEGIN_COMBAT"
+                            },
+                            "binding": "ANY",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "triggerCondition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "TurnTracking",
+                                    "player": "Each",
+                                    "tracker": "CARDS_PUT_INTO_EXILE"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "descriptionOverride": "At the beginning of combat on your turn, if a card was put into exile this turn, put a +1/+1 counter on this token."
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -7
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "AggregateZone",
+                                    "player": "You",
+                                    "zone": "Exile",
+                                    "aggregation": "SUM",
+                                    "property": "MANA_VALUE"
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "exiled_top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled_top",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "ReplaceLifePaymentWithLibraryExile"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "MYTHIC",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c4d0db1-74a5-42c0-ac95-e696585d8022.jpg?1783915111",
+        "rulings": [
+            {
+                "date": "2023-09-01",
+                "text": "Ashiok, Wicked Nightmare's first ability isn't optional. You can't choose to pay life instead of exiling cards from the top of your library while you control Ashiok, and you can't split the payment between life and cards."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "If you would pay life while you control Ashiok and your library does not have at least that many cards in it, you'll just pay life as normal."
+            },
+            {
+                "date": "2023-09-01",
+                "text": "Ashiok's first ability doesn't allow you to attempt to pay an amount of life greater than your current life total."
+            }
+        ]
+    },
+    "startingLoyalty": 5,
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Asinine Antics
 {
     "name": "Asinine Antics",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -615,6 +615,9 @@ class TriggerMatcher(
                     event.oldLife > event.newLife &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            // Replacement-effect-only: a life payment reaches triggers as the LifeChangedEvent it
+            // produces (matched by LifeLossEvent above), never as a payment event of its own.
+            is EventPattern.LifePaymentEvent -> false
             is EventPattern.LifeGainOrLossEvent -> {
                 event is LifeChangedEvent &&
                     event.oldLife != event.newLife &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.handlers.effects.library.MillAmountModifier
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.mechanics.mana.ManaPool
@@ -262,9 +263,9 @@ class CostHandler {
                 if (amount == 0) {
                     CostPaymentResult.success(state, manaPool)
                 } else {
-                    val (newState, event) = DamageUtils.loseLife(state, controllerId, amount, LifeChangeReason.PAYMENT)
-                    if (event == null) return CostPaymentResult.failure("Player has no life total")
-                    CostPaymentResult.success(newState, manaPool, events = listOf(event))
+                    val (newState, events) = LifePaymentService.pay(state, controllerId, amount)
+                        ?: return CostPaymentResult.failure("Player has no life total")
+                    CostPaymentResult.success(newState, manaPool, events = events)
                 }
             }
             is AbilityCost.SacrificeChosenCreatureType -> {
@@ -649,9 +650,9 @@ class CostHandler {
             CostPaymentResult.success(state, newPool)
         }
         is CostAtom.PayLife -> {
-            val (newState, event) = DamageUtils.loseLife(state, controllerId, atom.amount, LifeChangeReason.PAYMENT)
-            if (event == null) return CostPaymentResult.failure("Player has no life total")
-            CostPaymentResult.success(newState, manaPool, events = listOf(event))
+            val (newState, events) = LifePaymentService.pay(state, controllerId, atom.amount)
+                ?: return CostPaymentResult.failure("Player has no life total")
+            CostPaymentResult.success(newState, manaPool, events = events)
         }
         is CostAtom.Sacrifice -> paySacrificeList(
             state, choices.sacrificeChoices, atom.filter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -48,6 +48,7 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.bend.BendEvents
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
@@ -2411,11 +2412,10 @@ class CastSpellHandler(
                 else -> continue
             }
             if (lifeToPay == 0) continue
-            val currentLife = currentState.lifeTotal(action.playerId) // CR 810.9a — team's shared total
-            val newLife = currentLife - lifeToPay
-            currentState = currentState.withLifeTotal(action.playerId, newLife)
-            currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId, lifeToPay)
-            events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+            val (afterPayment, paymentEvents) =
+                LifePaymentService.pay(currentState, action.playerId, lifeToPay) ?: continue
+            currentState = afterPayment
+            events.addAll(paymentEvents)
         }
         if (flattenedAllCosts.isNotEmpty() && action.additionalCostPayment != null) {
             for (additionalCost in flattenedAllCosts) {
@@ -3001,11 +3001,11 @@ class CastSpellHandler(
                 currentState, action.playerId, action.targets
             )
             if (additionalLifeCost > 0) {
-                val currentLife = currentState.lifeTotal(action.playerId) // CR 810.9a — team's shared total
-                val newLife = currentLife - additionalLifeCost
-                currentState = currentState.withLifeTotal(action.playerId, newLife)
-                events.add(LifeChangedEvent(action.playerId, currentLife, newLife, LifeChangeReason.PAYMENT))
-                currentState = DamageUtils.markLifeLostThisTurn(currentState, action.playerId, additionalLifeCost)
+                LifePaymentService.pay(currentState, action.playerId, additionalLifeCost)
+                    ?.let { (afterPayment, paymentEvents) ->
+                        currentState = afterPayment
+                        events.addAll(paymentEvents)
+                    }
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
@@ -201,14 +202,8 @@ class ManaPaymentContinuationResumer(
                 return checkForMore(counterResult.newState, counterResult.events)
             }
 
-            val newLife = currentLife - continuation.lifeCost
-            var newState = state.withLifeTotal(playerId, newLife)
-            newState = com.wingedsheep.engine.handlers.effects.DamageUtils
-                .markLifeLostThisTurn(newState, playerId, continuation.lifeCost)
-
-            val events = listOf<GameEvent>(
-                LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)
-            )
+            val (newState, events) = LifePaymentService.pay(state, playerId, continuation.lifeCost)
+                ?: return ExecutionResult.error(state, "Paying player has no life total")
             // If this life cost was one component of a composite ward cost, charge the next
             // component before the spell is allowed to resolve.
             chargeNextWardPartOrNull(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -860,17 +861,11 @@ class ModalAndCloneContinuationResumer(
 
         if (response.choice) {
             // Player chose to pay life
-            if (newState.getEntity(continuation.controllerId)
-                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
-            ) return ExecutionResult.error(state, "Player has no life total")
-            // CR 810.9a — life paid as a cost comes out of the team's shared total.
-            val currentLife = newState.lifeTotal(continuation.controllerId)
-            val newLife = currentLife - continuation.lifeCost
-            newState = newState.withLifeTotal(continuation.controllerId, newLife)
-            newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(
-                newState, continuation.controllerId, continuation.lifeCost
-            )
-            events.add(LifeChangedEvent(continuation.controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+            val (afterPayment, paymentEvents) = LifePaymentService
+                .pay(newState, continuation.controllerId, continuation.lifeCost)
+                ?: return ExecutionResult.error(state, "Player has no life total")
+            newState = afterPayment
+            events.addAll(paymentEvents)
         } else {
             // Player chose not to pay — land enters tapped
             newState = newState.updateEntity(continuation.landId) { c ->
@@ -931,17 +926,11 @@ class ModalAndCloneContinuationResumer(
 
         if (response.choice) {
             // Player chose to pay life
-            if (newState.getEntity(continuation.controllerId)
-                    ?.get<com.wingedsheep.engine.state.components.identity.LifeTotalComponent>() == null
-            ) return ExecutionResult.error(state, "Player has no life total")
-            // CR 810.9a — life paid as a cost comes out of the team's shared total.
-            val currentLife = newState.lifeTotal(continuation.controllerId)
-            val newLife = currentLife - continuation.lifeCost
-            newState = newState.withLifeTotal(continuation.controllerId, newLife)
-            newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(
-                newState, continuation.controllerId, continuation.lifeCost
-            )
-            events.add(LifeChangedEvent(continuation.controllerId, currentLife, newLife, LifeChangeReason.PAYMENT))
+            val (afterPayment, paymentEvents) = LifePaymentService
+                .pay(newState, continuation.controllerId, continuation.lifeCost)
+                ?: return ExecutionResult.error(state, "Player has no life total")
+            newState = afterPayment
+            events.addAll(paymentEvents)
         }
 
         // Complete the permanent entry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.handlers.effects.zones.ForceExileMultiZoneExecutor
 import com.wingedsheep.engine.handlers.effects.zones.ForceSacrificeExecutor
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
@@ -398,23 +399,9 @@ class SacrificeAndPayContinuationResumer(
         }
 
         // Player chose to pay life
-        val playerId = continuation.playerId
-        val lifeToPay = continuation.requiredCount
-        // CR 810.9a — life paid as a cost comes out of the team's shared total.
-        val currentLife = state.lifeTotal(playerId)
-        val newLife = currentLife - lifeToPay
-
-        var newState = state.withLifeTotal(playerId, newLife)
-        newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(newState, playerId, lifeToPay)
-
-        val events = listOf(
-            LifeChangedEvent(
-                playerId = playerId,
-                oldLife = currentLife,
-                newLife = newLife,
-                reason = LifeChangeReason.PAYMENT
-            )
-        )
+        val (newState, events) = LifePaymentService
+            .pay(state, continuation.playerId, continuation.requiredCount)
+            ?: return ExecutionResult.error(state, "Player has no life total")
 
         return checkForMore(newState, events)
     }
@@ -704,20 +691,10 @@ class SacrificeAndPayContinuationResumer(
                     return askNextPlayerForAnyPlayerMayPay(state, continuation, checkForMore)
                 }
 
-                val lifeToPay = continuation.requiredCount
-                // CR 810.9a — life paid as a cost comes out of the team's shared total.
-                val currentLife = state.lifeTotal(playerId)
-                val newLife = currentLife - lifeToPay
-                var newState = state.withLifeTotal(playerId, newLife)
-                newState = com.wingedsheep.engine.handlers.effects.DamageUtils.markLifeLostThisTurn(newState, playerId, lifeToPay)
-                val events = mutableListOf<GameEvent>(
-                    LifeChangedEvent(
-                        playerId = playerId,
-                        oldLife = currentLife,
-                        newLife = newLife,
-                        reason = LifeChangeReason.PAYMENT
-                    )
-                )
+                val (newState, paymentEvents) = LifePaymentService
+                    .pay(state, playerId, continuation.requiredCount)
+                    ?: return ExecutionResult.error(state, "Player has no life total")
+                val events = paymentEvents.toMutableList()
                 return runAnyPlayerMayPayConsequence(newState, continuation, continuation.consequence, events, checkForMore)
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifePaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifePaymentService.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.handlers.effects.life
+
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ReplaceLifePaymentWithLibraryExile
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The single choke point for **paying** life (CR 118.8) — life spent to satisfy a cost, as opposed
+ * to life lost to damage or to a "you lose N life" effect.
+ *
+ * Every payment site in the engine funnels here: cost atoms ([com.wingedsheep.sdk.scripting.costs.CostAtom.PayLife]),
+ * additional casting costs, Phyrexian-style and ward life costs paid through a continuation,
+ * pain-cost mana abilities, and the `PayLife` / `PayDynamicLife` resolution effects. They used to
+ * each hand-roll the same read-subtract-write-emit; centralising it means a replacement effect that
+ * intercepts life payments has exactly one place to hook in.
+ *
+ * The one such replacement today is [ReplaceLifePaymentWithLibraryExile] (Ashiok, Wicked
+ * Manipulator). It is deliberately *not* routed through [com.wingedsheep.engine.replacement.ReplacementEffectProcessor]:
+ * that pipeline models replaceable events that can pause on a competing-replacement choice, and a
+ * life payment can't. Ashiok's ability is mandatory and unsplittable, and once applied the payment
+ * is no longer a life payment, so a second copy has nothing left to replace — there is never a
+ * choice to present. This mirrors how `ModifyLifeLoss` / `LifeLossFloor` are applied by a direct
+ * battlefield scan in [DamageUtils].
+ *
+ * Life *loss* is a different event and keeps its own path ([DamageUtils.loseLife] with
+ * `LifeChangeReason.LIFE_LOSS`, or the damage pipeline) — which is why Ashiok's reminder text says
+ * damage and unpayable costs still cause you to lose life.
+ */
+object LifePaymentService {
+
+    /**
+     * Pay [amount] life from [payerId], applying any life-payment replacement first.
+     *
+     * @return the updated state paired with the events the payment produced, or `null` when
+     *   [payerId] has no life total (nothing mutated) so cost callers can surface a payment
+     *   failure. A non-positive [amount] is a no-op that still succeeds.
+     */
+    fun pay(state: GameState, payerId: EntityId, amount: Int): Pair<GameState, List<GameEvent>>? {
+        if (state.getEntity(payerId)?.get<LifeTotalComponent>() == null) return null
+        if (amount <= 0) return state to emptyList()
+
+        exileFromLibraryInstead(state, payerId, amount)?.let { return it }
+
+        val (newState, event) = DamageUtils.loseLife(state, payerId, amount, LifeChangeReason.PAYMENT)
+        return newState to listOfNotNull(event)
+    }
+
+    /**
+     * Apply [ReplaceLifePaymentWithLibraryExile] if [payerId] is under one and their library holds
+     * at least [amount] cards, exiling that many cards off the top instead of deducting life.
+     *
+     * The exile goes through [ZoneTransitionService.moveToZoneBatch] so it is a real zone change:
+     * it emits `ZoneChangeEvent`s, feeds the `CARDS_PUT_INTO_EXILE` turn tracker (which Ashiok's
+     * own Nightmare tokens read), and lets leaves-the-library and enters-exile effects see it.
+     *
+     * Returns `null` when no replacement applies, so the caller pays life normally.
+     */
+    private fun exileFromLibraryInstead(
+        state: GameState,
+        payerId: EntityId,
+        amount: Int
+    ): Pair<GameState, List<GameEvent>>? {
+        if (!hasLibraryExileReplacement(state, payerId)) return null
+
+        val library = state.getZone(ZoneKey(payerId, Zone.LIBRARY))
+        // "while your library has at least that many cards in it" — a shallower library means the
+        // replacement simply doesn't apply and life is paid as normal (printed ruling).
+        if (library.size < amount) return null
+
+        val result = ZoneTransitionService.moveToZoneBatch(state, library.take(amount), Zone.EXILE)
+        return result.state to result.events
+    }
+
+    /**
+     * Whether any battlefield permanent grants [payerId] a life-payment-to-library-exile
+     * replacement. Reads the *projected* controller so a stolen Ashiok follows its new controller
+     * (control change is a layer-2 effect, so the base `ControllerComponent` still names the
+     * original controller).
+     */
+    private fun hasLibraryExileReplacement(state: GameState, payerId: EntityId): Boolean {
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacements = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = state.projectedState.getController(entityId)
+                ?: container.get<ControllerComponent>()?.playerId
+                ?: continue
+
+            for (effect in replacements.replacementEffects) {
+                if (effect !is ReplaceLifePaymentWithLibraryExile) continue
+                val pattern = effect.appliesTo as? EventPattern.LifePaymentEvent ?: continue
+                val applies = when (pattern.player) {
+                    Player.Each, Player.Any -> true
+                    Player.You -> payerId == sourceControllerId
+                    Player.EachOpponent -> payerId != sourceControllerId
+                    else -> false
+                }
+                if (applies) return true
+            }
+        }
+        return false
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayDynamicLifeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayDynamicLifeEffectExecutor.kt
@@ -1,16 +1,11 @@
 package com.wingedsheep.engine.handlers.effects.life
 
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
-import com.wingedsheep.engine.core.LifeChangedEvent
-import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
@@ -43,20 +38,8 @@ class PayDynamicLifeEffectExecutor(
             .resolvePlayerTarget(EffectTarget.PlayerRef(effect.payer), context, state)
             ?: context.controllerId
 
-        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) {
-            return EffectResult.error(state, "Player not found for life payment")
-        }
-
-        // CR 810.9a — life paid as a cost comes out of the team's shared total.
-        val currentLife = state.lifeTotal(playerId)
-        val newLife = currentLife - amount
-        val newState = state.withLifeTotal(playerId, newLife)
-
-        val events = listOf<EngineGameEvent>(
-            LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)
-        )
-
-        val finalState = DamageUtils.markLifeLostThisTurn(newState, playerId, amount)
-        return EffectResult.success(finalState, events)
+        val (newState, events) = LifePaymentService.pay(state, playerId, amount)
+            ?: return EffectResult.error(state, "Player not found for life payment")
+        return EffectResult.success(newState, events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayLifeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayLifeEffectExecutor.kt
@@ -1,14 +1,9 @@
 package com.wingedsheep.engine.handlers.effects.life
 
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
-import com.wingedsheep.engine.core.LifeChangedEvent
-import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import kotlin.reflect.KClass
 
@@ -25,22 +20,8 @@ class PayLifeEffectExecutor : EffectExecutor<PayLifeEffect> {
         effect: PayLifeEffect,
         context: EffectContext
     ): EffectResult {
-        val playerId = context.controllerId
-
-        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) {
-            return EffectResult.error(state, "Player not found for life payment")
-        }
-        // CR 810.9a — life paid as a cost comes out of the team's shared total.
-        val currentLife = state.lifeTotal(playerId)
-
-        val newLife = currentLife - effect.amount
-        val newState = state.withLifeTotal(playerId, newLife)
-
-        val events = listOf<EngineGameEvent>(
-            LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)
-        )
-
-        val finalState = DamageUtils.markLifeLostThisTurn(newState, playerId, effect.amount)
-        return EffectResult.success(finalState, events)
+        val (newState, events) = LifePaymentService.pay(state, context.controllerId, effect.amount)
+            ?: return EffectResult.error(state, "Player not found for life payment")
+        return EffectResult.success(newState, events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -10,8 +10,6 @@ import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.DecisionRequestedEvent
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.core.GameEvent
-import com.wingedsheep.engine.core.LifeChangeReason
-import com.wingedsheep.engine.core.LifeChangedEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PermanentsSacrificedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
@@ -20,10 +18,10 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
-import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.handlers.effects.library.MillAmountModifier
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -485,8 +483,9 @@ class CostPaymentService(private val services: EngineServices) {
     }
 
     private fun payLife(state: GameState, payerId: EntityId, amount: Int): CostPaymentExecution {
-        val (newState, event) = DamageUtils.loseLife(state, payerId, amount, LifeChangeReason.PAYMENT)
-        return CostPaymentExecution(newState, listOfNotNull(event), success = true)
+        val (newState, events) = LifePaymentService.pay(state, payerId, amount)
+            ?: return CostPaymentExecution(state, emptyList(), success = false)
+        return CostPaymentExecution(newState, events, success = true)
     }
 
     private fun discardSelected(state: GameState, payerId: EntityId, selected: List<EntityId>): CostPaymentExecution {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1048,6 +1048,9 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.ModifyLifeGain,
             is com.wingedsheep.sdk.scripting.ModifyLifeLoss,
             is com.wingedsheep.sdk.scripting.LifeLossFloor,
+            // Life payment (Ashiok, Wicked Manipulator) — consulted from the battlefield by
+            // LifePaymentService every time its controller would pay life.
+            is com.wingedsheep.sdk.scripting.ReplaceLifePaymentWithLibraryExile,
             // Draws:
             is com.wingedsheep.sdk.scripting.PreventDraw,
             is com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -110,11 +111,10 @@ class ManaAbilitySideEffectExecutor(
         // priority, but never deducts the life.
         val lifeCost = payLifeCost(matchingAbility.cost)
         if (lifeCost > 0) {
-            val (afterLife, lifeEvent) = DamageUtils.loseLife(
-                currentState, controllerId, lifeCost, LifeChangeReason.PAYMENT
-            )
-            currentState = afterLife
-            lifeEvent?.let(events::add)
+            LifePaymentService.pay(currentState, controllerId, lifeCost)?.let { (afterLife, lifeEvents) ->
+                currentState = afterLife
+                events.addAll(lifeEvents)
+            }
         }
 
         val sideEffects = nonManaSubEffects(matchingAbility.effect)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshiokWickedManipulatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AshiokWickedManipulatorScenarioTest.kt
@@ -1,0 +1,317 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.collections.shouldHaveSize
+
+/**
+ * Scenario tests for **Ashiok, Wicked Manipulator** (WOE #78).
+ *
+ * The load-bearing piece is the static replacement — "If you would pay life while your library has
+ * at least that many cards in it, exile that many cards from the top of your library instead" —
+ * which is the first effect in the engine to intercept a life *payment*. It is implemented as
+ * `ReplaceLifePaymentWithLibraryExile` on the new `EventPattern.LifePaymentEvent`, consulted by
+ * `LifePaymentService`, the choke point every life payment now funnels through.
+ *
+ * The three loyalty abilities are all built from existing primitives, so they get lighter coverage:
+ * enough to prove the composition is wired to the right pieces (impulse-to-hand rather than
+ * impulse-to-exile on the +1, the `CARDS_PUT_INTO_EXILE` intervening-if on the −2's tokens, and the
+ * exile-mana-value X on the −7).
+ */
+class AshiokWickedManipulatorScenarioTest : ScenarioTestBase() {
+
+    /** A permanent with a pure "Pay N life" activated cost — the cheapest way to trigger a payment. */
+    private val lifeTap = card("Test Life Tap") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        activatedAbility {
+            cost = Costs.PayLife(3)
+            effect = Effects.GainLife(0)
+        }
+    }
+
+    /** "You lose 3 life" — life *loss*, not a payment, so Ashiok must leave it alone. */
+    private val lifeDrain = card("Test Life Drain") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        activatedAbility {
+            cost = Costs.Mana("{0}")
+            effect = Effects.LoseLife(3, EffectTarget.Controller)
+        }
+    }
+
+    /** How many cards named [cardName] sit in a player's exile. */
+    private fun TestGame.exiledCount(playerNumber: Int, cardName: String): Int {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).count {
+            state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == cardName
+        }
+    }
+
+    private fun TestGame.plusOneCounters(entity: EntityId): Int =
+        state.getEntity(entity)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Activate the loyalty ability whose loyalty change is [loyaltyChange]. */
+    private fun TestGame.activateLoyalty(
+        playerNumber: Int,
+        loyaltyChange: Int,
+        targets: List<EntityId> = emptyList(),
+    ) = run {
+        val ashiok = findPermanent("Ashiok, Wicked Manipulator")!!
+        val ability = cardRegistry.getCard("Ashiok, Wicked Manipulator")!!
+            .script.activatedAbilities
+            .first { (it.cost as? AbilityCost.Loyalty)?.change == loyaltyChange }
+        execute(
+            ActivateAbility(
+                playerId = if (playerNumber == 1) player1Id else player2Id,
+                sourceId = ashiok,
+                abilityId = ability.id,
+                targets = targets.map { entityIdToChosenTarget(state, it) },
+            )
+        )
+    }
+
+    private fun TestGame.activateFirstAbility(playerNumber: Int, cardName: String) =
+        run {
+            val permanent = findPermanent(cardName)!!
+            val ability = cardRegistry.getCard(cardName)!!.script.activatedAbilities.first()
+            execute(ActivateAbility(if (playerNumber == 1) player1Id else player2Id, permanent, ability.id))
+        }
+
+    private fun ScenarioBuilder.withLibrary(playerNumber: Int, cardName: String, count: Int) =
+        also { repeat(count) { withCardInLibrary(playerNumber, cardName) } }
+
+    init {
+        cardRegistry.register(lifeTap)
+        cardRegistry.register(lifeDrain)
+
+        context("Static ability — paying life becomes exiling from the top of your library") {
+
+            test("a life payment covered by the library exiles that many cards and costs no life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withCardOnBattlefield(1, "Test Life Tap")
+                    .withLibrary(1, "Grizzly Bears", 5)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.activateFirstAbility(1, "Test Life Tap")
+                withClue("paying the life cost should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("no life is paid — the payment was replaced") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+                withClue("three cards came off the top of the library instead") {
+                    game.librarySize(1) shouldBe 2
+                }
+                withClue("and they went to exile") {
+                    game.exiledCount(1, "Grizzly Bears") shouldBe 3
+                }
+            }
+
+            test("a library shallower than the payment falls through to paying life normally") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withCardOnBattlefield(1, "Test Life Tap")
+                    .withLibrary(1, "Grizzly Bears", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateFirstAbility(1, "Test Life Tap").error shouldBe null
+                game.resolveStack()
+
+                withClue("2 cards can't cover a 3-life payment, so life is paid as normal") {
+                    game.getLifeTotal(1) shouldBe 17
+                    game.librarySize(1) shouldBe 2
+                    game.exiledCount(1, "Grizzly Bears") shouldBe 0
+                }
+            }
+
+            test("life loss is untouched — only payments are replaced") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withCardOnBattlefield(1, "Test Life Drain")
+                    .withLibrary(1, "Grizzly Bears", 5)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateFirstAbility(1, "Test Life Drain").error shouldBe null
+                game.resolveStack()
+
+                withClue("\"you lose 3 life\" is life loss, not a payment (the printed reminder text)") {
+                    game.getLifeTotal(1) shouldBe 17
+                    game.librarySize(1) shouldBe 5
+                }
+            }
+
+            test("an opponent's life payment is unaffected — the replacement is yours only") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withCardOnBattlefield(2, "Test Life Tap")
+                    .withLibrary(2, "Grizzly Bears", 5)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateFirstAbility(2, "Test Life Tap").error shouldBe null
+                game.resolveStack()
+
+                withClue("Ashiok reads \"you\" — the opponent pays life the normal way") {
+                    game.getLifeTotal(2) shouldBe 17
+                    game.librarySize(2) shouldBe 5
+                }
+            }
+        }
+
+        context("+1 — look at the top two, exile one, the other to hand") {
+
+            test("the kept card goes to hand and the remainder is exiled") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withLibrary(1, "Grizzly Bears", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateLoyalty(1, 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("the ability pauses to pick which of the two to keep") {
+                    game.state.pendingDecision shouldNotBe null
+                }
+                val looked = game.findCardsInLibrary(1, "Grizzly Bears").take(1)
+                game.selectCards(looked)
+                game.resolveStack()
+
+                withClue("one card to hand, one to exile, one left in the library") {
+                    game.handSize(1) shouldBe 1
+                    game.exiledCount(1, "Grizzly Bears") shouldBe 1
+                    game.librarySize(1) shouldBe 1
+                }
+            }
+        }
+
+        context("−2 — two Nightmare tokens with the exile-gated combat trigger") {
+
+            test("creates two 1/1 black Nightmares") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateLoyalty(1, -2).error shouldBe null
+                game.resolveStack()
+
+                game.findAllPermanents("Nightmare Token") shouldHaveSize 2
+            }
+
+            test("the tokens grow at combat when a card was put into exile this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withCardOnBattlefield(1, "Test Life Tap")
+                    .withLibrary(1, "Grizzly Bears", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateLoyalty(1, -2).error shouldBe null
+                game.resolveStack()
+
+                // Ashiok's own static ability feeds the CARDS_PUT_INTO_EXILE tracker: paying 3 life
+                // exiles three cards off the top instead.
+                game.activateFirstAbility(1, "Test Life Tap").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                val tokens = game.findAllPermanents("Nightmare Token")
+                tokens shouldHaveSize 2
+                withClue("cards were exiled this turn, so the intervening-if holds for both tokens") {
+                    tokens.forEach { game.plusOneCounters(it) shouldBe 1 }
+                }
+            }
+
+            test("no counters at combat when nothing was put into exile this turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.activateLoyalty(1, -2).error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("nothing was exiled, so the intervening-if is false") {
+                    game.findAllPermanents("Nightmare Token").forEach { game.plusOneCounters(it) shouldBe 0 }
+                }
+            }
+        }
+
+        context("−7 — target player exiles the top X, X = total mana value of cards you own in exile") {
+
+            test("X counts the mana value of your exiled cards, and the target mills to exile") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ashiok, Wicked Manipulator")
+                    // Two Grizzly Bears ({1}{G}) already in your exile → X = 4.
+                    .withCardInExile(1, "Grizzly Bears")
+                    .withCardInExile(1, "Grizzly Bears")
+                    .withLibrary(2, "Grizzly Bears", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Ashiok enters at 5 loyalty; the ultimate needs 7, so tick it up first.
+                val ashiok = game.findPermanent("Ashiok, Wicked Manipulator")!!
+                game.state = game.state.updateEntity(ashiok) { c ->
+                    c.with((c.get<CountersComponent>() ?: CountersComponent()).withAdded(CounterType.LOYALTY, 2))
+                }
+
+                game.activateLoyalty(1, -7, targets = listOf(game.player2Id)).error shouldBe null
+                game.resolveStack()
+
+                withClue("X = 2 + 2 = 4, so the opponent exiles four cards off the top") {
+                    game.librarySize(2) shouldBe 2
+                    game.exiledCount(2, "Grizzly Bears") shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -211,6 +211,18 @@ abstract class ScenarioTestBase : FunSpec() {
                 container = staticHandler.addContinuousEffectComponent(container, cardDef)
                 container = staticHandler.addReplacementEffectComponent(container, cardDef)
 
+                // A planeswalker enters with its starting loyalty as loyalty counters (CR 306.5b).
+                // Placing one directly on the battlefield skips the ETB path that normally does
+                // this, which leaves it at 0 loyalty — harmless for `+N` abilities but makes every
+                // minus ability unactivatable ("Not enough loyalty").
+                cardDef.startingLoyalty?.let { loyalty ->
+                    val counters = container.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
+                        ?: com.wingedsheep.engine.state.components.battlefield.CountersComponent()
+                    container = container.with(
+                        counters.withAdded(com.wingedsheep.sdk.core.CounterType.LOYALTY, loyalty)
+                    )
+                }
+
                 // Rule 712.8a: if placing a DFC back face directly on the battlefield, add
                 // DoubleFacedComponent with the saved front-face card so ZoneTransitionService
                 // can restore it when the entity leaves.


### PR DESCRIPTION
Implements **Ashiok, Wicked Manipulator** (WOE #78, mythic), the last unimplemented card in Wilds of Eldraine. The set is now 266/266, so its `incomplete = true` override is dropped.

## The card

Three of the four abilities compose existing primitives:

| Ability | Built from |
|---|---|
| **+1** Look at top two, exile one, other to hand | `Patterns.Library.lookAtTopAndKeep` with the destinations swapped relative to a normal impulse draw — the *selected* card goes to hand, the remainder is exiled |
| **−2** Two 1/1 black Nightmares with a combat trigger | `CreateTokenEffect(triggeredAbilities = …)` whose intervening "if" (CR 603.4) reuses `Conditions.CardsPutIntoExileThisTurn` — the `CARDS_PUT_INTO_EXILE` tracker built for Ennis, Debate Moderator |
| **−7** Target player exiles top X | `Patterns.Library.exileTop(DynamicAmounts.zone(You, EXILE).sumManaValue(), …)`; the engine keys the exile zone by owner, so that is exactly "cards you own in exile" |

## The static ability needed new vocabulary

> If you would pay life while your library has at least that many cards in it, exile that many cards from the top of your library instead.

This is the first effect in the engine to intercept a life **payment**, so it adds:

- **`EventPattern.LifePaymentEvent`** — life spent on a cost (CR 118.8), distinct from `LifeLossEvent`. Replacement-only: a payment still reaches triggered abilities as the `LifeChangedEvent` it produces.
- **`ReplaceLifePaymentWithLibraryExile`** — the replacement. Mandatory and unsplittable, falls through to paying life normally when the library is too shallow, and does not change cost legality (CR 118.5 still requires a life total at least equal to the payment), all per the printed rulings.
- **`LifePaymentService`** — one choke point for paying life. Thirteen sites (cost atoms, additional casting costs, ward and Phyrexian-style payments through continuations, pain-cost mana abilities, and both `PayLife` resolution executors) each hand-rolled the same read-subtract-write-emit; they now share it, so a future payment replacement has a single place to hook in.

Life *loss* keeps its own path untouched — which is precisely the printed reminder text: *damage and unpayable costs still cause you to lose life*.

It is deliberately **not** routed through `ReplacementEffectProcessor`. That pipeline models replaceable events that can pause on a competing-replacement choice, and a life payment can't: the ability is mandatory, and once applied the event is no longer a life payment, so a second copy has nothing left to replace. This mirrors how `ModifyLifeLoss` / `LifeLossFloor` are applied by a direct battlefield scan in `DamageUtils`.

## Incidental fix

`ScenarioTestBase` never stamped starting loyalty on a planeswalker placed directly onto the battlefield, so every such permanent sat at 0 loyalty. Harmless for `+N` abilities — which is why nobody hit it — but it made every minus ability unactivatable. Now stamped per CR 306.5b.

## Verification

- `AshiokWickedManipulatorScenarioTest` — 9 tests, all passing: the replacement applying, falling through on a shallow library, leaving life *loss* alone, and not touching an opponent's payments; plus each loyalty ability and both sides of the tokens' intervening "if".
- Full `:rules-engine:test` re-run from scratch (`--rerun-tasks`) — green, confirming the loyalty-stamping fixture change breaks no existing planeswalker test.
- `just build` (all module tests) and `just check` — green.
- `just check-card-printing "Ashiok, Wicked Manipulator"` — clean; canonical sits in WOE, its earliest real printing.
- `WOE.json` golden re-blessed; the diff is purely additive (Ashiok only).
- `docs/card-sdk-language-reference.md` updated with the new replacement effect and its scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)