### PR TITLE
Add four Marvel's Spider-Man cards + chosen-card-type / harness display plumbing

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 181 / 188
+**Implemented:** 182 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -166,7 +166,7 @@
 - [x] Terrific Team-Up
 - [ ] The Clone Saga
 - [x] The Death of Gwen Stacy
-- [ ] The Soul Stone
+- [x] The Soul Stone
 - [x] The Spot's Portal
 - [x] The Spot, Living Portal
 - [x] Thwip!

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,13 +2,13 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 180 / 188
+**Implemented:** 181 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
 - [x] Anti-Venom, Horrifying Healer
-- [ ] Arachne, Psionic Weaver
+- [x] Arachne, Psionic Weaver
 - [x] Araña, Heart of the Spider
 - [x] Aunt May
 - [x] Bagel and Schmear

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 182 / 188
+**Implemented:** 183 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -164,7 +164,7 @@
 - [x] Symbiote Spider-Man
 - [x] Taxi Driver
 - [x] Terrific Team-Up
-- [ ] The Clone Saga
+- [x] The Clone Saga
 - [x] The Death of Gwen Stacy
 - [x] The Soul Stone
 - [x] The Spot's Portal

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 179 / 188
+**Implemented:** 180 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -22,7 +22,7 @@
 - [x] City Pigeon
 - [x] Common Crook
 - [x] Cosmic Spider-Man
-- [ ] Costume Closet
+- [x] Costume Closet
 - [x] Daily Bugle Building
 - [x] Daily Bugle Reporters
 - [x] Damage Control Crew

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -41,7 +41,17 @@ Still blocked (not on web-slinging itself):
   keyword is now grantable in principle, but the "your legendary spells have web-slinging" grant is
   not yet wired — separate follow-up).
 
-## "Choose a card type" durable enters-choice + "spells of the chosen type cost {1} more" static
+## "Choose a card type" durable enters-choice + "spells of the chosen type cost {1} more" static — ✅ IMPLEMENTED
+
+**Done** (branch `spm-arachne`). New durable card-type choice dimension: `ChoiceSlot.CARD_TYPE`,
+`Effects.ChooseCardTypeForSource(allowedCardTypes, lookAtOpponentHand)` (on-resolution, writes the slot
+durably — the analogue of `ChooseNumberForSource`, run from a "when ~ enters" trigger), and
+`CardPredicate.CardTypeEqualsChosenComponent` / `GameObjectFilter.ofChosenCardTypeComponent()` read at
+cost-calculation time. The tax is a plain `ModifySpellCost(AnyCaster(ofChosenCardTypeComponent()),
+IncreaseGeneric(1))` (Thalia shape). Scenario test pins the durable write + the symmetric tax
+(chosen-type spell costs {1} more, other types untaxed).
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > As Arachne enters, look at an opponent's hand, then **choose a card type** other than creature.
 > **Spells of the chosen type cost {1} more to cast.**
@@ -56,6 +66,8 @@ stored choice feeding a cost-increase). "Look at an opponent's hand" is informat
 
 Blocked cards:
 - **Arachne, Psionic Weaver** [2] — web-slinging implemented; the choose-a-card-type tax is the blocker.
+
+</details>
 
 ## Harness / Infinity Stone ∞ ability
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -208,7 +208,18 @@ Blocked cards:
 - **Spider-Slayer, Hatred Honed** [175] — `{2}` Legendary Artifact Creature; "Whenever Spider-Slayer deals damage to a Spider, destroy that creature" (blocked). Its other ability — `{6}`, exile-from-graveyard → two tapped 1/1 flying Robot tokens — works fine.
 </details>
 
-## Chosen card name surviving into a later-firing delayed trigger
+## Chosen card name surviving into a later-firing delayed trigger — ✅ IMPLEMENTED
+
+**Done** (branch `spm-clone-saga`). `CreateDelayedTriggerExecutor.bakeChosenValuesIntoTrigger` now
+also rewrites `NameEqualsChosen(v)` → literal `NameEquals(chosen[v])` and handles a
+`DealsDamageEvent.sourceFilter` (not just `SpellCastEvent.spellFilter`), via a shared
+`bakeChosenValuesIntoFilter` helper. So chapter III models as `Composite(ChooseCardName("clonedName"),
+CreateDelayedTrigger(dealsDamage(Combat, AnyPlayer, Creature.namedFromVariable("clonedName")),
+DrawCards(1)))`. Chapters I (Surveil 3) and II (`CreateDelayedTrigger(YouCastCreature,
+CopyTargetSpell(TriggeringEntity, removeLegendary=true), fireOnce=true)`) needed no engine change.
+Scenario test pins the chapter-III chosen-name combat-damage draw.
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Choose a card name. Whenever a creature with the **chosen name** deals combat damage to a
 > player this turn, draw a card.
@@ -225,6 +236,8 @@ event filters (e.g. `DealsDamageEvent.sourceFilter`), + verify the delayed match
 
 Blocked cards:
 - **The Clone Saga** [28] — `{3}{U}` Enchantment — Saga; chapters I (Surveil 3) and II (copy your next creature spell, non-legendary — both expressible today) are fine, but chapter III ("choose a card name … whenever a creature with the chosen name deals combat damage, draw") is blocked
+
+</details>
 
 ## Exchange life totals with a player (CR 701.12c) + "life you lost this way" draw amount — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -69,7 +69,18 @@ Blocked cards:
 
 </details>
 
-## Harness / Infinity Stone ∞ ability
+## Harness / Infinity Stone ∞ ability — ✅ IMPLEMENTED
+
+**Done** (branch `spm-soul-stone`). Modeled composition-first: "Harness" is a binary marker counter
+(`Counters.HARNESS`, a new `CounterType` enum value — the only new vocabulary). The Harness activated
+ability places one via `Effects.AddCounters`; the `∞` triggered ability is gated on the permanent
+having a harness counter (`Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.HARNESS))`),
+so it's dormant until harnessed and reactivates each qualifying trigger thereafter. A counter (not a
+durable component) matches the flavor — it resets if the permanent leaves, and re-placing is
+idempotent. No new engine executor/handler needed. Scenario test pins the gating (reanimates only
+while harnessed).
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > `{cost}, {T}, Exile a creature you control: Harness <this>. (Once harnessed, its ∞ ability
 > is active.)` — ∞ — <ongoing ability>
@@ -80,6 +91,8 @@ static/triggered ability). `add-feature` territory.
 
 Blocked cards:
 - **The Soul Stone** [66] — `{1}{B}` Legendary Artifact — Infinity Stone; harness → `∞` upkeep reanimation
+
+</details>
 
 ## Mayhem (new keyword — self graveyard-cast gated on "you discarded this card this turn") — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -123,7 +123,16 @@ which requires Riot to exist as a grantable keyword. `add-feature` scope.
 Blocked cards:
 - **Spider-Punk** [92] — `{1}{R}` Riot; "Other Spiders you control have riot"; also "Spells and abilities can't be countered" + "Damage can't be prevented" (verify those two independently)
 
-## "Modified" state on a leaves-the-battlefield (last-known-information) trigger
+## "Modified" state on a leaves-the-battlefield (last-known-information) trigger — ✅ IMPLEMENTED
+
+**Done** (branch `spm-modified-ltb`). `EntitySnapshot` now captures `wasEquipped` / `wasEnchanted`
+(populated in `ZoneTransitionService` before the exit cleanup strips attachments), and
+`TriggerMatcher.matchesStatePredicateForZoneChangeTrigger` evaluates `IsModified` / `IsEquipped` /
+`IsEnchanted` against the snapshot (counters + those flags) on a leaves-battlefield trigger instead
+of falling through fail-open. Costume Closet ships with a scenario test covering the counter,
+equipped, and unmodified (regression-guard) legs.
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Whenever a **modified** creature you control **leaves the battlefield**, …
 
