### PR TITLE
Add variable-count sacrifice costs and mana recipients; implement Radiant Lotus

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -323,21 +323,34 @@ excluded.
   ("{X}, {T}, Exile X cards from your graveyard") pays X in mana too, so the mana-X picker fixes the
   count first and the selection is pinned to exactly that many. Selecting nothing is legal and
   settles as X = 0.
-- `Costs.ExilePermanents(filter = Any, minCount = 1, excludeSelf = true)` — **variable-count** "exile
-  one or more permanents you control matching `filter`" activated-ability cost (CR 601.2b — the
-  player chooses how many, at least `minCount`, as the ability is activated). With `excludeSelf` the
-  ability's own source is excluded ("one or more *other* …"). Unlike the fixed-count
-  `Sacrifice`/`ExileFromGraveyard` atoms, the **total mana value of the exiled permanents becomes the
-  ability's X value** — read it with `DynamicAmount.XValue` (or `GameObjectFilter.manaValueAtMostX()`
-  on a target) to bound "mana value X or less" reads. The value is fixed at activation and stored on
-  the stack, so an X-bounded target is re-validated against it at resolution (CR 608.2b). Backs
-  **Fabrication Foundry** ("{2}{W}, {T}, Exile one or more other artifacts you control with total
-  mana value X: Return target artifact card with mana value X or less from your graveyard to the
-  battlefield"). The engine drives the activation in order: it pauses for the on-battlefield exile
-  selection (min = `minCount`, max = all eligible), computes X, then pauses again for the X-bounded
-  target — so an over-MV target can never be chosen. Pair with `TimingRule.SorcerySpeed` where the
-  card says "Activate only as a sorcery." (permanents leave via the normal battlefield→exile
-  transition, so Auras fall off, tokens cease to exist, and leaves-the-battlefield triggers fire).
+- `Costs.ExilePermanents(filter = Any, minCount = 1, excludeSelf = true, xMeasure = TOTAL_MANA_VALUE)`
+  / `Costs.SacrificePermanents(filter = Any, minCount = 1, excludeSelf = false, xMeasure = COUNT)` —
+  **variable-count** "exile/sacrifice one or more permanents you control matching `filter`"
+  activated-ability cost (CR 601.2b — the player chooses how many, at least `minCount`, as the
+  ability is activated). One atom, `CostAtom.VariablePermanents`, with two orthogonal axes; the two
+  facades are the named entry points to it. With `excludeSelf` the ability's own source is excluded
+  ("one or more *other* …"); leave it false when the source may pay for itself.
+  - **`action`** (set by which facade you call) — `EXILE` moves the permanents via the normal
+    battlefield→exile transition; `SACRIFICE` puts them in their owners' graveyards through the same
+    path a fixed-count sacrifice cost uses, so "whenever you sacrifice" triggers and Food tracking
+    fire. Either way Auras fall off, tokens cease to exist, and leaves-the-battlefield triggers fire.
+  - **`xMeasure`** — how the choice becomes the ability's **X**, read with `DynamicAmount.XValue`.
+    `TOTAL_MANA_VALUE` sums the chosen permanents' mana values, for "…with total mana value X" cards
+    whose target is bounded by `GameObjectFilter.manaValueAtMostX()`; `COUNT` is simply how many were
+    chosen, for "…for each permanent sacrificed this way". Either value is fixed at activation and
+    stored on the stack, so an X-bounded target is re-validated against it at resolution (CR 608.2b)
+    and a resolution-time `XValue` read can't be changed by removal in response.
+
+  Backs **Fabrication Foundry** ("{2}{W}, {T}, Exile one or more other artifacts you control with
+  total mana value X: Return target artifact card with mana value X or less from your graveyard to
+  the battlefield") and **Radiant Lotus** ("{T}, Sacrifice one or more artifacts: Choose a color.
+  Target player adds three mana of the chosen color for each artifact sacrificed this way" —
+  `Costs.SacrificePermanents(Artifact, excludeSelf = false)` plus
+  `AddManaOfChoice(amount = Multiply(XValue, 3), recipient = <the target>)`). The engine drives the
+  activation in order: it pauses for the on-battlefield selection (min = `minCount`, max = all
+  eligible), computes X, then pauses again for the ability's target — so an over-X target can never
+  be chosen. Both pauses precede cost payment, so cancelling either is side-effect-free. Pair with
+  `TimingRule.SorcerySpeed` where the card says "Activate only as a sorcery."
 - `Costs.Forage()` (ability cost) / `Costs.additional.Forage` (additional cost) — Forage (CR
   701.61): "exile three cards from your graveyard **or** sacrifice a Food." A *choice* between two
   sub-costs that belongs to the player. All cost-shaped forage payment is unified in the engine's
@@ -1100,7 +1113,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   emptying (CR 500.5, `CleanupPhaseManager.emptyManaPools` → `ManaPoolComponent.emptyAtBoundary(...)`)
   the kept colours survive while everything else empties, until the marker clears at end-of-turn
   cleanup. The Last Agni Kai (`RetainUnspentMana(Color.RED)`).
-- `AddManaOfChoice(colorSet, amount?, restriction?, riders?)` — **unified primitive.** Add N mana of one color the controller picks from a resolved [ManaColorSet](#manacolorset). All "any-color from a constrained pool" cards (any color, commander identity, among permanents, lands could produce, source-chosen color) are expressed as this effect plus a different `ManaColorSet`. `riders` is a `Set<ManaSpellRider>` consumed when the mana pays for a spell (e.g. Path of Ancestry tags its mana with `ScryOnSharedTypeWithCommander`); when riders are set without a `restriction`, the engine stores the entries under `ManaRestriction.AnySpend` to preserve the rider through the pool.
+- `AddManaOfChoice(colorSet, amount?, restriction?, riders?, recipient?)` — **unified primitive.** Add N mana of one color the controller picks from a resolved [ManaColorSet](#manacolorset). All "any-color from a constrained pool" cards (any color, commander identity, among permanents, lands could produce, source-chosen color) are expressed as this effect plus a different `ManaColorSet`. `riders` is a `Set<ManaSpellRider>` consumed when the mana pays for a spell (e.g. Path of Ancestry tags its mana with `ScryOnSharedTypeWithCommander`); when riders are set without a `restriction`, the engine stores the entries under `ManaRestriction.AnySpend` to preserve the rider through the pool. `recipient` is an `EffectTarget` naming **whose pool** the mana lands in — it defaults to `EffectTarget.Controller` (the only shape a mana ability can have, CR 605.1a) and takes a chosen target for "**target player** adds …" (Radiant Lotus). Only the pool moves: the *colour* is still chosen by the ability's controller, because "Choose a color" names no other chooser. An ability with a non-default `recipient` targets, so by definition it isn't a mana ability — it uses the stack, can be responded to, and the mana arrives in the recipient's pool at resolution (and empties at end of step like any other mana, CR 500.4).
 - `AddAnyColorMana(amount?, restriction?)` — sugar for `AddManaOfChoice(ManaColorSet.AnyColor, amount)`. "Add N mana of any **one** color" (Gilded Lotus): one chosen color, N of it. For "any **combination** of colors" use `AddManaInAnyCombination`.
 - `AddManaOfChosenColor(amount?)` — sugar for `AddManaOfChoice(ManaColorSet.SourceChosenColor, amount)`.
 - `AddManaOfColorAmong(filter)` — sugar for `AddManaOfChoice(ManaColorSet.AmongPermanents(filter))`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -14,6 +14,8 @@ import com.wingedsheep.sdk.scripting.CostZone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.costs.PermanentCostAction
+import com.wingedsheep.sdk.scripting.costs.VariableCostMeasure
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -253,16 +255,39 @@ object Costs {
     /**
      * Exile one or more permanents matching [filter] you control (variable count, at least
      * [minCount]); with [excludeSelf] the ability's own source is excluded ("one or more *other*
-     * …"). The exiled set's **total mana value** becomes the ability's X value — read it with
-     * `DynamicAmount.XValue` (e.g. to bound a reanimation target "with mana value X or less").
+     * …"). By default the exiled set's **total mana value** becomes the ability's X value — read it
+     * with `DynamicAmount.XValue` (e.g. to bound a reanimation target "with mana value X or less");
+     * pass [xMeasure] `COUNT` for the "for each permanent exiled this way" shape instead.
      * Backs Fabrication Foundry's "Exile one or more other artifacts you control with total mana
      * value X" activation cost. Pair with a sorcery-speed timing rule where the card demands it.
      */
     fun ExilePermanents(
         filter: GameObjectFilter = GameObjectFilter.Any,
         minCount: Int = 1,
-        excludeSelf: Boolean = true
-    ): AbilityCost = AbilityCost.Atom(CostAtom.ExilePermanents(filter, minCount, excludeSelf))
+        excludeSelf: Boolean = true,
+        xMeasure: VariableCostMeasure = VariableCostMeasure.TOTAL_MANA_VALUE
+    ): AbilityCost = AbilityCost.Atom(
+        CostAtom.VariablePermanents(filter, minCount, excludeSelf, PermanentCostAction.EXILE, xMeasure)
+    )
+
+    /**
+     * Sacrifice one or more permanents matching [filter] you control (variable count, at least
+     * [minCount]) — the sacrificing twin of [ExilePermanents]. The number sacrificed becomes the
+     * ability's X value by default, so the resolving effect can scale with it via
+     * `DynamicAmount.XValue` ("for each artifact sacrificed this way" — Radiant Lotus).
+     *
+     * [excludeSelf] defaults to false: the ability's own source is usually a legal choice for its
+     * own cost (Radiant Lotus is an artifact and may sacrifice itself). Pass [xMeasure]
+     * `TOTAL_MANA_VALUE` for the "with total mana value X" shape.
+     */
+    fun SacrificePermanents(
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        minCount: Int = 1,
+        excludeSelf: Boolean = false,
+        xMeasure: VariableCostMeasure = VariableCostMeasure.COUNT
+    ): AbilityCost = AbilityCost.Atom(
+        CostAtom.VariablePermanents(filter, minCount, excludeSelf, PermanentCostAction.SACRIFICE, xMeasure)
+    )
 
     // =========================================================================
     // Loyalty Costs

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2094,14 +2094,23 @@ object Effects {
         colorSet: ManaColorSet = ManaColorSet.AnyColor,
         amount: Int = 1,
         restriction: ManaRestriction? = null,
-    ): Effect = AddManaOfChoiceEffect(colorSet, DynamicAmount.Fixed(amount), restriction)
+        recipient: EffectTarget = EffectTarget.Controller,
+    ): Effect = AddManaOfChoiceEffect(
+        colorSet, DynamicAmount.Fixed(amount), restriction, recipient = recipient
+    )
 
-    /** Dynamic-amount variant of [AddManaOfChoice]. */
+    /**
+     * Dynamic-amount variant of [AddManaOfChoice].
+     *
+     * Pass [recipient] for "**target player** adds …" (Radiant Lotus). The colour is still chosen by
+     * the ability's controller; only the pool the mana lands in moves.
+     */
     fun AddManaOfChoice(
         colorSet: ManaColorSet,
         amount: DynamicAmount,
         restriction: ManaRestriction? = null,
-    ): Effect = AddManaOfChoiceEffect(colorSet, amount, restriction)
+        recipient: EffectTarget = EffectTarget.Controller,
+    ): Effect = AddManaOfChoiceEffect(colorSet, amount, restriction, recipient = recipient)
 
     /**
      * Add N mana of any *one* color ("Add three mana of any one color" — Gilded Lotus):

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -601,6 +601,18 @@ data class AdditionalCostPayment(
     /** Cards that were exiled */
     val exiledCards: List<EntityId> = emptyList(),
 
+    /**
+     * Permanents chosen for a [com.wingedsheep.sdk.scripting.costs.CostAtom.VariablePermanents]
+     * variable-count cost — "exile/sacrifice **one or more** [filter] you control".
+     *
+     * Its own channel rather than [exiledCards] / [sacrificedPermanents] because the count is the
+     * payer's choice (CR 601.2b) and the same ability may also carry a fixed-count sacrifice or
+     * exile cost: mixing them into one list would make "which permanents paid which leg" ambiguous.
+     * The engine derives the ability's X from this list — its size, or the total mana value of its
+     * members, per the atom's `xMeasure`.
+     */
+    val variableCostPermanents: List<EntityId> = emptyList(),
+
     /** Cards chosen via Behold (from battlefield or hand) */
     val beheldCards: List<EntityId> = emptyList(),
 
@@ -639,6 +651,7 @@ data class AdditionalCostPayment(
                 discardedCards.isEmpty() &&
                 lifePaid == 0 &&
                 exiledCards.isEmpty() &&
+                variableCostPermanents.isEmpty() &&
                 beheldCards.isEmpty() &&
                 tappedPermanents.isEmpty() &&
                 bouncedPermanents.isEmpty() &&

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -112,31 +112,44 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
     }
 
     /**
-     * Exile one or more permanents matching [filter] you control — a *variable-count* cost: the
-     * payer chooses how many to exile (at least [minCount]). Unlike the fixed-count [Sacrifice] /
-     * [ExileFrom] atoms, the number exiled is a player choice made as the ability is activated (CR
-     * 601.2b — the value of a variable defined by a cost choice is announced at activation). The
-     * resolving ability reads the **total mana value** of the exiled permanents as its X value
-     * ([com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue]), so a target/effect can be
-     * bounded "with mana value X or less".
+     * Put one or more permanents matching [filter] you control into another zone — a
+     * *variable-count* cost: the payer chooses how many (at least [minCount]). Unlike the
+     * fixed-count [Sacrifice] / [ExileFrom] atoms, the number is a player choice made as the ability
+     * is activated (CR 601.2b — the value of a variable defined by a cost choice is announced at
+     * activation), and the resolving ability reads it as its X value
+     * ([com.wingedsheep.sdk.scripting.values.DynamicAmount.XValue]).
      *
-     * @property filter which permanents you control may be exiled.
-     * @property minCount minimum number to exile (default 1 — "one or more").
+     * Two orthogonal axes cover the printed shapes:
+     *
+     *  - [action] — what happens to the chosen permanents. `EXILE` for "exile one or more …"
+     *    (Fabrication Foundry), `SACRIFICE` for "sacrifice one or more …" (Radiant Lotus). A
+     *    sacrifice fires "whenever you sacrifice" triggers; an exile does not.
+     *  - [xMeasure] — how the choice becomes X. `TOTAL_MANA_VALUE` for "… with total mana value X"
+     *    (bounds a "mana value X or less" target); `COUNT` for "… for each permanent chosen this
+     *    way", where X is simply how many were chosen.
+     *
+     * @property filter which permanents you control may be chosen.
+     * @property minCount minimum number to choose (default 1 — "one or more").
      * @property excludeSelf when true the cost's source permanent is excluded — "exile one or more
-     *   *other* [filter] you control" (Fabrication Foundry).
+     *   *other* [filter] you control" (Fabrication Foundry). Leave false when the source may pay for
+     *   itself (Radiant Lotus is an artifact and may sacrifice itself to its own cost).
+     * @property action what the cost does with the chosen permanents.
+     * @property xMeasure how the chosen set becomes the ability's X.
      */
-    @SerialName("AtomExilePermanents")
+    @SerialName("AtomVariablePermanents")
     @Serializable
-    data class ExilePermanents(
+    data class VariablePermanents(
         val filter: GameObjectFilter = GameObjectFilter.Any,
         val minCount: Int = 1,
-        val excludeSelf: Boolean = true
+        val excludeSelf: Boolean = true,
+        val action: PermanentCostAction = PermanentCostAction.EXILE,
+        val xMeasure: VariableCostMeasure = VariableCostMeasure.TOTAL_MANA_VALUE
     ) : CostAtom {
         // Variable count — the floor the payer must at least select. The picker's max is the number
         // of eligible permanents, resolved by the engine at activation time.
         override val selectionCount: Int get() = minCount
         override val description: String get() = buildString {
-            append("exile ")
+            append(if (action == PermanentCostAction.EXILE) "exile " else "sacrifice ")
             append(if (minCount <= 1) "one or more " else "$minCount or more ")
             if (excludeSelf) append("other ")
             append("${filter.description}s you control")
@@ -336,3 +349,37 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
     }
 }
 
+
+/**
+ * What a [CostAtom.VariablePermanents] cost does with the permanents the payer chose.
+ *
+ * The distinction is not cosmetic: a sacrifice puts the permanents into their owners' graveyards
+ * and fires "whenever you sacrifice a permanent" triggers (CR 701.17), while an exile moves them
+ * to exile and fires none of those.
+ */
+@Serializable
+enum class PermanentCostAction {
+    /** "Exile one or more artifacts you control …" (Fabrication Foundry). */
+    EXILE,
+
+    /** "Sacrifice one or more artifacts …" (Radiant Lotus). */
+    SACRIFICE
+}
+
+/**
+ * How a [CostAtom.VariablePermanents] choice becomes the ability's X (CR 601.2b).
+ */
+@Serializable
+enum class VariableCostMeasure {
+    /**
+     * X is the sum of the chosen permanents' mana values — "… with total mana value X"
+     * (Fabrication Foundry, whose reanimation target is then bounded "mana value X or less").
+     */
+    TOTAL_MANA_VALUE,
+
+    /**
+     * X is simply how many permanents were chosen — the "… for each permanent sacrificed this way"
+     * shape (Radiant Lotus adds three mana per artifact sacrificed).
+     */
+    COUNT
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.sdk.scripting.effects
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
@@ -158,7 +159,7 @@ data class AddColorlessManaEffect(
  *      mana abilities when the player picked at activation time) or
  *      `EffectContext.chosenColor` (set by a wrapping `ChooseColorThenEffect`). If
  *      neither is present, the engine pauses for a `ChooseManaColorContinuation`.
- *   4. The chosen color is added to the controller's mana pool [amount] times.
+ *   4. The chosen color is added to [recipient]'s mana pool [amount] times.
  *
  * Example bindings:
  *   - "Add one mana of any color" → `AddManaOfChoiceEffect(ManaColorSet.AnyColor)`
@@ -166,6 +167,7 @@ data class AddColorlessManaEffect(
  *   - Mox Amber → `AddManaOfChoiceEffect(ManaColorSet.AmongPermanents(filter))`
  *   - Fellwar Stone → `AddManaOfChoiceEffect(ManaColorSet.LandsCouldProduce(OPPONENTS))`
  *   - Uncharted Haven → `AddManaOfChoiceEffect(ManaColorSet.SourceChosenColor)`
+ *   - Radiant Lotus → `AddManaOfChoiceEffect(..., recipient = EffectTarget.ContextTarget(0))`
  */
 @SerialName("AddManaOfChoice")
 @Serializable
@@ -180,6 +182,17 @@ data class AddManaOfChoiceEffect(
      * (the mana remains spendable on anything).
      */
     val riders: Set<ManaSpellRider> = emptySet(),
+    /**
+     * Whose pool the mana lands in. Defaults to the ability's controller — the only shape a *mana
+     * ability* can have (CR 605.1a), and what every land/rock produces. Point it at a player
+     * reference or a chosen target for "**target player** adds …" (Radiant Lotus), which is by
+     * definition not a mana ability because it targets.
+     *
+     * The *color* is still chosen by the ability's controller, not by the recipient: "Choose a
+     * color. Target player adds three mana of the chosen color …" names no other chooser, so the
+     * choice falls to the controller (CR 608.2). Only the pool the mana is added to moves.
+     */
+    val recipient: EffectTarget = EffectTarget.Controller,
 ) : Effect {
     constructor(colorSet: ManaColorSet, amount: Int, restriction: ManaRestriction? = null) :
         this(colorSet, DynamicAmount.Fixed(amount), restriction)
@@ -189,7 +202,8 @@ data class AddManaOfChoiceEffect(
             is DynamicAmount.Fixed -> if (a.amount == 1) "one mana of" else "${a.amount} mana of"
             else -> "${a.description} mana of"
         }
-        append("Add $amountText ${colorSet.description}")
+        if (recipient == EffectTarget.Controller) append("Add $amountText ${colorSet.description}")
+        else append("${recipient.description} adds $amountText ${colorSet.description}")
         if (restriction != null && restriction.description.isNotEmpty()) append(". ${restriction.description}")
         for (rider in riders) append(". ${rider.description}")
     }

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -33,7 +33,7 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.Discard(count = 1, filter = GameObjectFilter.Any, random = true),
         CostAtom.ExileFrom(Zone.GRAVEYARD, GameObjectFilter.Creature, count = 3),
         CostAtom.Mill(count = 1),
-        CostAtom.ExilePermanents(GameObjectFilter.Artifact, minCount = 1, excludeSelf = true),
+        CostAtom.VariablePermanents(GameObjectFilter.Artifact, minCount = 1, excludeSelf = true),
         CostAtom.TapPermanents(count = 1, filter = GameObjectFilter.Creature),
         CostAtom.ReturnToHand(GameObjectFilter.Any, count = 1),
         CostAtom.RevealFromHand(GameObjectFilter.Any, count = 1),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RadiantLotus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/RadiantLotus.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Radiant Lotus — {6}
+ * Artifact
+ * Mythic Rare — Aetherdrift #240
+ *
+ * "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the
+ *  chosen color for each artifact sacrificed this way."
+ *
+ * A Black Lotus that pays someone else. Two SDK axes carry it:
+ *
+ *  - [Costs.SacrificePermanents] — the sacrificing twin of `Costs.ExilePermanents`: a
+ *    *variable-count* cost where the payer chooses how many artifacts to sacrifice (at least one),
+ *    and that count becomes the ability's X (CR 601.2b — a variable defined by a cost choice is
+ *    announced as the ability is activated). `excludeSelf = false` because Radiant Lotus is itself
+ *    an artifact and may be one of the artifacts sacrificed to its own cost; tapping it and
+ *    sacrificing it are both legal parts of the same cost (CR 601.2h, costs paid in any order).
+ *  - [Effects.AddManaOfChoice]'s `recipient` — "**target player** adds …", so the mana lands in the
+ *    target's pool rather than the controller's. The *colour* is still the controller's choice:
+ *    "Choose a color" names no other chooser.
+ *
+ * Because it targets, this is **not** a mana ability (CR 605.1a) — it uses the stack, can be
+ * responded to, and can fizzle if the target becomes illegal. The mana therefore arrives during the
+ * target player's own priority window and, like all mana, empties at the end of the step or phase
+ * (CR 500.4) — so it's the target player who has to spend it.
+ *
+ * Three mana per artifact is `DynamicAmount.Multiply(XValue, 3)`, evaluated at resolution against
+ * the X stored on the stack, so removing artifacts in response can't change the amount.
+ */
+val RadiantLotus = card("Radiant Lotus") {
+    manaCost = "{6}"
+    typeLine = "Artifact"
+    oracleText = "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three " +
+        "mana of the chosen color for each artifact sacrificed this way."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificePermanents(GameObjectFilter.Artifact, minCount = 1, excludeSelf = false)
+        )
+        val player = target("target player", TargetPlayer())
+        effect = Effects.AddManaOfChoice(
+            colorSet = ManaColorSet.AnyColor,
+            amount = DynamicAmount.Multiply(DynamicAmount.XValue, 3),
+            recipient = player,
+        )
+        description = "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds " +
+            "three mana of the chosen color for each artifact sacrificed this way."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "240"
+        artist = "Bruce Brenneise"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg?1783907846"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -12684,6 +12684,62 @@
     "colorIdentityOverride": []
 }
 
+// Radiant Lotus
+{
+    "name": "Radiant Lotus",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomVariablePermanents",
+                                "filter": "artifact",
+                                "excludeSelf": false,
+                                "action": "SACRIFICE",
+                                "xMeasure": "COUNT"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Multiply",
+                        "amount": "XValue",
+                        "multiplier": 3
+                    },
+                    "recipient": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "MYTHIC",
+        "artist": "Bruce Brenneise",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be6dac83-39c2-40dc-a322-76a3ea4e7aee.jpg?1783907846"
+    }
+}
+
 // Rangers' Aetherhive
 {
     "name": "Rangers' Aetherhive",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6627,7 +6627,7 @@
                         {
                             "type": "CostAtomWrapper",
                             "atom": {
-                                "type": "AtomExilePermanents",
+                                "type": "AtomVariablePermanents",
                                 "filter": "artifact"
                             }
                         }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -243,6 +243,29 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("Loyalty", "cost: planeswalker loyalty +N/-N (loyaltyAbility(change) { })")
     supported("SacrificeAPermanent", "cost: sacrifice")
     supported("SacrificeNumberPermanents", "cost: sacrifice N")
+    // Variable-count permanent costs — "exile/sacrifice **one or more** [filter] you control" as an
+    // activated-ability cost, where the payer chooses how many and that choice defines the ability's
+    // X (CR 601.2b). Both map to the single `CostAtom.VariablePermanents` atom, differing only in its
+    // `action` and `xMeasure` axes, surfaced as `Costs.ExilePermanents(...)` /
+    // `Costs.SacrificePermanents(...)`. The engine pauses for the on-battlefield selection, computes
+    // X from it (total mana value, or the count), then pauses for the ability's target so an
+    // X-bounded target can't be picked and then fizzle.
+    //
+    // Capability-only: both sit squarely in the extra-cost / chosen-value area the emitter declines
+    // to render exactly (creator's note), so their cards stay SCAFFOLD even though the capability is
+    // present. Note the near-miss neighbour `SacrificeAnyNumberOfPermanents` stays unregistered — it
+    // is a min-0 sacrifice used as a *spell* cost/effect, not an activated-ability cost, and this
+    // atom is activated-ability-only.
+    supported(
+        "ExileNumberOrMoreGroupPermanents",
+        "cost: exile one or more permanents you control, X = their total mana value " +
+            "(Costs.ExilePermanents(filter, minCount, excludeSelf)) — Fabrication Foundry"
+    )
+    supported(
+        "SacrificeOneOrMorePermanents",
+        "cost: sacrifice one or more permanents you control, X = how many " +
+            "(Costs.SacrificePermanents(filter, minCount, excludeSelf)) — Radiant Lotus"
+    )
     // "Pay N life" as an activation cost -> Costs.PayLife(n). The emitter renders fixed-integer amounts
     // (abilityCostDsl); non-integer amounts ({X}, life-total halves, …) are declined -> SCAFFOLD.
     supported("PayLife", "cost: pay life")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -714,37 +714,38 @@ data class ActivateAbilitySacrificeContinuation(
 ) : ContinuationFrame
 
 /**
- * Resume after the controller picks which permanents to exile for a variable-count
- * [com.wingedsheep.sdk.scripting.costs.CostAtom.ExilePermanents] cost — "Exile one or more other
- * [filter] you control with total mana value X" (Fabrication Foundry).
+ * Resume after the controller picks which permanents pay a variable-count
+ * [com.wingedsheep.sdk.scripting.costs.CostAtom.VariablePermanents] cost — "Exile one or more other
+ * [filter] you control with total mana value X" (Fabrication Foundry) or "Sacrifice one or more
+ * [filter]" (Radiant Lotus).
  *
- * The bare [ActivateAbility] arrives with no exile selection; the handler raised a
- * [SelectCardsDecision] over the eligible permanents (min [minCount], max = all eligible) and pushed
- * this frame. The resumer validates the pick, fills it into `costPayment.exiledCards`, and re-enters
- * the handler — which then computes X (the exiled set's total mana value) and pauses again for the
- * X-bounded target ([ActivateAbilityControllerTargetContinuation]). The exile pause happens before
- * any cost is paid, so cancellation pops this frame with no side effects.
+ * The bare [ActivateAbility] arrives with no selection; the handler raised a [SelectCardsDecision]
+ * over the eligible permanents (min [minCount], max = all eligible) and pushed this frame. The
+ * resumer validates the pick, fills it into `costPayment.variableCostPermanents`, and re-enters the
+ * handler — which then computes X from it and pauses again for the target
+ * ([ActivateAbilityControllerTargetContinuation]). The selection pause happens before any cost is
+ * paid, so cancellation pops this frame with no side effects.
  *
- * @property action The original [ActivateAbility] (`costPayment.exiledCards` still empty).
- * @property exileCandidates The eligible permanents offered as options (used to validate the pick).
- * @property minCount Minimum number of permanents that must be exiled (the cost's floor).
+ * @property action The original [ActivateAbility] (`costPayment.variableCostPermanents` still empty).
+ * @property candidates The eligible permanents offered as options (used to validate the pick).
+ * @property minCount Minimum number of permanents that must be chosen (the cost's floor).
  */
 @Serializable
-data class ActivateAbilityExilePermanentsContinuation(
+data class ActivateAbilityVariablePermanentsContinuation(
     override val decisionId: String,
     val action: ActivateAbility,
-    val exileCandidates: List<EntityId>,
+    val candidates: List<EntityId>,
     val minCount: Int
 ) : ContinuationFrame
 
 /**
  * Resume after the controller picks the target for an activated ability whose target legality
  * depends on a value determined during activation — specifically the X-bounded reanimation target of
- * a [com.wingedsheep.sdk.scripting.costs.CostAtom.ExilePermanents] ability (Fabrication Foundry:
+ * a [com.wingedsheep.sdk.scripting.costs.CostAtom.VariablePermanents] ability (Fabrication Foundry:
  * "Return target artifact card with mana value X or less from your graveyard to the battlefield").
  *
  * Because X isn't known until the exile selection is made, the target is chosen *after* the exile
- * ([ActivateAbilityExilePermanentsContinuation]) rather than up front. The handler raised a
+ * ([ActivateAbilityVariablePermanentsContinuation]) rather than up front. The handler raised a
  * [ChooseTargetsDecision] whose legal targets were found with X threaded through the predicate
  * context, and pushed this frame. The resumer converts the response into [ChosenTarget]s, fills
  * `action.targets`, and re-enters the handler to pay the cost and put the ability on the stack.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -347,7 +347,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ActivateAbilityOpponentChooserContinuation::class)
         subclass(ActivateAbilityOpponentTargetContinuation::class)
         subclass(ActivateAbilitySacrificeContinuation::class)
-        subclass(ActivateAbilityExilePermanentsContinuation::class)
+        subclass(ActivateAbilityVariablePermanentsContinuation::class)
         subclass(ActivateAbilityControllerTargetContinuation::class)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.DistributedCounterRemoval
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.PermanentCostAction
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -578,7 +579,7 @@ class CostHandler {
                 eligible.size >= atom.count
             }
         }
-        is CostAtom.ExilePermanents -> {
+        is CostAtom.VariablePermanents -> {
             val candidates = findMatchingPermanentsUnified(state, controllerId, atom.filter)
             val eligible = if (atom.excludeSelf) candidates.filter { it != sourceId } else candidates
             eligible.size >= atom.minCount
@@ -659,9 +660,8 @@ class CostHandler {
             requiredCount = atom.count, excludeSelf = atom.excludeSelf, sourceId, controllerId, manaPool,
             distinctNames = atom.distinctNames
         )
-        is CostAtom.ExilePermanents -> payExilePermanentsList(
-            state, choices.exileChoices, atom.filter,
-            minCount = atom.minCount, excludeSelf = atom.excludeSelf, sourceId, controllerId, manaPool
+        is CostAtom.VariablePermanents -> payVariablePermanentsList(
+            state, atom, choices.variablePermanentChoices, sourceId, controllerId, manaPool
         )
         is CostAtom.Discard -> {
             var workState = state
@@ -881,48 +881,62 @@ class CostHandler {
     }
 
     /**
-     * Pay a [CostAtom.ExilePermanents] variable-count cost: exile every permanent the player chose
-     * ([exileChoices]), re-validating that each matches [filter], is controlled by the activator,
-     * and — when [excludeSelf] — isn't the ability's own source. At least [minCount] must be chosen.
-     * Unlike the fixed-count sacrifice / exile-from-zone atoms this exiles *all* selected permanents
-     * (the count is the player's choice, CR 601.2b). Permanents move to exile via
-     * [ZoneTransitionService.moveToZone], so attached Auras fall off, tokens cease to exist, and
-     * leaves-the-battlefield triggers fire.
+     * Pay a [CostAtom.VariablePermanents] variable-count cost: exile or sacrifice *every* permanent
+     * the player chose, re-validating that each matches the atom's filter, is controlled by the
+     * activator, and — when `excludeSelf` — isn't the ability's own source. At least `minCount` must
+     * be chosen. Unlike the fixed-count sacrifice / exile-from-zone atoms this pays with all
+     * selected permanents (the count is the player's choice, CR 601.2b).
+     *
+     * A `SACRIFICE` atom delegates to the shared [paySacrificeList] so it fires "whenever you
+     * sacrifice" triggers and tracks Food/permanent sacrifices exactly like a fixed-count sacrifice
+     * cost; only the required count differs (all chosen, rather than a printed N). An `EXILE` atom
+     * moves the permanents via [ZoneTransitionService.moveToZone], so attached Auras fall off,
+     * tokens cease to exist, and leaves-the-battlefield triggers fire.
      */
-    private fun payExilePermanentsList(
+    private fun payVariablePermanentsList(
         state: GameState,
-        exileChoices: List<EntityId>,
-        filter: GameObjectFilter,
-        minCount: Int,
-        excludeSelf: Boolean,
+        atom: CostAtom.VariablePermanents,
+        choices: List<EntityId>,
         sourceId: EntityId,
         controllerId: EntityId,
         manaPool: ManaPool,
     ): CostPaymentResult {
+        val filter = atom.filter
+        val minCount = atom.minCount
+        val excludeSelf = atom.excludeSelf
+        val verb = if (atom.action == PermanentCostAction.SACRIFICE) "sacrifice" else "exile"
         // With no selection supplied, auto-pick ONLY when the choice is forced (exactly minCount
         // eligible). A real choice (more eligible than minCount) is paused for by
-        // ActivateAbilityHandler; never silently guess which permanents to exile.
-        val toExile: List<EntityId> = if (exileChoices.isEmpty()) {
+        // ActivateAbilityHandler; never silently guess which permanents to pay with.
+        val toPay: List<EntityId> = if (choices.isEmpty()) {
             val candidates = findMatchingCardsUnified(state, state.getBattlefield(controllerId), filter, controllerId)
                 .let { if (excludeSelf) it.filter { id -> id != sourceId } else it }
             if (candidates.size < minCount) {
-                return CostPaymentResult.failure("Not enough permanents to exile (need $minCount, got ${candidates.size})")
+                return CostPaymentResult.failure("Not enough permanents to $verb (need $minCount, got ${candidates.size})")
             }
             if (candidates.size > minCount) {
-                return CostPaymentResult.failure("No permanents chosen to exile (need at least $minCount)")
+                return CostPaymentResult.failure("No permanents chosen to $verb (need at least $minCount)")
             }
             candidates
         } else {
-            exileChoices
+            choices
         }
-        if (toExile.size < minCount) {
-            return CostPaymentResult.failure("Not enough permanents chosen to exile (need $minCount, got ${toExile.size})")
+        if (toPay.size < minCount) {
+            return CostPaymentResult.failure("Not enough permanents chosen to $verb (need $minCount, got ${toPay.size})")
+        }
+        if (atom.action == PermanentCostAction.SACRIFICE) {
+            // requiredCount = the whole chosen set: the count is the payer's choice, not a printed N.
+            return paySacrificeList(
+                state, toPay, filter,
+                requiredCount = toPay.size, excludeSelf = excludeSelf,
+                sourceId = sourceId, controllerId = controllerId, manaPool = manaPool,
+            )
         }
         val context = PredicateContext(controllerId = controllerId)
         val projected = state.projectedState
         var newState = state
         val events = mutableListOf<GameEvent>()
-        for (id in toExile) {
+        for (id in toPay) {
             val container = newState.getEntity(id)
                 ?: return CostPaymentResult.failure("Permanent to exile not found")
             val itsController = container.get<ControllerComponent>()?.playerId
@@ -1078,9 +1092,9 @@ class CostHandler {
                 // Mana / return-to-hand / reveal / put-counters-on-self / exile-permanents / mill
                 // are not produced as spell additional costs today (put-counters-on-self is
                 // inherently ability-scoped — a spell on the stack has no permanent to put the
-                // counters on; and ExilePermanents is an activated-ability cost only).
+                // counters on; and VariablePermanents is an activated-ability cost only).
                 is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand,
-                is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents, is CostAtom.Mill -> false
+                is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents, is CostAtom.Mill -> false
             }
             is AdditionalCost.PayLifePerTarget -> {
                 // Always payable: choosing zero targets pays zero life. Per-target life
@@ -1464,6 +1478,12 @@ data class CostPaymentChoices(
     val sacrificeChoices: List<EntityId> = emptyList(),
     val discardChoices: List<EntityId> = emptyList(),
     val exileChoices: List<EntityId> = emptyList(),
+    /**
+     * Permanents chosen for a [CostAtom.VariablePermanents] variable-count cost, kept apart from
+     * [exileChoices] / [sacrificeChoices] so an ability carrying both a fixed and a variable
+     * permanent cost stays unambiguous. Mirrors `AdditionalCostPayment.variableCostPermanents`.
+     */
+    val variablePermanentChoices: List<EntityId> = emptyList(),
     val tapChoices: List<EntityId> = emptyList(),
     val bounceChoices: List<EntityId> = emptyList(),
     val xValue: Int = 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -55,6 +55,8 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.PermanentCostAction
+import com.wingedsheep.sdk.scripting.costs.VariableCostMeasure
 import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
@@ -435,15 +437,16 @@ class ActivateAbilityHandler(
         // yet at submission time (the opponent's pick is validated when it's made). See
         // [com.wingedsheep.sdk.scripting.targets.TargetChooser].
         val controllerTargetReqs = effectiveTargetReqs.filter { it.chooser == TargetChooser.Controller }
-        // For an "Exile one or more other permanents you control with total mana value X" cost
-        // (Fabrication Foundry), X is the total mana value of the exiled permanents (CR 601.2b), and
-        // the reanimation target's "mana value X or less" legality is measured against it. Derive X
-        // from the chosen exiled permanents so target validation sees the right cap; when the cost is
-        // paid via the two-step pause flow the exiled set already rides on the action's costPayment.
-        val exilePermanentsCost = extractExilePermanentsCost(effectiveCost)
-        val exiledForCost = action.costPayment?.exiledCards ?: emptyList()
-        val effectiveXValue = if (exilePermanentsCost != null && exiledForCost.isNotEmpty()) {
-            sumExiledManaValue(state, exiledForCost)
+        // For a variable-count "exile/sacrifice one or more permanents you control" cost, X is
+        // defined by the payer's cost choice (CR 601.2b) — the chosen set's total mana value
+        // (Fabrication Foundry, whose reanimation target's "mana value X or less" legality is
+        // measured against it) or simply how many were chosen (Radiant Lotus). Derive X here so
+        // target validation sees the right cap; when the cost is paid via the two-step pause flow
+        // the chosen set already rides on the action's costPayment.
+        val variablePermanentsCost = extractVariablePermanentsCost(effectiveCost)
+        val chosenForCost = action.costPayment?.variableCostPermanents ?: emptyList()
+        val effectiveXValue = if (variablePermanentsCost != null && chosenForCost.isNotEmpty()) {
+            variableCostX(state, variablePermanentsCost, chosenForCost)
         } else {
             action.xValue
         }
@@ -468,11 +471,11 @@ class ActivateAbilityHandler(
             // An empty target list is only illegal when at least one controller-chosen
             // requirement is mandatory. For an ability whose controller targets are all
             // optional ("up to one target …", e.g. Boom Box), choosing no targets is a
-            // legal activation, so don't reject it here. An ExilePermanents cost drives the
+            // legal activation, so don't reject it here. An VariablePermanents cost drives the
             // target choice *after* the exile selection (X isn't known until then), so the
             // bare initial submission legitimately arrives with no target — the engine pauses
             // for it during execute(); don't reject that here either.
-            if (exilePermanentsCost == null && controllerTargetReqs.any { it.effectiveMinCount > 0 }) {
+            if (variablePermanentsCost == null && controllerTargetReqs.any { it.effectiveMinCount > 0 }) {
                 return "This ability requires a target"
             }
         }
@@ -607,15 +610,17 @@ class ActivateAbilityHandler(
             )
         )
 
-        // "Exile one or more other permanents you control with total mana value X" cost (Fabrication
-        // Foundry): X is the total mana value of the exiled permanents (CR 601.2b — a variable
-        // defined by a cost choice is announced as the ability is activated). It bounds the X-limited
-        // reanimation target and is stored on the stack for 608.2b re-validation. When the cost is
-        // being paid, the exiled set already rides on the action's costPayment.
-        val exilePermanentsCost = extractExilePermanentsCost(effectiveCost)
-        val exiledForCost = action.costPayment?.exiledCards ?: emptyList()
+        // Variable-count "exile/sacrifice one or more permanents you control" cost: X is defined by
+        // the payer's cost choice (CR 601.2b — a variable defined by a cost choice is announced as
+        // the ability is activated), measured as the chosen set's total mana value (Fabrication
+        // Foundry) or its size (Radiant Lotus). It bounds any X-limited target and is stored on the
+        // stack for 608.2b re-validation and for `DynamicAmount.XValue` reads at resolution. When
+        // the cost is being paid, the chosen set already rides on the action's costPayment.
+        val variablePermanentsCost = extractVariablePermanentsCost(effectiveCost)
+        val chosenForCost = action.costPayment?.variableCostPermanents ?: emptyList()
         val effectiveXValue: Int? =
-            if (exilePermanentsCost != null && exiledForCost.isNotEmpty()) sumExiledManaValue(state, exiledForCost)
+            if (variablePermanentsCost != null && chosenForCost.isNotEmpty())
+                variableCostX(state, variablePermanentsCost, chosenForCost)
             else action.xValue
 
         // -------------------------------------------------------------------
@@ -936,26 +941,28 @@ class ActivateAbilityHandler(
         }
 
         // -------------------------------------------------------------------
-        // ExilePermanents cost-choice pause (legal-actions submission path).
+        // VariablePermanents cost-choice pause (legal-actions submission path).
         //
-        // "Exile one or more other [filter] you control with total mana value X" (Fabrication
-        // Foundry). The player picks which permanents to exile — a variable-count choice (at least
+        // "Exile/sacrifice one or more [filter] you control" (Fabrication Foundry, Radiant Lotus).
+        // The player picks which permanents to pay with — a variable-count choice (at least
         // minCount). The bare ActivateAbility arrives with no selection; pause and raise a
-        // SelectCardsDecision over the eligible permanents. The resumer computes X (their total mana
-        // value) and re-enters, which then pauses again for the X-bounded target (block below).
+        // SelectCardsDecision over the eligible permanents. The resumer fills the selection and
+        // re-enters, which computes X from it and — for an ability whose target wasn't gathered up
+        // front — pauses again for that target (block below).
         //
-        // Skipped when exiledCards is already filled (engine-direct path / resumed replay).
+        // Skipped when variableCostPermanents is already filled (engine-direct path / resumed replay).
         // -------------------------------------------------------------------
-        if (exilePermanentsCost != null && exiledForCost.isEmpty()) {
+        if (variablePermanentsCost != null && chosenForCost.isEmpty()) {
+            val verb = if (variablePermanentsCost.action == PermanentCostAction.SACRIFICE) "sacrifice" else "exile"
             val candidates = costHandler
-                .findMatchingCardsUnified(state, state.getBattlefield(action.playerId), exilePermanentsCost.filter, action.playerId)
-                .let { if (exilePermanentsCost.excludeSelf) it.filter { id -> id != action.sourceId } else it }
-            val minCount = exilePermanentsCost.minCount
+                .findMatchingCardsUnified(state, state.getBattlefield(action.playerId), variablePermanentsCost.filter, action.playerId)
+                .let { if (variablePermanentsCost.excludeSelf) it.filter { id -> id != action.sourceId } else it }
+            val minCount = variablePermanentsCost.minCount
             if (candidates.size < minCount) {
-                return ExecutionResult.error(state, "Not enough permanents to exile for ${cardComponent.name}")
+                return ExecutionResult.error(state, "Not enough permanents to $verb for ${cardComponent.name}")
             }
             val decisionId = java.util.UUID.randomUUID().toString()
-            val prompt = "Choose one or more ${exilePermanentsCost.filter.description}s to exile for ${cardComponent.name}"
+            val prompt = "Choose one or more ${variablePermanentsCost.filter.description}s to $verb for ${cardComponent.name}"
             val decision = com.wingedsheep.engine.core.SelectCardsDecision(
                 id = decisionId,
                 playerId = action.playerId,
@@ -969,10 +976,10 @@ class ActivateAbilityHandler(
                 minSelections = minCount,
                 maxSelections = candidates.size
             )
-            val continuation = com.wingedsheep.engine.core.ActivateAbilityExilePermanentsContinuation(
+            val continuation = com.wingedsheep.engine.core.ActivateAbilityVariablePermanentsContinuation(
                 decisionId = decisionId,
                 action = action,
-                exileCandidates = candidates,
+                candidates = candidates,
                 minCount = minCount
             )
             val pausedState = state.withPendingDecision(decision).pushContinuation(continuation)
@@ -986,15 +993,17 @@ class ActivateAbilityHandler(
         }
 
         // -------------------------------------------------------------------
-        // X-bounded target pause for an ExilePermanents ability (Fabrication Foundry).
+        // Target pause for a VariablePermanents ability (Fabrication Foundry, Radiant Lotus).
         //
-        // Once the exile selection is known (block above resumed → exiledCards filled → X computed),
-        // raise the controller's target choice with the "mana value X or less" cap resolved against
-        // X (threaded through the predicate context). The resumer fills action.targets and re-enters
-        // to pay + resolve. Skipped on the engine-direct path (targets already supplied) and for
-        // abilities with no controller target.
+        // The enumerator deliberately surfaces these abilities with no target gathered up front,
+        // because a target may be bounded by X ("mana value X or less") and X isn't known until the
+        // cost choice is made. Once that selection is known (block above resumed → X computed),
+        // raise the controller's target choice with X threaded through the predicate context, so an
+        // over-X target can't be picked and then fizzle. The resumer fills action.targets and
+        // re-enters to pay + resolve. Skipped on the engine-direct path (targets already supplied)
+        // and for abilities with no controller target.
         // -------------------------------------------------------------------
-        if (exilePermanentsCost != null && exiledForCost.isNotEmpty() && action.targets.isEmpty()) {
+        if (variablePermanentsCost != null && chosenForCost.isNotEmpty() && action.targets.isEmpty()) {
             val execTargetReqs = if (textReplacement != null) {
                 ability.targetRequirements.map { it.applyTextReplacement(textReplacement) }
             } else {
@@ -1081,7 +1090,7 @@ class ActivateAbilityHandler(
 
         // Pay mana costs before paying other costs
         var effectiveManaCost = extractManaCost(effectiveCost)
-        // For an ExilePermanents cost, X is the exiled permanents' total mana value (computed above);
+        // For an VariablePermanents cost, X is the exiled permanents' total mana value (computed above);
         // otherwise it's the action's chosen X. Identical to `action.xValue ?: 0` for every other card.
         val xValue = effectiveXValue ?: 0
 
@@ -1187,6 +1196,7 @@ class ActivateAbilityHandler(
             sacrificeChoices = action.costPayment?.sacrificedPermanents ?: emptyList(),
             discardChoices = action.costPayment?.discardedCards ?: emptyList(),
             exileChoices = action.costPayment?.exiledCards ?: emptyList(),
+            variablePermanentChoices = action.costPayment?.variableCostPermanents ?: emptyList(),
             tapChoices = firstTapSlice,
             bounceChoices = action.costPayment?.bouncedPermanents ?: emptyList(),
             xValue = xValue,
@@ -1196,8 +1206,10 @@ class ActivateAbilityHandler(
         )
 
         // Snapshot projected subtypes and P/T of sacrifice targets before zone change
-        // (Rule 112.7a / 608.2h — "as it last existed on the battlefield")
-        val sacrificeTargetIds = action.costPayment?.sacrificedPermanents ?: emptyList()
+        // (Rule 112.7a / 608.2h — "as it last existed on the battlefield"). Covers both the
+        // fixed-count sacrifice cost and a variable-count one, which moves permanents just the same.
+        val sacrificeTargetIds = (action.costPayment?.sacrificedPermanents ?: emptyList()) +
+            (action.costPayment?.variableCostPermanents ?: emptyList())
         val sacrificedSnapshots = captureEntitySnapshots(sacrificeTargetIds, currentState.projectedState)
 
         // Mirror sacrifice snapshots for tapped-as-cost permanents — they may leave the
@@ -1734,7 +1746,7 @@ class ActivateAbilityHandler(
             controllerId = action.playerId,
             effect = finalEffect,
             sacrificedPermanents = sacrificedSnapshots,
-            // ExilePermanents X (exiled total mana value) is stored so 608.2b re-validation of the
+            // VariablePermanents X (exiled total mana value) is stored so 608.2b re-validation of the
             // "mana value X or less" target and any XValue read resolve against it; else action.xValue.
             xValue = effectiveXValue,
             tappedPermanents = firstTapSlice,
@@ -3082,27 +3094,38 @@ class ActivateAbilityHandler(
     }
 
     /**
-     * Pull the [CostAtom.ExilePermanents] variable-count sub-cost out of an ability cost, or null if
+     * Pull the [CostAtom.VariablePermanents] variable-count sub-cost out of an ability cost, or null if
      * none. Drives the two-step activation flow for "Exile one or more other [filter] you control
      * with total mana value X" costs (Fabrication Foundry): the handler pauses to let the player pick
      * which permanents to exile, then — because the target's legality depends on the resulting X —
      * pauses again for the target choice.
      */
-    private fun extractExilePermanentsCost(cost: AbilityCost): CostAtom.ExilePermanents? = when (cost) {
-        is AbilityCost.Atom -> cost.atom as? CostAtom.ExilePermanents
+    private fun extractVariablePermanentsCost(cost: AbilityCost): CostAtom.VariablePermanents? = when (cost) {
+        is AbilityCost.Atom -> cost.atom as? CostAtom.VariablePermanents
         is AbilityCost.Composite -> cost.costs.firstNotNullOfOrNull {
-            (it as? AbilityCost.Atom)?.atom as? CostAtom.ExilePermanents
+            (it as? AbilityCost.Atom)?.atom as? CostAtom.VariablePermanents
         }
         else -> null
     }
 
     /**
-     * Total mana value (CR 202.3) of the permanents chosen to pay a [CostAtom.ExilePermanents] cost.
-     * This is the ability's X value (CR 601.2b — a variable defined by a cost choice is announced at
-     * activation), read at target validation and stored on the stack for resolution re-validation.
-     * Mana value is intrinsic, so it reads correctly whether the permanents are still on the
-     * battlefield (validation) or already exiled (resolution).
+     * The ability's X value for a [CostAtom.VariablePermanents] cost, measured from the permanents
+     * the payer chose (CR 601.2b — a variable defined by a cost choice is announced at activation).
+     * Read at target validation and stored on the stack for resolution re-validation and
+     * `DynamicAmount.XValue`.
+     *
+     * `TOTAL_MANA_VALUE` sums their mana values (CR 202.3); `COUNT` is simply how many were chosen.
+     * Both read correctly whether the permanents are still on the battlefield (validation) or
+     * already gone (resolution): mana value is intrinsic to the card, and the count is a property of
+     * the selection rather than of the game state.
      */
-    private fun sumExiledManaValue(state: GameState, exiledIds: List<EntityId>): Int =
-        exiledIds.sumOf { state.getEntity(it)?.get<CardComponent>()?.manaValue ?: 0 }
+    private fun variableCostX(
+        state: GameState,
+        atom: CostAtom.VariablePermanents,
+        chosenIds: List<EntityId>,
+    ): Int = when (atom.xMeasure) {
+        VariableCostMeasure.TOTAL_MANA_VALUE ->
+            chosenIds.sumOf { state.getEntity(it)?.get<CardComponent>()?.manaValue ?: 0 }
+        VariableCostMeasure.COUNT -> chosenIds.size
+    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1651,10 +1651,10 @@ class CastSpellHandler(
                     }
                     // Mana / reveal are not produced as spell additional costs today;
                     // put-counters-on-self is ability-scoped (no permanent to accrue them on);
-                    // ExilePermanents and Mill are activated-ability-only costs, never spell
+                    // VariablePermanents and Mill are activated-ability-only costs, never spell
                     // additional costs (canPayAdditionalCost already reports Mill unpayable).
                     is CostAtom.Mana, is CostAtom.RevealFromHand,
-                    is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents,
+                    is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents,
                     is CostAtom.Mill -> {}
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
@@ -2501,11 +2501,11 @@ class CastSpellHandler(
                         }
                         // PayLife is auto-paid in the loop above; mana / reveal aren't spell additional
                         // costs; put-counters-on-self is ability-scoped (a spell on the stack has no
-                        // permanent to accrue them on); ExilePermanents and Mill are
+                        // permanent to accrue them on); VariablePermanents and Mill are
                         // activated-ability-only costs, never spell additional costs (and
                         // canPayAdditionalCost reports Mill unpayable, so this is unreachable).
                         is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand,
-                        is CostAtom.PutCountersOnSelf, is CostAtom.ExilePermanents,
+                        is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents,
                         is CostAtom.Mill -> {}
                         is CostAtom.RemoveCounters -> {
                             val resolvedRemovals = resolveDistributedCounterRemovalsForPayment(action)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ActivateAbilityXCostContinuationResumer.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.ActivateAbilityChooseManaXContinuation
 import com.wingedsheep.engine.core.ActivateAbilityChooseXContinuation
 import com.wingedsheep.engine.core.ActivateAbilityControllerTargetContinuation
 import com.wingedsheep.engine.core.ActivateAbilityExileFromGraveyardContinuation
-import com.wingedsheep.engine.core.ActivateAbilityExilePermanentsContinuation
+import com.wingedsheep.engine.core.ActivateAbilityVariablePermanentsContinuation
 import com.wingedsheep.engine.core.ActivateAbilityExileXFromGraveyardContinuation
 import com.wingedsheep.engine.core.ActivateAbilitySacrificeContinuation
 import com.wingedsheep.engine.core.ActivateAbilityTapXTargetsContinuation
@@ -57,7 +57,7 @@ class ActivateAbilityXCostContinuationResumer(
         resumer(ActivateAbilityTapXTargetsContinuation::class, ::resumeTapXTargets),
         resumer(ActivateAbilityExileFromGraveyardContinuation::class, ::resumeExileFromGraveyard),
         resumer(ActivateAbilitySacrificeContinuation::class, ::resumeSacrifice),
-        resumer(ActivateAbilityExilePermanentsContinuation::class, ::resumeExilePermanents),
+        resumer(ActivateAbilityVariablePermanentsContinuation::class, ::resumeVariablePermanents),
         resumer(ActivateAbilityControllerTargetContinuation::class, ::resumeControllerTargets)
     )
 
@@ -257,48 +257,48 @@ class ActivateAbilityXCostContinuationResumer(
     }
 
     /**
-     * Resume after the controller picks which permanents to exile for a variable-count
-     * `CostAtom.ExilePermanents` cost — "Exile one or more other [filter] you control with total
-     * mana value X" (Fabrication Foundry). Fills the chosen permanents into
-     * `costPayment.exiledCards` and re-enters the handler, which computes X (their total mana value)
-     * and pauses again for the X-bounded target.
+     * Resume after the controller picks which permanents pay a variable-count
+     * `CostAtom.VariablePermanents` cost — "Exile one or more other [filter] you control with total
+     * mana value X" (Fabrication Foundry) or "Sacrifice one or more [filter]" (Radiant Lotus).
+     * Fills the chosen permanents into `costPayment.variableCostPermanents` and re-enters the
+     * handler, which computes X from them and pauses again for the ability's target.
      */
-    private fun resumeExilePermanents(
+    private fun resumeVariablePermanents(
         state: GameState,
-        continuation: ActivateAbilityExilePermanentsContinuation,
+        continuation: ActivateAbilityVariablePermanentsContinuation,
         response: DecisionResponse,
         checkForMore: CheckForMore
     ): ExecutionResult {
         if (response is CancelDecisionResponse) {
-            // The exile cost is paid after this pause, so bailing here is side-effect-free.
+            // The cost is paid after this pause, so bailing here is side-effect-free.
             return ExecutionResult.success(state.withPriority(continuation.action.playerId))
         }
         if (response !is CardsSelectedResponse) {
-            return ExecutionResult.error(state, "Expected card-selection response for ActivateAbility ExilePermanents")
+            return ExecutionResult.error(state, "Expected card-selection response for ActivateAbility VariablePermanents")
         }
         val selected = response.selectedCards
         if (selected.size < continuation.minCount) {
             return ExecutionResult.error(
                 state,
-                "Must exile at least ${continuation.minCount} permanent(s), got ${selected.size}"
+                "Must choose at least ${continuation.minCount} permanent(s), got ${selected.size}"
             )
         }
         if (selected.toSet().size != selected.size) {
-            return ExecutionResult.error(state, "Cannot exile the same permanent twice for one cost")
+            return ExecutionResult.error(state, "Cannot choose the same permanent twice for one cost")
         }
-        if (selected.any { it !in continuation.exileCandidates }) {
-            return ExecutionResult.error(state, "Selected permanent is not in the list of valid exile candidates")
+        if (selected.any { it !in continuation.candidates }) {
+            return ExecutionResult.error(state, "Selected permanent is not in the list of valid candidates")
         }
         val action = continuation.action
         val replay = action.copy(
             costPayment = (action.costPayment ?: AdditionalCostPayment())
-                .copy(exiledCards = selected)
+                .copy(variableCostPermanents = selected)
         )
         return reenter(handler.execute(state, replay), checkForMore)
     }
 
     /**
-     * Resume after the controller picks the X-bounded target of an `ExilePermanents` ability
+     * Resume after the controller picks the X-bounded target of an `VariablePermanents` ability
      * (Fabrication Foundry: "Return target artifact card with mana value X or less …"). The exile
      * selection — and thus X — is already on the action; convert the response into [ChosenTarget]s,
      * fill `action.targets`, and re-enter the handler to pay the cost and put the ability on the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -76,9 +76,9 @@ class CostPaymentContinuationResumer(
             // (nothing to select) if one is ever built.
             is CostAtom.PutCountersOnSelf ->
                 resumeYesNo(state, continuation, cost, response, checkForMore)
-            // ExilePermanents is an activated-ability-only cost, never a PayCost — unreachable here.
-            is CostAtom.ExilePermanents ->
-                ExecutionResult.error(state, "ExilePermanents is not a payable cost in this context")
+            // VariablePermanents is an activated-ability-only cost, never a PayCost — unreachable here.
+            is CostAtom.VariablePermanents ->
+                ExecutionResult.error(state, "VariablePermanents is not a payable cost in this context")
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaOfChoiceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/mana/AddManaOfChoiceExecutor.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import kotlin.reflect.KClass
 
 /**
@@ -99,8 +100,13 @@ class AddManaOfChoiceExecutor(
     }
 
     /**
-     * Add [color] mana to the controller's pool. Exposed for the
+     * Add [color] mana to the recipient's pool. Exposed for the
      * `ChooseManaColorContinuation` resumer to call after a color decision.
+     *
+     * The recipient is the controller for every mana ability (CR 605.1a) and for the default
+     * [AddManaOfChoiceEffect.recipient]; a targeted "target player adds …" ability (Radiant Lotus)
+     * resolves it to that player instead. A recipient that can no longer be resolved — a targeted
+     * player who has left the game — produces no mana rather than silently paying the controller.
      *
      * @param availableColors The resolved color set at decision time; passed back here so
      *   a stale `manaColorChoice` from another path can't slip an illegal color through.
@@ -113,6 +119,8 @@ class AddManaOfChoiceExecutor(
         availableColors: Set<Color>,
     ): EffectResult {
         if (color !in availableColors) return EffectResult.success(state)
+        val recipientId = if (effect.recipient == EffectTarget.Controller) context.controllerId
+            else context.resolvePlayerTarget(effect.recipient, state) ?: return EffectResult.success(state)
         val amount = amountEvaluator.evaluate(state, effect.amount, context)
         if (amount <= 0) return EffectResult.success(state)
 
@@ -122,7 +130,7 @@ class AddManaOfChoiceExecutor(
         val effectiveRestriction: ManaRestriction? = effect.restriction
             ?: if (effect.riders.isNotEmpty()) ManaRestriction.AnySpend else null
 
-        var newState = state.updateEntity(context.controllerId) { container ->
+        var newState = state.updateEntity(recipientId) { container ->
             val pool = container.get<ManaPoolComponent>() ?: ManaPoolComponent()
             val updated = if (effectiveRestriction != null) {
                 pool.addRestricted(color, amount, effectiveRestriction, effect.riders)
@@ -133,12 +141,12 @@ class AddManaOfChoiceExecutor(
         }
 
         if (effectiveRestriction == null) {
-            newState = ManaProvenanceTracker.tagAddedMana(newState, context.controllerId, context.sourceId, amount)
+            newState = ManaProvenanceTracker.tagAddedMana(newState, recipientId, context.sourceId, amount)
         }
 
         val sourceName = context.sourceId?.let { newState.getEntity(it)?.get<CardComponent>()?.name }
         val event = ManaAddedEvent(
-            playerId = context.controllerId,
+            playerId = recipientId,
             sourceId = context.sourceId,
             sourceName = sourceName,
             white = if (color == Color.WHITE) amount else 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -88,7 +88,7 @@ class PayOrSufferExecutor(
                 is CostAtom.RevealFromHand -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
                 is CostAtom.PutCountersOnSelf -> EffectResult.error(state, "PutCountersOnSelf is an activated-ability cost, not a PayOrSuffer cost")
                 is CostAtom.Mill -> EffectResult.error(state, "Mill payment for PayOrSuffer not yet implemented")
-                is CostAtom.ExilePermanents -> EffectResult.error(state, "ExilePermanents payment for PayOrSuffer not supported")
+                is CostAtom.VariablePermanents -> EffectResult.error(state, "VariablePermanents payment for PayOrSuffer not supported")
                 is CostAtom.RemoveCounters -> handleRemoveCountersCost(state, effect, context, atom, sourceId, sourceCard.name, payingPlayerId)
             }
         }
@@ -714,7 +714,7 @@ class PayOrSufferExecutor(
                 is CostAtom.ReturnToHand -> false
                 is CostAtom.RevealFromHand -> false
                 is CostAtom.PutCountersOnSelf -> false
-                is CostAtom.ExilePermanents -> false
+                is CostAtom.VariablePermanents -> false
                 // No printed PayOrSuffer cost mills, and the execute branch above has no handler,
                 // so report it unpayable rather than offering a prompt that would error out.
                 is CostAtom.Mill -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -239,7 +239,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                             )
                             if (sacrificeTargets.size < atom.count) continue
                         }
-                        is CostAtom.ExilePermanents -> {
+                        is CostAtom.VariablePermanents -> {
                             // "Exile one or more other [filter] you control …" (Fabrication Foundry).
                             // Affordable when at least minCount eligible permanents exist; the player
                             // picks which during activation (the handler pauses). Same candidate pool
@@ -388,7 +388,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                             break
                                         }
                                     }
-                                    is CostAtom.ExilePermanents -> {
+                                    is CostAtom.VariablePermanents -> {
                                         // "Exile one or more other [filter] you control …" as one leg
                                         // of a composite cost (Fabrication Foundry's {2}{W}, {T},
                                         // Exile …). Affordable when at least minCount eligible
@@ -840,7 +840,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     // fizzle. Surface a bare action; the handler pauses first for the exile selection,
                     // then for the X-bounded target, in order. (The satisfiability gate above still
                     // applies — no artifact card in the graveyard means no legal target at any X.)
-                    if (costContainsExilePermanents(effectiveCost)) {
+                    if (costContainsVariablePermanents(effectiveCost)) {
                         result.add(LegalAction(
                             actionType = "ActivateAbility",
                             description = displayDescription,
@@ -1256,10 +1256,10 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
      * "real" effect is hidden inside (e.g., Figure of Fable's `ConditionalEffect(... BecomeCreature)`) is
      * also excluded.
      */
-    /** True when [cost] contains a [CostAtom.ExilePermanents] atom (top-level or in a Composite). */
-    private fun costContainsExilePermanents(cost: AbilityCost): Boolean = when (cost) {
-        is AbilityCost.Atom -> cost.atom is CostAtom.ExilePermanents
-        is AbilityCost.Composite -> cost.costs.any { costContainsExilePermanents(it) }
+    /** True when [cost] contains a [CostAtom.VariablePermanents] atom (top-level or in a Composite). */
+    private fun costContainsVariablePermanents(cost: AbilityCost): Boolean = when (cost) {
+        is AbilityCost.Atom -> cost.atom is CostAtom.VariablePermanents
+        is AbilityCost.Composite -> cost.costs.any { costContainsVariablePermanents(it) }
         else -> false
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -172,8 +172,8 @@ class CostPaymentService(private val services: EngineServices) {
                         }
                     }
                 }
-                // ExilePermanents is an activated-ability-only cost, never a PayCost.
-                is CostAtom.ExilePermanents -> PaymentResult.Unaffordable(state)
+                // VariablePermanents is an activated-ability-only cost, never a PayCost.
+                is CostAtom.VariablePermanents -> PaymentResult.Unaffordable(state)
             }
         }
     }
@@ -320,8 +320,8 @@ class CostPaymentService(private val services: EngineServices) {
             // cost is paid through CostHandler.payAtom, which owns the counter-placement path.
             is CostAtom.PutCountersOnSelf -> CostPaymentExecution(state, emptyList(), success = false)
             is CostAtom.RemoveCounters -> performRemoveCounters(state, payerId, atom, sourceId, selected)
-            // ExilePermanents is an activated-ability-only cost, never a PayCost.
-            is CostAtom.ExilePermanents -> CostPaymentExecution(state, emptyList(), success = false)
+            // VariablePermanents is an activated-ability-only cost, never a PayCost.
+            is CostAtom.VariablePermanents -> CostPaymentExecution(state, emptyList(), success = false)
         }
     }
 
@@ -685,8 +685,8 @@ class CostPaymentService(private val services: EngineServices) {
                             total >= needed
                         }
                     }
-                    // ExilePermanents is an activated-ability-only cost, never a PayCost.
-                    is CostAtom.ExilePermanents -> false
+                    // VariablePermanents is an activated-ability-only cost, never a PayCost.
+                    is CostAtom.VariablePermanents -> false
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FabricationFoundryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FabricationFoundryScenarioTest.kt
@@ -21,7 +21,7 @@ import io.kotest.matchers.shouldBe
  * control with total mana value X: Return target artifact card with mana value X or less from your
  * graveyard to the battlefield. Activate only as a sorcery."
  *
- * Exercises the new `Costs.ExilePermanents` variable-count cost end to end: X is the total mana
+ * Exercises the new `Costs.VariablePermanents` variable-count cost end to end: X is the total mana
  * value of the exiled artifacts (CR 601.2b), and the graveyard target's "mana value X or less"
  * legality is measured against it at activation (CR 601.2c) and re-validated at resolution
  * (CR 608.2b). Drives the engine-direct path (a fully-formed action with the exile selection and
@@ -61,7 +61,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(toExile))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(toExile))
             )
         )
         driver.bothPass()
@@ -89,7 +89,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(exile1, exile2))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(exile1, exile2))
             )
         )
         driver.bothPass()
@@ -115,7 +115,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(toExile))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(toExile))
             )
         )
         result.isSuccess shouldBe false
@@ -142,7 +142,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(toExile))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(toExile))
             )
         )
         driver.bothPass()
@@ -166,7 +166,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(toExile))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(toExile))
             )
         )
         result.isSuccess shouldBe false
@@ -188,7 +188,7 @@ class FabricationFoundryScenarioTest : FunSpec({
                 sourceId = foundry,
                 abilityId = reanimateAbilityId(),
                 targets = listOf(ChosenTarget.Card(inGraveyard, p1, Zone.GRAVEYARD)),
-                costPayment = AdditionalCostPayment(exiledCards = listOf(foundry))
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(foundry))
             )
         )
         result.isSuccess shouldBe false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadiantLotusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadiantLotusScenarioTest.kt
@@ -1,0 +1,330 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dft.cards.RadiantLotus
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Radiant Lotus — "{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three
+ * mana of the chosen color for each artifact sacrificed this way."
+ *
+ * Exercises both halves of the feature end to end:
+ *
+ *  - `Costs.SacrificePermanents` — the variable-count *sacrifice* cost whose X is the **count** of
+ *    permanents chosen (CR 601.2b), not their total mana value. The chosen artifacts must land in
+ *    the graveyard (a sacrifice, CR 701.17a), not in exile.
+ *  - `AddManaOfChoiceEffect.recipient` — the mana goes to the **target player's** pool while the
+ *    colour is still the controller's choice.
+ *
+ * Also pins the timing consequences: because the ability targets it is *not* a mana ability
+ * (CR 605.1a), so it uses the stack and no mana appears until it resolves.
+ */
+class RadiantLotusScenarioTest : FunSpec({
+
+    // A plain artifact to feed the sacrifice cost, and a non-artifact permanent that must not be
+    // an eligible choice for it.
+    val trinket = card("Test Trinket") { manaCost = "{1}"; typeLine = "Artifact" }
+    val totem = card("Test Totem") { manaCost = "{2}"; typeLine = "Enchantment" }
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RadiantLotus, trinket, totem))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    val abilityId = RadiantLotus.activatedAbilities.first().id
+
+    fun GameTestDriver.pool(playerId: com.wingedsheep.sdk.model.EntityId): ManaPoolComponent =
+        state.getEntity(playerId)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    test("sacrificing one artifact gives the target player three mana of the chosen colour") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val sacrificed = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(sacrificed))
+            )
+        )
+        d.bothPass()
+
+        // "Choose a color" — the controller picks, not the recipient.
+        val decision = d.pendingDecision
+        decision.shouldBeInstanceOf<ChooseColorDecision>()
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.BLUE))
+
+        // Three mana of the chosen colour, in the *target's* pool only.
+        d.pool(opponent).getAmount(Color.BLUE) shouldBe 3
+        d.pool(opponent).getAmount(Color.RED) shouldBe 0
+        d.pool(you).getAmount(Color.BLUE) shouldBe 0
+    }
+
+    test("three mana per artifact — sacrificing three artifacts adds nine") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val a = d.putPermanentOnBattlefield(you, "Test Trinket")
+        val b = d.putPermanentOnBattlefield(you, "Test Trinket")
+        val c = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(a, b, c))
+            )
+        )
+        d.bothPass()
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.GREEN))
+
+        // X is the *count* of artifacts sacrificed (3), not their total mana value (also 3 here by
+        // coincidence of MV1 each — the next test separates the two measures).
+        d.pool(opponent).getAmount(Color.GREEN) shouldBe 9
+    }
+
+    test("X is the count of artifacts sacrificed, not their total mana value") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        // Two artifacts of mana value 1 and 6: total MV 7, count 2.
+        val cheap = d.putPermanentOnBattlefield(you, "Test Trinket")
+        val expensive = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(cheap, expensive))
+            )
+        )
+        d.bothPass()
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.WHITE))
+
+        // 2 artifacts × 3 = 6. A TOTAL_MANA_VALUE measure would have produced 21.
+        d.pool(opponent).getAmount(Color.WHITE) shouldBe 6
+    }
+
+    test("the cost is a sacrifice — the artifacts go to the graveyard, not exile") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val sacrificed = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(sacrificed))
+            )
+        )
+
+        d.state.getZone(ZoneKey(you, Zone.GRAVEYARD)).contains(sacrificed) shouldBe true
+        d.state.getZone(ZoneKey(you, Zone.EXILE)).contains(sacrificed) shouldBe false
+        d.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(sacrificed) shouldBe false
+    }
+
+    test("Radiant Lotus may sacrifice itself to its own cost") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+
+        // The only artifact on the battlefield is the Lotus itself — it is a legal choice, so the
+        // ability is activatable with nothing else in play (`excludeSelf = false`).
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(lotus))
+            )
+        )
+        d.state.getZone(ZoneKey(you, Zone.GRAVEYARD)).contains(lotus) shouldBe true
+
+        d.bothPass()
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.BLACK))
+
+        // The ability resolves even though its source is gone — it is independent of the source
+        // once on the stack (CR 113.7a).
+        d.pool(opponent).getAmount(Color.BLACK) shouldBe 3
+    }
+
+    test("the target player may be yourself") {
+        val d = setup()
+        val you = d.activePlayer!!
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val sacrificed = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(you)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(sacrificed))
+            )
+        )
+        d.bothPass()
+        val decision = d.pendingDecision as ChooseColorDecision
+        d.submitDecision(you, ColorChosenResponse(decision.id, Color.RED))
+
+        d.pool(you).getAmount(Color.RED) shouldBe 3
+    }
+
+    test("it is not a mana ability — no mana appears until the ability resolves") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val sacrificed = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(sacrificed))
+            )
+        )
+
+        // Because it targets, it uses the stack (CR 605.1a): the cost is paid but no mana yet.
+        d.state.stack.size shouldBe 1
+        d.pool(opponent).getAmount(Color.BLUE) shouldBe 0
+        d.pool(opponent).getAmount(Color.RED) shouldBe 0
+    }
+
+    test("a non-artifact permanent cannot pay the sacrifice cost") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val enchantment = d.putPermanentOnBattlefield(you, "Test Totem")
+
+        val result = d.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = lotus,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                costPayment = AdditionalCostPayment(variableCostPermanents = listOf(enchantment))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull()
+        d.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(enchantment) shouldBe true
+    }
+
+    test("UI flow: a bare activation pauses for the sacrifice choice, then the target, then the colour") {
+        val d = setup()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val a = d.putPermanentOnBattlefield(you, "Test Trinket")
+        val b = d.putPermanentOnBattlefield(you, "Test Trinket")
+        val totemId = d.putPermanentOnBattlefield(you, "Test Totem")
+
+        // The client submits the bare action — no cost selection, no target. The engine pauses
+        // rather than succeeding outright.
+        d.submit(ActivateAbility(playerId = you, sourceId = lotus, abilityId = abilityId))
+            .isPaused shouldBe true
+
+        // 1. Which artifacts to sacrifice. All three artifacts (including the Lotus) are offered;
+        //    the enchantment is not.
+        val sacrificeDecision = d.pendingDecision
+        sacrificeDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        sacrificeDecision.options.toSet() shouldBe setOf(lotus, a, b)
+        sacrificeDecision.options.contains(totemId) shouldBe false
+        sacrificeDecision.minSelections shouldBe 1
+        sacrificeDecision.maxSelections shouldBe 3
+        d.submitDecision(you, CardsSelectedResponse(sacrificeDecision.id, listOf(a, b)))
+
+        // 2. Which player to target.
+        val targetDecision = d.pendingDecision
+        targetDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        d.submitDecision(you, TargetsResponse(targetDecision.id, mapOf(0 to listOf(opponent))))
+
+        // The cost is paid and the ability is on the stack.
+        d.state.getZone(ZoneKey(you, Zone.GRAVEYARD)).contains(a) shouldBe true
+        d.state.getZone(ZoneKey(you, Zone.GRAVEYARD)).contains(b) shouldBe true
+        d.bothPass()
+
+        // 3. Which colour, chosen by the controller as the ability resolves.
+        val colorDecision = d.pendingDecision
+        colorDecision.shouldBeInstanceOf<ChooseColorDecision>()
+        d.submitDecision(you, ColorChosenResponse(colorDecision.id, Color.RED))
+
+        d.pool(opponent).getAmount(Color.RED) shouldBe 6
+    }
+
+    test("cancelling the sacrifice choice leaves the board untouched") {
+        val d = setup()
+        val you = d.activePlayer!!
+
+        val lotus = d.putPermanentOnBattlefield(you, "Radiant Lotus")
+        val sacrificed = d.putPermanentOnBattlefield(you, "Test Trinket")
+
+        d.submit(ActivateAbility(playerId = you, sourceId = lotus, abilityId = abilityId))
+            .isPaused shouldBe true
+        val decision = d.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, com.wingedsheep.engine.core.CancelDecisionResponse(decision.id))
+
+        // The cost is paid after the pause, so backing out costs nothing.
+        d.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(sacrificed) shouldBe true
+        d.state.getZone(ZoneKey(you, Zone.BATTLEFIELD)).contains(lotus) shouldBe true
+        d.isTapped(lotus) shouldBe false
+        d.state.stack.size shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements **Radiant Lotus** (Aetherdrift #240) — *"{T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way."*

It was one of the five Aetherdrift cards blocked on engine capability, and it needed two things the SDK didn't have. Both are generalizations of primitives already in the engine rather than new one-off types, so the diff is mostly a rename plus two parameters.

## Variable-count permanent costs

`CostAtom.ExilePermanents` becomes `CostAtom.VariablePermanents` with two orthogonal axes, so one atom and one set of engine machinery covers both printed shapes:

| Axis | Values | Cards |
|---|---|---|
| `action` | `EXILE` / `SACRIFICE` | Fabrication Foundry / Radiant Lotus |
| `xMeasure` | `TOTAL_MANA_VALUE` / `COUNT` | "with total mana value X" / "for each … sacrificed this way" |

A `SACRIFICE` cost routes through the shared `paySacrificeList`, so the permanents land in their owners' graveyards and fire "whenever you sacrifice" triggers and Food tracking; an `EXILE` cost keeps the battlefield→exile transition it had. Either `xMeasure` is announced at activation (CR 601.2b) and stored on the stack, so an X-bounded target is re-validated at resolution (CR 608.2b) and a resolution-time `DynamicAmount.XValue` read can't be changed by removal in response.

The chosen permanents travel in their own `variableCostPermanents` channel on `AdditionalCostPayment` rather than sharing `exiledCards` / `sacrificedPermanents`, so an ability carrying both a fixed and a variable permanent cost stays unambiguous.

`Costs.ExilePermanents(...)` keeps its signature; `Costs.SacrificePermanents(...)` is the new named entry point (`excludeSelf = false` by default — Radiant Lotus is an artifact and may sacrifice itself to its own cost).

## Mana recipients

`AddManaOfChoiceEffect` gains `recipient: EffectTarget`, defaulting to the controller — the only shape a mana ability can have (CR 605.1a). Pointing it at a target routes the mana to that player's pool, `ManaAddedEvent` and provenance tag, while the **colour stays the controller's choice**: "Choose a color" names no other chooser. An ability with a non-default recipient targets, so by definition it isn't a mana ability — it uses the stack, can be responded to, and the mana arrives at resolution.

## Tests

`RadiantLotusScenarioTest` (10 cases) covers the rules matrix: three mana per artifact; X measured as the *count* rather than total mana value (two artifacts of MV 1 and 6 → 6 mana, not 21); the cost is a sacrifice so the artifacts hit the graveyard, not exile; the Lotus sacrificing itself and the ability still resolving from the stack; targeting yourself; the stack-not-mana-ability timing; a non-artifact rejected; the full client pause flow (select artifacts → choose target → choose colour); and a cancel leaving the board untouched.

`FabricationFoundryScenarioTest` passes unchanged apart from the renamed payment field, which is the regression net for the refactor.

## Verification

- `just test` — full suite green
- `just rebless-cards` — snapshot diff is exactly Radiant Lotus's tree added to `DFT.json` plus the one-line `AtomExilePermanents` → `AtomVariablePermanents` rename in `LCI.json`; no unrelated card moved
- `just check-card-printing "Radiant Lotus"` — canonical sits in DFT, its earliest real printing
- `just check-backlog` — in sync

Also updates `docs/card-sdk-language-reference.md` and registers the two mtgish IR cost tags this unlocks (`SacrificeOneOrMorePermanents`, `ExileNumberOrMoreGroupPermanents`) in the bridge.

Aetherdrift is now **272/276**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)