### PR TITLE
Marvel's Spider-Man: Norman Osborn, Peter Parker, Gwenom, Black Cat (+ play-from-exile/top
  fixes)

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 185 / 188
+**Implemented:** 186 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -43,7 +43,7 @@
 - [x] Grow Extra Arms
 - [x] Guy in the Chair
 - [x] Gwen Stacy // Ghost-Spider
-- [ ] Gwenom, Remorseless
+- [x] Gwenom, Remorseless
 - [x] Heroes' Hangout
 - [x] Hide on the Ceiling
 - [x] Hobgoblin, Mantled Marauder

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 181 / 188
+**Implemented:** 182 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -166,7 +166,7 @@
 - [x] Terrific Team-Up
 - [ ] The Clone Saga
 - [x] The Death of Gwen Stacy
-- [ ] The Soul Stone
+- [x] The Soul Stone
 - [x] The Spot's Portal
 - [x] The Spot, Living Portal
 - [x] Thwip!

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,13 +2,13 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 180 / 188
+**Implemented:** 181 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
 - [x] Amazing Acrobatics
 - [x] Anti-Venom, Horrifying Healer
-- [ ] Arachne, Psionic Weaver
+- [x] Arachne, Psionic Weaver
 - [x] Araña, Heart of the Spider
 - [x] Aunt May
 - [x] Bagel and Schmear

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 182 / 188
+**Implemented:** 183 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -164,7 +164,7 @@
 - [x] Symbiote Spider-Man
 - [x] Taxi Driver
 - [x] Terrific Team-Up
-- [ ] The Clone Saga
+- [x] The Clone Saga
 - [x] The Death of Gwen Stacy
 - [x] The Soul Stone
 - [x] The Spot's Portal

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 186 / 188
+**Implemented:** 187 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -15,7 +15,7 @@
 - [x] Beetle, Legacy Criminal
 - [x] Behold the Sinister Six!
 - [x] Biorganic Carapace
-- [ ] Black Cat, Cunning Thief
+- [x] Black Cat, Cunning Thief
 - [x] Carnage, Crimson Chaos
 - [x] Chameleon, Master of Disguise
 - [x] Cheering Crowd

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 184 / 188
+**Implemented:** 185 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -87,7 +87,7 @@
 - [x] Oscorp Research Team
 - [x] Parker Luck
 - [x] Passenger Ferry
-- [ ] Peter Parker // Amazing Spider-Man
+- [x] Peter Parker // Amazing Spider-Man
 - [x] Peter Parker's Camera
 - [x] Pictures of Spider-Man
 - [x] Prison Break

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 183 / 188
+**Implemented:** 184 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -80,7 +80,7 @@
 - [x] Mysterio's Phantasm
 - [x] Mysterio, Master of Illusion
 - [x] News Helicopter
-- [ ] Norman Osborn // Green Goblin
+- [x] Norman Osborn // Green Goblin
 - [x] Ominous Asylum
 - [x] Origin of Spider-Man
 - [x] Oscorp Industries

--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 179 / 188
+**Implemented:** 180 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -22,7 +22,7 @@
 - [x] City Pigeon
 - [x] Common Crook
 - [x] Cosmic Spider-Man
-- [ ] Costume Closet
+- [x] Costume Closet
 - [x] Daily Bugle Building
 - [x] Daily Bugle Reporters
 - [x] Damage Control Crew

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -36,10 +36,13 @@ Still blocked (not on web-slinging itself):
   opponent's hand, then choose a card type other than creature; spells of the chosen type cost {1}
   more to cast" needs a **durable card-type enters-choice + a chosen-card-type spell-tax static**
   (see the new section below). Deferred rather than approximated.
-- **Peter Parker // Amazing Spider-Man** [10] — transform DFC whose *back face grants* web-slinging to
-  your legendary spells; blocked on transform + a **grant-web-slinging-to-your-spells** static (the
-  keyword is now grantable in principle, but the "your legendary spells have web-slinging" grant is
-  not yet wired — separate follow-up).
+- **Peter Parker // Amazing Spider-Man** [10] — ✅ DONE (branch `spm-peter-parker`). Transform DFC (front:
+  ETB 2/1 green Spider token + sorcery-speed transform, both pre-existing). Back's "each legendary spell
+  you cast that's one or more colors has web-slinging {G}{W}{U}" is the new `GrantWebSlingingToSpells(cost,
+  spellFilter)` static (parallel to `GraveyardCardsHaveMayhem`): `WebSlinging.effectiveWebSlinging` now also
+  scans the battlefield for it (printed → group grant), threaded through `WebSlingingCastEnumerator` +
+  `CastSpellHandler` (validate/cost×2/rider). Filter = `IsLegendary` + `IsColored`. Scenario test pins the
+  grant (legendary+colored → offered; nonlegendary → not; no granter → not).
 
 ## "Choose a card type" durable enters-choice + "spells of the chosen type cost {1} more" static — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -41,7 +41,17 @@ Still blocked (not on web-slinging itself):
   keyword is now grantable in principle, but the "your legendary spells have web-slinging" grant is
   not yet wired — separate follow-up).
 
-## "Choose a card type" durable enters-choice + "spells of the chosen type cost {1} more" static
+## "Choose a card type" durable enters-choice + "spells of the chosen type cost {1} more" static — ✅ IMPLEMENTED
+
+**Done** (branch `spm-arachne`). New durable card-type choice dimension: `ChoiceSlot.CARD_TYPE`,
+`Effects.ChooseCardTypeForSource(allowedCardTypes, lookAtOpponentHand)` (on-resolution, writes the slot
+durably — the analogue of `ChooseNumberForSource`, run from a "when ~ enters" trigger), and
+`CardPredicate.CardTypeEqualsChosenComponent` / `GameObjectFilter.ofChosenCardTypeComponent()` read at
+cost-calculation time. The tax is a plain `ModifySpellCost(AnyCaster(ofChosenCardTypeComponent()),
+IncreaseGeneric(1))` (Thalia shape). Scenario test pins the durable write + the symmetric tax
+(chosen-type spell costs {1} more, other types untaxed).
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > As Arachne enters, look at an opponent's hand, then **choose a card type** other than creature.
 > **Spells of the chosen type cost {1} more to cast.**
@@ -56,6 +66,8 @@ stored choice feeding a cost-increase). "Look at an opponent's hand" is informat
 
 Blocked cards:
 - **Arachne, Psionic Weaver** [2] — web-slinging implemented; the choose-a-card-type tax is the blocker.
+
+</details>
 
 ## Harness / Infinity Stone ∞ ability
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -128,9 +128,12 @@ Still blocked (not on Mayhem itself):
   graveyard land-plays (lands bypass `ZoneTransitionService`).
 - **Ultimate Green Goblin** [157] — `{1}{B/R}{B/R}` Mayhem `{2}{B/R}`; the upkeep "discard a card, then create a
   Treasure" is expressible, but was not authored in this batch — a straightforward follow-up now that Mayhem exists.
-- **Norman Osborn // Green Goblin** [39] — transform DFC; back's "Goblin Formula" grants Mayhem (cost = mana cost) to
-  every nonland card in your graveyard — blocked on transform + a **group `GraveyardCardsHaveMayhem` grant**
-  (`MayhemGrants` already reads per-entity grants, so the group-grant static is the remaining piece).
+- **Norman Osborn // Green Goblin** [39] — ✅ DONE (branch `spm-norman-osborn`). Transform DFC (front: unblockable +
+  connive-on-combat-damage + sorcery-speed transform; all pre-existing). Back's "Goblin Formula" is the new
+  `GraveyardCardsHaveMayhem(filter, cost?)` static (mirrors `GraveyardCardsHaveFlashback`): `MayhemGrants.effectiveMayhem`
+  now also scans the battlefield for it (group grant → per-entity → printed), threaded through the four cast read sites,
+  still gated on discarded-this-turn. Back's gy-cast `{2}` reduction is a plain `ModifySpellCost(YouCastFromZones(GRAVEYARD))`.
+  Scenario test pins the group-granted mayhem (grant on, grant off, discard-gate).
 
 Also enabled by the **discarded-this-turn tracking** half (now implemented) but not yet authored:
 - **Green Goblin, Revenant** [130] — `{3}{B}{R}` Flying/deathtouch; "Whenever Green Goblin attacks, discard a card.

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -382,7 +382,20 @@ the land and spell turn-conditions.
 - **Spider-Man 2099** [150] — `{U}{R}` double strike/vigilance; the "From the Future" turn-number cast restriction (`ControllerTurnsTakenAtMost`) and "deal power to any target" are fine, but the end-step intervening-if "if you've played a land or cast a spell this turn from anywhere other than your hand" is the blocker.
 </details>
 
-## Temporary "play from top of library, paying life = mana value instead of mana cost"
+## Temporary "play from top of library, paying life = mana value instead of mana cost" — ✅ IMPLEMENTED
+
+**Done** (branch `spm-gwenom`). New `PlayFromTopWithAlternativeCost(withoutPayingManaCost, additionalCost,
+filter)` static (the top-of-library counterpart to `GrantMayCastFromLinkedExile`). `CastPermissionUtils`
+gained `playFromTopAlternativeCost(...)` which scans BOTH printed `staticAbilities` and
+`state.grantedStaticAbilities` (mirroring `MayCastFromGraveyard`), and every top-of-library read site
+(`CastPermissionUtils`, `CastZoneResolver` incl. `hasPlayWithoutPayingCost`, the enumerator cost branch,
+`CastSpellHandler` validate+execute) now honors it: mana is waived and `PayLifeEqualToManaValueOfSpell`
+is charged. Gwenom's attack trigger grants it (+ `LookAtTopOfLibrary`) to Self until end of turn.
+Scenario test pins it (not castable before the attack; after, casts for life = mana value, no mana).
+(The durationally-granted look's client-side top-card reveal remains printed-scan only — a UI/visibility
+gap with no rules impact.)
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Whenever Gwenom attacks, until end of turn, you may look at the top card of your library any
 > time and you may play cards from the top. If you cast a spell this way, **pay life equal to its
@@ -401,6 +414,8 @@ sites to consult granted statics (mirroring `MayCastFromGraveyard`).
 
 Blocked cards:
 - **Gwenom, Remorseless** [56] — `{3}{B}{B}` Deathtouch/lifelink; the attack-granted "play from top, pay life = mana value" is the blocker (deathtouch, lifelink, and the attack trigger itself are fine).
+
+</details>
 
 ## "Prevent damage to this creature, put that many +1/+1 counters on it" self-replacement — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -208,7 +208,18 @@ Blocked cards:
 - **Spider-Slayer, Hatred Honed** [175] — `{2}` Legendary Artifact Creature; "Whenever Spider-Slayer deals damage to a Spider, destroy that creature" (blocked). Its other ability — `{6}`, exile-from-graveyard → two tapped 1/1 flying Robot tokens — works fine.
 </details>
 
-## Chosen card name surviving into a later-firing delayed trigger
+## Chosen card name surviving into a later-firing delayed trigger — ✅ IMPLEMENTED
+
+**Done** (branch `spm-clone-saga`). `CreateDelayedTriggerExecutor.bakeChosenValuesIntoTrigger` now
+also rewrites `NameEqualsChosen(v)` → literal `NameEquals(chosen[v])` and handles a
+`DealsDamageEvent.sourceFilter` (not just `SpellCastEvent.spellFilter`), via a shared
+`bakeChosenValuesIntoFilter` helper. So chapter III models as `Composite(ChooseCardName("clonedName"),
+CreateDelayedTrigger(dealsDamage(Combat, AnyPlayer, Creature.namedFromVariable("clonedName")),
+DrawCards(1)))`. Chapters I (Surveil 3) and II (`CreateDelayedTrigger(YouCastCreature,
+CopyTargetSpell(TriggeringEntity, removeLegendary=true), fireOnce=true)`) needed no engine change.
+Scenario test pins the chapter-III chosen-name combat-damage draw.
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Choose a card name. Whenever a creature with the **chosen name** deals combat damage to a
 > player this turn, draw a card.
@@ -225,6 +236,8 @@ event filters (e.g. `DealsDamageEvent.sourceFilter`), + verify the delayed match
 
 Blocked cards:
 - **The Clone Saga** [28] — `{3}{U}` Enchantment — Saga; chapters I (Surveil 3) and II (copy your next creature spell, non-legendary — both expressible today) are fine, but chapter III ("choose a card name … whenever a creature with the chosen name deals combat damage, draw") is blocked
+
+</details>
 
 ## Exchange life totals with a player (CR 701.12c) + "life you lost this way" draw amount — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -69,7 +69,18 @@ Blocked cards:
 
 </details>
 
-## Harness / Infinity Stone ∞ ability
+## Harness / Infinity Stone ∞ ability — ✅ IMPLEMENTED
+
+**Done** (branch `spm-soul-stone`). Modeled composition-first: "Harness" is a binary marker counter
+(`Counters.HARNESS`, a new `CounterType` enum value — the only new vocabulary). The Harness activated
+ability places one via `Effects.AddCounters`; the `∞` triggered ability is gated on the permanent
+having a harness counter (`Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.HARNESS))`),
+so it's dormant until harnessed and reactivates each qualifying trigger thereafter. A counter (not a
+durable component) matches the flavor — it resets if the permanent leaves, and re-placing is
+idempotent. No new engine executor/handler needed. Scenario test pins the gating (reanimates only
+while harnessed).
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > `{cost}, {T}, Exile a creature you control: Harness <this>. (Once harnessed, its ∞ ability
 > is active.)` — ∞ — <ongoing ability>
@@ -80,6 +91,8 @@ static/triggered ability). `add-feature` territory.
 
 Blocked cards:
 - **The Soul Stone** [66] — `{1}{B}` Legendary Artifact — Infinity Stone; harness → `∞` upkeep reanimation
+
+</details>
 
 ## Mayhem (new keyword — self graveyard-cast gated on "you discarded this card this turn") — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -123,7 +123,16 @@ which requires Riot to exist as a grantable keyword. `add-feature` scope.
 Blocked cards:
 - **Spider-Punk** [92] — `{1}{R}` Riot; "Other Spiders you control have riot"; also "Spells and abilities can't be countered" + "Damage can't be prevented" (verify those two independently)
 
-## "Modified" state on a leaves-the-battlefield (last-known-information) trigger
+## "Modified" state on a leaves-the-battlefield (last-known-information) trigger — ✅ IMPLEMENTED
+
+**Done** (branch `spm-modified-ltb`). `EntitySnapshot` now captures `wasEquipped` / `wasEnchanted`
+(populated in `ZoneTransitionService` before the exit cleanup strips attachments), and
+`TriggerMatcher.matchesStatePredicateForZoneChangeTrigger` evaluates `IsModified` / `IsEquipped` /
+`IsEnchanted` against the snapshot (counters + those flags) on a leaves-battlefield trigger instead
+of falling through fail-open. Costume Closet ships with a scenario test covering the counter,
+equipped, and unmodified (regression-guard) legs.
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Whenever a **modified** creature you control **leaves the battlefield**, …
 
@@ -141,6 +150,8 @@ battlefield-exit (or the predicate evaluated against pre-leave state). `add-feat
 
 Blocked cards:
 - **Costume Closet** [5] — `{1}{W}` Artifact; enters with two +1/+1 counters + sorcery-speed "{T}: move a counter to target creature you control" (both of those work today) + "Whenever a **modified** creature you control leaves the battlefield, put a +1/+1 counter on this artifact" (the blocked part)
+
+</details>
 
 ## "Deals damage to a [filtered] creature" trigger (RecipientFilter.Matching on a deals-damage trigger) — ✅ IMPLEMENTED
 

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -529,7 +529,19 @@ Blocked cards:
 - **Spider-Verse** [93] — `{3}{R}{R}` Enchantment; the legend-rule exemption for Spiders is the blocker (the copy-spell-from-non-hand clause is fine).
 </details>
 
-## Play cards exiled **face down** from an opponent's library (controller may look + cast)
+## Play cards exiled **face down** from an opponent's library (controller may look + cast) — ✅ IMPLEMENTED
+
+**Done** (branch `spm-black-cat`). Needed **no new code** — the enabling feature (`FaceDownMode.HIDDEN`
+controller-visible-in-exile masking + `GrantMayPlayFromExileEffect(withAnyManaType = true)` + the
+cast-from-face-down-exile legal-action path) has landed since this card was first drafted (used by
+Laughing Jasper Flint / Cruelclaw's Heist). Black Cat's prior draft (from branch `spm-no-engine`,
+removed pending the feature) was restored verbatim: ETB `Gather` top-9 of `Targets.Opponent`'s library
+→ `SelectFromCollection(ChooseExactly(2), showAllCards, storeRemainder)` → exile the two
+`FaceDownMode.HIDDEN` + bottom the rest `CardOrder.Random` → `GrantMayPlayFromExile(Permanent,
+withAnyManaType = true)`. Scenario test pins the face-down exile + casting a stolen off-color spell
+paying entirely with off-color mana. Full regression green.
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Look at the top nine cards of target opponent's library, **exile two of them face down**, then
 > put the rest on the bottom in a random order. **You may play the exiled cards** for as long as
@@ -551,6 +563,8 @@ CastSpellHandler).
 
 Blocked cards:
 - **Black Cat, Cunning Thief** [52] — `{3}{B}{B}` Legendary Creature — Human Rogue Villain, 2/3; the ETB look/exile-two-face-down/bottom-rest pipeline resolves, but "you may play the exiled cards" is uncastable because the face-down HIDDEN exiled cards never surface as playable to the controller. (Previously authored on branch `spm-no-engine`, then removed pending this feature.)
+
+</details>
 
 ---
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6072,6 +6072,12 @@ composite abilities).
   `ChoiceSlot.WEB_SLUNG` (read via `Conditions.WebSlungCostWasPaid`, e.g. *Spiders-Man, Heroic Horde*'s enters trigger) and
   the returned creature's mana value under `ChoiceSlot.WEB_SLUNG_RETURNED_MV` (read via `DynamicAmount.CastChoice`, e.g.
   *Scarlet Spider, Ben Reilly* enters with that many +1/+1 counters).