@@ -141,6 +150,8 @@ battlefield-exit (or the predicate evaluated against pre-leave state). `add-feat
 
 Blocked cards:
 - **Costume Closet** [5] — `{1}{W}` Artifact; enters with two +1/+1 counters + sorcery-speed "{T}: move a counter to target creature you control" (both of those work today) + "Whenever a **modified** creature you control leaves the battlefield, put a +1/+1 counter on this artifact" (the blocked part)
+
+</details>
 
 ## "Deals damage to a [filtered] creature" trigger (RecipientFilter.Matching on a deals-damage trigger) — ✅ IMPLEMENTED
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1998,6 +1998,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   promised opponent in the same slot as part of the cast — see § 11 "Gift".) The *as-enters* analogue
   is `EntersWithChoice(ChoiceType.OPPONENT)`,
   which writes the same slot (Jihad, The Rack).
+- `Effects.ChooseCardTypeForSource(allowedCardTypes=null, lookAtOpponentHand=false, slot=ChoiceSlot.CARD_TYPE, prompt)`
+  — the controller picks a card type (CR 205.2a), **stored durably on the source entity** under
+  `ChoiceSlot.CARD_TYPE` (a `ChoiceValue.TextChoice`) and read back at cost-calculation / projection
+  time by `CardPredicate.CardTypeEqualsChosenComponent` (build the filter with
+  `GameObjectFilter.…ofChosenCardTypeComponent()`). `allowedCardTypes` restricts the offered set (pass
+  the non-creature list for "a card type other than creature"); `lookAtOpponentHand` reveals an
+  opponent's hand to the controller first. The on-resolution, durable-slot analogue of an as-enters
+  card-type choice — the same relationship `ChooseNumberForSource` has to `EntersWithChoice(NUMBER)`;
+  use it in a "when ~ enters" trigger when the chosen type only feeds a continuous tax (Arachne,
+  Psionic Weaver — "choose a card type … Spells of the chosen type cost {1} more").
 - `GrantHexproofFromChosenColorEffect(target)` — hexproof from chosen color.
 - `GrantProtectionFromChosenColorEffect(target)` — protection from chosen color. Must run inside `ChooseColorThen`; wrap in `ForEachInGroup` for the group case (Akroma's Blessing: "Creatures you control gain protection from the chosen color").
 - `Effects.GrantProtectionFromChosenCardType(target, duration)` — "gains protection from the card type of your choice" (Pippin, Guard of the Citadel). The card-type analogue of `GrantProtectionFromChosenColor`, but **self-contained**: its executor owns the choice — it presents a `ChooseOptionDecision` over the fixed protectable card-type set (Artifact, Creature, Enchantment, Instant, Land, Planeswalker, Sorcery, Battle) and, on response, grants a floating `PROTECTION_FROM_CARDTYPE_<TYPE>` keyword for `duration`. The targeting validator, `StackResolver` spell-targeting, `DamageUtils`, the combat-damage pipeline/manager, and a `ProtectionFromCardTypeRule` block-evasion rule all match the protected keyword against the source's projected card types. (The "can't be enchanted/equipped by that type" clause is reminder text and unenforced at attach time, mirroring color/subtype protection.)
@@ -2884,6 +2894,12 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   evaluated. Pair with `replacementEffect(EntersWithChoice(ChoiceType.CARD_NAME))`. Fails closed (no match) before
   a name is chosen. Used by name-keyed static abilities (Petrified Hamlet — "sources with the chosen name … /
   Lands with the chosen name …").
+- `.ofChosenCardTypeComponent(slot = ChoiceSlot.CARD_TYPE)` — `CardPredicate.CardTypeEqualsChosenComponent`:
+  the card-type analogue of `.namedFromChosenComponent`. Matches cards whose **card type** equals the type
+  **durably chosen by the source permanent** (read from its `CastChoicesComponent` under `slot`). Same
+  static-projection / cost-calculation safety and source-id keying. Pair with a trigger running
+  `Effects.ChooseCardTypeForSource`. Fails closed before a type is chosen. Used by card-type-keyed taxes
+  (Arachne, Psionic Weaver — "Spells of the chosen type cost {1} more").
 - `.originallyPrintedInSet(setCode)` — `CardPredicate.OriginallyPrintedInSet`: matches a card whose
   *canonical* set code equals `setCode` (case-insensitive), i.e. the set it was *originally printed* in —
   reprints still match their original set, regardless of the printing in play. Reads the entity's

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -158,6 +158,7 @@ class ScenarioBuilderService(
                 summoningSickness = card.summoningSickness ?: false,
                 counters = card.counters ?: emptyMap(),
                 chosenCreatureType = card.chosenCreatureType,
+                chosenCardType = card.chosenCardType,
                 chosenColor = card.chosenColor
             )
         }
@@ -243,6 +244,7 @@ class ScenarioBuilderService(
             summoningSickness: Boolean = false,
             counters: Map<String, Int> = emptyMap(),
             chosenCreatureType: String? = null,
+            chosenCardType: String? = null,
             chosenColor: String? = null
         ): ScenarioBuilder {
             val playerId = playerFor(playerNumber)
@@ -269,6 +271,12 @@ class ScenarioBuilderService(
             if (chosenCreatureType != null) {
                 container = container.withCastChoice(
                     ChoiceSlot.CREATURE_TYPE, ChoiceValue.TextChoice(chosenCreatureType)
+                )
+            }
+
+            if (chosenCardType != null) {
+                container = container.withCastChoice(
+                    ChoiceSlot.CARD_TYPE, ChoiceValue.TextChoice(chosenCardType)
                 )
             }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
@@ -130,6 +130,12 @@ data class BattlefieldCardConfig(
     /** For permanents with "As this enters, choose a creature type" — skips the ETB choice by pre-setting it. */
     val chosenCreatureType: String? = null,
     /**
+     * For permanents that durably choose a card type (CR 205.2a — e.g. Arachne, Psionic Weaver's
+     * "choose a card type other than creature") — skips the ETB choice by pre-setting it. Value is a
+     * card-type name, e.g. "Artifact", "Enchantment", "Instant".
+     */
+    val chosenCardType: String? = null,
+    /**
      * For permanents with "As this enters, choose a color" — skips the ETB choice by pre-setting it.
      * Value must be a [com.wingedsheep.sdk.core.Color] name, e.g. "WHITE", "GREEN".
      */

--- a/manual-scenarios/sets/spm/arachne.json
+++ b/manual-scenarios/sets/spm/arachne.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Arachne, Psionic Weaver", "Whoosh!", "Amazing Acrobatics", "Electro's Bolt", "Prison Break"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Electro's Bolt", "Whoosh!", "Prison Break"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/batch5-new-cards-castable.json
+++ b/manual-scenarios/sets/spm/batch5-new-cards-castable.json
@@ -1,0 +1,47 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "The Clone Saga",
+      "Costume Closet"
+    ],
+    "battlefield": [
+      {"name": "The Soul Stone", "counters": {"HARNESS": 1}},
+      {"name": "Arachne, Psionic Weaver", "chosenCardType": "Instant"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Grizzly Bears", "Serra Angel"],
+    "library": ["Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Smother"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/sets/spm/costume-closet.json
+++ b/manual-scenarios/sets/spm/costume-closet.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Costume Closet"],
+    "battlefield": [
+      {"name": "Costume Closet", "counters": {"PLUS_ONE_PLUS_ONE": 2}},
+      {"name": "City Pigeon", "counters": {"PLUS_ONE_PLUS_ONE": 1}},
+      {"name": "Spider-Bot"},
+      {"name": "Web-Shooters", "attachedTo": "Spider-Bot"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Rhino, Barreling Brute"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/the-clone-saga.json
+++ b/manual-scenarios/sets/spm/the-clone-saga.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["The Clone Saga", "Spider-Bot", "City Pigeon"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island", "City Pigeon", "Spider-Bot"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP", "DRAW"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/the-soul-stone.json
+++ b/manual-scenarios/sets/spm/the-soul-stone.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["The Soul Stone"],
+    "battlefield": [
+      {"name": "City Pigeon"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Spider-Bot", "Rhino, Barreling Brute"],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -81,7 +81,16 @@ enum class CounterType {
     SKEWER,
     ENERGY,
     ICE,
-    OMEN;
+    OMEN,
+
+    /**
+     * Harness counter (Marvel's Spider-Man Infinity Stones). A binary "harnessed" marker: the Stone's
+     * activated Harness ability places one, and its `∞` ability is gated on the Stone having a harness
+     * counter (CR-style "as long as this permanent has a harness counter"). Not a resource — exactly
+     * one is ever placed; it models the permanent "once harnessed" state that resets if the Stone
+     * leaves the battlefield.
+     */
+    HARNESS;
 
     companion object {
         /**
@@ -380,6 +389,9 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val FILM = "film"
+
+    /** Harness marker counter — the Infinity Stones' "once harnessed" binary state. */
+    const val HARNESS = "harness"
 
     /**
      * Skewer counter (WOE — Rotisserie Elemental). A tally counter with no inherent rule: the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2759,6 +2759,26 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect(prompt)
 
     /**
+     * The controller chooses a card type (CR 205.2a), stored durably on the source entity under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE] and read back at cost-calculation /
+     * projection time through
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent] (build
+     * the filter with `GameObjectFilter.…ofChosenCardTypeComponent()`). [allowedCardTypes] restricts
+     * the offered set (default all); pass the non-creature list for "a card type other than
+     * creature". [lookAtOpponentHand] reveals an opponent's hand to the controller first. Powers
+     * Arachne, Psionic Weaver's "look at an opponent's hand, then choose a card type … Spells of the
+     * chosen type cost {1} more."
+     */
+    fun ChooseCardTypeForSource(
+        allowedCardTypes: List<String>? = null,
+        lookAtOpponentHand: Boolean = false,
+        slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE,
+        prompt: String = "Choose a card type"
+    ): Effect = com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect(
+        allowedCardTypes, lookAtOpponentHand, slot, prompt
+    )
+
+    /**
      * Grant Toxic N to a target until end of turn.
      *
      * Composes [GrantKeywordEffect] with the `TOXIC_<n>` string keyword — the same projected

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
@@ -42,6 +42,17 @@ enum class ChoiceSlot {
      */
     CARD_NAME,
 
+    /**
+     * A card type chosen as the object entered (e.g. Arachne, Psionic Weaver "choose a card type
+     * other than creature"). Stored as a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice] holding the
+     * card-type name ("Artifact", "Instant", …). Read back at static-projection / cost-calculation
+     * time by [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent],
+     * the card-type analogue of [CARD_NAME]'s
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosenComponent].
+     */
+    CARD_TYPE,
+
     /** Another creature chosen as the object entered (e.g. Dauntless Bodyguard). */
     CREATURE,
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -977,3 +977,43 @@ data class ChooseOpponentForSourceEffect(
 ) : Effect {
     override val description: String = "choose an opponent"
 }
+
+/**
+ * The controller chooses a card type (CR 205.2a); the choice is written durably onto the source
+ * entity's cast-choices bag under [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE], where a
+ * static ability reads it back at cost-calculation / projection time through
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent].
+ *
+ * The on-resolution, durable-slot analogue of an as-enters card-type choice — the same relationship
+ * [ChooseNumberForSourceEffect] has to the `NUMBER` [com.wingedsheep.sdk.scripting.ReplacementEffect
+ * .ChoiceType]. Modeled as a `When ~ enters` triggered ability rather than a replacement because the
+ * chosen type only feeds a continuous tax, so it need not be locked in strictly *during* entry.
+ *
+ * When [lookAtOpponentHand] is true the controller first sees an opponent's hand (a durable reveal,
+ * CR 402.3) before choosing — the "look at an opponent's hand, then choose a card type" clause of
+ * Arachne, Psionic Weaver. The look is purely informational.
+ *
+ * @property allowedCardTypes Restrict the offered set to these card types (values from CR 205.2a:
+ *   "Artifact", "Battle", "Creature", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery").
+ *   `null` offers all of them. Arachne passes the seven non-creature types ("other than creature").
+ * @property lookAtOpponentHand Reveal an opponent's hand to the controller before the choice.
+ * @property slot Durable cast-choices slot to write (default
+ *   [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE]).
+ * @property prompt Player-facing prompt text.
+ */
+@SerialName("ChooseCardTypeForSource")
+@Serializable
+data class ChooseCardTypeForSourceEffect(
+    val allowedCardTypes: List<String>? = null,
+    val lookAtOpponentHand: Boolean = false,
+    val slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE,
+    val prompt: String = "Choose a card type"
+) : Effect {
+    override val description: String = buildString {
+        if (lookAtOpponentHand) append("look at an opponent's hand, then ")
+        append("choose a card type")
+        if (allowedCardTypes != null && !allowedCardTypes.contains("Creature")) {
+            append(" other than creature")
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -365,6 +365,16 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.NameEqualsChosenComponent(slot)
     )
 
+    /**
+     * Match cards whose *card type* equals the card type durably chosen by the *source permanent*
+     * as it entered (its [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent]
+     * under [slot]). Static-projection / cost-calculation safe — use this in cost-static filters
+     * (Arachne, Psionic Weaver's "spells of the chosen type cost {1} more").
+     */
+    fun ofChosenCardTypeComponent(slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE) = copy(
+        cardPredicates = cardPredicates + CardPredicate.CardTypeEqualsChosenComponent(slot)
+    )
+
     /** Mana value equals */
     fun manaValue(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -302,6 +302,25 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches cards whose **card type** equals a card type **durably chosen by the source
+     * permanent** as it entered — read from that permanent's
+     * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under [slot] (a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice] holding one of the
+     * CR 205.2a card-type names). The card-type analogue of [NameEqualsChosenComponent].
+     *
+     * Like its name sibling, this is **static-projection / cost-calculation safe**: the source
+     * permanent's id is supplied as the predicate-context source wherever a static ability's filter
+     * is evaluated. Used by card-type-keyed taxes such as Arachne, Psionic Weaver ("Spells of the
+     * chosen type cost {1} more to cast"). Fails closed (no match) when the source has made no such
+     * choice.
+     */
+    @SerialName("CardTypeEqualsChosenComponent")
+    @Serializable
+    data class CardTypeEqualsChosenComponent(val slot: ChoiceSlot = ChoiceSlot.CARD_TYPE) : CardPredicate {
+        override val description: String = "of the chosen type"
+    }
+
+    /**
      * Matches a card whose name is **not** shared with any Room the evaluating player controls
      * (CR 709). Per the Central Elevator ruling, only the names of a Room's *unlocked* doors
      * count: a Room with no unlocked doors contributes neither of its names, and a split Room

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -348,6 +348,7 @@ object CardLinter {
         "NotOfSourceChosenType" to "CREATURE_TYPE",
         "SneakCostWasPaid" to "SNEAK",
         "SourceChosenModeIs" to "MODE",
+        "CardTypeEqualsChosenComponent" to "CARD_TYPE",
     )
 
     /** Node types whose `slot` field names the slot they read. */
@@ -358,7 +359,7 @@ object CardLinter {
      * [com.wingedsheep.sdk.scripting.effects.ChooseNumberForSourceEffect] records a number under the
      * named slot (e.g. `CHOSEN_NUMBER` for Shapeshifter), which a `CastChoice` read then resolves.
      */
-    private val slotFieldDeclarers = setOf("ChooseNumberForSource")
+    private val slotFieldDeclarers = setOf("ChooseNumberForSource", "ChooseCardTypeForSource")
 
     private class SlotUsage {
         val declared = mutableSetOf<String>()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ArachnePsionicWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ArachnePsionicWeaver.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.webSlinging
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Arachne, Psionic Weaver (Marvel's Spider-Man, #2)
+ * {2}{W}
+ * Legendary Creature — Spider Human Hero
+ * 3/3
+ *
+ * Web-slinging {W} (You may cast this spell for {W} if you also return a tapped creature you control
+ * to its owner's hand.)
+ * As Arachne enters, look at an opponent's hand, then choose a card type other than creature.
+ * Spells of the chosen type cost {1} more to cast.
+ *
+ * Implementation:
+ *  - **Web-slinging {W}** — the `webSlinging(cost)` alternative-cost keyword (CR 702.188).
+ *  - **Choose a card type (durable)** — a "When Arachne enters" trigger running
+ *    [Effects.ChooseCardTypeForSource] with `lookAtOpponentHand = true` and the seven non-creature
+ *    card types. It reveals an opponent's hand to the controller, then writes the chosen type onto
+ *    Arachne's `CastChoicesComponent` under [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE].
+ *    (An ETB trigger + durable-slot write — the on-resolution analogue of an as-enters replacement,
+ *    the same relationship `ChooseNumberForSource` has to the `NUMBER` enters-with choice — because
+ *    the chosen type only feeds a continuous tax, so it need not be locked in strictly during entry.)
+ *  - **The tax** — a symmetric [ModifySpellCost] on every caster whose spell is
+ *    `ofChosenCardTypeComponent()` (matches the type stored on Arachne), adding {1} generic
+ *    ([CostModification.IncreaseGeneric]) — the same shape as Thalia, keyed to the chosen type via
+ *    [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent].
+ */
+val ArachnePsionicWeaver = card("Arachne, Psionic Weaver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Spider Human Hero"
+    power = 3
+    toughness = 3
+    oracleText = "Web-slinging {W} (You may cast this spell for {W} if you also return a tapped " +
+        "creature you control to its owner's hand.)\n" +
+        "As Arachne enters, look at an opponent's hand, then choose a card type other than creature.\n" +
+        "Spells of the chosen type cost {1} more to cast."
+
+    webSlinging("{W}")
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ChooseCardTypeForSource(
+            allowedCardTypes = listOf(
+                "Artifact", "Battle", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery"
+            ),
+            lookAtOpponentHand = true,
+            prompt = "Choose a card type other than creature"
+        )
+        description = "As Arachne enters, look at an opponent's hand, then choose a card type " +
+            "other than creature."
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Any.ofChosenCardTypeComponent()),
+            modification = CostModification.IncreaseGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Steve Argyle"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1f871a-bd85-402e-b474-1deb64c18a52.jpg?1783905365"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CostumeCloset.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CostumeCloset.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Costume Closet (Marvel's Spider-Man, #5)
+ * {1}{W}
+ * Artifact
+ *
+ * This artifact enters with two +1/+1 counters on it.
+ * {T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a
+ * sorcery.
+ * Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this
+ * artifact. (Equipment, Auras you control, and counters are modifications.)
+ *
+ * Implementation (fully built from composable primitives):
+ *  - Enters-with-counters: [EntersWithCounters] replacement (`selfOnly = true`, count 2) — same
+ *    shape as Peter Parker's Camera / Braided Net.
+ *  - Move-counter: sorcery-speed `{T}` activated ability. [Effects.MoveCounters] moves one +1/+1
+ *    counter from this artifact ([EffectTarget.Self]) onto a target creature you control, capped at
+ *    the number actually present.
+ *  - Modified-LTB trigger: a [Triggers.leavesBattlefield] with `TriggerBinding.ANY` over a
+ *    "creature you control" filter narrowed by [StatePredicate.IsModified] (has a counter, an Aura,
+ *    or Equipment attached — the MTG "modified" definition). The filter is evaluated against the
+ *    departing permanent's last-known information, so a creature that was modified as it left still
+ *    triggers this. The reward is one +1/+1 counter on the Closet itself.
+ */
+val CostumeCloset = card("Costume Closet") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with two +1/+1 counters on it.\n" +
+        "{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate " +
+        "only as a sorcery.\n" +
+        "Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on " +
+        "this artifact. (Equipment, Auras you control, and counters are modifications.)"
+
+    // This artifact enters with two +1/+1 counters on it.
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE),
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    // {T}: Move a +1/+1 counter from this artifact onto target creature you control. Sorcery speed.
+    activatedAbility {
+        cost = Costs.Tap
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.MoveCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.Fixed(1),
+            source = EffectTarget.Self,
+            destination = creature
+        )
+        description = "{T}: Move a +1/+1 counter from this artifact onto target creature you " +
+            "control. Activate only as a sorcery."
+    }
+
+    // Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().let {
+                it.copy(statePredicates = it.statePredicates + StatePredicate.IsModified)
+            },
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever a modified creature you control leaves the battlefield, put a " +
+            "+1/+1 counter on this artifact."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Bastien Grivet"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc641f4a-ddbe-4f7d-bb55-eabf11f8b7fb.jpg?1783905363"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheCloneSaga.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheCloneSaga.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Clone Saga (Marvel's Spider-Man, #28)
+ * {3}{U}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Surveil 3.
+ * II — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.
+ * III — Choose a card name. Whenever a creature with the chosen name deals combat damage to a
+ * player this turn, draw a card.
+ *
+ * Implementation:
+ *  - **I** — `Effects.Surveil(3)`.
+ *  - **II** — a one-shot event-based delayed trigger on `Triggers.YouCastCreature` (SpellCastEvent,
+ *    Player.You, creature) whose effect copies the triggering spell with `removeLegendary = true`
+ *    (the copy is a non-legendary token — same primitive as Jackal, Genius Geneticist). `fireOnce`
+ *    makes it "the next" creature spell; `TriggeringEntity` binds to the just-cast spell at fire
+ *    time and the trigger resolves above it while it's still on the stack.
+ *  - **III** — `Effects.ChooseCardName` stores the name in `chosenValues["clonedName"]`, then a
+ *    delayed combat-damage trigger keyed to a creature *named that* (`namedFromVariable`) draws a
+ *    card each time such a creature deals combat damage to a player this turn. The chosen name is
+ *    baked into the trigger's source filter at creation time (`CreateDelayedTriggerExecutor
+ *    .bakeChosenValuesIntoTrigger`).
+ */
+val TheCloneSaga = card("The Clone Saga") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice " +
+        "after III.)\n" +
+        "I — Surveil 3.\n" +
+        "II — When you next cast a creature spell this turn, copy it, except the copy isn't " +
+        "legendary.\n" +
+        "III — Choose a card name. Whenever a creature with the chosen name deals combat damage " +
+        "to a player this turn, draw a card."
+
+    // I — Surveil 3.
+    sagaChapter(1) {
+        effect = Effects.Surveil(3)
+    }
+
+    // II — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.
+    sagaChapter(2) {
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouCastCreature,
+            effect = Effects.CopyTargetSpell(
+                target = EffectTarget.TriggeringEntity,
+                removeLegendary = true,
+            ),
+            fireOnce = true,
+            expiry = DelayedTriggerExpiry.EndOfTurn,
+        )
+    }
+
+    // III — Choose a card name. Whenever a creature with the chosen name deals combat damage to a
+    // player this turn, draw a card.
+    sagaChapter(3) {
+        effect = Effects.Composite(
+            Effects.ChooseCardName(storeAs = "clonedName"),
+            CreateDelayedTriggerEffect(
+                trigger = Triggers.dealsDamage(
+                    damageType = DamageType.Combat,
+                    recipient = RecipientFilter.AnyPlayer,
+                    sourceFilter = GameObjectFilter.Creature.namedFromVariable("clonedName"),
+                    binding = TriggerBinding.ANY,
+                ),
+                effect = Effects.DrawCards(1),
+                fireOnce = false,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "28"
+        artist = "Bill Sienkiewicz"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/976432b3-bc17-4edb-86d6-00fd1baf9670.jpg?1783905356"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheSoulStone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheSoulStone.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Soul Stone (Marvel's Spider-Man, #66)
+ * {1}{B}
+ * Legendary Artifact — Infinity Stone
+ *
+ * Indestructible
+ * {T}: Add {B}.
+ * {6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its ∞
+ * ability is active.)
+ * ∞ — At the beginning of your upkeep, return target creature card from your graveyard to the
+ * battlefield.
+ *
+ * Implementation (composition-first — the only new vocabulary is the `harness` marker counter):
+ *  - **Harness** is modeled as a binary marker counter ([Counters.HARNESS]). The Harness activated
+ *    ability places one; the `∞` triggered ability is gated on the Stone having a harness counter
+ *    ([Conditions.SourceHasCounter]), so it does nothing until harnessed and reactivates every
+ *    upkeep thereafter. A counter (not a durable component) matches the flavor: it resets if the
+ *    Stone leaves the battlefield, and re-placing it is idempotent.
+ *  - `{T}: Add {B}` is a mana ability; the Harness cost pairs `{6}{B}` + tap + an exile-a-creature
+ *    additional cost ([Costs.ExilePermanents]); the `∞` reanimates a targeted creature card from
+ *    your graveyard ([Effects.PutOntoBattlefield]).
+ */
+val TheSoulStone = card("The Soul Stone") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Artifact — Infinity Stone"
+    oracleText = "Indestructible\n" +
+        "{T}: Add {B}.\n" +
+        "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its " +
+        "∞ ability is active.)\n" +
+        "∞ — At the beginning of your upkeep, return target creature card from your graveyard to " +
+        "the battlefield."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // {T}: Add {B}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    // {6}{B}, {T}, Exile a creature you control: Harness The Soul Stone.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{6}{B}"),
+            Costs.Tap,
+            Costs.ExilePermanents(GameObjectFilter.Creature.youControl(), minCount = 1, excludeSelf = false)
+        )
+        effect = Effects.AddCounters(Counters.HARNESS, 1, EffectTarget.Self)
+        description = "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone."
+    }
+
+    // ∞ — At the beginning of your upkeep (once harnessed), return target creature card from your
+    // graveyard to the battlefield.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.HARNESS))
+        val graveyardCreature = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(graveyardCreature)
+        description = "∞ — At the beginning of your upkeep, return target creature card from your " +
+            "graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "66"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1982f910-a9bd-4e94-a187-84381b22aacc.jpg?1783905342"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11845,7 +11845,7 @@
                         {
                             "type": "CostAtomWrapper",
                             "atom": {
-                                "type": "AtomExilePermanents",
+                                "type": "AtomVariablePermanents",
                                 "filter": "creature ctrl:you",
                                 "excludeSelf": false
                             }

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -315,6 +315,79 @@
     ]
 }
 
+// Arachne, Psionic Weaver
+{
+    "name": "Arachne, Psionic Weaver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Spider Human Hero",
+    "oracleText": "Web-slinging {W} (You may cast this spell for {W} if you also return a tapped creature you control to its owner's hand.)\nAs Arachne enters, look at an opponent's hand, then choose a card type other than creature.\nSpells of the chosen type cost {1} more to cast.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "WEB_SLINGING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "WebSlinging",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ChooseCardTypeForSource",
+                    "allowedCardTypes": [
+                        "Artifact",
+                        "Battle",
+                        "Enchantment",
+                        "Instant",
+                        "Land",
+                        "Planeswalker",
+                        "Sorcery"
+                    ],
+                    "lookAtOpponentHand": true,
+                    "prompt": "Choose a card type other than creature"
+                },
+                "descriptionOverride": "As Arachne enters, look at an opponent's hand, then choose a card type other than creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": {
+                        "cardPredicates": [
+                            "CardTypeEqualsChosenComponent"
+                        ]
+                    }
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "RARE",
+        "artist": "Steve Argyle",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c1f871a-bd85-402e-b474-1deb64c18a52.jpg?1783905365"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Araña, Heart of the Spider
 {
     "name": "Araña, Heart of the Spider",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11538,6 +11538,97 @@
     ]
 }
 
+// The Clone Saga
+{
+    "name": "The Clone Saga",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Surveil 3.\nII — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.\nIII — Choose a card name. Whenever a creature with the chosen name deals combat damage to a player this turn, draw a card.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Surveil",
+                    "count": 3
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity",
+                        "removeLegendary": true
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "SpellCastEvent",
+                            "spellFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ]
+                            }
+                        },
+                        "binding": "ANY"
+                    },
+                    "fireOnce": true
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ChooseOption",
+                            "optionType": "CARD_NAME",
+                            "storeAs": "clonedName"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "trigger": {
+                                "event": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat",
+                                    "recipient": "AnyPlayer",
+                                    "sourceFilter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "NameEqualsChosen",
+                                                "variableName": "clonedName"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "binding": "ANY"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "RARE",
+        "artist": "Bill Sienkiewicz",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/976432b3-bc17-4edb-86d6-00fd1baf9670.jpg?1783905356"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // The Death of Gwen Stacy
 {
     "name": "The Death of Gwen Stacy",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11679,6 +11679,109 @@
     ]
 }
 
+// The Soul Stone
+{
+    "name": "The Soul Stone",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Artifact — Infinity Stone",
+    "oracleText": "Indestructible\n{T}: Add {B}.\n{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its ∞ ability is active.)\n∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card in your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "HARNESS"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExilePermanents",
+                                "filter": "creature ctrl:you",
+                                "excludeSelf": false
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "harness",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1982f910-a9bd-4e94-a187-84381b22aacc.jpg?1783905342"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // The Spot's Portal
 {
     "name": "The Spot's Portal",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1174,6 +1174,92 @@
     ]
 }
 
+// Costume Closet
+{
+    "name": "Costume Closet",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with two +1/+1 counters on it.\n{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a sorcery.\nWhenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this artifact. (Equipment, Auras you control, and counters are modifications.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsModified"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this artifact."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "source": "Self",
+                    "destination": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a sorcery."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "+1/+1"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Bastien Grivet",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc641f4a-ddbe-4f7d-bb55-eabf11f8b7fb.jpg?1783905363"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Daily Bugle Building
 {
     "name": "Daily Bugle Building",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
@@ -47,6 +47,30 @@ data class ChooseOpponentForSourceContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after a player picks the card type for a
+ * [com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect]. The resumer writes the
+ * chosen type name as a [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice]
+ * into the source entity's
+ * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under [slot], where
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent] reads it
+ * back at cost-calculation / projection time (Arachne, Psionic Weaver).
+ *
+ * @property sourceId The permanent whose cast-choices bag receives the card type.
+ * @property controllerId The player who made the choice.
+ * @property slot Which durable cast-choices slot to write.
+ * @property cardTypes The offered option list, positionally aligned with the
+ *   [com.wingedsheep.engine.core.ChooseOptionDecision]'s options.
+ */
+@Serializable
+data class ChooseCardTypeForSourceContinuation(
+    override val decisionId: String,
+    val sourceId: EntityId,
+    val controllerId: EntityId,
+    val slot: ChoiceSlot,
+    val cardTypes: List<String>
+) : ContinuationFrame
+
+/**
  * Resume after the controller picks *which* opponent makes a
  * [com.wingedsheep.sdk.scripting.effects.Chooser.Opponent] decision (CR 601.7a / 602.3a and
  * the matching resolution-time rulings — see

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -222,6 +222,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseNumberForSourceContinuation::class)
         subclass(ChooseOpponentForSourceContinuation::class)
+        subclass(ChooseCardTypeForSourceContinuation::class)
         subclass(ChooseOpponentDeciderContinuation::class)
         subclass(ConvertCountersToTokensContinuation::class)
         subclass(ChooseManaColorContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1,5 +1,8 @@
 package com.wingedsheep.engine.event
 
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.handlers.predicates.isModified
+
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
@@ -1812,6 +1815,27 @@ class TriggerMatcher(
                 counters?.counters?.values?.any { it > 0 } ?: false
             }
         }
+        // "Modified" (has a counter, an attached Equipment, or an attached Aura — CR 122/301/303) on
+        // a permanent that has left the battlefield reads last-known info: the live counters and
+        // attachment links are gone by trigger-gating time. Counters come from the snapshot; the
+        // equipped/enchanted legs come from the frozen wasEquipped/wasEnchanted flags captured in
+        // ZoneTransitionService before exit cleanup. For non-leave triggers (ETB) the entity is live.
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified -> {
+            if (event.fromZone == Zone.BATTLEFIELD) {
+                val lk = event.lastKnown
+                (lk?.totalCounters ?: 0) > 0 || lk?.wasEquipped == true || lk?.wasEnchanted == true
+            } else {
+                isModified(state, event.entityId)
+            }
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEquipped == true
+            else hasAttachmentOfKind(state, event.entityId, equipment = true)
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEnchanted == true
+            else hasAttachmentOfKind(state, event.entityId, equipment = false)
+        }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Or ->
             predicate.predicates.any { matchesStatePredicateForZoneChangeTrigger(it, state, event) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.And ->
@@ -1912,4 +1936,18 @@ class TriggerMatcher(
             .replace("+1/+1", "plus_one_plus_one")
             .replace("-1/-1", "minus_one_minus_one")
             .replace(" ", "_")
+
+    /**
+     * Live check for whether [entityId] has an Equipment (or, when [equipment] is false, an Aura)
+     * attached — the last-known-info counterpart is the `wasEquipped`/`wasEnchanted` flag on the
+     * [ZoneChangeEvent]'s snapshot. Used only for the non-leave (ETB) branch of an
+     * `IsEquipped`/`IsEnchanted` zone-change gate.
+     */
+    private fun hasAttachmentOfKind(state: GameState, entityId: EntityId, equipment: Boolean): Boolean {
+        val attachments = state.getEntity(entityId)?.get<AttachmentsComponent>() ?: return false
+        return attachments.attachedIds.any { attachId ->
+            val typeLine = state.getEntity(attachId)?.get<CardComponent>()?.typeLine
+            if (equipment) typeLine?.isEquipment == true else typeLine?.isAura == true
+        }
+    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -740,6 +740,18 @@ class PredicateEvaluator {
                 card.name.equals(chosenName, ignoreCase = true)
             }
 
+            // Source-component card-type reference: the card type durably chosen by the source
+            // permanent as it entered (Arachne). Read from the source's CastChoicesComponent[slot];
+            // works at cost-calculation / projection time as long as the predicate context supplies
+            // the choosing permanent as the source. The card-type analogue of NameEqualsChosenComponent.
+            is CardPredicate.CardTypeEqualsChosenComponent -> {
+                val sourceId = context?.sourceId ?: return false
+                val chosenType = (state.getEntity(sourceId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
+                card.typeLine.cardTypes.any { it.displayName.equals(chosenType, ignoreCase = true) }
+            }
+
             is CardPredicate.OriginallyPrintedInSet ->
                 card.originalSetCode?.equals(predicate.setCode, ignoreCase = true) == true
 
@@ -1552,9 +1564,10 @@ class PredicateEvaluator {
             is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,
             is CardPredicate.HasSubtypeInEachStoredGroup -> false
-            // Source-component name reference is a permanent-static predicate, not meaningful for a
-            // cast-spell record.
+            // Source-component name/card-type references are permanent-static predicates, not
+            // meaningful for a cast-spell record.
             is CardPredicate.NameEqualsChosenComponent -> false
+            is CardPredicate.CardTypeEqualsChosenComponent -> false
 
             // Stack ability check — cast spells are not abilities
             CardPredicate.IsActivatedOrTriggeredAbility -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -872,6 +872,7 @@ class CastZoneResolver(
                 is CardPredicate.SharesChosenColorWithSource,
                 is CardPredicate.NameEqualsChosen,
                 is CardPredicate.NameEqualsChosenComponent,
+                is CardPredicate.CardTypeEqualsChosenComponent,
                 is CardPredicate.NameNotSharedWithControlledRoom,
                 is CardPredicate.NameNotSharedWithControlledToken,
                 is CardPredicate.NameNotSharedWithAnotherControlledPermanent,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -20,6 +20,7 @@ class ColorChoiceContinuationResumer(
         resumer(ChooseNumberThenContinuation::class, ::resumeChooseNumberThen),
         resumer(ChooseNumberForSourceContinuation::class, ::resumeChooseNumberForSource),
         resumer(ChooseOpponentForSourceContinuation::class, ::resumeChooseOpponentForSource),
+        resumer(ChooseCardTypeForSourceContinuation::class, ::resumeChooseCardTypeForSource),
         resumer(ChooseOpponentDeciderContinuation::class, ::resumeChooseOpponentDecider),
         resumer(ChooseManaColorContinuation::class, ::resumeChooseManaColor),
         resumer(ChooseColorForTargetContinuation::class, ::resumeChooseColorForTarget),
@@ -114,6 +115,28 @@ class ColorChoiceContinuationResumer(
         }
         val newState = state.updateEntity(continuation.sourceId) { container ->
             container.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosen))
+        }
+        return checkForMore(newState, emptyList())
+    }
+
+    fun resumeChooseCardTypeForSource(
+        state: GameState,
+        continuation: ChooseCardTypeForSourceContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option choice response for ChooseCardTypeForSource effect")
+        }
+        val chosen = continuation.cardTypes.getOrNull(response.optionIndex)
+            ?: return ExecutionResult.error(state, "Card type choice index ${response.optionIndex} out of range")
+        // Record the chosen card type durably on the source permanent so
+        // CardPredicate.CardTypeEqualsChosenComponent reads it at cost-calculation / projection time.
+        if (state.getEntity(continuation.sourceId) == null) {
+            return checkForMore(state, emptyList())
+        }
+        val newState = state.updateEntity(continuation.sourceId) { container ->
+            container.withCastChoice(continuation.slot, ChoiceValue.TextChoice(chosen))
         }
         return checkForMore(newState, emptyList())
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -271,6 +271,22 @@ object ZoneTransitionService {
         // battlefield. Carried on the ZoneChangeEvent for trigger resolution AND stashed on the
         // entity itself (LastKnownPermanentComponent) for resolution-time reads that outlive the
         // permanent ("Destroy target creature. Its controller creates two Map tokens.").
+        // Was this permanent equipped / enchanted as it left? The live attachment links are torn
+        // down by the exit cleanup below (CR 704.5m/n), so "modified/equipped/enchanted creature
+        // leaves the battlefield" triggers must freeze it here as last-known information (CR 608.2h).
+        val lastKnownAttachedTypeLines = if (leavingBattlefield) {
+            state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent>()
+                ?.attachedIds
+                ?.mapNotNull { attachId ->
+                    state.getEntity(attachId)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.typeLine
+                }
+                ?: emptyList()
+        } else emptyList()
+        val lastKnownWasEquipped = lastKnownAttachedTypeLines.any { it.isEquipment }
+        val lastKnownWasEnchanted = lastKnownAttachedTypeLines.any { it.isAura }
+
         val lastKnownSnapshot = if (leavingBattlefield) {
             com.wingedsheep.engine.state.components.stack.EntitySnapshot(
                 entityId = entityId,
@@ -288,6 +304,8 @@ object ZoneTransitionService {
                 typeLine = lastKnownTypeLine,
                 cardDefinitionId = cardComponent.cardDefinitionId,
                 attachedTo = lastKnownAttachedTo,
+                wasEquipped = lastKnownWasEquipped,
+                wasEnchanted = lastKnownWasEnchanted,
                 blockingOrBlockedByIds = lastKnownBlockingOrBlockedByIds,
                 wasAttacking = lastKnownWasAttacking,
                 wasToken = lastKnownWasToken,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.scripting.effects.MoveTrackedBattlefieldObjectEffect
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -176,20 +177,50 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
     private fun bakeChosenValuesIntoTrigger(trigger: TriggerSpec, context: EffectContext): TriggerSpec {
         val chosen = context.pipeline.chosenValues
         if (chosen.isEmpty()) return trigger
-        val event = trigger.event
-        if (event !is EventPattern.SpellCastEvent) return trigger
-        val filter = event.spellFilter
+        return when (val event = trigger.event) {
+            is EventPattern.SpellCastEvent -> {
+                val newFilter = bakeChosenValuesIntoFilter(event.spellFilter, chosen) ?: return trigger
+                trigger.copy(event = event.copy(spellFilter = newFilter))
+            }
+            // The Clone Saga ch. III: "whenever a creature with the chosen name deals combat damage
+            // to a player this turn, draw a card." The chosen name is baked into the damage source
+            // filter now, so the delayed-trigger matcher can evaluate it without the (gone) pipeline.
+            is EventPattern.DealsDamageEvent -> {
+                val filter = event.sourceFilter ?: return trigger
+                val newFilter = bakeChosenValuesIntoFilter(filter, chosen) ?: return trigger
+                trigger.copy(event = event.copy(sourceFilter = newFilter))
+            }
+            else -> trigger
+        }
+    }
+
+    /**
+     * Rewrite chosen-value-dependent card predicates in [filter] into concrete ones using [chosen]
+     * (= `EffectContext.pipeline.chosenValues`). Returns null when nothing changed so the caller
+     * keeps the original TriggerSpec instance.
+     *
+     *  - `HasSubtypeFromVariable(v)` → `HasSubtype(Subtype(chosen[v]))` (Long List of the Ents)
+     *  - `NameEqualsChosen(v)`       → `NameEquals(chosen[v])`          (The Clone Saga ch. III)
+     */
+    private fun bakeChosenValuesIntoFilter(
+        filter: GameObjectFilter,
+        chosen: Map<String, String>
+    ): GameObjectFilter? {
         val newPredicates = filter.cardPredicates.map { predicate ->
-            if (predicate is CardPredicate.HasSubtypeFromVariable) {
-                val value = chosen[predicate.variableName] ?: return@map predicate
-                CardPredicate.HasSubtype(Subtype(value))
-            } else {
-                predicate
+            when (predicate) {
+                is CardPredicate.HasSubtypeFromVariable -> {
+                    val value = chosen[predicate.variableName] ?: return@map predicate
+                    CardPredicate.HasSubtype(Subtype(value))
+                }
+                is CardPredicate.NameEqualsChosen -> {
+                    val value = chosen[predicate.variableName] ?: return@map predicate
+                    CardPredicate.NameEquals(value)
+                }
+                else -> predicate
             }
         }
-        if (newPredicates == filter.cardPredicates) return trigger
-        val newFilter = filter.copy(cardPredicates = newPredicates)
-        return trigger.copy(event = event.copy(spellFilter = newFilter))
+        if (newPredicates == filter.cardPredicates) return null
+        return filter.copy(cardPredicates = newPredicates)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseCardTypeForSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseCardTypeForSourceExecutor.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.ChooseCardTypeForSourceContinuation
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.withCastChoice
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ChooseCardTypeForSourceEffect].
+ *
+ * The controller chooses a card type (CR 205.2a); the choice is written durably onto the source
+ * entity's cast-choices bag under the effect's slot ([com.wingedsheep.sdk.scripting.ChoiceSlot
+ * .CARD_TYPE]), where [com.wingedsheep.sdk.scripting.predicates.CardPredicate
+ * .CardTypeEqualsChosenComponent] reads it at cost-calculation / projection time (Arachne, Psionic
+ * Weaver's "spells of the chosen type cost {1} more").
+ *
+ * When [ChooseCardTypeForSourceEffect.lookAtOpponentHand] is set, the controller first sees an
+ * opponent's hand (a durable reveal) before choosing. With a single allowed type the choice is
+ * forced and recorded without a prompt; otherwise it pauses for a [ChooseOptionDecision] and the
+ * [ChooseCardTypeForSourceContinuation] resumer writes the pick. No source entity → no-op.
+ */
+class ChooseCardTypeForSourceExecutor : EffectExecutor<ChooseCardTypeForSourceEffect> {
+
+    override val effectType: KClass<ChooseCardTypeForSourceEffect> = ChooseCardTypeForSourceEffect::class
+
+    /** The card types (CR 205.2a) offered when the effect doesn't restrict the set. */
+    private val allCardTypes = listOf(
+        "Artifact", "Battle", "Creature", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery"
+    )
+
+    override fun execute(
+        state: GameState,
+        effect: ChooseCardTypeForSourceEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId ?: return EffectResult.success(state)
+        val source = state.getEntity(sourceId) ?: return EffectResult.success(state)
+
+        val options = effect.allowedCardTypes ?: allCardTypes
+        if (options.isEmpty()) return EffectResult.success(state)
+
+        // "look at an opponent's hand, then choose …" — a durable reveal to the controller first.
+        val (baseState, lookEvents) = if (effect.lookAtOpponentHand) {
+            PermanentEntryReplacements.revealOpponentHandForEntersChoice(state, context.controllerId)
+        } else state to emptyList()
+
+        // Sole allowed type → forced choice, no prompt.
+        if (options.size == 1) {
+            val newState = baseState.updateEntity(sourceId) { container ->
+                container.withCastChoice(effect.slot, ChoiceValue.TextChoice(options.single()))
+            }
+            return EffectResult.success(newState, lookEvents)
+        }
+
+        val decisionId = "choose-card-type-for-source-${sourceId.value}"
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = context.controllerId,
+            prompt = effect.prompt,
+            context = DecisionContext(
+                sourceId = sourceId,
+                sourceName = source.get<CardComponent>()?.name ?: "Unknown",
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = options
+        )
+        val continuation = ChooseCardTypeForSourceContinuation(
+            decisionId = decisionId,
+            sourceId = sourceId,
+            controllerId = context.controllerId,
+            slot = effect.slot,
+            cardTypes = options
+        )
+
+        return EffectResult.paused(
+            baseState.withPendingDecision(decision).pushContinuation(continuation),
+            decision,
+            lookEvents
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -50,6 +50,7 @@ class PlayerExecutors(
         CantPlayCardsFromHandExecutor(),
         ChooseNumberForSourceExecutor(decisionHandler),
         ChooseOpponentForSourceExecutor(),
+        ChooseCardTypeForSourceExecutor(),
         CreateGlobalTriggeredAbilityExecutor(),
         CreatePermanentEmblemExecutor(),
         EachPlayerChoosesCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -778,6 +778,7 @@ internal class AffectsFilterResolver {
         // Resolved separately in resolveGenericFilter against the source's CastChoicesComponent
         // (no source in scope here) — fail closed if it ever reaches this generic path.
         is CardPredicate.NameEqualsChosenComponent,
+        is CardPredicate.CardTypeEqualsChosenComponent,
         is CardPredicate.HasSubtypeInEachStoredGroup -> false
         // Stack-only predicates — never match a battlefield entity being projected.
         CardPredicate.IsActivatedOrTriggeredAbility,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1114,6 +1114,13 @@ class CostCalculator(
                     as? ChoiceValue.TextChoice)?.text ?: return false
                 cardDef.name.equals(chosenName, ignoreCase = true)
             }
+            is CardPredicate.CardTypeEqualsChosenComponent -> {
+                if (sourceEntityId == null || state == null) return false
+                val chosenType = (state.getEntity(sourceEntityId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
+                cardDef.typeLine.cardTypes.any { it.displayName.equals(chosenType, ignoreCase = true) }
+            }
 
             is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }
             is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
@@ -106,6 +106,10 @@ fun ComponentContainer.chosenModeId(): String? =
 fun ComponentContainer.chosenCardName(): String? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_NAME) as? ChoiceValue.TextChoice)?.text
 
+/** The card type chosen as this object entered (e.g. Arachne, Psionic Weaver), or null. */
+fun ComponentContainer.chosenCardType(): String? =
+    (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE) as? ChoiceValue.TextChoice)?.text
+
 /** The creature chosen as this object entered, or null. */
 fun ComponentContainer.chosenCreatureRef(): EntityId? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CREATURE) as? ChoiceValue.EntityChoice)?.entityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -99,6 +99,20 @@ data class EntitySnapshot(
     val copyOfOriginalName: String? = null,
     /** For auras/equipment: the entity this was attached to when it left (enchanted-creature dies triggers). */
     val attachedTo: EntityId? = null,
+    /**
+     * True if this permanent had at least one Equipment attached when it left the battlefield. The
+     * live attachment links are torn down by the exit cleanup, so leaves/dies triggers asking "was
+     * it modified/equipped?" must read last-known information (CR 608.2h). Backs the last-known leg
+     * of [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped] and (together with
+     * counters / [wasEnchanted]) [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified].
+     */
+    val wasEquipped: Boolean = false,
+    /**
+     * True if this permanent had at least one Aura attached when it left the battlefield (CR 303.4).
+     * Last-known counterpart to [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted];
+     * a leg of the last-known [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified].
+     */
+    val wasEnchanted: Boolean = false,
     /** Creatures blocking, or blocked by, this one when it left (CR 509; Abu Ja'far). */
     val blockingOrBlockedByIds: List<EntityId> = emptyList(),
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -417,6 +417,9 @@ data class ClientCard(
     /** Chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet) */
     val chosenCardName: String? = null,
 
+    /** Chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver) */
+    val chosenCardType: String? = null,
+
     /** Triggering entity ID for triggered abilities on the stack (for source arrows) */
     val triggeringEntityId: EntityId? = null,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1086,6 +1086,9 @@ class ClientStateTransformer(
         // Get chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet)
         val chosenCardName = container.chosenCardName()
 
+        // Get chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver)
+        val chosenCardType = container.chosenCardType()
+
         // Get sacrificed creature types for spells with sacrifice-as-cost (e.g., Endemic Plague)
         val sacrificedCreatureTypes = spellOnStack?.sacrificedPermanents
             ?.flatMap { it.subtypes }?.toSet()
@@ -1301,6 +1304,7 @@ class ClientStateTransformer(
             chosenColor = chosenColor,
             chosenMode = chosenMode,
             chosenCardName = chosenCardName,
+            chosenCardType = chosenCardType,
             sacrificedCreatureTypes = sacrificedCreatureTypes,
             playableFromExile = playableFromExile,
             copyOf = container.get<com.wingedsheep.engine.state.components.identity.CopyOfComponent>()?.let { copyComp ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.ArachnePsionicWeaver
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Arachne, Psionic Weaver (SPM) — "As Arachne enters, look at an opponent's hand, then choose a card
+ * type other than creature. Spells of the chosen type cost {1} more to cast."
+ *
+ * Pins the new durable card-type choice ([Effects.ChooseCardTypeForSource] → [ChoiceSlot.CARD_TYPE])
+ * and the cost tax keyed to it ([CardPredicate.CardTypeEqualsChosenComponent] read at
+ * cost-calculation time).
+ */
+class ArachnePsionicWeaverScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ArachnePsionicWeaver))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    /** Cast Arachne and lock in [type] as its chosen card type. Returns Arachne's entity id. */
+    fun castArachneChoosing(driver: GameTestDriver, you: EntityId, type: String): EntityId {
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveColorlessMana(you, 2)
+        val arachne = driver.putCardInHand(you, "Arachne, Psionic Weaver")
+        driver.castSpell(you, arachne)
+        settle(driver) // Arachne resolves, ETB trigger resolves, pauses on the card-type choice
+        val pick = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        driver.submitDecision(you, OptionChosenResponse(pick.id, pick.options.indexOf(type)))
+        settle(driver)
+        return arachne
+    }
+
+    test("the chosen card type is written durably onto Arachne") {
+        val (driver, you, opponent) = newGame()
+        driver.putCardInHand(opponent, "Lightning Bolt") // so the hand-look has content
+        val arachne = castArachneChoosing(driver, you, "Instant")
+
+        val chosen = driver.state.getEntity(arachne)
+            ?.get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE)
+        (chosen as? ChoiceValue.TextChoice)?.text shouldBe "Instant"
+    }
+
+    test("spells of the chosen type cost {1} more; other types are untaxed") {
+        val (driver, you, opponent) = newGame()
+        castArachneChoosing(driver, you, "Instant")
+
+        // Lightning Bolt is an instant ({R}); with the tax it costs {1}{R}.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1) // only {R} — not enough for the taxed {1}{R}
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldNotBe null
+
+        driver.giveColorlessMana(you, 1) // now {1}{R} available
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        settle(driver) // resolve the bolt so the stack is empty for the sorcery-speed control cast
+
+        // A sorcery is not the chosen type, so it is untaxed: Careful Study ({B}) pays exactly {B}.
+        val study = driver.putCardInHand(you, "Careful Study")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.castSpell(you, study).error shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.mtg.sets.definitions.spm.cards.ArachnePsionicWeaver
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
@@ -64,6 +65,18 @@ class ArachnePsionicWeaverScenarioTest : FunSpec({
         val chosen = driver.state.getEntity(arachne)
             ?.get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE)
         (chosen as? ChoiceValue.TextChoice)?.text shouldBe "Instant"
+    }
+
+    test("the chosen card type is surfaced to the client view") {
+        val (driver, you, opponent) = newGame()
+        driver.putCardInHand(opponent, "Lightning Bolt")
+        val arachne = castArachneChoosing(driver, you, "Instant")
+
+        // The durable card-type choice is visible to the client (rendered as a badge), not just
+        // stored on the permanent's CastChoicesComponent.
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = you)
+        view.cards[arachne]?.chosenCardType shouldBe "Instant"
     }
 
     test("spells of the chosen type cost {1} more; other types are untaxed") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostumeClosetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostumeClosetScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.CostumeCloset
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Costume Closet (SPM) — "Whenever a modified creature you control leaves the battlefield, put a
+ * +1/+1 counter on this artifact."
+ *
+ * Pins the last-known-information fix for the modified-LTB trigger: when a modified creature leaves,
+ * its counters and attachments are already stripped, so the `StatePredicate.IsModified` filter must
+ * be evaluated against the departing permanent's [EntitySnapshot] (counters +
+ * `wasEquipped`/`wasEnchanted`). Before the fix the predicate fell through fail-open, so the Closet
+ * would have gained a counter for *any* creature-you-control departure — the "unmodified creature"
+ * case is the regression guard.
+ */
+class CostumeClosetScenarioTest : FunSpec({
+
+    // A trivial Equipment so we can exercise the "modified because equipped" leg.
+    val testEquipment = CardDefinition.equipment(
+        name = "Test Blade",
+        manaCost = ManaCost.parse("{1}"),
+        equipCost = ManaCost.parse("{1}"),
+    )
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CostumeCloset, testEquipment))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun closetCounters(driver: GameTestDriver, closet: EntityId): Int =
+        driver.state.getEntity(closet)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun destroy(driver: GameTestDriver, you: EntityId, victim: EntityId) {
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        val doomBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.castSpellWithTargets(you, doomBlade, listOf(ChosenTarget.Permanent(victim)))
+        resolveStack(driver)
+    }
+
+    test("a modified (counter) creature leaving adds a +1/+1 counter to the Closet") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        driver.addComponent(lions, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 1
+    }
+
+    test("a modified (equipped) creature leaving adds a +1/+1 counter to the Closet") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val blade = driver.putPermanentOnBattlefield(you, "Test Blade")
+        driver.addComponent(blade, AttachedToComponent(lions))
+        driver.addComponent(lions, AttachmentsComponent(listOf(blade)))
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 1
+    }
+
+    test("an unmodified creature leaving does NOT add a counter (regression guard)") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheCloneSagaChapterThreeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheCloneSagaChapterThreeTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Clone Saga chapter III — "Choose a card name. Whenever a creature with the chosen name deals
+ * combat damage to a player this turn, draw a card." Pins the `bakeChosenValuesIntoTrigger`
+ * extension that bakes the chosen card name into a delayed combat-damage trigger's source filter.
+ *
+ * Exercised in isolation via an inline sorcery that runs the same effect (ChooseCardName →
+ * CreateDelayedTrigger over `Creature.namedFromVariable`), so it doesn't need the Saga to advance
+ * three chapters.
+ */
+class TheCloneSagaChapterThreeTest : FunSpec({
+
+    // "Choose a card name. Whenever a creature with the chosen name deals combat damage to a player
+    // this turn, draw a card." — the Saga's chapter III effect, as a one-shot sorcery.
+    val chapterThree = CardDefinition(
+        name = "Chosen Name Draw Test",
+        manaCost = ManaCost.parse("{U}"),
+        typeLine = TypeLine.parse("Sorcery"),
+        oracleText = "",
+        script = CardScript.spell(
+            effect = Effects.Composite(
+                Effects.ChooseCardName(storeAs = "clonedName"),
+                CreateDelayedTriggerEffect(
+                    trigger = Triggers.dealsDamage(
+                        damageType = DamageType.Combat,
+                        recipient = RecipientFilter.AnyPlayer,
+                        sourceFilter = GameObjectFilter.Creature.namedFromVariable("clonedName"),
+                        binding = TriggerBinding.ANY,
+                    ),
+                    effect = Effects.DrawCards(1),
+                    fireOnce = false,
+                    expiry = DelayedTriggerExpiry.EndOfTurn,
+                ),
+            )
+        )
+    )
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(chapterThree))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("a creature with the chosen name dealing combat damage to a player draws a card") {
+        val (driver, you, opponent) = newGame()
+
+        // Attacker: a Savannah Lions we will name with chapter III.
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        driver.removeSummoningSickness(lions)
+
+        // Cast the chapter-III sorcery and choose "Savannah Lions".
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLUE, 1)
+        val spell = driver.putCardInHand(you, "Chosen Name Draw Test")
+        driver.castSpell(you, spell)
+        settle(driver)
+        val pick = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(you, OptionChosenResponse(pick.id, pick.options.indexOf("Savannah Lions")))
+        settle(driver)
+
+        // Attack the opponent with the Lions and deal combat damage.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(lions), opponent)
+        val handBeforeDamage = driver.getHandSize(you)
+        driver.declareNoBlockers(opponent)
+        // Advance through the combat-damage step, resolving the chapter-III draw trigger.
+        var guard = 0
+        while (guard++ < 40 && driver.state.step != Step.POSTCOMBAT_MAIN) {
+            if (driver.isPaused) break
+            driver.bothPass()
+        }
+        settle(driver)
+
+        // The delayed chapter-III trigger drew a card when the Lions dealt combat damage.
+        driver.getHandSize(you) shouldBe handBeforeDamage + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSoulStoneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSoulStoneScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.TheSoulStone
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Soul Stone (SPM) — "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. Once
+ * harnessed, its ∞ ability is active. ∞ — At the beginning of your upkeep, return target creature
+ * card from your graveyard to the battlefield."
+ *
+ * Pins the Harness gating: the ∞ upkeep trigger reanimates only while the Stone has a harness
+ * counter (the new `Counters.HARNESS` marker read by `Conditions.SourceHasCounter`).
+ */
+class TheSoulStoneScenarioTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheSoulStone))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        return driver to you
+    }
+
+    /** Advance to the controller's own next upkeep, submitting the ∞ target if it triggers. */
+    fun advanceToMyUpkeep(driver: GameTestDriver, me: EntityId, reanimateTarget: EntityId?) {
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        if (driver.activePlayer != me && !driver.isPaused) {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+            driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        }
+        // Resolve the upkeep: submit the ∞ target when prompted, otherwise pass through the stack.
+        var guard = 0
+        while (guard++ < 60) {
+            if (driver.isPaused && driver.pendingDecision is ChooseTargetsDecision) {
+                if (reanimateTarget == null) break
+                driver.submitTargetSelection(me, listOf(reanimateTarget))
+            } else if (!driver.isPaused && driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else {
+                break
+            }
+        }
+    }
+
+    test("once harnessed, the ∞ upkeep trigger reanimates a creature from your graveyard") {
+        val (driver, you) = newGame()
+        val stone = driver.putPermanentOnBattlefield(you, "The Soul Stone")
+        driver.addComponent(stone, CountersComponent(mapOf(CounterType.HARNESS to 1)))
+        val lions = driver.putCardInGraveyard(you, "Savannah Lions")
+
+        advanceToMyUpkeep(driver, you, reanimateTarget = lions)
+
+        driver.getPermanents(you).contains(lions) shouldBe true
+        driver.getGraveyard(you).contains(lions) shouldBe false
+    }
+
+    test("without a harness counter the ∞ ability does not trigger") {
+        val (driver, you) = newGame()
+        driver.putPermanentOnBattlefield(you, "The Soul Stone") // NOT harnessed
+        val lions = driver.putCardInGraveyard(you, "Savannah Lions")
+
+        advanceToMyUpkeep(driver, you, reanimateTarget = null)
+
+        driver.getGraveyard(you).contains(lions) shouldBe true
+        driver.getPermanents(you).contains(lions) shouldBe false
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -132,4 +132,5 @@ export const counterManaClass: Record<string, string> = {
   INGENUITY: 'counter-charge',
   FILM: 'counter-charge',
   ICE: 'counter-flood',
+  HARNESS: 'counter-devotion',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -786,6 +786,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.INGENUITY,
   CounterType.FILM,
   CounterType.ICE,
+  CounterType.HARNESS,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2031,6 +2031,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   REVIVAL: { bg: 'rgba(22, 34, 30, 0.95)', border: 'rgba(120, 205, 165, 0.7)', color: '#9ee0c0', glow: 'rgba(120, 205, 165, 0.55)' },
   FILM: { bg: 'rgba(28, 28, 32, 0.95)', border: 'rgba(180, 185, 195, 0.7)', color: '#d0d4dc', glow: 'rgba(180, 185, 195, 0.5)' },
   ICE: { bg: 'rgba(18, 42, 58, 0.95)', border: 'rgba(140, 210, 240, 0.7)', color: '#b8e4f5', glow: 'rgba(140, 210, 240, 0.55)' },
+  HARNESS: { bg: 'rgba(48, 26, 12, 0.95)', border: 'rgba(240, 180, 80, 0.8)', color: '#ffc860', glow: 'rgba(240, 180, 80, 0.7)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -2142,8 +2142,8 @@ function GameCardImpl({
         </div>
       )}
 
-      {/* Chosen creature type / color / mode / card name badge (e.g., Doom Cannon, Riptide Replicator, Outpost Siege, Petrified Hamlet) */}
-      {!faceDown && (card.chosenCreatureType ?? card.chosenColor ?? card.chosenMode ?? card.chosenCardName) && (
+      {/* Chosen creature type / color / mode / card name / card type badge (e.g., Doom Cannon, Riptide Replicator, Outpost Siege, Petrified Hamlet, Arachne) */}
+      {!faceDown && (card.chosenCreatureType ?? card.chosenColor ?? card.chosenMode ?? card.chosenCardName ?? card.chosenCardType) && (
         <div style={{
           position: 'absolute',
           bottom: card.power != null ? 22 : 4,
@@ -2158,7 +2158,7 @@ function GameCardImpl({
           pointerEvents: 'none',
           zIndex: 5,
         }}>
-          {[card.chosenColor, card.chosenCreatureType, card.chosenMode, card.chosenCardName].filter(Boolean).join(' ')}
+          {[card.chosenColor, card.chosenCreatureType, card.chosenMode, card.chosenCardName, card.chosenCardType].filter(Boolean).join(' ')}
         </div>
       )}
 

--- a/web-client/src/components/scenario/types.ts
+++ b/web-client/src/components/scenario/types.ts
@@ -15,6 +15,8 @@ export interface ScenarioBattlefieldCard {
   attachedTo?: string
   chosenCreatureType?: string
   chosenColor?: string
+  /** Durable chosen card type, e.g. Arachne, Psionic Weaver (CR 205.2a). */
+  chosenCardType?: string
 }
 
 export interface ScenarioPlayerConfig {

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -449,6 +449,7 @@ export enum CounterType {
   SKEWER = 'SKEWER',
   ENERGY = 'ENERGY',
   ICE = 'ICE',
+  HARNESS = 'HARNESS',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -519,6 +520,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.SKEWER]: 'Skewer',
   [CounterType.ENERGY]: 'Energy',
   [CounterType.ICE]: 'Ice',
+  [CounterType.HARNESS]: 'Harness',
 }
 
 /**

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -374,6 +374,9 @@ export interface ClientCard {
   /** Chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet) */
   readonly chosenCardName?: string | null
 
+  /** Chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver) */
+  readonly chosenCardType?: string | null
+
   /** Triggering entity ID for triggered abilities on the stack (for source arrows) */
   readonly triggeringEntityId?: EntityId | null
 


### PR DESCRIPTION

<img width="572" height="284" alt="image" src="https://github.com/user-attachments/assets/c5d3adde-ba5e-42a7-8436-b49bdbc9c3e5" />


## Marvel's Spider-Man: four cards + display plumbing

Adds four SPM cards and the small cross-layer plumbing two of them need to be visible in the client. Composition-first throughout — the only genuinely new SDK vocabulary is the durable card-type choice and the `harness` marker counter; everything else reuses existing primitives.

### Cards

- **Costume Closet** `{1}{W}` — Artifact. Fixes a modified-leaves-battlefield trigger.
- **Arachne, Psionic Weaver** `{2}{W}` — Legendary Creature. Web-slinging `{W}`; "As Arachne enters, look at an opponent's hand, then choose a card type other than creature. Spells of the chosen type cost `{1}` more." Introduces the durable **chosen card type** (CR 205.2a) on `ChoiceSlot.CARD_TYPE`, read by a symmetric `ModifySpellCost` tax — the same shape as Thalia, keyed to the chosen type.
- **The Soul Stone** `{1}{B}` — Legendary Artifact — Infinity Stone. Indestructible; `{T}: Add {B}`; a Harness activated ability, and an `∞` upkeep reanimation gated on being harnessed. **Harness** is modeled as a binary `HARNESS` marker counter (the only new vocabulary) — resets if the Stone leaves the battlefield, idempotent to re-place.
- **The Clone Saga** `{3}{U}` — Enchantment — Saga. I: Surveil 3. II: delayed "when you next cast a creature spell, copy it (non-legendary)". III: "choose a card name; whenever a creature with that name deals combat damage to a player this turn, draw." Chapters II and III compose existing primitives (delayed triggers, `CopyTargetSpell(removeLegendary)`, `ChooseCardName`); the one engine change generalizes `CreateDelayedTriggerExecutor`'s chosen-value baking to also rewrite `NameEqualsChosen → NameEquals` and to bake into a `DealsDamageEvent.sourceFilter`, via a shared `bakeChosenValuesIntoFilter` helper.

### Supporting engine/client work

- **Scenario builder** — `BattlefieldCardConfig.chosenCardType` lets a scenario pre-set a permanent's durable chosen card type (mirrors the existing `chosenCreatureType` / `chosenColor` paths), so scenarios can show Arachne mid-game.
- **Client display surfacing** — the chosen card type and the harness counter were stored engine-side but never reached the client. Added a `chosenCardType()` accessor + `ClientCard.chosenCardType` (populated in `ClientStateTransformer`, mirroring `chosenCreatureType` end to end) and the on-permanent badge; and added `HARNESS` to the passive-counter badge system (`CounterType` enum + display name, `counterManaClass` icon, `passiveCounterBadgeStyle` palette, `PASSIVE_COUNTER_TYPES`) so a harnessed permanent renders a badge.

### Tests

One scenario test per card (`rules-engine` `scenarios/`): `CostumeClosetScenarioTest`, `ArachnePsionicWeaverScenarioTest` (incl. the durable choice, the tax, and the client-view surfacing), `TheSoulStoneScenarioTest` (harnessed `∞` fires / unharnessed does not), `TheCloneSagaChapterThreeTest` (chosen-name combat-damage draw). Manual scenarios under `manual-scenarios/sets/spm/`, including `batch5-new-cards-castable.json` that boots all four. `docs/card-sdk-language-reference.md` updated for the card-type choice.

### Verification

`rules-engine` scenario tests green (Costume Closet, Arachne, Soul Stone, Clone Saga); web-client `tsc` clean for all touched files. Branch rebased on `main` (the `HARNESS` counter coexists with main's new `ICE` counter across the SDK enum and the web-client counter lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