+- `GrantWebSlingingToSpells(cost, spellFilter)` — a static ability that **grants web-slinging `cost`** to spells the
+  controller casts matching `spellFilter` (web-slinging carries a `ManaCost`, which the generic `GrantKeywordToOwnSpells`
+  can't express). Read through `WebSlinging.effectiveWebSlinging` (printed → this battlefield grant), which the
+  `WebSlingingCastEnumerator` and `CastSpellHandler` consult, so a granted web-slinging behaves exactly like a printed
+  one. Amazing Spider-Man (back of Peter Parker): "Each legendary spell you cast that's one or more colors has web-slinging
+  {G}{W}{U}" → `GrantWebSlingingToSpells({G}{W}{U}, GameObjectFilter(cardPredicates = [IsLegendary, IsColored]))`.
 - `Mayhem(cost)` — `card { mayhem("{cost}") }` builder helper (CR 702.187, Marvel's Spider-Man). A **graveyard**
   alternative cost: *"As long as you discarded this card this turn, you may cast it from your graveyard by paying [cost]
   rather than paying its mana cost."* Grants **no timing permission** (normal timing — sorcery speed unless the card is an

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1998,6 +1998,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   promised opponent in the same slot as part of the cast — see § 11 "Gift".) The *as-enters* analogue
   is `EntersWithChoice(ChoiceType.OPPONENT)`,
   which writes the same slot (Jihad, The Rack).
+- `Effects.ChooseCardTypeForSource(allowedCardTypes=null, lookAtOpponentHand=false, slot=ChoiceSlot.CARD_TYPE, prompt)`
+  — the controller picks a card type (CR 205.2a), **stored durably on the source entity** under
+  `ChoiceSlot.CARD_TYPE` (a `ChoiceValue.TextChoice`) and read back at cost-calculation / projection
+  time by `CardPredicate.CardTypeEqualsChosenComponent` (build the filter with
+  `GameObjectFilter.…ofChosenCardTypeComponent()`). `allowedCardTypes` restricts the offered set (pass
+  the non-creature list for "a card type other than creature"); `lookAtOpponentHand` reveals an
+  opponent's hand to the controller first. The on-resolution, durable-slot analogue of an as-enters
+  card-type choice — the same relationship `ChooseNumberForSource` has to `EntersWithChoice(NUMBER)`;
+  use it in a "when ~ enters" trigger when the chosen type only feeds a continuous tax (Arachne,
+  Psionic Weaver — "choose a card type … Spells of the chosen type cost {1} more").
 - `GrantHexproofFromChosenColorEffect(target)` — hexproof from chosen color.
 - `GrantProtectionFromChosenColorEffect(target)` — protection from chosen color. Must run inside `ChooseColorThen`; wrap in `ForEachInGroup` for the group case (Akroma's Blessing: "Creatures you control gain protection from the chosen color").
 - `Effects.GrantProtectionFromChosenCardType(target, duration)` — "gains protection from the card type of your choice" (Pippin, Guard of the Citadel). The card-type analogue of `GrantProtectionFromChosenColor`, but **self-contained**: its executor owns the choice — it presents a `ChooseOptionDecision` over the fixed protectable card-type set (Artifact, Creature, Enchantment, Instant, Land, Planeswalker, Sorcery, Battle) and, on response, grants a floating `PROTECTION_FROM_CARDTYPE_<TYPE>` keyword for `duration`. The targeting validator, `StackResolver` spell-targeting, `DamageUtils`, the combat-damage pipeline/manager, and a `ProtectionFromCardTypeRule` block-evasion rule all match the protected keyword against the source's projected card types. (The "can't be enchanted/equipped by that type" clause is reminder text and unenforced at attach time, mirroring color/subtype protection.)
@@ -2884,6 +2894,12 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   evaluated. Pair with `replacementEffect(EntersWithChoice(ChoiceType.CARD_NAME))`. Fails closed (no match) before
   a name is chosen. Used by name-keyed static abilities (Petrified Hamlet — "sources with the chosen name … /
   Lands with the chosen name …").
+- `.ofChosenCardTypeComponent(slot = ChoiceSlot.CARD_TYPE)` — `CardPredicate.CardTypeEqualsChosenComponent`:
+  the card-type analogue of `.namedFromChosenComponent`. Matches cards whose **card type** equals the type
+  **durably chosen by the source permanent** (read from its `CastChoicesComponent` under `slot`). Same
+  static-projection / cost-calculation safety and source-id keying. Pair with a trigger running
+  `Effects.ChooseCardTypeForSource`. Fails closed before a type is chosen. Used by card-type-keyed taxes
+  (Arachne, Psionic Weaver — "Spells of the chosen type cost {1} more").
 - `.originallyPrintedInSet(setCode)` — `CardPredicate.OriginallyPrintedInSet`: matches a card whose
   *canonical* set code equals `setCode` (case-insensitive), i.e. the set it was *originally printed* in —
   reprints still match their original set, regardless of the printing in play. Reads the entity's

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5411,6 +5411,14 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
   shown to all players, but can only be played once drawn. (**Goblin Spy**)
 - `PlayFromTopOfLibrary` — public reveal **and** "play lands and cast spells from the top of your
   library" (all card types). (Future Sight)
+- `PlayFromTopWithAlternativeCost(withoutPayingManaCost = false, additionalCost = null, filter = null)`
+  — "you may play cards from the top of your library; a spell cast this way pays an alternative cost"
+  (mana waived and/or an `AdditionalCost` substituted). Gwenom, Remorseless grants this until end of
+  turn (`GrantStaticAbility(..., Duration.EndOfTurn)`) with `withoutPayingManaCost = true` +
+  `Costs.additional.PayLifeEqualToManaValueOfSpell` — "play from the top; pay life equal to a spell's
+  mana value rather than its mana cost." Read through the top-of-library cast path, which scans
+  `grantedStaticAbilities` for it (so a durationally-granted permission works), waives the mana, and
+  charges the life. Pass `filter` to restrict which cards it covers (null = all).
 - `PlayLandsAndCastFilteredFromTopOfLibrary(spellFilter)` — like `PlayFromTopOfLibrary` but only
   spells matching `spellFilter` are castable (lands always playable), and **no public reveal** (pair
   with `LookAtTopOfLibrary` to let just the controller see). `spellFilter = GameObjectFilter.Any`

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5255,6 +5255,14 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   in your graveyard has flashback … equal to that card's mana cost") and one for
   `InstantOrSorcery.withSubtype(Lesson)` with `cost = {1}` ("each Lesson card in your graveyard has
   flashback {1}"), both `duringYourTurnOnly = true`.
+- `GraveyardCardsHaveMayhem(filter, cost = null, duringYourTurnOnly = false)` — the Mayhem (CR 702.187)
+  analogue of `GraveyardCardsHaveFlashback`: a whole-graveyard group grant of the Mayhem keyword to
+  every graveyard card matching `filter`. `cost = null` means "mayhem cost equal to that card's mana
+  cost". Read through the shared `MayhemGrants.effectiveMayhem` resolver (enumerator, cast cost,
+  permission), which now scans the battlefield for this static; the mayhem discarded-this-turn gate
+  still applies, and (unlike flashback) the spell is not exiled on resolution. Used by Green Goblin's
+  "Goblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is equal to its
+  mana cost" (`GraveyardCardsHaveMayhem(GameObjectFilter.Nonland)`).
 - `GrantMayCastFromLinkedExile(filter = Nonland, duringYourTurnOnly = false, additionalCost = null, ownedByYou = false, withoutPayingManaCost = false, oncePerTurn = false, maxManaValue = null, exiledThisTurnOnly = false, entersWithCounter = null)`
   — "you may cast cards exiled with this permanent" — reads the source's `LinkedExileComponent` (Rona,
   Disciple of Gix; Maralen, Fae Ascendant; Dawnhand Dissident). Casting spells from linked exile is

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -158,6 +158,7 @@ class ScenarioBuilderService(
                 summoningSickness = card.summoningSickness ?: false,
                 counters = card.counters ?: emptyMap(),
                 chosenCreatureType = card.chosenCreatureType,
+                chosenCardType = card.chosenCardType,
                 chosenColor = card.chosenColor
             )
         }
@@ -243,6 +244,7 @@ class ScenarioBuilderService(
             summoningSickness: Boolean = false,
             counters: Map<String, Int> = emptyMap(),
             chosenCreatureType: String? = null,
+            chosenCardType: String? = null,
             chosenColor: String? = null
         ): ScenarioBuilder {
             val playerId = playerFor(playerNumber)
@@ -269,6 +271,12 @@ class ScenarioBuilderService(
             if (chosenCreatureType != null) {
                 container = container.withCastChoice(
                     ChoiceSlot.CREATURE_TYPE, ChoiceValue.TextChoice(chosenCreatureType)
+                )
+            }
+
+            if (chosenCardType != null) {
+                container = container.withCastChoice(
+                    ChoiceSlot.CARD_TYPE, ChoiceValue.TextChoice(chosenCardType)
                 )
             }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
@@ -130,6 +130,12 @@ data class BattlefieldCardConfig(
     /** For permanents with "As this enters, choose a creature type" — skips the ETB choice by pre-setting it. */
     val chosenCreatureType: String? = null,
     /**
+     * For permanents that durably choose a card type (CR 205.2a — e.g. Arachne, Psionic Weaver's
+     * "choose a card type other than creature") — skips the ETB choice by pre-setting it. Value is a
+     * card-type name, e.g. "Artifact", "Enchantment", "Instant".
+     */
+    val chosenCardType: String? = null,
+    /**
      * For permanents with "As this enters, choose a color" — skips the ETB choice by pre-setting it.
      * Value must be a [com.wingedsheep.sdk.core.Color] name, e.g. "WHITE", "GREEN".
      */

--- a/manual-scenarios/sets/spm/arachne.json
+++ b/manual-scenarios/sets/spm/arachne.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Arachne, Psionic Weaver", "Whoosh!", "Amazing Acrobatics", "Electro's Bolt", "Prison Break"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Electro's Bolt", "Whoosh!", "Prison Break"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/batch5-new-cards-castable.json
+++ b/manual-scenarios/sets/spm/batch5-new-cards-castable.json
@@ -1,0 +1,47 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "The Clone Saga",
+      "Costume Closet"
+    ],
+    "battlefield": [
+      {"name": "The Soul Stone", "counters": {"HARNESS": 1}},
+      {"name": "Arachne, Psionic Weaver", "chosenCardType": "Instant"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Grizzly Bears", "Serra Angel"],
+    "library": ["Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Smother"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Plains", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/sets/spm/black-cat.json
+++ b/manual-scenarios/sets/spm/black-cat.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Black Cat, Cunning Thief"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": [
+      "Pumpkin Bombardment", "Rhino, Barreling Brute", "City Pigeon", "Kraven's Cats",
+      "Electro's Bolt", "Scout the City", "Prison Break", "Spider-Bot", "Kapow!",
+      "Mountain", "Mountain", "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/costume-closet.json
+++ b/manual-scenarios/sets/spm/costume-closet.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Costume Closet"],
+    "battlefield": [
+      {"name": "Costume Closet", "counters": {"PLUS_ONE_PLUS_ONE": 2}},
+      {"name": "City Pigeon", "counters": {"PLUS_ONE_PLUS_ONE": 1}},
+      {"name": "Spider-Bot"},
+      {"name": "Web-Shooters", "attachedTo": "Spider-Bot"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Rhino, Barreling Brute"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/gwenom.json
+++ b/manual-scenarios/sets/spm/gwenom.json
@@ -1,0 +1,29 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Gwenom, Remorseless"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Rhino, Barreling Brute", "City Pigeon", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "POSTCOMBAT_MAIN"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/heroes-and-villains-castable.json
+++ b/manual-scenarios/sets/spm/heroes-and-villains-castable.json
@@ -1,0 +1,53 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Norman Osborn",
+      "Peter Parker",
+      "Gwenom, Remorseless",
+      "Black Cat, Cunning Thief"
+    ],
+    "battlefield": [
+      {"name": "Jalum Tome"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Plains", "Swamp", "Island", "Plains", "Swamp", "Island", "Plains", "Swamp", "Island", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Plains", "Island", "Swamp", "Plains", "Island", "Swamp", "Plains", "Island", "Swamp", "Plains", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/sets/spm/norman-osborn.json
+++ b/manual-scenarios/sets/spm/norman-osborn.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Norman Osborn"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": ["Electro's Bolt", "Pumpkin Bombardment"],
+    "library": ["Island", "Island", "Swamp", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "City Pigeon"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/peter-parker.json
+++ b/manual-scenarios/sets/spm/peter-parker.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Peter Parker", "Silk, Web Weaver", "Araña, Heart of the Spider"],
+    "battlefield": [
+      {"name": "City Pigeon", "tapped": true},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Plains", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/the-clone-saga.json
+++ b/manual-scenarios/sets/spm/the-clone-saga.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["The Clone Saga", "Spider-Bot", "City Pigeon"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island", "Island", "City Pigeon", "Spider-Bot"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP", "DRAW"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/spm/the-soul-stone.json
+++ b/manual-scenarios/sets/spm/the-soul-stone.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["The Soul Stone"],
+    "battlefield": [
+      {"name": "City Pigeon"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Spider-Bot", "Rhino, Barreling Brute"],
+    "library": ["Swamp", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -81,7 +81,16 @@ enum class CounterType {
     SKEWER,
     ENERGY,
     ICE,
-    OMEN;
+    OMEN,
+
+    /**
+     * Harness counter (Marvel's Spider-Man Infinity Stones). A binary "harnessed" marker: the Stone's
+     * activated Harness ability places one, and its `∞` ability is gated on the Stone having a harness
+     * counter (CR-style "as long as this permanent has a harness counter"). Not a resource — exactly
+     * one is ever placed; it models the permanent "once harnessed" state that resets if the Stone
+     * leaves the battlefield.
+     */
+    HARNESS;
 
     companion object {
         /**
@@ -380,6 +389,9 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val FILM = "film"
+
+    /** Harness marker counter — the Infinity Stones' "once harnessed" binary state. */
+    const val HARNESS = "harness"
 
     /**
      * Skewer counter (WOE — Rotisserie Elemental). A tally counter with no inherent rule: the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2759,6 +2759,26 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect(prompt)
 
     /**
+     * The controller chooses a card type (CR 205.2a), stored durably on the source entity under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE] and read back at cost-calculation /
+     * projection time through
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent] (build
+     * the filter with `GameObjectFilter.…ofChosenCardTypeComponent()`). [allowedCardTypes] restricts
+     * the offered set (default all); pass the non-creature list for "a card type other than
+     * creature". [lookAtOpponentHand] reveals an opponent's hand to the controller first. Powers
+     * Arachne, Psionic Weaver's "look at an opponent's hand, then choose a card type … Spells of the
+     * chosen type cost {1} more."
+     */
+    fun ChooseCardTypeForSource(
+        allowedCardTypes: List<String>? = null,
+        lookAtOpponentHand: Boolean = false,
+        slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE,
+        prompt: String = "Choose a card type"
+    ): Effect = com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect(
+        allowedCardTypes, lookAtOpponentHand, slot, prompt
+    )
+
+    /**
      * Grant Toxic N to a target until end of turn.
      *
      * Composes [GrantKeywordEffect] with the `TOXIC_<n>` string keyword — the same projected

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ChoiceSlot.kt
@@ -42,6 +42,17 @@ enum class ChoiceSlot {
      */
     CARD_NAME,
 
+    /**
+     * A card type chosen as the object entered (e.g. Arachne, Psionic Weaver "choose a card type
+     * other than creature"). Stored as a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice] holding the
+     * card-type name ("Artifact", "Instant", …). Read back at static-projection / cost-calculation
+     * time by [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent],
+     * the card-type analogue of [CARD_NAME]'s
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameEqualsChosenComponent].
+     */
+    CARD_TYPE,
+
     /** Another creature chosen as the object entered (e.g. Dauntless Bodyguard). */
     CREATURE,
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -378,6 +378,47 @@ data object PlayFromTopOfLibrary : StaticAbility {
 }
 
 /**
+ * You may play cards from the top of your library, and a spell cast this way is cast with an
+ * alternative cost — its mana cost waived ([withoutPayingManaCost]) and/or an [additionalCost]
+ * substituted. Gwenom, Remorseless grants this until end of turn: "you may play cards from the top
+ * of your library. If you cast a spell this way, pay life equal to its mana value rather than pay
+ * its mana cost" (`withoutPayingManaCost = true`, `additionalCost = PayLifeEqualToManaValueOfSpell`).
+ *
+ * The alternative-cost analogue of [PlayFromTopOfLibrary] (which plays for normal costs) — kept a
+ * separate type so the plain data object stays identity-checked. When granted durationally (e.g.
+ * via [com.wingedsheep.sdk.scripting.effects.GrantStaticAbilityEffect]) the top-of-library read
+ * sites scan `grantedStaticAbilities` for it alongside printed statics.
+ *
+ * @property withoutPayingManaCost When true, the spell's mana cost is waived (paid as {0}).
+ * @property additionalCost An additional cost substituted for the mana cost (e.g. pay life equal to
+ *   the spell's mana value). Null for none.
+ * @property filter Restrict which cards this permission covers; null = all cards (lands + spells).
+ */
+@SerialName("PlayFromTopWithAlternativeCost")
+@Serializable
+data class PlayFromTopWithAlternativeCost(
+    val withoutPayingManaCost: Boolean = false,
+    val additionalCost: AdditionalCost? = null,
+    val filter: GameObjectFilter? = null,
+) : StaticAbility {
+    override val description: String = buildString {
+        append("You may play cards from the top of your library")
+        if (withoutPayingManaCost || additionalCost != null) {
+            append("; a spell cast this way")
+            if (withoutPayingManaCost) append(" doesn't pay its mana cost")
+            if (additionalCost != null) append(" and instead ${additionalCost.description}")
+        }
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter?.applyTextReplacement(replacer)
+        val newCost = additionalCost?.applyTextReplacement(replacer)
+        return if (newFilter !== filter || newCost !== additionalCost) {
+            copy(filter = newFilter, additionalCost = newCost)
+        } else this
+    }
+}
+
+/**
  * You may cast spells matching a filter from the top of your library.
  * Unlike PlayFromTopOfLibrary, this only allows specific spell types (not all spells/lands).
  * Used for Precognition Field (instant and sorcery only).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -392,6 +392,35 @@ data class GraveyardCardsHaveFlashback(
 }
 
 /**
+ * "Each [filter] card in your graveyard has mayhem [cost]." The Mayhem analogue of
+ * [GraveyardCardsHaveFlashback] — a whole-graveyard group grant of the Mayhem keyword ability
+ * (CR 702.187), read through `MayhemGrants.effectiveMayhem` alongside the discarded-this-turn gate.
+ * Green Goblin's "Goblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost
+ * is equal to its mana cost."
+ *
+ * @property filter Which graveyard cards gain mayhem (matched against the card's characteristics).
+ * @property cost The granted mayhem cost, or null for "equal to that card's mana cost".
+ * @property duringYourTurnOnly If true, the grant is active only during the controller's turn.
+ */
+@SerialName("GraveyardCardsHaveMayhem")
+@Serializable
+data class GraveyardCardsHaveMayhem(
+    val filter: GameObjectFilter,
+    val cost: ManaCost? = null,
+    val duringYourTurnOnly: Boolean = false
+) : StaticAbility {
+    override val description: String = buildString {
+        if (duringYourTurnOnly) append("During your turn, e") else append("E")
+        append("ach ${filter.description} card in your graveyard has mayhem")
+        if (cost != null) append(" $cost")
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * "Creature cards in your graveyard have sneak [cost]. You may cast creature spells from your
  * graveyard using their sneak abilities." (Ninja Teen level 3.)
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -216,6 +216,32 @@ data class GrantKeywordToOwnSpells(
 }
 
 /**
+ * Grants **web-slinging [cost]** (CR 702.188) to spells the controller casts that match
+ * [spellFilter]. Web-slinging carries a [ManaCost], which the generic [GrantKeywordToOwnSpells]
+ * (keyword + optional int) cannot express, so it gets its own static. Read by the web-slinging cast
+ * enumerator / handler via `WebSlinging.effectiveWebSlinging`, alongside printed web-slinging.
+ *
+ * Amazing Spider-Man: "Each legendary spell you cast that's one or more colors has web-slinging
+ * {G}{W}{U}" → `GrantWebSlingingToSpells({G}{W}{U}, GameObjectFilter.legendary + IsColored)`.
+ *
+ * @property cost The granted web-slinging cost.
+ * @property spellFilter Which spells you cast gain web-slinging (matched against the spell's card).
+ */
+@SerialName("GrantWebSlingingToSpells")
+@Serializable
+data class GrantWebSlingingToSpells(
+    val cost: ManaCost,
+    val spellFilter: GameObjectFilter
+) : StaticAbility {
+    override val description: String =
+        "${spellFilter.description.replaceFirstChar { it.uppercase() }} spells you cast have web-slinging $cost"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = spellFilter.applyTextReplacement(replacer)
+        return if (newFilter !== spellFilter) copy(spellFilter = newFilter) else this
+    }
+}
+
+/**
  * Grants warp (CR 702.185) to cards in the granter's controller's hand that match [filter].
  * Models oracle text like "Artifact cards and red creature cards in your hand have warp {2}{R}."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -977,3 +977,43 @@ data class ChooseOpponentForSourceEffect(
 ) : Effect {
     override val description: String = "choose an opponent"
 }
+
+/**
+ * The controller chooses a card type (CR 205.2a); the choice is written durably onto the source
+ * entity's cast-choices bag under [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE], where a
+ * static ability reads it back at cost-calculation / projection time through
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent].
+ *
+ * The on-resolution, durable-slot analogue of an as-enters card-type choice — the same relationship
+ * [ChooseNumberForSourceEffect] has to the `NUMBER` [com.wingedsheep.sdk.scripting.ReplacementEffect
+ * .ChoiceType]. Modeled as a `When ~ enters` triggered ability rather than a replacement because the
+ * chosen type only feeds a continuous tax, so it need not be locked in strictly *during* entry.
+ *
+ * When [lookAtOpponentHand] is true the controller first sees an opponent's hand (a durable reveal,
+ * CR 402.3) before choosing — the "look at an opponent's hand, then choose a card type" clause of
+ * Arachne, Psionic Weaver. The look is purely informational.
+ *
+ * @property allowedCardTypes Restrict the offered set to these card types (values from CR 205.2a:
+ *   "Artifact", "Battle", "Creature", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery").
+ *   `null` offers all of them. Arachne passes the seven non-creature types ("other than creature").
+ * @property lookAtOpponentHand Reveal an opponent's hand to the controller before the choice.
+ * @property slot Durable cast-choices slot to write (default
+ *   [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE]).
+ * @property prompt Player-facing prompt text.
+ */
+@SerialName("ChooseCardTypeForSource")
+@Serializable
+data class ChooseCardTypeForSourceEffect(
+    val allowedCardTypes: List<String>? = null,
+    val lookAtOpponentHand: Boolean = false,
+    val slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE,
+    val prompt: String = "Choose a card type"
+) : Effect {
+    override val description: String = buildString {
+        if (lookAtOpponentHand) append("look at an opponent's hand, then ")
+        append("choose a card type")
+        if (allowedCardTypes != null && !allowedCardTypes.contains("Creature")) {
+            append(" other than creature")
+        }
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -365,6 +365,16 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.NameEqualsChosenComponent(slot)
     )
 
+    /**
+     * Match cards whose *card type* equals the card type durably chosen by the *source permanent*
+     * as it entered (its [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent]
+     * under [slot]). Static-projection / cost-calculation safe — use this in cost-static filters
+     * (Arachne, Psionic Weaver's "spells of the chosen type cost {1} more").
+     */
+    fun ofChosenCardTypeComponent(slot: com.wingedsheep.sdk.scripting.ChoiceSlot = com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE) = copy(
+        cardPredicates = cardPredicates + CardPredicate.CardTypeEqualsChosenComponent(slot)
+    )
+
     /** Mana value equals */
     fun manaValue(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.ManaValueEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -302,6 +302,25 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches cards whose **card type** equals a card type **durably chosen by the source
+     * permanent** as it entered — read from that permanent's
+     * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under [slot] (a
+     * [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice] holding one of the
+     * CR 205.2a card-type names). The card-type analogue of [NameEqualsChosenComponent].
+     *
+     * Like its name sibling, this is **static-projection / cost-calculation safe**: the source
+     * permanent's id is supplied as the predicate-context source wherever a static ability's filter
+     * is evaluated. Used by card-type-keyed taxes such as Arachne, Psionic Weaver ("Spells of the
+     * chosen type cost {1} more to cast"). Fails closed (no match) when the source has made no such
+     * choice.
+     */
+    @SerialName("CardTypeEqualsChosenComponent")
+    @Serializable
+    data class CardTypeEqualsChosenComponent(val slot: ChoiceSlot = ChoiceSlot.CARD_TYPE) : CardPredicate {
+        override val description: String = "of the chosen type"
+    }
+
+    /**
      * Matches a card whose name is **not** shared with any Room the evaluating player controls
      * (CR 709). Per the Central Elevator ruling, only the names of a Room's *unlocked* doors
      * count: a Room with no unlocked doors contributes neither of its names, and a split Room

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -348,6 +348,7 @@ object CardLinter {
         "NotOfSourceChosenType" to "CREATURE_TYPE",
         "SneakCostWasPaid" to "SNEAK",
         "SourceChosenModeIs" to "MODE",
+        "CardTypeEqualsChosenComponent" to "CARD_TYPE",
     )
 
     /** Node types whose `slot` field names the slot they read. */
@@ -358,7 +359,7 @@ object CardLinter {
      * [com.wingedsheep.sdk.scripting.effects.ChooseNumberForSourceEffect] records a number under the
      * named slot (e.g. `CHOSEN_NUMBER` for Shapeshifter), which a `CastChoice` read then resolves.
      */
-    private val slotFieldDeclarers = setOf("ChooseNumberForSource")
+    private val slotFieldDeclarers = setOf("ChooseNumberForSource", "ChooseCardTypeForSource")
 
     private class SlotUsage {
         val declared = mutableSetOf<String>()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ArachnePsionicWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/ArachnePsionicWeaver.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.webSlinging
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Arachne, Psionic Weaver (Marvel's Spider-Man, #2)
+ * {2}{W}
+ * Legendary Creature — Spider Human Hero
+ * 3/3
+ *
+ * Web-slinging {W} (You may cast this spell for {W} if you also return a tapped creature you control
+ * to its owner's hand.)
+ * As Arachne enters, look at an opponent's hand, then choose a card type other than creature.
+ * Spells of the chosen type cost {1} more to cast.
+ *
+ * Implementation:
+ *  - **Web-slinging {W}** — the `webSlinging(cost)` alternative-cost keyword (CR 702.188).
+ *  - **Choose a card type (durable)** — a "When Arachne enters" trigger running
+ *    [Effects.ChooseCardTypeForSource] with `lookAtOpponentHand = true` and the seven non-creature
+ *    card types. It reveals an opponent's hand to the controller, then writes the chosen type onto
+ *    Arachne's `CastChoicesComponent` under [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_TYPE].
+ *    (An ETB trigger + durable-slot write — the on-resolution analogue of an as-enters replacement,
+ *    the same relationship `ChooseNumberForSource` has to the `NUMBER` enters-with choice — because
+ *    the chosen type only feeds a continuous tax, so it need not be locked in strictly during entry.)
+ *  - **The tax** — a symmetric [ModifySpellCost] on every caster whose spell is
+ *    `ofChosenCardTypeComponent()` (matches the type stored on Arachne), adding {1} generic
+ *    ([CostModification.IncreaseGeneric]) — the same shape as Thalia, keyed to the chosen type via
+ *    [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent].
+ */
+val ArachnePsionicWeaver = card("Arachne, Psionic Weaver") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Spider Human Hero"
+    power = 3
+    toughness = 3
+    oracleText = "Web-slinging {W} (You may cast this spell for {W} if you also return a tapped " +
+        "creature you control to its owner's hand.)\n" +
+        "As Arachne enters, look at an opponent's hand, then choose a card type other than creature.\n" +
+        "Spells of the chosen type cost {1} more to cast."
+
+    webSlinging("{W}")
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ChooseCardTypeForSource(
+            allowedCardTypes = listOf(
+                "Artifact", "Battle", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery"
+            ),
+            lookAtOpponentHand = true,
+            prompt = "Choose a card type other than creature"
+        )
+        description = "As Arachne enters, look at an opponent's hand, then choose a card type " +
+            "other than creature."
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Any.ofChosenCardTypeComponent()),
+            modification = CostModification.IncreaseGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Steve Argyle"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1f871a-bd85-402e-b474-1deb64c18a52.jpg?1783905365"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/BlackCatCunningThief.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/BlackCatCunningThief.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Black Cat, Cunning Thief
+ * {3}{B}{B}
+ * Legendary Creature — Human Rogue Villain
+ * 2/3
+ *
+ * When Black Cat enters, look at the top nine cards of target opponent's library, exile two of
+ * them face down, then put the rest on the bottom of their library in a random order. You may play
+ * the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells
+ * this way.
+ *
+ * ETB triggered ability targeting an opponent, composed from the standard look-at-top pipeline:
+ *  - [GatherCardsEffect] over the opponent's [CardSource.TopOfLibrary] (nine), which the controller
+ *    looks at ([com.wingedsheep.sdk.scripting.effects.LookAudience.Controller] default).
+ *  - [SelectFromCollectionEffect] `ChooseExactly(2)` (`showAllCards` so all nine are visible) →
+ *    `exiled`, remainder → `rest`.
+ *  - `exiled` moved to the owner's exile face down ([FaceDownMode.HIDDEN]); `rest` to the bottom of
+ *    that library in a random order ([CardOrder.Random]).
+ *  - [GrantMayPlayFromExileEffect] over `exiled` with `Permanent` expiry (playable "for as long as
+ *    they remain exiled") and `withAnyManaType = true` for "Mana of any type can be spent to cast
+ *    spells this way" — the same impulse-from-an-opponent's-library primitive Laughing Jasper Flint
+ *    and Cruelclaw's Heist use.
+ */
+val BlackCatCunningThief = card("Black Cat, Cunning Thief") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Rogue Villain"
+    power = 2
+    toughness = 3
+    oracleText = "When Black Cat enters, look at the top nine cards of target opponent's library, " +
+        "exile two of them face down, then put the rest on the bottom of their library in a random " +
+        "order. You may play the exiled cards for as long as they remain exiled. Mana of any type " +
+        "can be spent to cast spells this way."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(
+                    count = DynamicAmount.Fixed(9),
+                    player = Player.ContextPlayer(0),
+                ),
+                storeAs = "topNine",
+            ),
+            SelectFromCollectionEffect(
+                from = "topNine",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                chooser = Chooser.Controller,
+                storeSelected = "exiled",
+                storeRemainder = "rest",
+                prompt = "Exile two of those cards face down.",
+                showAllCards = true,
+            ),
+            MoveCollectionEffect(
+                from = "exiled",
+                destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                faceDown = FaceDownMode.HIDDEN,
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(
+                    Zone.LIBRARY,
+                    Player.ContextPlayer(0),
+                    ZonePlacement.Bottom,
+                ),
+                order = CardOrder.Random,
+            ),
+            GrantMayPlayFromExileEffect(
+                from = "exiled",
+                expiry = MayPlayExpiry.Permanent,
+                withAnyManaType = true,
+            ),
+        )
+        description = "When Black Cat enters, look at the top nine cards of target opponent's " +
+            "library, exile two of them face down, then put the rest on the bottom of their " +
+            "library in a random order. You may play the exiled cards for as long as they remain " +
+            "exiled. Mana of any type can be spent to cast spells this way."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "52"
+        artist = "Alessandra Pisano"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ed36ada-22c8-4e40-86c5-c116a0bee1c2.jpg?1783905347"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CostumeCloset.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/CostumeCloset.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Costume Closet (Marvel's Spider-Man, #5)
+ * {1}{W}
+ * Artifact
+ *
+ * This artifact enters with two +1/+1 counters on it.
+ * {T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a
+ * sorcery.
+ * Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this
+ * artifact. (Equipment, Auras you control, and counters are modifications.)
+ *
+ * Implementation (fully built from composable primitives):
+ *  - Enters-with-counters: [EntersWithCounters] replacement (`selfOnly = true`, count 2) — same
+ *    shape as Peter Parker's Camera / Braided Net.
+ *  - Move-counter: sorcery-speed `{T}` activated ability. [Effects.MoveCounters] moves one +1/+1
+ *    counter from this artifact ([EffectTarget.Self]) onto a target creature you control, capped at
+ *    the number actually present.
+ *  - Modified-LTB trigger: a [Triggers.leavesBattlefield] with `TriggerBinding.ANY` over a
+ *    "creature you control" filter narrowed by [StatePredicate.IsModified] (has a counter, an Aura,
+ *    or Equipment attached — the MTG "modified" definition). The filter is evaluated against the
+ *    departing permanent's last-known information, so a creature that was modified as it left still
+ *    triggers this. The reward is one +1/+1 counter on the Closet itself.
+ */
+val CostumeCloset = card("Costume Closet") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with two +1/+1 counters on it.\n" +
+        "{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate " +
+        "only as a sorcery.\n" +
+        "Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on " +
+        "this artifact. (Equipment, Auras you control, and counters are modifications.)"
+
+    // This artifact enters with two +1/+1 counters on it.
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE),
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    // {T}: Move a +1/+1 counter from this artifact onto target creature you control. Sorcery speed.
+    activatedAbility {
+        cost = Costs.Tap
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.MoveCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.Fixed(1),
+            source = EffectTarget.Self,
+            destination = creature
+        )
+        description = "{T}: Move a +1/+1 counter from this artifact onto target creature you " +
+            "control. Activate only as a sorcery."
+    }
+
+    // Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().let {
+                it.copy(statePredicates = it.statePredicates + StatePredicate.IsModified)
+            },
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever a modified creature you control leaves the battlefield, put a " +
+            "+1/+1 counter on this artifact."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Bastien Grivet"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc641f4a-ddbe-4f7d-bb55-eabf11f8b7fb.jpg?1783905363"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GwenomRemorseless.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/GwenomRemorseless.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gwenom, Remorseless (Marvel's Spider-Man, #56)
+ * {3}{B}{B}
+ * Legendary Creature — Symbiote Spider Hero
+ * 4/4
+ *
+ * Deathtouch, lifelink
+ * Whenever Gwenom attacks, until end of turn, you may look at the top card of your library any time
+ * and you may play cards from the top of your library. If you cast a spell this way, pay life equal
+ * to its mana value rather than pay its mana cost.
+ *
+ * The attack trigger grants two statics to its controller until end of turn (Duration.EndOfTurn,
+ * dropped at cleanup): [LookAtTopOfLibrary] (see the top card) and [PlayFromTopWithAlternativeCost]
+ * with `withoutPayingManaCost = true` + `PayLifeEqualToManaValueOfSpell` — a Bolas's-Citadel-style
+ * "play from the top, pay life = mana value" permission. The top-of-library cast path scans
+ * `grantedStaticAbilities` for the permission (via `CastPermissionUtils.playFromTopAlternativeCost` /
+ * `CastZoneResolver`), waives the spell's mana, and charges life equal to its mana value.
+ */
+val GwenomRemorseless = card("Gwenom, Remorseless") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Symbiote Spider Hero"
+    power = 4
+    toughness = 4
+    oracleText = "Deathtouch, lifelink\n" +
+        "Whenever Gwenom attacks, until end of turn, you may look at the top card of your library " +
+        "any time and you may play cards from the top of your library. If you cast a spell this " +
+        "way, pay life equal to its mana value rather than pay its mana cost."
+
+    keywords(Keyword.DEATHTOUCH, Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            Effects.GrantStaticAbility(
+                ability = PlayFromTopWithAlternativeCost(
+                    withoutPayingManaCost = true,
+                    additionalCost = Costs.additional.PayLifeEqualToManaValueOfSpell,
+                ),
+                target = EffectTarget.Self,
+                duration = Duration.EndOfTurn,
+            ),
+            Effects.GrantStaticAbility(
+                ability = LookAtTopOfLibrary,
+                target = EffectTarget.Self,
+                duration = Duration.EndOfTurn,
+            ),
+        )
+        description = "Whenever Gwenom attacks, until end of turn, you may look at the top card of " +
+            "your library any time and you may play cards from the top of your library. If you " +
+            "cast a spell this way, pay life equal to its mana value rather than pay its mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "56"
+        artist = "Lordigan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46b6cc5d-7a37-4e8b-a1a5-9a573056610c.jpg?1783905344"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/NormanOsborn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/NormanOsborn.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.GraveyardCardsHaveMayhem
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Norman Osborn // Green Goblin — Marvel's Spider-Man #39 (mythic)
+ *
+ * Front — Norman Osborn · {1}{U} · Legendary Creature — Human Scientist Villain · 1/1
+ *   Norman Osborn can't be blocked.
+ *   Whenever Norman Osborn deals combat damage to a player, he connives.
+ *   {1}{U}{B}{R}: Transform Norman Osborn. Activate only as a sorcery.
+ *
+ * Back — Green Goblin · Legendary Creature — Goblin Human Villain · 3/3
+ *   Flying, menace
+ *   Spells you cast from your graveyard cost {2} less to cast.
+ *   Goblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is equal to
+ *   its mana cost.
+ *
+ * Modeled as a transforming double-faced creature ([CardDefinition.doubleFacedCreature]); the front
+ * owns the sorcery-speed [TransformEffect] flip. The back is a transformed face reached only via the
+ * flip, so it carries no castable mana cost — its U/B/R colors come from a color indicator (CR 204).
+ *
+ *  - Front: [com.wingedsheep.sdk.scripting.CantBeBlocked] (unblockable), a combat-damage
+ *    [Effects.Connive] trigger, and the transform ability.
+ *  - Back: flying/menace keywords; a `YouCastFromZones(GRAVEYARD)` [ModifySpellCost] `{2}` reduction;
+ *    and the Goblin Formula — a [GrantMayhemToGraveyard] static granting mayhem (cost = each card's
+ *    own mana value) to every nonland card in your graveyard, consulted by the mayhem cast path.
+ */
+
+private val NormanOsbornFront = card("Norman Osborn") {
+    manaCost = "{1}{U}"
+    colorIdentity = "UBR"
+    typeLine = "Legendary Creature — Human Scientist Villain"
+    power = 1
+    toughness = 1
+    oracleText = "Norman Osborn can't be blocked.\n" +
+        "Whenever Norman Osborn deals combat damage to a player, he connives. (Draw a card, then " +
+        "discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\n" +
+        "{1}{U}{B}{R}: Transform Norman Osborn. Activate only as a sorcery."
+
+    // Norman Osborn can't be blocked.
+    staticAbility {
+        ability = com.wingedsheep.sdk.scripting.CantBeBlocked()
+    }
+
+    // Whenever Norman Osborn deals combat damage to a player, he connives.
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Connive(EffectTarget.Self)
+        description = "Whenever Norman Osborn deals combat damage to a player, he connives."
+    }
+
+    // {1}{U}{B}{R}: Transform Norman Osborn. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}{B}{R}")
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        description = "Transform Norman Osborn. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "39"
+        artist = "Scott M. Fischer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5c53af9-7150-4e78-8771-2de7980aa307.jpg?1783905356"
+    }
+}
+
+private val GreenGoblinBack = card("Green Goblin") {
+    manaCost = ""
+    colorIdentity = "UBR"
+    colorIndicator = "UBR" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Legendary Creature — Goblin Human Villain"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, menace\n" +
+        "Spells you cast from your graveyard cost {2} less to cast.\n" +
+        "Goblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is " +
+        "equal to its mana cost. (You may cast a card from your graveyard for its mayhem cost if " +
+        "you discarded it this turn. Timing rules still apply.)"
+
+    keywords(Keyword.FLYING, Keyword.MENACE)
+
+    // Spells you cast from your graveyard cost {2} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCastFromZones(setOf(Zone.GRAVEYARD)),
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    // Goblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is equal to
+    // its mana cost.
+    staticAbility {
+        ability = GraveyardCardsHaveMayhem(filter = GameObjectFilter.Nonland)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "39"
+        artist = "Scott M. Fischer"
+        imageUri = "https://cards.scryfall.io/normal/back/d/5/d5c53af9-7150-4e78-8771-2de7980aa307.jpg?1783905356"
+    }
+}
+
+val NormanOsborn: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = NormanOsbornFront,
+    backFace = GreenGoblinBack,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PeterParker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/PeterParker.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantWebSlingingToSpells
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Peter Parker // Amazing Spider-Man — Marvel's Spider-Man #10 (mythic)
+ *
+ * Front — Peter Parker · {1}{W} · Legendary Creature — Human Scientist Hero · 0/1
+ *   When Peter Parker enters, create a 2/1 green Spider creature token with reach.
+ *   {1}{G}{W}{U}: Transform Peter Parker. Activate only as a sorcery.
+ *
+ * Back — Amazing Spider-Man · Legendary Creature — Spider Human Hero · 4/4
+ *   Vigilance, reach
+ *   Each legendary spell you cast that's one or more colors has web-slinging {G}{W}{U}.
+ *
+ * Modeled as a transforming double-faced creature ([CardDefinition.doubleFacedCreature]); the front
+ * owns the sorcery-speed [TransformEffect] flip. The back is a transformed face reached only via the
+ * flip, so it carries no castable mana cost — its G/W/U colors come from a color indicator (CR 204).
+ *
+ *  - Front: an ETB [Effects.CreateToken] (2/1 green Spider with reach) and the transform ability.
+ *  - Back: vigilance/reach; and a [GrantWebSlingingToSpells] static granting web-slinging {G}{W}{U}
+ *    to every legendary, one-or-more-colored spell its controller casts — read by the web-slinging
+ *    cast enumerator / handler via `WebSlinging.effectiveWebSlinging` alongside printed web-slinging.
+ */
+
+private val PeterParkerFront = card("Peter Parker") {
+    manaCost = "{1}{W}"
+    colorIdentity = "GWU"
+    typeLine = "Legendary Creature — Human Scientist Hero"
+    power = 0
+    toughness = 1
+    oracleText = "When Peter Parker enters, create a 2/1 green Spider creature token with reach.\n" +
+        "{1}{G}{W}{U}: Transform Peter Parker. Activate only as a sorcery."
+
+    // When Peter Parker enters, create a 2/1 green Spider creature token with reach.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH),
+            imageUri = "https://cards.scryfall.io/normal/front/4/a/4a40f6e1-3545-4503-af3e-f0acfb735e3a.jpg?1783905184",
+        )
+        description = "When Peter Parker enters, create a 2/1 green Spider creature token with reach."
+    }
+
+    // {1}{G}{W}{U}: Transform Peter Parker. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}{W}{U}")
+        effect = TransformEffect(EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+        description = "Transform Peter Parker. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "10"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3ce33422-5dba-4a42-8375-dd8ccc692a7b.jpg?1783905367"
+    }
+}
+
+private val AmazingSpiderManBack = card("Amazing Spider-Man") {
+    manaCost = ""
+    colorIdentity = "GWU"
+    colorIndicator = "GWU" // Transformed back face, no mana cost (CR 204).
+    typeLine = "Legendary Creature — Spider Human Hero"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance, reach\n" +
+        "Each legendary spell you cast that's one or more colors has web-slinging {G}{W}{U}. (You " +
+        "may cast a spell for its web-slinging cost if you also return a tapped creature you " +
+        "control to its owner's hand.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.REACH)
+
+    // Each legendary spell you cast that's one or more colors has web-slinging {G}{W}{U}.
+    staticAbility {
+        ability = GrantWebSlingingToSpells(
+            cost = ManaCost.parse("{G}{W}{U}"),
+            spellFilter = GameObjectFilter(
+                cardPredicates = listOf(CardPredicate.IsLegendary, CardPredicate.IsColored)
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "10"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/back/3/c/3ce33422-5dba-4a42-8375-dd8ccc692a7b.jpg?1783905367"
+    }
+}
+
+val PeterParker: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = PeterParkerFront,
+    backFace = AmazingSpiderManBack,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheCloneSaga.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheCloneSaga.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Clone Saga (Marvel's Spider-Man, #28)
+ * {3}{U}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Surveil 3.
+ * II — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.
+ * III — Choose a card name. Whenever a creature with the chosen name deals combat damage to a
+ * player this turn, draw a card.
+ *
+ * Implementation:
+ *  - **I** — `Effects.Surveil(3)`.
+ *  - **II** — a one-shot event-based delayed trigger on `Triggers.YouCastCreature` (SpellCastEvent,
+ *    Player.You, creature) whose effect copies the triggering spell with `removeLegendary = true`
+ *    (the copy is a non-legendary token — same primitive as Jackal, Genius Geneticist). `fireOnce`
+ *    makes it "the next" creature spell; `TriggeringEntity` binds to the just-cast spell at fire
+ *    time and the trigger resolves above it while it's still on the stack.
+ *  - **III** — `Effects.ChooseCardName` stores the name in `chosenValues["clonedName"]`, then a
+ *    delayed combat-damage trigger keyed to a creature *named that* (`namedFromVariable`) draws a
+ *    card each time such a creature deals combat damage to a player this turn. The chosen name is
+ *    baked into the trigger's source filter at creation time (`CreateDelayedTriggerExecutor
+ *    .bakeChosenValuesIntoTrigger`).
+ */
+val TheCloneSaga = card("The Clone Saga") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice " +
+        "after III.)\n" +
+        "I — Surveil 3.\n" +
+        "II — When you next cast a creature spell this turn, copy it, except the copy isn't " +
+        "legendary.\n" +
+        "III — Choose a card name. Whenever a creature with the chosen name deals combat damage " +
+        "to a player this turn, draw a card."
+
+    // I — Surveil 3.
+    sagaChapter(1) {
+        effect = Effects.Surveil(3)
+    }
+
+    // II — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.
+    sagaChapter(2) {
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouCastCreature,
+            effect = Effects.CopyTargetSpell(
+                target = EffectTarget.TriggeringEntity,
+                removeLegendary = true,
+            ),
+            fireOnce = true,
+            expiry = DelayedTriggerExpiry.EndOfTurn,
+        )
+    }
+
+    // III — Choose a card name. Whenever a creature with the chosen name deals combat damage to a
+    // player this turn, draw a card.
+    sagaChapter(3) {
+        effect = Effects.Composite(
+            Effects.ChooseCardName(storeAs = "clonedName"),
+            CreateDelayedTriggerEffect(
+                trigger = Triggers.dealsDamage(
+                    damageType = DamageType.Combat,
+                    recipient = RecipientFilter.AnyPlayer,
+                    sourceFilter = GameObjectFilter.Creature.namedFromVariable("clonedName"),
+                    binding = TriggerBinding.ANY,
+                ),
+                effect = Effects.DrawCards(1),
+                fireOnce = false,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "28"
+        artist = "Bill Sienkiewicz"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/976432b3-bc17-4edb-86d6-00fd1baf9670.jpg?1783905356"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheSoulStone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/TheSoulStone.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Soul Stone (Marvel's Spider-Man, #66)
+ * {1}{B}
+ * Legendary Artifact — Infinity Stone
+ *
+ * Indestructible
+ * {T}: Add {B}.
+ * {6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its ∞
+ * ability is active.)
+ * ∞ — At the beginning of your upkeep, return target creature card from your graveyard to the
+ * battlefield.
+ *
+ * Implementation (composition-first — the only new vocabulary is the `harness` marker counter):
+ *  - **Harness** is modeled as a binary marker counter ([Counters.HARNESS]). The Harness activated
+ *    ability places one; the `∞` triggered ability is gated on the Stone having a harness counter
+ *    ([Conditions.SourceHasCounter]), so it does nothing until harnessed and reactivates every
+ *    upkeep thereafter. A counter (not a durable component) matches the flavor: it resets if the
+ *    Stone leaves the battlefield, and re-placing it is idempotent.
+ *  - `{T}: Add {B}` is a mana ability; the Harness cost pairs `{6}{B}` + tap + an exile-a-creature
+ *    additional cost ([Costs.ExilePermanents]); the `∞` reanimates a targeted creature card from
+ *    your graveyard ([Effects.PutOntoBattlefield]).
+ */
+val TheSoulStone = card("The Soul Stone") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Artifact — Infinity Stone"
+    oracleText = "Indestructible\n" +
+        "{T}: Add {B}.\n" +
+        "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its " +
+        "∞ ability is active.)\n" +
+        "∞ — At the beginning of your upkeep, return target creature card from your graveyard to " +
+        "the battlefield."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // {T}: Add {B}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    // {6}{B}, {T}, Exile a creature you control: Harness The Soul Stone.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{6}{B}"),
+            Costs.Tap,
+            Costs.ExilePermanents(GameObjectFilter.Creature.youControl(), minCount = 1, excludeSelf = false)
+        )
+        effect = Effects.AddCounters(Counters.HARNESS, 1, EffectTarget.Self)
+        description = "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone."
+    }
+
+    // ∞ — At the beginning of your upkeep (once harnessed), return target creature card from your
+    // graveyard to the battlefield.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.HARNESS))
+        val graveyardCreature = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(graveyardCreature)
+        description = "∞ — At the beginning of your upkeep, return target creature card from your " +
+            "graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "66"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1982f910-a9bd-4e94-a187-84381b22aacc.jpg?1783905342"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -5728,6 +5728,165 @@
     "colorIdentityOverride": []
 }
 
+// Norman Osborn
+{
+    "name": "Norman Osborn",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Creature — Human Scientist Villain",
+    "oracleText": "Norman Osborn can't be blocked.\nWhenever Norman Osborn deals combat damage to a player, he connives. (Draw a card, then discard a card. If you discarded a nonland card, put a +1/+1 counter on this creature.)\n{1}{U}{B}{R}: Transform Norman Osborn. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "connive_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "connive_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "connive_discarded",
+                            "prompt": "Choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "connive_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "connive_discarded",
+                            "ifNotEmpty": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Connive"
+                },
+                "descriptionOverride": "Whenever Norman Osborn deals combat damage to a player, he connives."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}{B}{R}"
+                    }
+                },
+                "effect": "Transform",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Transform Norman Osborn. Activate only as a sorcery."
+            }
+        ],
+        "staticAbilities": [
+            "CantBeBlocked"
+        ]
+    },
+    "backFace": {
+        "name": "Green Goblin",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Goblin Human Villain",
+        "oracleText": "Flying, menace\nSpells you cast from your graveyard cost {2} less to cast.\nGoblin Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is equal to its mana cost. (You may cast a card from your graveyard for its mayhem cost if you discarded it this turn. Timing rules still apply.)",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "FLYING",
+            "MENACE"
+        ],
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ModifySpellCost",
+                    "target": {
+                        "type": "YouCastFromZones",
+                        "zones": [
+                            "Graveyard"
+                        ]
+                    },
+                    "modification": {
+                        "type": "ReduceGeneric",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "GraveyardCardsHaveMayhem",
+                    "filter": "nonland"
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "39",
+            "rarity": "MYTHIC",
+            "artist": "Scott M. Fischer",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/5/d5c53af9-7150-4e78-8771-2de7980aa307.jpg?1783905356"
+        },
+        "colorIdentityOverride": [
+            "BLUE",
+            "BLACK",
+            "RED"
+        ],
+        "colorIndicator": [
+            "BLUE",
+            "BLACK",
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "MYTHIC",
+        "artist": "Scott M. Fischer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5c53af9-7150-4e78-8771-2de7980aa307.jpg?1783905356"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Ominous Asylum
 {
     "name": "Ominous Asylum",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11845,7 +11845,7 @@
                         {
                             "type": "CostAtomWrapper",
                             "atom": {
-                                "type": "AtomExilePermanents",
+                                "type": "AtomVariablePermanents",
                                 "filter": "creature ctrl:you",
                                 "excludeSelf": false
                             }

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -315,6 +315,79 @@
     ]
 }
 
+// Arachne, Psionic Weaver
+{
+    "name": "Arachne, Psionic Weaver",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Spider Human Hero",
+    "oracleText": "Web-slinging {W} (You may cast this spell for {W} if you also return a tapped creature you control to its owner's hand.)\nAs Arachne enters, look at an opponent's hand, then choose a card type other than creature.\nSpells of the chosen type cost {1} more to cast.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "WEB_SLINGING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "WebSlinging",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ChooseCardTypeForSource",
+                    "allowedCardTypes": [
+                        "Artifact",
+                        "Battle",
+                        "Enchantment",
+                        "Instant",
+                        "Land",
+                        "Planeswalker",
+                        "Sorcery"
+                    ],
+                    "lookAtOpponentHand": true,
+                    "prompt": "Choose a card type other than creature"
+                },
+                "descriptionOverride": "As Arachne enters, look at an opponent's hand, then choose a card type other than creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": {
+                        "cardPredicates": [
+                            "CardTypeEqualsChosenComponent"
+                        ]
+                    }
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "RARE",
+        "artist": "Steve Argyle",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c1f871a-bd85-402e-b474-1deb64c18a52.jpg?1783905365"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Araña, Heart of the Spider
 {
     "name": "Araña, Heart of the Spider",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -6030,7 +6030,8 @@
             "BLUE",
             "BLACK",
             "RED"
-        ]
+        ],
+        "hasNoManaCost": true
     },
     "metadata": {
         "collectorNumber": "39",
@@ -6630,7 +6631,8 @@
             "GREEN",
             "WHITE",
             "BLUE"
-        ]
+        ],
+        "hasNoManaCost": true
     },
     "metadata": {
         "collectorNumber": "10",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11538,6 +11538,97 @@
     ]
 }
 
+// The Clone Saga
+{
+    "name": "The Clone Saga",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Surveil 3.\nII — When you next cast a creature spell this turn, copy it, except the copy isn't legendary.\nIII — Choose a card name. Whenever a creature with the chosen name deals combat damage to a player this turn, draw a card.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Surveil",
+                    "count": 3
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "CopyTargetSpell",
+                        "target": "TriggeringEntity",
+                        "removeLegendary": true
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "SpellCastEvent",
+                            "spellFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ]
+                            }
+                        },
+                        "binding": "ANY"
+                    },
+                    "fireOnce": true
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ChooseOption",
+                            "optionType": "CARD_NAME",
+                            "storeAs": "clonedName"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "trigger": {
+                                "event": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat",
+                                    "recipient": "AnyPlayer",
+                                    "sourceFilter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "NameEqualsChosen",
+                                                "variableName": "clonedName"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "binding": "ANY"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "rarity": "RARE",
+        "artist": "Bill Sienkiewicz",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/976432b3-bc17-4edb-86d6-00fd1baf9670.jpg?1783905356"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // The Death of Gwen Stacy
 {
     "name": "The Death of Gwen Stacy",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -11679,6 +11679,109 @@
     ]
 }
 
+// The Soul Stone
+{
+    "name": "The Soul Stone",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Artifact — Infinity Stone",
+    "oracleText": "Indestructible\n{T}: Add {B}.\n{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. (Once harnessed, its ∞ ability is active.)\n∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card in your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "HARNESS"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "∞ — At the beginning of your upkeep, return target creature card from your graveyard to the battlefield."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExilePermanents",
+                                "filter": "creature ctrl:you",
+                                "excludeSelf": false
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "harness",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1982f910-a9bd-4e94-a187-84381b22aacc.jpg?1783905342"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // The Spot's Portal
 {
     "name": "The Spot's Portal",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -3040,6 +3040,59 @@
     ]
 }
 
+// Gwenom, Remorseless
+{
+    "name": "Gwenom, Remorseless",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Symbiote Spider Hero",
+    "oracleText": "Deathtouch, lifelink\nWhenever Gwenom attacks, until end of turn, you may look at the top card of your library any time and you may play cards from the top of your library. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantStaticAbility",
+                            "ability": {
+                                "type": "PlayFromTopWithAlternativeCost",
+                                "withoutPayingManaCost": true,
+                                "additionalCost": "PayLifeEqualToManaValueOfSpell"
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantStaticAbility",
+                            "ability": "LookAtTopOfLibrary",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Gwenom attacks, until end of turn, you may look at the top card of your library any time and you may play cards from the top of your library. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "MYTHIC",
+        "artist": "Lordigan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46b6cc5d-7a37-4e8b-a1a5-9a573056610c.jpg?1783905344"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Heroes' Hangout
 {
     "name": "Heroes' Hangout",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1174,6 +1174,92 @@
     ]
 }
 
+// Costume Closet
+{
+    "name": "Costume Closet",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with two +1/+1 counters on it.\n{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a sorcery.\nWhenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this artifact. (Equipment, Auras you control, and counters are modifications.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "IsModified"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a modified creature you control leaves the battlefield, put a +1/+1 counter on this artifact."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "source": "Self",
+                    "destination": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{T}: Move a +1/+1 counter from this artifact onto target creature you control. Activate only as a sorcery."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "+1/+1"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Bastien Grivet",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc641f4a-ddbe-4f7d-bb55-eabf11f8b7fb.jpg?1783905363"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Daily Bugle Building
 {
     "name": "Daily Bugle Building",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -879,6 +879,111 @@
     ]
 }
 
+// Black Cat, Cunning Thief
+{
+    "name": "Black Cat, Cunning Thief",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Human Rogue Villain",
+    "oracleText": "When Black Cat enters, look at the top nine cards of target opponent's library, exile two of them face down, then put the rest on the bottom of their library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 9
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "topNine"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "topNine",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "exiled",
+                            "storeRemainder": "rest",
+                            "prompt": "Exile two of those cards face down.",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiled",
+                            "expiry": "Permanent",
+                            "withAnyManaType": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When Black Cat enters, look at the top nine cards of target opponent's library, exile two of them face down, then put the rest on the bottom of their library in a random order. You may play the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells this way."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "RARE",
+        "artist": "Alessandra Pisano",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0ed36ada-22c8-4e40-86c5-c116a0bee1c2.jpg?1783905347"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Carnage, Crimson Chaos
 {
     "name": "Carnage, Crimson Chaos",

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -6378,6 +6378,115 @@
     ]
 }
 
+// Peter Parker
+{
+    "name": "Peter Parker",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Human Scientist Hero",
+    "oracleText": "When Peter Parker enters, create a 2/1 green Spider creature token with reach.\n{1}{G}{W}{U}: Transform Peter Parker. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a40f6e1-3545-4503-af3e-f0acfb735e3a.jpg?1783905184"
+                },
+                "descriptionOverride": "When Peter Parker enters, create a 2/1 green Spider creature token with reach."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}{W}{U}"
+                    }
+                },
+                "effect": "Transform",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Transform Peter Parker. Activate only as a sorcery."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Amazing Spider-Man",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Spider Human Hero",
+        "oracleText": "Vigilance, reach\nEach legendary spell you cast that's one or more colors has web-slinging {G}{W}{U}. (You may cast a spell for its web-slinging cost if you also return a tapped creature you control to its owner's hand.)",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 4
+        },
+        "keywords": [
+            "VIGILANCE",
+            "REACH"
+        ],
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "GrantWebSlingingToSpells",
+                    "cost": "{G}{W}{U}",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsLegendary",
+                            "IsColored"
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "10",
+            "rarity": "MYTHIC",
+            "artist": "Thanh Tuấn",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/c/3ce33422-5dba-4a42-8375-dd8ccc692a7b.jpg?1783905367"
+        },
+        "colorIdentityOverride": [
+            "GREEN",
+            "WHITE",
+            "BLUE"
+        ],
+        "colorIndicator": [
+            "GREEN",
+            "WHITE",
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "MYTHIC",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3ce33422-5dba-4a42-8375-dd8ccc692a7b.jpg?1783905367"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Peter Parker's Camera
 {
     "name": "Peter Parker's Camera",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
@@ -47,6 +47,30 @@ data class ChooseOpponentForSourceContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after a player picks the card type for a
+ * [com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect]. The resumer writes the
+ * chosen type name as a [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.TextChoice]
+ * into the source entity's
+ * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under [slot], where
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.CardTypeEqualsChosenComponent] reads it
+ * back at cost-calculation / projection time (Arachne, Psionic Weaver).
+ *
+ * @property sourceId The permanent whose cast-choices bag receives the card type.
+ * @property controllerId The player who made the choice.
+ * @property slot Which durable cast-choices slot to write.
+ * @property cardTypes The offered option list, positionally aligned with the
+ *   [com.wingedsheep.engine.core.ChooseOptionDecision]'s options.
+ */
+@Serializable
+data class ChooseCardTypeForSourceContinuation(
+    override val decisionId: String,
+    val sourceId: EntityId,
+    val controllerId: EntityId,
+    val slot: ChoiceSlot,
+    val cardTypes: List<String>
+) : ContinuationFrame
+
+/**
  * Resume after the controller picks *which* opponent makes a
  * [com.wingedsheep.sdk.scripting.effects.Chooser.Opponent] decision (CR 601.7a / 602.3a and
  * the matching resolution-time rulings — see

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -222,6 +222,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseNumberForSourceContinuation::class)
         subclass(ChooseOpponentForSourceContinuation::class)
+        subclass(ChooseCardTypeForSourceContinuation::class)
         subclass(ChooseOpponentDeciderContinuation::class)
         subclass(ConvertCountersToTokensContinuation::class)
         subclass(ChooseManaColorContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1,5 +1,8 @@
 package com.wingedsheep.engine.event
 
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.handlers.predicates.isModified
+
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
@@ -1812,6 +1815,27 @@ class TriggerMatcher(
                 counters?.counters?.values?.any { it > 0 } ?: false
             }
         }
+        // "Modified" (has a counter, an attached Equipment, or an attached Aura — CR 122/301/303) on
+        // a permanent that has left the battlefield reads last-known info: the live counters and
+        // attachment links are gone by trigger-gating time. Counters come from the snapshot; the
+        // equipped/enchanted legs come from the frozen wasEquipped/wasEnchanted flags captured in
+        // ZoneTransitionService before exit cleanup. For non-leave triggers (ETB) the entity is live.
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified -> {
+            if (event.fromZone == Zone.BATTLEFIELD) {
+                val lk = event.lastKnown
+                (lk?.totalCounters ?: 0) > 0 || lk?.wasEquipped == true || lk?.wasEnchanted == true
+            } else {
+                isModified(state, event.entityId)
+            }
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEquipped == true
+            else hasAttachmentOfKind(state, event.entityId, equipment = true)
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEnchanted == true
+            else hasAttachmentOfKind(state, event.entityId, equipment = false)
+        }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Or ->
             predicate.predicates.any { matchesStatePredicateForZoneChangeTrigger(it, state, event) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.And ->
@@ -1912,4 +1936,18 @@ class TriggerMatcher(
             .replace("+1/+1", "plus_one_plus_one")
             .replace("-1/-1", "minus_one_minus_one")
             .replace(" ", "_")
+
+    /**
+     * Live check for whether [entityId] has an Equipment (or, when [equipment] is false, an Aura)
+     * attached — the last-known-info counterpart is the `wasEquipped`/`wasEnchanted` flag on the
+     * [ZoneChangeEvent]'s snapshot. Used only for the non-leave (ETB) branch of an
+     * `IsEquipped`/`IsEnchanted` zone-change gate.
+     */
+    private fun hasAttachmentOfKind(state: GameState, entityId: EntityId, equipment: Boolean): Boolean {
+        val attachments = state.getEntity(entityId)?.get<AttachmentsComponent>() ?: return false
+        return attachments.attachedIds.any { attachId ->
+            val typeLine = state.getEntity(attachId)?.get<CardComponent>()?.typeLine
+            if (equipment) typeLine?.isEquipment == true else typeLine?.isAura == true
+        }
+    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -740,6 +740,18 @@ class PredicateEvaluator {
                 card.name.equals(chosenName, ignoreCase = true)
             }
 
+            // Source-component card-type reference: the card type durably chosen by the source
+            // permanent as it entered (Arachne). Read from the source's CastChoicesComponent[slot];
+            // works at cost-calculation / projection time as long as the predicate context supplies
+            // the choosing permanent as the source. The card-type analogue of NameEqualsChosenComponent.
+            is CardPredicate.CardTypeEqualsChosenComponent -> {
+                val sourceId = context?.sourceId ?: return false
+                val chosenType = (state.getEntity(sourceId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
+                card.typeLine.cardTypes.any { it.displayName.equals(chosenType, ignoreCase = true) }
+            }
+
             is CardPredicate.OriginallyPrintedInSet ->
                 card.originalSetCode?.equals(predicate.setCode, ignoreCase = true) == true
 
@@ -1552,9 +1564,10 @@ class PredicateEvaluator {
             is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,
             is CardPredicate.HasSubtypeInEachStoredGroup -> false
-            // Source-component name reference is a permanent-static predicate, not meaningful for a
-            // cast-spell record.
+            // Source-component name/card-type references are permanent-static predicates, not
+            // meaningful for a cast-spell record.
             is CardPredicate.NameEqualsChosenComponent -> false
+            is CardPredicate.CardTypeEqualsChosenComponent -> false
 
             // Stack ability check — cast spells are not abilities
             CardPredicate.IsActivatedOrTriggeredAbility -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.permissions.activeMayPlayFor
 import com.wingedsheep.engine.state.permissions.hasMayPlayFor
 import com.wingedsheep.engine.state.permissions.removeMayPlayPermissionsForCard
@@ -143,6 +144,13 @@ class PlayLandHandler(
             ZoneKey(action.playerId, fromZone)
         }
         newState = newState.removeFromZone(sourceZoneKey, action.cardId)
+
+        // A land played from a face-down exile enters face up as the real land, never as a face-down
+        // 2/2. Black Cat, Cunning Thief exiles cards face down (HIDDEN) and lets you play them; lands
+        // bypass ZoneTransitionService/StackResolver — where every other play path reveals a
+        // hidden-in-exile card (StackResolver strips FaceDownComponent as a spell hits the stack) —
+        // so strip the marker here (CR 305.1: a land is always played face up). No-op when absent.
+        newState = newState.updateEntity(action.cardId) { c -> c.without<FaceDownComponent>() }
 
         // Record Muldrotha graveyard land permission usage
         if (fromZone == Zone.GRAVEYARD) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -445,6 +445,15 @@ class CastSpellHandler(
             if (linkedCostError != null) return linkedCostError
         }
 
+        // Gwenom: a spell cast from the top of the library under a PlayFromTopWithAlternativeCost
+        // permission pays the grant's additional cost (pay life equal to its mana value).
+        val topOfLibraryAdditionalCost = zoneResolver
+            .topOfLibraryAlternativeGrant(state, action.playerId, action.cardId)?.additionalCost
+        if (topOfLibraryAdditionalCost != null) {
+            val topCostError = validateAdditionalCosts(state, listOf(topOfLibraryAdditionalCost), action)
+            if (topCostError != null) return topCostError
+        }
+
         // Validate a self-referential MayCastSelfFromZones grant's additional cost (e.g. Alien
         // Symbiosis: "cast this from your graveyard by discarding a card").
         val mayCastFromZoneAbility = zoneResolver.findMayCastSelfFromZoneAbility(state, action.playerId, action.cardId)
@@ -2395,6 +2404,10 @@ class CastSpellHandler(
             // Self-referential MayCastSelfFromZones grant's additional cost (e.g. Alien
             // Symbiosis' "by discarding a card")
             zoneResolver.findMayCastSelfFromZoneAbility(currentState, action.playerId, action.cardId)
+                ?.additionalCost?.let { add(it) }
+
+            // Gwenom: pay-life additional cost for a spell cast from the top of the library.
+            zoneResolver.topOfLibraryAlternativeGrant(currentState, action.playerId, action.cardId)
                 ?.additionalCost?.let { add(it) }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -398,7 +398,7 @@ class CastSpellHandler(
         val castingForWebSling = action.useAlternativeCost &&
             action.altAllows(AlternativeCostType.WEB_SLINGING) &&
             cardDef != null &&
-            WebSlinging.webSlingingAbility(cardDef) != null
+            WebSlinging.effectiveWebSlinging(state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator) != null
         if (castingForWebSling) {
             val bounced = action.additionalCostPayment?.bouncedPermanents ?: emptyList()
             if (bounced.size != 1) {
@@ -878,7 +878,7 @@ class CastSpellHandler(
                     val sneakCost = SneakWindow.effectiveSneakCost(state, cardDef, action.cardId, action.playerId, cardRegistry)
                     // Check web-slinging cost (CR 702.188 — an alternative cost bundling a
                     // return-a-tapped-creature payment, cast at the spell's normal timing).
-                    val webSlingingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.WebSlinging>().firstOrNull()
+                    val webSlingingAbility = WebSlinging.effectiveWebSlinging(state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator)
                     // Check evoke cost
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
                     // Check dash cost (CR 702.109 — hand only, printed only for now).
@@ -2134,7 +2134,7 @@ class CastSpellHandler(
                     val sneakCost = SneakWindow.effectiveSneakCost(currentState, cardDef, action.cardId, action.playerId, cardRegistry)
                     // Check web-slinging cost (CR 702.188 — mana portion; the return-a-tapped-creature
                     // bounce is paid separately, alongside).
-                    val webSlingingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.WebSlinging>().firstOrNull()
+                    val webSlingingAbility = WebSlinging.effectiveWebSlinging(currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator)
                     // Check evoke cost
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
                     // Check dash cost (CR 702.109 — hand only, printed only for now).
@@ -3096,7 +3096,7 @@ class CastSpellHandler(
         // (CR 118.9c — its own mana value, needed by Scarlet Spider, Ben Reilly) before it leaves.
         val wasWebSlung = action.useAlternativeCost && cardDef != null &&
             action.altAllows(AlternativeCostType.WEB_SLINGING) &&
-            WebSlinging.webSlingingAbility(cardDef) != null
+            WebSlinging.effectiveWebSlinging(currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator) != null
         var webSlungReturnedManaValue = 0
         if (wasWebSlung) {
             val bounceId = action.additionalCostPayment?.bouncedPermanents?.firstOrNull()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -856,11 +856,11 @@ class CastSpellHandler(
                 // applied afterward via alternativePayment.
                 costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, harmonizeAbility.cost, action.playerId)
             } else if (action.altAllows(AlternativeCostType.MAYHEM) &&
-                MayhemGrants.effectiveMayhem(state, action.cardId, cardDef) != null &&
+                MayhemGrants.effectiveMayhem(state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator) != null &&
                 zoneResolver.hasMayhemPermission(state, action.playerId, action.cardId)) {
                 // Mayhem cost (CR 702.187) — cast from graveyard for its mayhem cost.
                 costCalculator.calculateEffectiveCostWithAlternativeBase(
-                    state, cardDef, MayhemGrants.effectiveMayhem(state, action.cardId, cardDef)!!.cost, action.playerId
+                    state, cardDef, MayhemGrants.effectiveMayhem(state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator)!!.cost, action.playerId
                 )
             } else {
                 // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
@@ -2113,11 +2113,11 @@ class CastSpellHandler(
             } else if (action.altAllows(AlternativeCostType.HARMONIZE) && harmonizeAbility != null && zoneResolver.hasHarmonizePermission(currentState, action.playerId, action.cardId)) {
                 costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, harmonizeAbility.cost, action.playerId)
             } else if (action.altAllows(AlternativeCostType.MAYHEM) &&
-                MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef) != null &&
+                MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator) != null &&
                 zoneResolver.hasMayhemPermission(currentState, action.playerId, action.cardId)) {
                 // Mayhem cost (CR 702.187) — cast from graveyard for its mayhem cost.
                 costCalculator.calculateEffectiveCostWithAlternativeBase(
-                    currentState, cardDef, MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef)!!.cost, action.playerId
+                    currentState, cardDef, MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator)!!.cost, action.playerId
                 )
             } else {
                 // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
@@ -3118,7 +3118,7 @@ class CastSpellHandler(
         // Drives Sandman's Quicksand's "if this spell's mayhem cost was paid" rider.
         val wasMayhem = action.useAlternativeCost && cardDef != null &&
             action.altAllows(AlternativeCostType.MAYHEM) &&
-            MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef) != null &&
+            MayhemGrants.effectiveMayhem(currentState, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator) != null &&
             currentState.getEntity(action.playerId)
                 ?.get<com.wingedsheep.engine.state.components.player.CardsDiscardedThisTurnComponent>()
                 ?.cardIds?.contains(action.cardId) == true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -497,7 +497,13 @@ class CastZoneResolver(
         val component = state.getEntity(cardId)?.get<PlayWithoutPayingCostComponent>()
         if (component?.controllerId == playerId) return true
         val granter = findLinkedExileGranter(state, playerId, cardId)
-        return granter?.withoutPayingManaCost == true
+        if (granter?.withoutPayingManaCost == true) return true
+        // Gwenom: a spell cast from the top of the library under a PlayFromTopWithAlternativeCost
+        // permission whose withoutPayingManaCost is set pays no mana (it pays life instead).
+        if (state.getLibrary(playerId).firstOrNull() == cardId) {
+            return playFromTopAlternativeCost(state, playerId)?.withoutPayingManaCost == true
+        }
+        return false
     }
 
     /**
@@ -670,7 +676,49 @@ class CastZoneResolver(
                 return true
             }
         }
-        return false
+        return playFromTopAlternativeCost(state, playerId) != null
+    }
+
+    /**
+     * The effective [com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost] for [playerId]
+     * (Gwenom) — printed on a permanent they control or granted durationally — or null. Mirrors the
+     * printed-or-granted scan in `CastPermissionUtils.playFromTopAlternativeCost`.
+     */
+    private fun playFromTopAlternativeCost(
+        state: GameState,
+        playerId: EntityId
+    ): com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost? {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            cardDef.script.staticAbilities
+                .firstOrNull { it is com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost }
+                ?.let { return it as com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost }
+        }
+        for (grant in state.grantedStaticAbilities) {
+            val ability = grant.ability
+            if (ability !is com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost) continue
+            if (state.getEntity(grant.entityId)?.get<ControllerComponent>()?.playerId != playerId) continue
+            return ability
+        }
+        return null
+    }
+
+    /**
+     * The [com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost] covering [cardId] when it is
+     * the top card of [playerId]'s library and the grant's filter matches — else null. Used by
+     * `CastSpellHandler` to inject the grant's additional cost (Gwenom's pay-life) into a
+     * top-of-library cast.
+     */
+    fun topOfLibraryAlternativeGrant(
+        state: GameState,
+        playerId: EntityId,
+        cardId: EntityId
+    ): com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost? {
+        if (state.getLibrary(playerId).firstOrNull() != cardId) return null
+        val grant = playFromTopAlternativeCost(state, playerId) ?: return null
+        val filter = grant.filter ?: return grant
+        return if (predicateEvaluator.matches(state, state.projectedState, cardId, filter, PredicateContext(controllerId = playerId))) grant else null
     }
 
     private fun hasLinkedExileCastPermission(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -872,6 +872,7 @@ class CastZoneResolver(
                 is CardPredicate.SharesChosenColorWithSource,
                 is CardPredicate.NameEqualsChosen,
                 is CardPredicate.NameEqualsChosenComponent,
+                is CardPredicate.CardTypeEqualsChosenComponent,
                 is CardPredicate.NameNotSharedWithControlledRoom,
                 is CardPredicate.NameNotSharedWithControlledToken,
                 is CardPredicate.NameNotSharedWithAnotherControlledPermanent,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -390,7 +390,10 @@ class CastZoneResolver(
         // Lands use the no-cost "play from graveyard" form (CR 702.187c), not the cast path.
         if (cardComponent.typeLine.isLand) return false
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-        if (com.wingedsheep.engine.mechanics.MayhemGrants.effectiveMayhem(state, cardId, cardDef) == null) return false
+        if (com.wingedsheep.engine.mechanics.MayhemGrants.effectiveMayhem(
+                state, cardId, cardDef, playerId, cardRegistry, predicateEvaluator
+            ) == null
+        ) return false
         // The Mayhem gate: you must have discarded this card this turn.
         return state.getEntity(playerId)
             ?.get<com.wingedsheep.engine.state.components.player.CardsDiscardedThisTurnComponent>()
@@ -403,7 +406,9 @@ class CastZoneResolver(
     fun getMayhemCost(cardId: EntityId, state: GameState): com.wingedsheep.sdk.core.ManaCost? {
         val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return null
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
-        return com.wingedsheep.engine.mechanics.MayhemGrants.effectiveMayhem(state, cardId, cardDef)?.cost
+        return com.wingedsheep.engine.mechanics.MayhemGrants.effectiveMayhem(
+            state, cardId, cardDef, cardComponent.ownerId, cardRegistry, predicateEvaluator
+        )?.cost
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -20,6 +20,7 @@ class ColorChoiceContinuationResumer(
         resumer(ChooseNumberThenContinuation::class, ::resumeChooseNumberThen),
         resumer(ChooseNumberForSourceContinuation::class, ::resumeChooseNumberForSource),
         resumer(ChooseOpponentForSourceContinuation::class, ::resumeChooseOpponentForSource),
+        resumer(ChooseCardTypeForSourceContinuation::class, ::resumeChooseCardTypeForSource),
         resumer(ChooseOpponentDeciderContinuation::class, ::resumeChooseOpponentDecider),
         resumer(ChooseManaColorContinuation::class, ::resumeChooseManaColor),
         resumer(ChooseColorForTargetContinuation::class, ::resumeChooseColorForTarget),
@@ -114,6 +115,28 @@ class ColorChoiceContinuationResumer(
         }
         val newState = state.updateEntity(continuation.sourceId) { container ->
             container.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosen))
+        }
+        return checkForMore(newState, emptyList())
+    }
+
+    fun resumeChooseCardTypeForSource(
+        state: GameState,
+        continuation: ChooseCardTypeForSourceContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option choice response for ChooseCardTypeForSource effect")
+        }
+        val chosen = continuation.cardTypes.getOrNull(response.optionIndex)
+            ?: return ExecutionResult.error(state, "Card type choice index ${response.optionIndex} out of range")
+        // Record the chosen card type durably on the source permanent so
+        // CardPredicate.CardTypeEqualsChosenComponent reads it at cost-calculation / projection time.
+        if (state.getEntity(continuation.sourceId) == null) {
+            return checkForMore(state, emptyList())
+        }
+        val newState = state.updateEntity(continuation.sourceId) { container ->
+            container.withCastChoice(continuation.slot, ChoiceValue.TextChoice(chosen))
         }
         return checkForMore(newState, emptyList())
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -271,6 +271,22 @@ object ZoneTransitionService {
         // battlefield. Carried on the ZoneChangeEvent for trigger resolution AND stashed on the
         // entity itself (LastKnownPermanentComponent) for resolution-time reads that outlive the
         // permanent ("Destroy target creature. Its controller creates two Map tokens.").
+        // Was this permanent equipped / enchanted as it left? The live attachment links are torn
+        // down by the exit cleanup below (CR 704.5m/n), so "modified/equipped/enchanted creature
+        // leaves the battlefield" triggers must freeze it here as last-known information (CR 608.2h).
+        val lastKnownAttachedTypeLines = if (leavingBattlefield) {
+            state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent>()
+                ?.attachedIds
+                ?.mapNotNull { attachId ->
+                    state.getEntity(attachId)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.typeLine
+                }
+                ?: emptyList()
+        } else emptyList()
+        val lastKnownWasEquipped = lastKnownAttachedTypeLines.any { it.isEquipment }
+        val lastKnownWasEnchanted = lastKnownAttachedTypeLines.any { it.isAura }
+
         val lastKnownSnapshot = if (leavingBattlefield) {
             com.wingedsheep.engine.state.components.stack.EntitySnapshot(
                 entityId = entityId,
@@ -288,6 +304,8 @@ object ZoneTransitionService {
                 typeLine = lastKnownTypeLine,
                 cardDefinitionId = cardComponent.cardDefinitionId,
                 attachedTo = lastKnownAttachedTo,
+                wasEquipped = lastKnownWasEquipped,
+                wasEnchanted = lastKnownWasEnchanted,
                 blockingOrBlockedByIds = lastKnownBlockingOrBlockedByIds,
                 wasAttacking = lastKnownWasAttacking,
                 wasToken = lastKnownWasToken,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.scripting.effects.MoveTrackedBattlefieldObjectEffect
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -176,20 +177,50 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
     private fun bakeChosenValuesIntoTrigger(trigger: TriggerSpec, context: EffectContext): TriggerSpec {
         val chosen = context.pipeline.chosenValues
         if (chosen.isEmpty()) return trigger
-        val event = trigger.event
-        if (event !is EventPattern.SpellCastEvent) return trigger
-        val filter = event.spellFilter
+        return when (val event = trigger.event) {
+            is EventPattern.SpellCastEvent -> {
+                val newFilter = bakeChosenValuesIntoFilter(event.spellFilter, chosen) ?: return trigger
+                trigger.copy(event = event.copy(spellFilter = newFilter))
+            }
+            // The Clone Saga ch. III: "whenever a creature with the chosen name deals combat damage
+            // to a player this turn, draw a card." The chosen name is baked into the damage source
+            // filter now, so the delayed-trigger matcher can evaluate it without the (gone) pipeline.
+            is EventPattern.DealsDamageEvent -> {
+                val filter = event.sourceFilter ?: return trigger
+                val newFilter = bakeChosenValuesIntoFilter(filter, chosen) ?: return trigger
+                trigger.copy(event = event.copy(sourceFilter = newFilter))
+            }
+            else -> trigger
+        }
+    }
+
+    /**
+     * Rewrite chosen-value-dependent card predicates in [filter] into concrete ones using [chosen]
+     * (= `EffectContext.pipeline.chosenValues`). Returns null when nothing changed so the caller
+     * keeps the original TriggerSpec instance.
+     *
+     *  - `HasSubtypeFromVariable(v)` → `HasSubtype(Subtype(chosen[v]))` (Long List of the Ents)
+     *  - `NameEqualsChosen(v)`       → `NameEquals(chosen[v])`          (The Clone Saga ch. III)
+     */
+    private fun bakeChosenValuesIntoFilter(
+        filter: GameObjectFilter,
+        chosen: Map<String, String>
+    ): GameObjectFilter? {
         val newPredicates = filter.cardPredicates.map { predicate ->
-            if (predicate is CardPredicate.HasSubtypeFromVariable) {
-                val value = chosen[predicate.variableName] ?: return@map predicate
-                CardPredicate.HasSubtype(Subtype(value))
-            } else {
-                predicate
+            when (predicate) {
+                is CardPredicate.HasSubtypeFromVariable -> {
+                    val value = chosen[predicate.variableName] ?: return@map predicate
+                    CardPredicate.HasSubtype(Subtype(value))
+                }
+                is CardPredicate.NameEqualsChosen -> {
+                    val value = chosen[predicate.variableName] ?: return@map predicate
+                    CardPredicate.NameEquals(value)
+                }
+                else -> predicate
             }
         }
-        if (newPredicates == filter.cardPredicates) return trigger
-        val newFilter = filter.copy(cardPredicates = newPredicates)
-        return trigger.copy(event = event.copy(spellFilter = newFilter))
+        if (newPredicates == filter.cardPredicates) return null
+        return filter.copy(cardPredicates = newPredicates)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseCardTypeForSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseCardTypeForSourceExecutor.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.ChooseCardTypeForSourceContinuation
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.withCastChoice
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.ChooseCardTypeForSourceEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ChooseCardTypeForSourceEffect].
+ *
+ * The controller chooses a card type (CR 205.2a); the choice is written durably onto the source
+ * entity's cast-choices bag under the effect's slot ([com.wingedsheep.sdk.scripting.ChoiceSlot
+ * .CARD_TYPE]), where [com.wingedsheep.sdk.scripting.predicates.CardPredicate
+ * .CardTypeEqualsChosenComponent] reads it at cost-calculation / projection time (Arachne, Psionic
+ * Weaver's "spells of the chosen type cost {1} more").
+ *
+ * When [ChooseCardTypeForSourceEffect.lookAtOpponentHand] is set, the controller first sees an
+ * opponent's hand (a durable reveal) before choosing. With a single allowed type the choice is
+ * forced and recorded without a prompt; otherwise it pauses for a [ChooseOptionDecision] and the
+ * [ChooseCardTypeForSourceContinuation] resumer writes the pick. No source entity → no-op.
+ */
+class ChooseCardTypeForSourceExecutor : EffectExecutor<ChooseCardTypeForSourceEffect> {
+
+    override val effectType: KClass<ChooseCardTypeForSourceEffect> = ChooseCardTypeForSourceEffect::class
+
+    /** The card types (CR 205.2a) offered when the effect doesn't restrict the set. */
+    private val allCardTypes = listOf(
+        "Artifact", "Battle", "Creature", "Enchantment", "Instant", "Land", "Planeswalker", "Sorcery"
+    )
+
+    override fun execute(
+        state: GameState,
+        effect: ChooseCardTypeForSourceEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId ?: return EffectResult.success(state)
+        val source = state.getEntity(sourceId) ?: return EffectResult.success(state)
+
+        val options = effect.allowedCardTypes ?: allCardTypes
+        if (options.isEmpty()) return EffectResult.success(state)
+
+        // "look at an opponent's hand, then choose …" — a durable reveal to the controller first.
+        val (baseState, lookEvents) = if (effect.lookAtOpponentHand) {
+            PermanentEntryReplacements.revealOpponentHandForEntersChoice(state, context.controllerId)
+        } else state to emptyList()
+
+        // Sole allowed type → forced choice, no prompt.
+        if (options.size == 1) {
+            val newState = baseState.updateEntity(sourceId) { container ->
+                container.withCastChoice(effect.slot, ChoiceValue.TextChoice(options.single()))
+            }
+            return EffectResult.success(newState, lookEvents)
+        }
+
+        val decisionId = "choose-card-type-for-source-${sourceId.value}"
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = context.controllerId,
+            prompt = effect.prompt,
+            context = DecisionContext(
+                sourceId = sourceId,
+                sourceName = source.get<CardComponent>()?.name ?: "Unknown",
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = options
+        )
+        val continuation = ChooseCardTypeForSourceContinuation(
+            decisionId = decisionId,
+            sourceId = sourceId,
+            controllerId = context.controllerId,
+            slot = effect.slot,
+            cardTypes = options
+        )
+
+        return EffectResult.paused(
+            baseState.withPendingDecision(decision).pushContinuation(continuation),
+            decision,
+            lookEvents
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -50,6 +50,7 @@ class PlayerExecutors(
         CantPlayCardsFromHandExecutor(),
         ChooseNumberForSourceExecutor(decisionHandler),
         ChooseOpponentForSourceExecutor(),
+        ChooseCardTypeForSourceExecutor(),
         CreateGlobalTriggeredAbilityExecutor(),
         CreatePermanentEmblemExecutor(),
         EachPlayerChoosesCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1379,7 +1379,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
             if (cardComponent.typeLine.isLand) continue
             val cardDef = context.cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
 
-            val mayhem = MayhemGrants.effectiveMayhem(state, cardId, cardDef) ?: continue
+            val mayhem = MayhemGrants.effectiveMayhem(
+                state, cardId, cardDef, playerId, context.cardRegistry, context.predicateEvaluator
+            ) ?: continue
 
             // Timing: Mayhem grants no permission — instants/flash any time, else sorcery speed.
             val isInstant = cardComponent.typeLine.isInstant

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -250,6 +250,24 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 // Check cast restrictions
                 val castRestrictions = topCardDef?.script?.castRestrictions ?: emptyList()
                 if (context.castPermissionUtils.checkCastRestrictions(state, playerId, castRestrictions)) {
+                    // Gwenom: a spell cast from the top under a PlayFromTopWithAlternativeCost
+                    // permission pays no mana and instead pays life equal to its mana value.
+                    val topAltCost = context.castPermissionUtils.playFromTopAlternativeCost(state, playerId)
+                        ?.takeIf { grant ->
+                            val grantFilter = grant.filter
+                            grantFilter == null || context.predicateEvaluator.matches(
+                                state, state.projectedState, topCardId, grantFilter,
+                                PredicateContext(controllerId = playerId)
+                            )
+                        }
+                    val freeCastFromTop = topAltCost?.withoutPayingManaCost == true
+                    val payLifeMv = topAltCost?.additionalCost is AdditionalCost.PayLifeEqualToManaValueOfSpell
+                    val lifeForThisCard = if (payLifeMv) topCardComponent.manaCost.cmc else 0
+                    val lifeAffordable = !payLifeMv || state.lifeTotal(playerId) >= lifeForThisCard
+                    val topAltAdditionalCostInfo = if (payLifeMv) {
+                        AdditionalCostData(description = "Pay $lifeForThisCard life", costType = "PayLife")
+                    } else null
+
                     val topEffectiveCost = if (topCardDef != null) {
                         context.costCalculator.calculateEffectiveCost(state, topCardDef, playerId)
                     } else {
@@ -262,14 +280,16 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     val topPayableCost = context.castPermissionUtils
                         .relaxSpellCostColorsIfAny(state, playerId, topCardId, topEffectiveCost)
                     val cachedSources = context.availableManaSources
-                    val canAfford = context.manaSolver.canPay(state, playerId, topPayableCost, precomputedSources = cachedSources)
+                    val canAfford = (freeCastFromTop ||
+                        context.manaSolver.canPay(state, playerId, topPayableCost, precomputedSources = cachedSources)) &&
+                        lifeAffordable
                     if (canAfford) {
                         val targetReqs = buildList {
                             addAll(topCardDef?.script?.targetRequirements ?: emptyList())
                             topCardDef?.script?.auraTarget?.let { add(it) }
                         }
 
-                        val manaCostString = topEffectiveCost.toString()
+                        val manaCostString = if (freeCastFromTop) "0" else topEffectiveCost.toString()
                         val hasXCost = topEffectiveCost.hasX
                         val maxAffordableX: Int? = if (hasXCost) {
                             val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = cachedSources)
@@ -305,7 +325,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                         maxAffordableX = maxAffordableX,
                                         manaCostString = manaCostString,
                                         autoTapPreview = autoTapPreview,
-                                        sourceZone = "LIBRARY"
+                                        sourceZone = "LIBRARY",
+                                        additionalCostInfo = topAltAdditionalCostInfo
                                     )
                                 )
                             }
@@ -319,7 +340,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                     maxAffordableX = maxAffordableX,
                                     manaCostString = manaCostString,
                                     autoTapPreview = autoTapPreview,
-                                    sourceZone = "LIBRARY"
+                                    sourceZone = "LIBRARY",
+                                    additionalCostInfo = topAltAdditionalCostInfo
                                 )
                             )
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/WebSlingingCastEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/WebSlingingCastEnumerator.kt
@@ -47,7 +47,9 @@ class WebSlingingCastEnumerator : ActionEnumerator {
             if (context.cantCastSpell(cardId)) continue
 
             val cardDef = context.cardRegistry.getCard(cardComponent.name) ?: continue
-            val webSlinging = WebSlinging.webSlingingAbility(cardDef) ?: continue
+            val webSlinging = WebSlinging.effectiveWebSlinging(
+                state, cardId, cardDef, playerId, context.cardRegistry, context.predicateEvaluator
+            ) ?: continue
 
             // Web-slinging carries no timing permission (CR 702.188) — respect the card's normal
             // timing exactly like the ordinary cast path: non-instants without flash need sorcery

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -374,7 +374,37 @@ class CastPermissionUtils(
                 return true
             }
         }
-        return false
+        // An alternative-cost play-from-top permission (Gwenom, Remorseless) also lets any card be
+        // played from the top — printed or granted durationally.
+        return playFromTopAlternativeCost(state, playerId) != null
+    }
+
+    /**
+     * The effective [com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost] permission for
+     * [playerId] (Gwenom's "play from the top; pay life equal to a spell's mana value rather than its
+     * mana cost"), or null. Printed on a permanent the player controls, or granted durationally in
+     * `grantedStaticAbilities` anchored to a permanent they control. Mirrors the printed-or-granted
+     * scan used for `MayCastFromGraveyard`.
+     */
+    fun playFromTopAlternativeCost(
+        state: GameState,
+        playerId: EntityId
+    ): com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost? {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            cardDef.script.staticAbilities
+                .firstOrNull { it is com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost }
+                ?.let { return it as com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost }
+        }
+        for (grant in state.grantedStaticAbilities) {
+            val ability = grant.ability
+            if (ability !is com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost) continue
+            val anchor = state.getEntity(grant.entityId) ?: continue
+            if (anchor.get<ControllerComponent>()?.playerId != playerId) continue
+            return ability
+        }
+        return null
     }
 
     /**
@@ -408,7 +438,8 @@ class CastPermissionUtils(
                 return true
             }
         }
-        return false
+        // "You may play cards from the top of your library" (Gwenom) also permits land plays from top.
+        return playFromTopAlternativeCost(state, playerId) != null
     }
 
     fun getCastFilteredFromTopOfLibraryFilter(state: GameState, playerId: EntityId): GameObjectFilter? {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/MayhemGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/MayhemGrants.kt
@@ -1,8 +1,13 @@
 package com.wingedsheep.engine.mechanics
 
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GraveyardCardsHaveMayhem
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
 /**
@@ -26,14 +31,52 @@ object MayhemGrants {
     fun effectiveMayhem(
         state: GameState,
         cardId: EntityId,
-        cardDef: CardDefinition?
+        cardDef: CardDefinition?,
+        controllerId: EntityId? = null,
+        cardRegistry: CardRegistry? = null,
+        predicateEvaluator: PredicateEvaluator? = null,
     ): KeywordAbility.Mayhem? {
         cardDef?.keywordAbilities
             ?.firstOrNull { it is KeywordAbility.Mayhem }
             ?.let { return it as KeywordAbility.Mayhem }
 
-        return state.grantedKeywordAbilities
+        state.grantedKeywordAbilities
             .lastOrNull { it.entityId == cardId && it.ability is KeywordAbility.Mayhem }
-            ?.let { it.ability as KeywordAbility.Mayhem }
+            ?.let { return it.ability as KeywordAbility.Mayhem }
+
+        if (controllerId != null && cardRegistry != null && predicateEvaluator != null) {
+            groupGrantMayhem(state, cardId, controllerId, cardRegistry, predicateEvaluator)
+                ?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * Scan [controllerId]'s battlefield for a [GraveyardCardsHaveMayhem] static whose filter matches
+     * [cardId] (during their turn, if the grant requires it), synthesizing a [KeywordAbility.Mayhem]
+     * carrying the granted cost — the grant's fixed cost, or the card's own mana cost when the grant
+     * leaves it null ("equal to that card's mana cost"). Mirrors `FlashbackGrants.groupGrantFlashback`.
+     */
+    private fun groupGrantMayhem(
+        state: GameState,
+        cardId: EntityId,
+        controllerId: EntityId,
+        cardRegistry: CardRegistry,
+        predicateEvaluator: PredicateEvaluator,
+    ): KeywordAbility.Mayhem? {
+        val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return null
+        val context = PredicateContext(controllerId = controllerId)
+        for (granterId in state.controlledBattlefield(controllerId)) {
+            val def = state.getEntity(granterId)?.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+            for (ability in def.script.staticAbilities) {
+                if (ability !is GraveyardCardsHaveMayhem) continue
+                if (ability.duringYourTurnOnly && !state.isActiveTurnFor(controllerId)) continue
+                if (predicateEvaluator.matches(state, state.projectedState, cardId, ability.filter, context)) {
+                    return KeywordAbility.Mayhem(ability.cost ?: cardComponent.manaCost)
+                }
+            }
+        }
+        return null
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/WebSlinging.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/WebSlinging.kt
@@ -1,9 +1,14 @@
 package com.wingedsheep.engine.mechanics
 
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantWebSlingingToSpells
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
 /**
@@ -27,6 +32,40 @@ object WebSlinging {
     /** The printed web-slinging ability on [cardDef], or null. */
     fun webSlingingAbility(cardDef: CardDefinition): KeywordAbility.WebSlinging? =
         cardDef.keywordAbilities.filterIsInstance<KeywordAbility.WebSlinging>().firstOrNull()
+
+    /**
+     * The effective web-slinging ability for the spell [spellCardId] (currently in [controllerId]'s
+     * hand), or null. A printed web-slinging on [cardDef] wins; otherwise, when
+     * [controllerId]/[cardRegistry]/[predicateEvaluator] are supplied, a battlefield
+     * [GrantWebSlingingToSpells] static controlled by [controllerId] whose `spellFilter` matches the
+     * spell grants web-slinging at the static's cost. Amazing Spider-Man: "Each legendary spell you
+     * cast that's one or more colors has web-slinging {G}{W}{U}." Mirrors `FlashbackGrants`.
+     */
+    fun effectiveWebSlinging(
+        state: GameState,
+        spellCardId: EntityId,
+        cardDef: CardDefinition?,
+        controllerId: EntityId? = null,
+        cardRegistry: CardRegistry? = null,
+        predicateEvaluator: PredicateEvaluator? = null,
+    ): KeywordAbility.WebSlinging? {
+        cardDef?.let { webSlingingAbility(it) }?.let { return it }
+
+        if (controllerId != null && cardRegistry != null && predicateEvaluator != null) {
+            val context = PredicateContext(controllerId = controllerId)
+            for (granterId in state.controlledBattlefield(controllerId)) {
+                val def = state.getEntity(granterId)?.get<CardComponent>()
+                    ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+                for (ability in def.script.staticAbilities) {
+                    if (ability !is GrantWebSlingingToSpells) continue
+                    if (predicateEvaluator.matches(state, state.projectedState, spellCardId, ability.spellFilter, context)) {
+                        return KeywordAbility.WebSlinging(ability.cost)
+                    }
+                }
+            }
+        }
+        return null
+    }
 
     /**
      * The tapped creatures [playerId] controls — the legal pool for the "return a tapped creature

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -778,6 +778,7 @@ internal class AffectsFilterResolver {
         // Resolved separately in resolveGenericFilter against the source's CastChoicesComponent
         // (no source in scope here) — fail closed if it ever reaches this generic path.
         is CardPredicate.NameEqualsChosenComponent,
+        is CardPredicate.CardTypeEqualsChosenComponent,
         is CardPredicate.HasSubtypeInEachStoredGroup -> false
         // Stack-only predicates — never match a battlefield entity being projected.
         CardPredicate.IsActivatedOrTriggeredAbility,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -883,6 +883,7 @@ class StaticAbilityHandler(
             is GrantMiracleToCardsInHand,
             is MayCastFromGraveyard,
             is GraveyardCardsHaveFlashback,
+            is com.wingedsheep.sdk.scripting.GraveyardCardsHaveMayhem,
             is com.wingedsheep.sdk.scripting.GraveyardCreaturesHaveSneak,
             is MayCastSelfFromZones,
             is MayCastWithoutPayingManaCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -898,6 +898,7 @@ class StaticAbilityHandler(
             is ReduceActivatedAbilityCost,
             is com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost,
             is PlayFromTopOfLibrary,
+            is com.wingedsheep.sdk.scripting.PlayFromTopWithAlternativeCost,
             is PlayLandsAndCastFilteredFromTopOfLibrary,
             is PlotFromTopOfLibrary,
             is PlayersCantCastSpells,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -917,6 +917,7 @@ class StaticAbilityHandler(
             // Spells on the stack (StackResolver / GrantedKeywordResolver):
             is GrantCantBeCountered,
             is GrantKeywordToOwnSpells,
+            is com.wingedsheep.sdk.scripting.GrantWebSlingingToSpells,
 
             // Activated abilities (ActivateAbilityHandler / ActivatedAbilityEnumerator):
             is ExtraLoyaltyActivation,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1114,6 +1114,13 @@ class CostCalculator(
                     as? ChoiceValue.TextChoice)?.text ?: return false
                 cardDef.name.equals(chosenName, ignoreCase = true)
             }
+            is CardPredicate.CardTypeEqualsChosenComponent -> {
+                if (sourceEntityId == null || state == null) return false
+                val chosenType = (state.getEntity(sourceEntityId)
+                    ?.get<CastChoicesComponent>()?.chosen?.get(predicate.slot)
+                    as? ChoiceValue.TextChoice)?.text ?: return false
+                cardDef.typeLine.cardTypes.any { it.displayName.equals(chosenType, ignoreCase = true) }
+            }
 
             is CardPredicate.And -> predicate.predicates.all { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }
             is CardPredicate.Or -> predicate.predicates.any { matchesCardPredicate(cardDef, it, sourceEntityId, state, projectedState) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/CastChoicesComponent.kt
@@ -106,6 +106,10 @@ fun ComponentContainer.chosenModeId(): String? =
 fun ComponentContainer.chosenCardName(): String? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_NAME) as? ChoiceValue.TextChoice)?.text
 
+/** The card type chosen as this object entered (e.g. Arachne, Psionic Weaver), or null. */
+fun ComponentContainer.chosenCardType(): String? =
+    (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE) as? ChoiceValue.TextChoice)?.text
+
 /** The creature chosen as this object entered, or null. */
 fun ComponentContainer.chosenCreatureRef(): EntityId? =
     (get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CREATURE) as? ChoiceValue.EntityChoice)?.entityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -99,6 +99,20 @@ data class EntitySnapshot(
     val copyOfOriginalName: String? = null,
     /** For auras/equipment: the entity this was attached to when it left (enchanted-creature dies triggers). */
     val attachedTo: EntityId? = null,
+    /**
+     * True if this permanent had at least one Equipment attached when it left the battlefield. The
+     * live attachment links are torn down by the exit cleanup, so leaves/dies triggers asking "was
+     * it modified/equipped?" must read last-known information (CR 608.2h). Backs the last-known leg
+     * of [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped] and (together with
+     * counters / [wasEnchanted]) [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified].
+     */
+    val wasEquipped: Boolean = false,
+    /**
+     * True if this permanent had at least one Aura attached when it left the battlefield (CR 303.4).
+     * Last-known counterpart to [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted];
+     * a leg of the last-known [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified].
+     */
+    val wasEnchanted: Boolean = false,
     /** Creatures blocking, or blocked by, this one when it left (CR 509; Abu Ja'far). */
     val blockingOrBlockedByIds: List<EntityId> = emptyList(),
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -417,6 +417,9 @@ data class ClientCard(
     /** Chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet) */
     val chosenCardName: String? = null,
 
+    /** Chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver) */
+    val chosenCardType: String? = null,
+
     /** Triggering entity ID for triggered abilities on the stack (for source arrows) */
     val triggeringEntityId: EntityId? = null,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1086,6 +1086,9 @@ class ClientStateTransformer(
         // Get chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet)
         val chosenCardName = container.chosenCardName()
 
+        // Get chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver)
+        val chosenCardType = container.chosenCardType()
+
         // Get sacrificed creature types for spells with sacrifice-as-cost (e.g., Endemic Plague)
         val sacrificedCreatureTypes = spellOnStack?.sacrificedPermanents
             ?.flatMap { it.subtypes }?.toSet()
@@ -1301,6 +1304,7 @@ class ClientStateTransformer(
             chosenColor = chosenColor,
             chosenMode = chosenMode,
             chosenCardName = chosenCardName,
+            chosenCardType = chosenCardType,
             sacrificedCreatureTypes = sacrificedCreatureTypes,
             playableFromExile = playableFromExile,
             copyOf = container.get<com.wingedsheep.engine.state.components.identity.CopyOfComponent>()?.let { copyComp ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -725,7 +725,19 @@ class ClientStateTransformer(
         // so only allow face-down status in zones where it makes sense (defense-in-depth).
         val spellOnStack = container.get<SpellOnStackComponent>()
         val isInFaceDownZone = zoneKey.zoneType == Zone.BATTLEFIELD || zoneKey.zoneType == Zone.STACK || zoneKey.zoneType == Zone.EXILE
-        val isFaceDown = isInFaceDownZone && (container.has<FaceDownComponent>() || spellOnStack?.castFaceDown == true)
+        // A card exiled face down that the viewer has been granted permission to PLAY
+        // ("look at and play the exiled cards" — Black Cat, Cunning Thief) must not be hidden from
+        // that viewer, or the client has no card data to act on the CastSpell the server offers.
+        // It stays face-down (masked) to everyone else. Keyed on the same may-play check that drives
+        // `playableFromExile` below, so visibility and playability stay in lockstep. Scoped to exile
+        // so battlefield/stack morph masking (a face-down 2/2 revealed via Spy Network stays a 2/2)
+        // is unchanged.
+        val viewerMayPlayThisExiledCard = !isSpectator &&
+            zoneKey.zoneType == Zone.EXILE &&
+            state.hasMayPlayFor(entityId, viewingPlayerId, conditionEvaluator, cardRegistry)
+        val isFaceDown = isInFaceDownZone &&
+            (container.has<FaceDownComponent>() || spellOnStack?.castFaceDown == true) &&
+            !viewerMayPlayThisExiledCard
         // Use projected P/T which correctly handles face-down base 2/2 + any modifications.
         // CR 208.3: a noncreature permanent has no power or toughness — even one with a printed P/T
         // (a Vehicle), and even a creature turned into an artifact/land by a type-changing effect

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/Visibility.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -85,6 +86,21 @@ class Visibility(
                     activeStaticAbility(state, ability, entityId, playerId)?.let(predicate) == true
                 }
             ) return true
+        }
+        // Also scan durationally granted statics (e.g. Gwenom, Remorseless grants LookAtTopOfLibrary
+        // to itself on attack until end of turn). These live in `grantedStaticAbilities` anchored to
+        // the granting permanent, never in `cardDef.script.staticAbilities`. Mirrors the printed-or-
+        // granted scan the cast-legality path already uses (CastPermissionUtils.playFromTopAlternativeCost),
+        // so visibility and castability stay in lockstep — otherwise the top card is castable but the
+        // controller never sees it, so there is nothing to play.
+        for (grant in state.grantedStaticAbilities) {
+            // Match the cast-legality scan in CastPermissionUtils.playFromTopAlternativeCost (base
+            // control) so visibility and castability stay in lockstep.
+            val anchor = state.getEntity(grant.entityId) ?: continue
+            if (anchor.get<ControllerComponent>()?.playerId != playerId) continue
+            if (activeStaticAbility(state, grant.ability, grant.entityId, playerId)?.let(predicate) == true) {
+                return true
+            }
         }
         return false
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.ArachnePsionicWeaver
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Arachne, Psionic Weaver (SPM) — "As Arachne enters, look at an opponent's hand, then choose a card
+ * type other than creature. Spells of the chosen type cost {1} more to cast."
+ *
+ * Pins the new durable card-type choice ([Effects.ChooseCardTypeForSource] → [ChoiceSlot.CARD_TYPE])
+ * and the cost tax keyed to it ([CardPredicate.CardTypeEqualsChosenComponent] read at
+ * cost-calculation time).
+ */
+class ArachnePsionicWeaverScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ArachnePsionicWeaver))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    /** Cast Arachne and lock in [type] as its chosen card type. Returns Arachne's entity id. */
+    fun castArachneChoosing(driver: GameTestDriver, you: EntityId, type: String): EntityId {
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveColorlessMana(you, 2)
+        val arachne = driver.putCardInHand(you, "Arachne, Psionic Weaver")
+        driver.castSpell(you, arachne)
+        settle(driver) // Arachne resolves, ETB trigger resolves, pauses on the card-type choice
+        val pick = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        driver.submitDecision(you, OptionChosenResponse(pick.id, pick.options.indexOf(type)))
+        settle(driver)
+        return arachne
+    }
+
+    test("the chosen card type is written durably onto Arachne") {
+        val (driver, you, opponent) = newGame()
+        driver.putCardInHand(opponent, "Lightning Bolt") // so the hand-look has content
+        val arachne = castArachneChoosing(driver, you, "Instant")
+
+        val chosen = driver.state.getEntity(arachne)
+            ?.get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE)
+        (chosen as? ChoiceValue.TextChoice)?.text shouldBe "Instant"
+    }
+
+    test("spells of the chosen type cost {1} more; other types are untaxed") {
+        val (driver, you, opponent) = newGame()
+        castArachneChoosing(driver, you, "Instant")
+
+        // Lightning Bolt is an instant ({R}); with the tax it costs {1}{R}.
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1) // only {R} — not enough for the taxed {1}{R}
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldNotBe null
+
+        driver.giveColorlessMana(you, 1) // now {1}{R} available
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        settle(driver) // resolve the bolt so the stack is empty for the sorcery-speed control cast
+
+        // A sorcery is not the chosen type, so it is untaxed: Careful Study ({B}) pays exactly {B}.
+        val study = driver.putCardInHand(you, "Careful Study")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.castSpell(you, study).error shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArachnePsionicWeaverScenarioTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.mtg.sets.definitions.spm.cards.ArachnePsionicWeaver
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
@@ -64,6 +65,18 @@ class ArachnePsionicWeaverScenarioTest : FunSpec({
         val chosen = driver.state.getEntity(arachne)
             ?.get<CastChoicesComponent>()?.chosen?.get(ChoiceSlot.CARD_TYPE)
         (chosen as? ChoiceValue.TextChoice)?.text shouldBe "Instant"
+    }
+
+    test("the chosen card type is surfaced to the client view") {
+        val (driver, you, opponent) = newGame()
+        driver.putCardInHand(opponent, "Lightning Bolt")
+        val arachne = castArachneChoosing(driver, you, "Instant")
+
+        // The durable card-type choice is visible to the client (rendered as a badge), not just
+        // stored on the permanent's CastChoicesComponent.
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = you)
+        view.cards[arachne]?.chosenCardType shouldBe "Instant"
     }
 
     test("spells of the chosen type cost {1} more; other types are untaxed") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlackCatCunningThiefScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlackCatCunningThiefScenarioTest.kt
@@ -1,15 +1,19 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
@@ -103,6 +107,120 @@ class BlackCatCunningThiefScenarioTest : ScenarioTestBase() {
                 withClue("The exiled card resolved onto the Black Cat controller's battlefield") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe true
                     game.state.getExile(game.player2Id).contains(grizzly) shouldBe false
+                }
+            }
+
+            // Regression: the two cards are exiled FACE DOWN, but the Black Cat controller "may play"
+            // them. The client view must reveal them (with a play-from-exile affordance) to that
+            // controller — otherwise the server offers a CastSpell the UI has no card data to act on,
+            // and the player is "unable to play" the exiled cards. Everyone else still sees only a
+            // face-down card. (Face-up impulse cards like Laughing Jasper Flint never hit this path.)
+            test("a face-down exiled card is revealed and playable to the controller, but masked to others") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Black Cat, Cunning Thief")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Black Cat, Cunning Thief").error shouldBe null
+                game.resolveStack()
+                val decision = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                val grizzly = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val aForest = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                }
+                game.selectCards(listOf(grizzly, aForest))
+
+                // The Black Cat controller (Player1) holds the may-play permission, so their view must
+                // expose the real card and flag it playable from exile.
+                val asController = stateTransformer
+                    .transform(game.state, viewingPlayerId = game.player1Id)
+                    .cards[grizzly].shouldNotBeNull()
+                withClue("The permission-holder sees the real, playable card rather than a masked stub") {
+                    asController.name shouldBe "Grizzly Bears"
+                    asController.isFaceDown shouldBe false
+                    asController.manaCost shouldNotBe ""
+                    asController.playableFromExile shouldBe true
+                }
+
+                // A spectator (no play permission) still sees only a face-down card with no identity.
+                val asSpectator = stateTransformer
+                    .transform(game.state, viewingPlayerId = game.player2Id, isSpectator = true)
+                    .cards[grizzly].shouldNotBeNull()
+                withClue("A viewer without permission still sees a masked, unplayable face-down card") {
+                    asSpectator.name shouldBe "Face-down card"
+                    asSpectator.isFaceDown shouldBe true
+                    asSpectator.playableFromExile shouldBe false
+                }
+            }
+
+            // Regression: a LAND exiled face down must enter the battlefield face up as the real land,
+            // not as a face-down 2/2. Lands bypass the stack (where face-down spells are revealed), so
+            // PlayLandHandler must strip the face-down marker itself (CR 305.1 — a land is played face up).
+            test("a land exiled face down is played face up as the real land, not a face-down creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Black Cat, Cunning Thief")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Black Cat, Cunning Thief").error shouldBe null
+                game.resolveStack()
+                val decision = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                val grizzly = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val aForest = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                }
+                game.selectCards(listOf(grizzly, aForest))
+
+                // Play the exiled Forest as a land (its may-play permission covers it).
+                val played = game.execute(PlayLand(game.player1Id, aForest))
+                withClue("Playing the exiled Forest as a land should succeed: ${played.error}") {
+                    played.error shouldBe null
+                }
+
+                withClue("The Forest entered face up as a real land, not a face-down 2/2 creature") {
+                    game.isOnBattlefield("Forest") shouldBe true
+                    // The face-down marker is stripped on the way in.
+                    game.state.getEntity(aForest)?.get<FaceDownComponent>() shouldBe null
+                }
+
+                // The client view confirms it renders as a Forest with no power/toughness — a
+                // face-down permanent would surface as a nameless 2/2.
+                val playedForest = stateTransformer
+                    .transform(game.state, viewingPlayerId = game.player1Id)
+                    .cards[aForest].shouldNotBeNull()
+                withClue("The played land shows as a Forest, not a face-down creature") {
+                    playedForest.name shouldBe "Forest"
+                    playedForest.isFaceDown shouldBe false
+                    playedForest.power shouldBe null
+                    playedForest.toughness shouldBe null
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlackCatCunningThiefScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlackCatCunningThiefScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Black Cat, Cunning Thief (SPM #52) — {3}{B}{B} Legendary Creature 2/3.
+ *
+ *   When Black Cat enters, look at the top nine cards of target opponent's library, exile two of
+ *   them face down, then put the rest on the bottom of their library in a random order. You may play
+ *   the exiled cards for as long as they remain exiled. Mana of any type can be spent to cast spells
+ *   this way.
+ *
+ * Covers the ETB dig (look at the top nine of the opponent's library, exile exactly two, bottom the
+ * remaining seven) and the impulse-with-any-mana payoff: the exiled off-color card carries a
+ * permanent may-play permission whose {G} pip is paid entirely from the Black Cat controller's
+ * Swamps — impossible without `withAnyManaType`.
+ */
+class BlackCatCunningThiefScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Black Cat, Cunning Thief") {
+
+            test("exiles two of the opponent's top nine, bottoms the rest, and an exiled off-color card is castable with any mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Black Cat, Cunning Thief")
+                    // {3}{B}{B} for Black Cat (5) + {1}{G} for the stolen Grizzly Bears (2) = 7 Swamps.
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    // Opponent's library = the nine looked-at cards: one off-color creature + eight lands.
+                    .withCardInLibrary(2, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Black Cat, Cunning Thief")
+                withClue("Casting Black Cat should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                // Resolve the creature; the ETB trigger auto-targets the sole opponent and pauses on
+                // the "exile two of them" selection.
+                game.resolveStack()
+
+                withClue("Black Cat resolved onto the battlefield") {
+                    game.isOnBattlefield("Black Cat, Cunning Thief") shouldBe true
+                }
+
+                val decision = game.getPendingDecision()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("The dig looks at nine cards and forces exactly two to be exiled") {
+                    decision.options.size shouldBe 9
+                    decision.minSelections shouldBe 2
+                    decision.maxSelections shouldBe 2
+                }
+
+                // Exile the off-color Grizzly Bears plus one Forest.
+                val grizzly = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val aForest = decision.options.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                }
+                game.selectCards(listOf(grizzly, aForest))
+
+                withClue("Exactly two cards were exiled (to the owner's exile), the other seven bottomed") {
+                    namesInExile(game, 2).size shouldBe 2
+                    game.state.getExile(game.player2Id).contains(grizzly).shouldBeTrue()
+                    game.librarySize(2) shouldBe 7
+                }
+
+                withClue("The Black Cat controller holds a permanent, any-mana play permission for the exiled card") {
+                    val permission = game.state.mayPlayPermissions.single { grizzly in it.cardIds }
+                    permission.controllerId shouldBe game.player1Id
+                    permission.permanent shouldBe true
+                    permission.withAnyManaType shouldBe true
+                }
+
+                // Cast the exiled Grizzly Bears from the opponent's exile as Player1, paying its {G}
+                // pip entirely from Swamps — only possible because mana of any type may be spent.
+                val castExiled = game.execute(CastSpell(game.player1Id, grizzly))
+                withClue("Casting the exiled Grizzly Bears from exile should succeed: ${castExiled.error}") {
+                    castExiled.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The exiled card resolved onto the Black Cat controller's battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.state.getExile(game.player2Id).contains(grizzly) shouldBe false
+                }
+            }
+        }
+    }
+
+    private fun namesInExile(game: TestGame, playerNumber: Int): List<String> {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getExile(playerId).mapNotNull { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostumeClosetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostumeClosetScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.CostumeCloset
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Costume Closet (SPM) — "Whenever a modified creature you control leaves the battlefield, put a
+ * +1/+1 counter on this artifact."
+ *
+ * Pins the last-known-information fix for the modified-LTB trigger: when a modified creature leaves,
+ * its counters and attachments are already stripped, so the `StatePredicate.IsModified` filter must
+ * be evaluated against the departing permanent's [EntitySnapshot] (counters +
+ * `wasEquipped`/`wasEnchanted`). Before the fix the predicate fell through fail-open, so the Closet
+ * would have gained a counter for *any* creature-you-control departure — the "unmodified creature"
+ * case is the regression guard.
+ */
+class CostumeClosetScenarioTest : FunSpec({
+
+    // A trivial Equipment so we can exercise the "modified because equipped" leg.
+    val testEquipment = CardDefinition.equipment(
+        name = "Test Blade",
+        manaCost = ManaCost.parse("{1}"),
+        equipCost = ManaCost.parse("{1}"),
+    )
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CostumeCloset, testEquipment))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun closetCounters(driver: GameTestDriver, closet: EntityId): Int =
+        driver.state.getEntity(closet)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun destroy(driver: GameTestDriver, you: EntityId, victim: EntityId) {
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        val doomBlade = driver.putCardInHand(you, "Doom Blade")
+        driver.castSpellWithTargets(you, doomBlade, listOf(ChosenTarget.Permanent(victim)))
+        resolveStack(driver)
+    }
+
+    test("a modified (counter) creature leaving adds a +1/+1 counter to the Closet") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        driver.addComponent(lions, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 1
+    }
+
+    test("a modified (equipped) creature leaving adds a +1/+1 counter to the Closet") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val blade = driver.putPermanentOnBattlefield(you, "Test Blade")
+        driver.addComponent(blade, AttachedToComponent(lions))
+        driver.addComponent(lions, AttachmentsComponent(listOf(blade)))
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 1
+    }
+
+    test("an unmodified creature leaving does NOT add a counter (regression guard)") {
+        val (driver, you, _) = newGame()
+        val closet = driver.putPermanentOnBattlefield(you, "Costume Closet")
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        closetCounters(driver, closet) shouldBe 0
+        destroy(driver, you, lions)
+        closetCounters(driver, closet) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantWebSlingingToSpellsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantWebSlingingToSpellsTest.kt
@@ -58,9 +58,16 @@ class GrantWebSlingingToSpellsTest : FunSpec({
         toughness = 3
     }
 
+    // A colorless legendary spell — legendary but not colored, so it fails the IsColored half of the
+    // filter ("that's one or more colors"). Exercises the predicate the nonlegendary case leaves alone.
+    val colorlessLegend = card("Test Colorless Relic") {
+        manaCost = "{4}"
+        typeLine = "Legendary Artifact"
+    }
+
     fun newGame(): Pair<GameTestDriver, EntityId> {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(amazingGrant, legendCreature, plainCreature))
+        driver.registerCards(TestCards.all + listOf(amazingGrant, legendCreature, plainCreature, colorlessLegend))
         driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return driver to driver.activePlayer!!
@@ -97,6 +104,14 @@ class GrantWebSlingingToSpellsTest : FunSpec({
         val plain = driver.putCardInHand(you, "Test Plain Spider")
 
         (plain in webSlingActionCardIds(driver, you)) shouldBe false
+    }
+
+    test("a colorless legendary spell does not get granted web-slinging") {
+        val (driver, you) = newGame()
+        setup(driver, you, withGranter = true)
+        val relic = driver.putCardInHand(you, "Test Colorless Relic")
+
+        (relic in webSlingActionCardIds(driver, you)) shouldBe false
     }
 
     test("no granter → no web-slinging for a legendary spell") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantWebSlingingToSpellsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantWebSlingingToSpellsTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantWebSlingingToSpells
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * `GrantWebSlingingToSpells` — behind Amazing Spider-Man's "Each legendary spell you cast that's one
+ * or more colors has web-slinging {G}{W}{U}." Pins that a battlefield static grants web-slinging to
+ * matching spells in hand (routed through `WebSlinging.effectiveWebSlinging`), while a tapped
+ * creature is available to return.
+ */
+class GrantWebSlingingToSpellsTest : FunSpec({
+
+    // Minimal granter: "Each legendary, one-or-more-colored spell you cast has web-slinging {G}{W}{U}".
+    val amazingGrant = card("Amazing Grant Test") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        staticAbility {
+            ability = GrantWebSlingingToSpells(
+                cost = ManaCost.parse("{G}{W}{U}"),
+                spellFilter = GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsLegendary, CardPredicate.IsColored)
+                ),
+            )
+        }
+    }
+
+    // A legendary, colored creature spell — matches the grant.
+    val legendCreature = card("Test Legend Spider") {
+        manaCost = "{4}{G}"
+        colorIdentity = "G"
+        typeLine = "Legendary Creature — Spider"
+        power = 3
+        toughness = 3
+    }
+
+    // A nonlegendary colored creature spell — does NOT match the grant.
+    val plainCreature = card("Test Plain Spider") {
+        manaCost = "{4}{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Spider"
+        power = 3
+        toughness = 3
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(amazingGrant, legendCreature, plainCreature))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun webSlingActionCardIds(driver: GameTestDriver, playerId: EntityId) =
+        LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, playerId)
+            .mapNotNull { it.action as? CastSpell }
+            .filter { it.alternativeCostType == AlternativeCostType.WEB_SLINGING }
+            .map { it.cardId }
+
+    fun setup(driver: GameTestDriver, you: EntityId, withGranter: Boolean): EntityId {
+        if (withGranter) driver.putPermanentOnBattlefield(you, "Amazing Grant Test")
+        // A tapped creature to return for the web-slinging cost.
+        val toReturn = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        driver.tapPermanent(toReturn)
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.giveMana(you, Color.BLUE, 1)
+        return toReturn
+    }
+
+    test("a static grants web-slinging to a legendary, colored spell you cast") {
+        val (driver, you) = newGame()
+        setup(driver, you, withGranter = true)
+        val legend = driver.putCardInHand(you, "Test Legend Spider")
+
+        webSlingActionCardIds(driver, you) shouldContain legend
+    }
+
+    test("a nonlegendary spell does not get granted web-slinging") {
+        val (driver, you) = newGame()
+        setup(driver, you, withGranter = true)
+        val plain = driver.putCardInHand(you, "Test Plain Spider")
+
+        (plain in webSlingActionCardIds(driver, you)) shouldBe false
+    }
+
+    test("no granter → no web-slinging for a legendary spell") {
+        val (driver, you) = newGame()
+        setup(driver, you, withGranter = false)
+        val legend = driver.putCardInHand(you, "Test Legend Spider")
+
+        (legend in webSlingActionCardIds(driver, you)) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GraveyardCardsHaveMayhemTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GraveyardCardsHaveMayhemTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.components.player.CardsDiscardedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GraveyardCardsHaveMayhem
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * `GraveyardCardsHaveMayhem` — the whole-graveyard Mayhem group grant behind Green Goblin's "Goblin
+ * Formula — Each nonland card in your graveyard has mayhem. The mayhem cost is equal to its mana
+ * cost." Pins that a battlefield static grants Mayhem to matching graveyard cards (still gated on the
+ * discarded-this-turn requirement), routed through `MayhemGrants.effectiveMayhem`.
+ */
+class GraveyardCardsHaveMayhemTest : FunSpec({
+
+    // A minimal battlefield granter — "Each nonland card in your graveyard has mayhem (= mana cost)".
+    val goblinFormula = card("Goblin Formula Test") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        staticAbility { ability = GraveyardCardsHaveMayhem(filter = GameObjectFilter.Nonland) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(goblinFormula))
+        return driver
+    }
+
+    fun markDiscarded(driver: GameTestDriver, playerId: EntityId, cardId: EntityId) {
+        val prior = driver.state.getEntity(playerId)?.get<CardsDiscardedThisTurnComponent>()
+            ?: CardsDiscardedThisTurnComponent()
+        driver.addComponent(playerId, prior.copy(cardIds = prior.cardIds + cardId, count = prior.count + 1))
+    }
+
+    fun mayhemActionCardIds(driver: GameTestDriver, playerId: EntityId) =
+        LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, playerId)
+            .mapNotNull { it.action as? CastSpell }
+            .filter { it.alternativeCostType == AlternativeCostType.MAYHEM }
+            .map { it.cardId }
+
+    test("a graveyard static grants mayhem to a discarded nonland card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Goblin Formula Test")
+        // Lightning Bolt has no printed mayhem; the grant supplies it (cost = its mana cost, {R}).
+        val bolt = driver.putCardInGraveyard(you, "Lightning Bolt")
+        markDiscarded(driver, you, bolt)
+        driver.giveMana(you, Color.RED, 1)
+
+        mayhemActionCardIds(driver, you) shouldContain bolt
+    }
+
+    test("no granter → no mayhem for a plain graveyard card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bolt = driver.putCardInGraveyard(you, "Lightning Bolt")
+        markDiscarded(driver, you, bolt)
+        driver.giveMana(you, Color.RED, 1)
+
+        (bolt in mayhemActionCardIds(driver, you)) shouldBe false
+    }
+
+    test("granted mayhem still requires the card to have been discarded this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Goblin Formula Test")
+        val bolt = driver.putCardInGraveyard(you, "Lightning Bolt") // NOT discarded this turn
+        driver.giveMana(you, Color.RED, 1)
+
+        (bolt in mayhemActionCardIds(driver, you)) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GraveyardCardsHaveMayhemTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GraveyardCardsHaveMayhemTest.kt
@@ -78,6 +78,24 @@ class GraveyardCardsHaveMayhemTest : FunSpec({
         (bolt in mayhemActionCardIds(driver, you)) shouldBe false
     }
 
+    test("the Nonland filter excludes a discarded land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Goblin Formula Test")
+        val bolt = driver.putCardInGraveyard(you, "Lightning Bolt")
+        markDiscarded(driver, you, bolt)
+        val land = driver.putCardInGraveyard(you, "Mountain")
+        markDiscarded(driver, you, land)
+        driver.giveMana(you, Color.RED, 1)
+
+        val ids = mayhemActionCardIds(driver, you)
+        ids shouldContain bolt        // nonland card gains mayhem
+        (land in ids) shouldBe false  // the land is excluded by GameObjectFilter.Nonland
+    }
+
     test("granted mayhem still requires the card to have been discarded this turn") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwenomRemorselessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwenomRemorselessScenarioTest.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.spm.cards.GwenomRemorseless
 import com.wingedsheep.sdk.core.ManaCost
@@ -87,5 +88,63 @@ class GwenomRemorselessScenarioTest : FunSpec({
 
         driver.getLifeTotal(you) shouldBe lifeBefore - 5           // paid life = mana value
         (driver.findPermanent(you, "Top Beast") != null) shouldBe true  // resolved onto the battlefield
+    }
+
+    // Regression: the attack also grants LookAtTopOfLibrary, so the controller must actually SEE the
+    // top card in their client view — otherwise it is castable but invisible, so there is nothing to
+    // play. The granted static lives in `grantedStaticAbilities` (not the card's printed statics), a
+    // path the visibility layer previously ignored.
+    test("after Gwenom attacks, the top card of the library is revealed to its controller in the client view") {
+        val (driver, you, opponent) = newGame()
+        val gwenom = driver.putCreatureOnBattlefield(you, "Gwenom, Remorseless")
+        driver.removeSummoningSickness(gwenom)
+        val beast = driver.putCardOnTopOfLibrary(you, "Top Beast")
+
+        // Before the attack there is no look permission, so the top card stays hidden.
+        val before = ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewingPlayerId = you)
+        (beast in before.cards) shouldBe false
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(gwenom), opponent)
+        resolveStack(driver)
+
+        // The granted LookAtTopOfLibrary now reveals the top card to its controller.
+        val yourView = ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewingPlayerId = you)
+        (beast in yourView.cards) shouldBe true
+        yourView.cards[beast]?.name shouldBe "Top Beast"
+
+        // It is a private look, not a public reveal — the opponent still cannot see it.
+        val oppView = ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewingPlayerId = opponent)
+        (beast in oppView.cards) shouldBe false
+    }
+
+    // The grant is `Duration.EndOfTurn`: on a later turn the top card must be neither castable nor
+    // revealed again. Without this, a permanent grant would pass every "yes after the attack" check.
+    test("the play-from-top permission and top-card reveal expire at end of turn") {
+        val (driver, you, opponent) = newGame()
+        val gwenom = driver.putCreatureOnBattlefield(you, "Gwenom, Remorseless")
+        driver.removeSummoningSickness(gwenom)
+        val beast = driver.putCardOnTopOfLibrary(you, "Top Beast")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(gwenom), opponent)
+        resolveStack(driver)
+        driver.declareNoBlockers(opponent)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        resolveStack(driver)
+
+        // Active this turn: in the post-combat main the (sorcery-speed) top creature is castable, and
+        // the top card is revealed to the controller.
+        (beast in topOfLibraryCastCardIds(driver, you)) shouldBe true
+        val duringTurn = ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewingPlayerId = you)
+        (beast in duringTurn.cards) shouldBe true
+
+        // Advance into the next turn; the EndOfTurn grant is dropped at cleanup. Stop in the
+        // opponent's precombat main so `you` hasn't drawn the beast off the top.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        (beast in topOfLibraryCastCardIds(driver, you)) shouldBe false
+        val nextTurn = ClientStateTransformer(driver.cardRegistry).transform(driver.state, viewingPlayerId = you)
+        (beast in nextTurn.cards) shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwenomRemorselessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GwenomRemorselessScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.GwenomRemorseless
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gwenom, Remorseless (SPM) — "Whenever Gwenom attacks, until end of turn, you may play cards from
+ * the top of your library. If you cast a spell this way, pay life equal to its mana value rather
+ * than pay its mana cost."
+ *
+ * Pins the new `PlayFromTopWithAlternativeCost` permission granted durationally: after Gwenom
+ * attacks, the top card of the library becomes castable for life (mana waived), and it isn't
+ * before the attack.
+ */
+class GwenomRemorselessScenarioTest : FunSpec({
+
+    // A vanilla creature ({4}{G}, mana value 5) to sit on top of the library.
+    val topBeast = CardDefinition(
+        name = "Top Beast",
+        manaCost = ManaCost.parse("{4}{G}"),
+        typeLine = TypeLine.parse("Creature — Beast"),
+        oracleText = "",
+        creatureStats = CreatureStats(3, 3),
+    )
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GwenomRemorseless, topBeast))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var g = 0
+        while (g++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun topOfLibraryCastCardIds(driver: GameTestDriver, playerId: EntityId) =
+        LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, playerId)
+            .filter { it.sourceZone == "LIBRARY" }
+            .mapNotNull { it.action as? CastSpell }
+            .map { it.cardId }
+
+    test("after Gwenom attacks, the top spell is castable for life; not before") {
+        val (driver, you, opponent) = newGame()
+        val gwenom = driver.putCreatureOnBattlefield(you, "Gwenom, Remorseless")
+        driver.removeSummoningSickness(gwenom)
+        val beast = driver.putCardOnTopOfLibrary(you, "Top Beast")
+
+        // Before attacking: no permission, so the top card isn't castable.
+        (beast in topOfLibraryCastCardIds(driver, you)) shouldBe false
+
+        // Gwenom attacks → the attack trigger grants the play-from-top permission until end of turn.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(gwenom), opponent)
+        resolveStack(driver)
+        driver.declareNoBlockers(opponent)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        resolveStack(driver)
+
+        // Now the top card is castable from the library.
+        (beast in topOfLibraryCastCardIds(driver, you)) shouldBe true
+
+        // Cast it: no mana is given, and it costs 5 life (its mana value).
+        val lifeBefore = driver.getLifeTotal(you)
+        val result = driver.submit(
+            CastSpell(playerId = you, cardId = beast, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.error shouldBe null
+        resolveStack(driver)
+
+        driver.getLifeTotal(you) shouldBe lifeBefore - 5           // paid life = mana value
+        (driver.findPermanent(you, "Top Beast") != null) shouldBe true  // resolved onto the battlefield
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheCloneSagaChapterThreeTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheCloneSagaChapterThreeTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Clone Saga chapter III — "Choose a card name. Whenever a creature with the chosen name deals
+ * combat damage to a player this turn, draw a card." Pins the `bakeChosenValuesIntoTrigger`
+ * extension that bakes the chosen card name into a delayed combat-damage trigger's source filter.
+ *
+ * Exercised in isolation via an inline sorcery that runs the same effect (ChooseCardName →
+ * CreateDelayedTrigger over `Creature.namedFromVariable`), so it doesn't need the Saga to advance
+ * three chapters.
+ */
+class TheCloneSagaChapterThreeTest : FunSpec({
+
+    // "Choose a card name. Whenever a creature with the chosen name deals combat damage to a player
+    // this turn, draw a card." — the Saga's chapter III effect, as a one-shot sorcery.
+    val chapterThree = CardDefinition(
+        name = "Chosen Name Draw Test",
+        manaCost = ManaCost.parse("{U}"),
+        typeLine = TypeLine.parse("Sorcery"),
+        oracleText = "",
+        script = CardScript.spell(
+            effect = Effects.Composite(
+                Effects.ChooseCardName(storeAs = "clonedName"),
+                CreateDelayedTriggerEffect(
+                    trigger = Triggers.dealsDamage(
+                        damageType = DamageType.Combat,
+                        recipient = RecipientFilter.AnyPlayer,
+                        sourceFilter = GameObjectFilter.Creature.namedFromVariable("clonedName"),
+                        binding = TriggerBinding.ANY,
+                    ),
+                    effect = Effects.DrawCards(1),
+                    fireOnce = false,
+                    expiry = DelayedTriggerExpiry.EndOfTurn,
+                ),
+            )
+        )
+    )
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(chapterThree))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("a creature with the chosen name dealing combat damage to a player draws a card") {
+        val (driver, you, opponent) = newGame()
+
+        // Attacker: a Savannah Lions we will name with chapter III.
+        val lions = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        driver.removeSummoningSickness(lions)
+
+        // Cast the chapter-III sorcery and choose "Savannah Lions".
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLUE, 1)
+        val spell = driver.putCardInHand(you, "Chosen Name Draw Test")
+        driver.castSpell(you, spell)
+        settle(driver)
+        val pick = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(you, OptionChosenResponse(pick.id, pick.options.indexOf("Savannah Lions")))
+        settle(driver)
+
+        // Attack the opponent with the Lions and deal combat damage.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(lions), opponent)
+        val handBeforeDamage = driver.getHandSize(you)
+        driver.declareNoBlockers(opponent)
+        // Advance through the combat-damage step, resolving the chapter-III draw trigger.
+        var guard = 0
+        while (guard++ < 40 && driver.state.step != Step.POSTCOMBAT_MAIN) {
+            if (driver.isPaused) break
+            driver.bothPass()
+        }
+        settle(driver)
+
+        // The delayed chapter-III trigger drew a card when the Lions dealt combat damage.
+        driver.getHandSize(you) shouldBe handBeforeDamage + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSoulStoneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSoulStoneScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.TheSoulStone
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Soul Stone (SPM) — "{6}{B}, {T}, Exile a creature you control: Harness The Soul Stone. Once
+ * harnessed, its ∞ ability is active. ∞ — At the beginning of your upkeep, return target creature
+ * card from your graveyard to the battlefield."
+ *
+ * Pins the Harness gating: the ∞ upkeep trigger reanimates only while the Stone has a harness
+ * counter (the new `Counters.HARNESS` marker read by `Conditions.SourceHasCounter`).
+ */
+class TheSoulStoneScenarioTest : FunSpec({
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheSoulStone))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        return driver to you
+    }
+
+    /** Advance to the controller's own next upkeep, submitting the ∞ target if it triggers. */
+    fun advanceToMyUpkeep(driver: GameTestDriver, me: EntityId, reanimateTarget: EntityId?) {
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        if (driver.activePlayer != me && !driver.isPaused) {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+            driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        }
+        // Resolve the upkeep: submit the ∞ target when prompted, otherwise pass through the stack.
+        var guard = 0
+        while (guard++ < 60) {
+            if (driver.isPaused && driver.pendingDecision is ChooseTargetsDecision) {
+                if (reanimateTarget == null) break
+                driver.submitTargetSelection(me, listOf(reanimateTarget))
+            } else if (!driver.isPaused && driver.state.stack.isNotEmpty()) {
+                driver.bothPass()
+            } else {
+                break
+            }
+        }
+    }
+
+    test("once harnessed, the ∞ upkeep trigger reanimates a creature from your graveyard") {
+        val (driver, you) = newGame()
+        val stone = driver.putPermanentOnBattlefield(you, "The Soul Stone")
+        driver.addComponent(stone, CountersComponent(mapOf(CounterType.HARNESS to 1)))
+        val lions = driver.putCardInGraveyard(you, "Savannah Lions")
+
+        advanceToMyUpkeep(driver, you, reanimateTarget = lions)
+
+        driver.getPermanents(you).contains(lions) shouldBe true
+        driver.getGraveyard(you).contains(lions) shouldBe false
+    }
+
+    test("without a harness counter the ∞ ability does not trigger") {
+        val (driver, you) = newGame()
+        driver.putPermanentOnBattlefield(you, "The Soul Stone") // NOT harnessed
+        val lions = driver.putCardInGraveyard(you, "Savannah Lions")
+
+        advanceToMyUpkeep(driver, you, reanimateTarget = null)
+
+        driver.getGraveyard(you).contains(lions) shouldBe true
+        driver.getPermanents(you).contains(lions) shouldBe false
+    }
+})

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -132,4 +132,5 @@ export const counterManaClass: Record<string, string> = {
   INGENUITY: 'counter-charge',
   FILM: 'counter-charge',
   ICE: 'counter-flood',
+  HARNESS: 'counter-devotion',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -786,6 +786,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.INGENUITY,
   CounterType.FILM,
   CounterType.ICE,
+  CounterType.HARNESS,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2031,6 +2031,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   REVIVAL: { bg: 'rgba(22, 34, 30, 0.95)', border: 'rgba(120, 205, 165, 0.7)', color: '#9ee0c0', glow: 'rgba(120, 205, 165, 0.55)' },
   FILM: { bg: 'rgba(28, 28, 32, 0.95)', border: 'rgba(180, 185, 195, 0.7)', color: '#d0d4dc', glow: 'rgba(180, 185, 195, 0.5)' },
   ICE: { bg: 'rgba(18, 42, 58, 0.95)', border: 'rgba(140, 210, 240, 0.7)', color: '#b8e4f5', glow: 'rgba(140, 210, 240, 0.55)' },
+  HARNESS: { bg: 'rgba(48, 26, 12, 0.95)', border: 'rgba(240, 180, 80, 0.8)', color: '#ffc860', glow: 'rgba(240, 180, 80, 0.7)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -2142,8 +2142,8 @@ function GameCardImpl({
         </div>
       )}
 
-      {/* Chosen creature type / color / mode / card name badge (e.g., Doom Cannon, Riptide Replicator, Outpost Siege, Petrified Hamlet) */}
-      {!faceDown && (card.chosenCreatureType ?? card.chosenColor ?? card.chosenMode ?? card.chosenCardName) && (
+      {/* Chosen creature type / color / mode / card name / card type badge (e.g., Doom Cannon, Riptide Replicator, Outpost Siege, Petrified Hamlet, Arachne) */}
+      {!faceDown && (card.chosenCreatureType ?? card.chosenColor ?? card.chosenMode ?? card.chosenCardName ?? card.chosenCardType) && (
         <div style={{
           position: 'absolute',
           bottom: card.power != null ? 22 : 4,
@@ -2158,7 +2158,7 @@ function GameCardImpl({
           pointerEvents: 'none',
           zIndex: 5,
         }}>
-          {[card.chosenColor, card.chosenCreatureType, card.chosenMode, card.chosenCardName].filter(Boolean).join(' ')}
+          {[card.chosenColor, card.chosenCreatureType, card.chosenMode, card.chosenCardName, card.chosenCardType].filter(Boolean).join(' ')}
         </div>
       )}
 

--- a/web-client/src/components/scenario/types.ts
+++ b/web-client/src/components/scenario/types.ts
@@ -15,6 +15,8 @@ export interface ScenarioBattlefieldCard {
   attachedTo?: string
   chosenCreatureType?: string
   chosenColor?: string
+  /** Durable chosen card type, e.g. Arachne, Psionic Weaver (CR 205.2a). */
+  chosenCardType?: string
 }
 
 export interface ScenarioPlayerConfig {

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -449,6 +449,7 @@ export enum CounterType {
   SKEWER = 'SKEWER',
   ENERGY = 'ENERGY',
   ICE = 'ICE',
+  HARNESS = 'HARNESS',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -519,6 +520,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.SKEWER]: 'Skewer',
   [CounterType.ENERGY]: 'Energy',
   [CounterType.ICE]: 'Ice',
+  [CounterType.HARNESS]: 'Harness',
 }
 
 /**

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -374,6 +374,9 @@ export interface ClientCard {
   /** Chosen card name for "as enters, choose a card name" permanents (e.g., Petrified Hamlet) */
   readonly chosenCardName?: string | null
 
+  /** Chosen card type for "choose a card type" permanents (e.g., Arachne, Psionic Weaver) */
+  readonly chosenCardType?: string | null
+
   /** Triggering entity ID for triggered abilities on the stack (for source arrows) */
   readonly triggeringEntityId?: EntityId | null
 


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1634

## Marvel's Spider-Man: heroes & villains (stacked on `spm-clone-saga`)

Stacked PR — base is `spm-clone-saga`, so this diff is only the four new cards
plus the bug fixes surfaced while playtesting them.

### New cards
- **Norman Osborn // Green Goblin** — `GraveyardCardsHaveMayhem` grant ("Goblin Formula — each nonland card in your graveyard has mayhem = its mana cost").
- **Peter Parker // Amazing Spider-Man** — `GrantWebSlingingToSpells` ("each legendary spell you cast that's one or more colors has web-slinging {G}{W}{U}").
- **Gwenom, Remorseless** — attack grants `PlayFromTopWithAlternativeCost` (play from the top; pay life = mana value) + `LookAtTopOfLibrary`, until end of turn.
- **Black Cat, Cunning Thief** — exile two of an opponent's top nine face down and play them with any mana (reuses the existing impulse-from-exile primitive).

New SDK statics mirror existing families (`GrantKeywordToOwnSpells`, `GraveyardCardsHaveFlashback`, `PlayFromTopOfLibrary`); `docs/card-sdk-language-reference.md` is updated in-diff.

### Bug fixes (found playtesting Black Cat & Gwenom)
1. **Black Cat's face-down exiled cards were unplayable** — `ClientStateTransformer` masked a face-down exiled card to the very player holding the may-play permission (an exiled card's view-controller falls back to its owner, the opponent). Now the permission holder sees the real, playable card; opponents/spectators still get the face-down stub.
2. **A land played from that exile entered as a face-down 2/2** — `PlayLandHandler` now strips `FaceDownComponent` (lands bypass the stack, where face-down cards are otherwise revealed; CR 305.1).
3. **Gwenom didn't reveal the top card** — `Visibility` now scans durationally-granted statics (not just printed ones), so the granted `LookAtTopOfLibrary` reveals the top card to its controller, keeping visibility and castability in lockstep.

### Tests
Scenario tests for every card mechanic and each fix (Black Cat view + face-up land; Gwenom top-card reveal + end-of-turn expiry; web-slinging colorless-legendary and mayhem land negative-filter cases). Full `rules-engine` suite green.

### Not addressed here
A minor projected-vs-base control inconsistency in the play-from-top permission scan (`CastPermissionUtils` / `CastZoneResolver`) is left for a dedicated follow-up — see the review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
