### PR TITLE
Add Stitcher's Graft (INR) with "becomes unattached" trigger support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2493,11 +2493,17 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   `resolveTarget(state, target)` overload.
 - `EnchantedPermanent` — same `AttachedToComponent` resolution as `EnchantedCreature`, but type-agnostic; use for
   Auras that enchant non-creature permanents (e.g. Wellspring enchants a land: "gain control of enchanted land").
-- `AttachedToTriggeringPermanent` — inside a `Triggers.becomesAttached` trigger, the permanent the
-  triggering attachment (Aura/Equipment) became attached to. Resolved live from the triggering
-  object's `AttachedToComponent` (so a "for as long as attached" payoff does nothing if the
-  attachment already left — CR 611.2b). Used by Eriette ("gain control of that permanent") and
-  Assimilation Aegis ("that creature becomes a copy …").
+- `AttachedToTriggeringPermanent` — the permanent on the other end of an attachment trigger; requires
+  the state-aware `resolveTarget(target, state)` overload. Inside `Triggers.becomesAttached` it is the
+  host the triggering attachment became attached to, resolved **live** from the triggering object's
+  `AttachedToComponent` (so a "for as long as attached" payoff does nothing if the attachment already
+  left — CR 611.2b): Eriette ("gain control of that permanent"), Assimilation Aegis ("that creature
+  becomes a copy …"). Inside `Triggers.becomesUnattached` it is instead the host it came **off**,
+  read from the id recorded on the trigger (`TriggerContext.unattachedFromEntityId`) — a live read
+  would be wrong there, since by resolution the link is gone or, if the unattach was caused by
+  equipping the attachment elsewhere, already re-pointed at the new host. That recorded id is scoped
+  to the battlefield, so a former host that has itself left resolves to nothing and the payoff
+  no-ops: Stitcher's Graft ("sacrifice that permanent").
 
 ### Cast-time (`Targets.*` / `TargetRequirement`)
 
@@ -4002,6 +4008,20 @@ Triggers.youCastSpell(
   `EntityReference.Triggering`, so relative predicates like
   `manaValueAtMostEntity(EntityReference.Triggering)` ("MV ≤ that Aura's MV") resolve against it.
   Indexed under `TriggerCategory.BECOMES_ATTACHED`.
+- `becomesUnattached(attachmentFilter = Any, attachmentController = Any, unattachedFromFilter = Any, binding = SELF)`
+  — the mirror: "whenever an Aura/Equipment becomes **unattached** from a permanent" (CR 701.3d).
+  Fires from `PermanentUnattachedEvent`, which every unattach path emits — the explicit
+  `Effects.UnattachEquipment`, equipping the attachment onto a *different* host, the CR 704.5m/n
+  state-based unattach (host stops being a creature, the Equipment itself becomes a creature,
+  protection), the host leaving the battlefield, and the attachment leaving the battlefield. The
+  three battlefield-staying paths route through the single `ZoneMovementUtils.unattachEmittingEvent`
+  chokepoint so none can skip the event; the leave path emits from `ZoneTransitionService` before
+  the link is cleared. Because the unattach can be *caused* by the attachment leaving, detection has
+  a `TriggerDetector` pass for a source no longer on the battlefield, exactly like a
+  leaves-the-battlefield trigger (CR 603.6e). "That permanent" is
+  `EffectTarget.AttachedToTriggeringPermanent`. Indexed under `TriggerCategory.BECOMES_UNATTACHED`.
+  Backs **Stitcher's Graft** ("Whenever this Equipment becomes unattached from a permanent,
+  sacrifice that permanent").
 - `Valiant` — Bloomburrow Valiant trigger.
 - `RoomFullyUnlocked` — Rooms — both doors unlocked.
 - `OnDoorUnlocked` — single Room door unlocked.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1655,6 +1655,39 @@ object Triggers {
         binding = binding
     )
 
+    /**
+     * Whenever an Aura/Equipment becomes **unattached** from a permanent (CR 701.3d) — the mirror
+     * of [becomesAttached].
+     *
+     * Fires on every unattach path: an explicit unattach effect, re-equipping to a different
+     * permanent, the attachment leaving the battlefield, the host leaving the battlefield, and the
+     * CR 704.5n state-based unattach when the pairing turns illegal.
+     *
+     * SELF binding (default) = "whenever this Equipment becomes unattached from a permanent"
+     * (Stitcher's Graft). The triggering entity is the attachment; the permanent it came off is
+     * reachable via [com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent]
+     * ("that permanent"). Both the attachment and its former host may already be gone by resolution —
+     * a payoff acting on either simply does nothing then.
+     *
+     * @param attachmentFilter which attachment qualifies (e.g. Aura, Equipment).
+     * @param attachmentController who must control the attachment.
+     * @param unattachedFromFilter what it must have come off (matched against the former host, with
+     *   the attachment as the comparison reference for relative predicates).
+     */
+    fun becomesUnattached(
+        attachmentFilter: GameObjectFilter = GameObjectFilter.Any,
+        attachmentController: Player = Player.Any,
+        unattachedFromFilter: GameObjectFilter = GameObjectFilter.Any,
+        binding: TriggerBinding = TriggerBinding.SELF,
+    ): TriggerSpec = TriggerSpec(
+        event = BecomesUnattachedEvent(
+            attachmentFilter = attachmentFilter,
+            attachmentController = attachmentController,
+            unattachedFromFilter = unattachedFromFilter,
+        ),
+        binding = binding
+    )
+
     // =========================================================================
     // Gift Triggers
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1314,6 +1314,65 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * When an Aura, Equipment, or Fortification becomes **unattached** from a permanent — the
+     * mirror of [BecomesAttachedEvent].
+     *
+     * Fires on every way an attachment stops being attached to its host while that attachment
+     * existed attached a moment earlier (CR 701.3d): an explicit "unattach it" effect, equipping it
+     * to a *different* permanent, the attachment leaving the battlefield, the host leaving the
+     * battlefield, and the CR 704.5n state-based unattach when the pairing becomes illegal (the
+     * host stops being a creature, the Equipment itself becomes a creature, protection). It does
+     * **not** fire for an attachment that was never attached.
+     *
+     * The triggering entity is the *attachment*; the permanent it came off is carried as the
+     * attached-to entity in the trigger context
+     * ([com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent]) —
+     * "that permanent" in the payoff.
+     *
+     * Because the unattach can be *caused* by the attachment leaving the battlefield, the ability
+     * fires from the attachment's last-known existence (CR 603.6e/603.10), exactly like a
+     * leaves-the-battlefield trigger. The former host may likewise be gone by resolution, in which
+     * case a payoff that acts on it simply does nothing — Stitcher's Graft's ruling spells this out:
+     * "It also becomes unattached if the equipped creature leaves the battlefield, but the triggered
+     * ability won't do anything in that case."
+     *
+     * Binding SELF = "whenever this Equipment becomes unattached from a permanent" (Stitcher's
+     * Graft). Binding ANY with [attachmentFilter] / [attachmentController] = "whenever an Aura you
+     * control becomes unattached …".
+     *
+     * @property attachmentFilter restricts which attachment qualifies (e.g. Aura, Equipment).
+     * @property attachmentController restricts who must control the attachment (e.g. [Player.You]).
+     * @property unattachedFromFilter restricts what it must have come off. Matched against the
+     *   former host with the triggering attachment exposed as the comparison reference, mirroring
+     *   [BecomesAttachedEvent.attachedToFilter]. Evaluated against the host's *current* state, so a
+     *   host that left the battlefield matches only [GameObjectFilter.Any].
+     */
+    @SerialName("BecomesUnattachedEvent")
+    @Serializable
+    data class BecomesUnattachedEvent(
+        val attachmentFilter: GameObjectFilter = GameObjectFilter.Any,
+        val attachmentController: Player = Player.Any,
+        val unattachedFromFilter: GameObjectFilter = GameObjectFilter.Any,
+    ) : EventPattern {
+        override val description: String = buildString {
+            append(describeObjectForEvent(attachmentFilter))
+            if (attachmentController == Player.You) append(" you control")
+            append(" becomes unattached")
+            if (unattachedFromFilter != GameObjectFilter.Any) {
+                append(" from ${describeObjectForEvent(unattachedFromFilter)}")
+            }
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val newAttachment = attachmentFilter.applyTextReplacement(replacer)
+            val newUnattachedFrom = unattachedFromFilter.applyTextReplacement(replacer)
+            return if (newAttachment !== attachmentFilter || newUnattachedFrom !== unattachedFromFilter) {
+                copy(attachmentFilter = newAttachment, unattachedFromFilter = newUnattachedFrom)
+            } else this
+        }
+    }
+
+    /**
      * When a player chooses one or more targets.
      *
      * Fires when [player] casts a spell, activates an ability, or puts a triggered ability

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
@@ -226,12 +226,15 @@ sealed interface EffectTarget {
 
     /**
      * ATTACHED-TO TRIGGERING PERMANENT: the permanent that the triggering attachment (Aura/
-     * Equipment) became attached to. Only meaningful inside a
-     * [com.wingedsheep.sdk.scripting.EventPattern.BecomesAttachedEvent] trigger, where the
-     * triggering entity is the attachment and this resolves to the thing it attached to.
+     * Equipment) became attached to — or, for the unattach mirror, came off of. Only meaningful
+     * inside a [com.wingedsheep.sdk.scripting.EventPattern.BecomesAttachedEvent] or
+     * [com.wingedsheep.sdk.scripting.EventPattern.BecomesUnattachedEvent] trigger, where the
+     * triggering entity is the attachment and this resolves to the host on the other end.
      *
-     * Used by Eriette, the Beguiler ("gain control of that permanent") and Assimilation Aegis
-     * ("that creature becomes a copy …").
+     * Used by Eriette, the Beguiler ("gain control of that permanent"), Assimilation Aegis
+     * ("that creature becomes a copy …"), and Stitcher's Graft ("sacrifice that permanent"). On the
+     * unattach side the host may already have left the battlefield — it then resolves to nothing and
+     * the payoff is a no-op, which is exactly what Stitcher's Graft's ruling calls for.
      */
     @SerialName("AttachedToTriggeringPermanent")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/StitchersGraft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/StitchersGraft.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stitcher's Graft — Eldritch Moon #200
+ * {1} · Artifact — Equipment
+ *
+ * Equipped creature gets +3/+3.
+ * Whenever equipped creature attacks, it doesn't untap during its controller's next untap step.
+ * Whenever this Equipment becomes unattached from a permanent, sacrifice that permanent.
+ * Equip {2}
+ *
+ * The attack rider is the same shape as Crippling Chill's: [AbilityFlag.DOESNT_UNTAP] granted for
+ * [Duration.UntilAfterAffectedControllersNextUntap], which the untap step already honours. Stacking
+ * two Grafts on one attacker grants the flag twice over the *same* untap step rather than two, per
+ * the 2016-07-13 ruling.
+ *
+ * The drawback rides [Triggers.becomesUnattached] — the mirror of "becomes attached", which fires on
+ * every way an Equipment can come off (CR 701.3d): equipping it to a new creature, the Graft leaving
+ * the battlefield, the host leaving the battlefield, and the CR 704.5n state-based unattach when the
+ * host stops being a creature or the Graft stops being an Equipment. "That permanent" is
+ * [EffectTarget.AttachedToTriggeringPermanent], the former host carried on the trigger. When that
+ * host is the thing that left the battlefield it resolves to nothing and the sacrifice is a no-op,
+ * which is precisely what the ruling calls for; likewise it can't sacrifice a permanent whose
+ * control you no longer have.
+ */
+val StitchersGraft = card("Stitcher's Graft") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +3/+3.\n" +
+        "Whenever equipped creature attacks, it doesn't untap during its controller's next untap step.\n" +
+        "Whenever this Equipment becomes unattached from a permanent, sacrifice that permanent.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+3, +3, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+        effect = Effects.GrantKeyword(
+            AbilityFlag.DOESNT_UNTAP,
+            EffectTarget.EquippedCreature,
+            Duration.UntilAfterAffectedControllersNextUntap
+        )
+        description = "Whenever equipped creature attacks, it doesn't untap during its " +
+            "controller's next untap step."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.becomesUnattached()
+        effect = Effects.SacrificeTarget(EffectTarget.AttachedToTriggeringPermanent)
+        description = "Whenever this Equipment becomes unattached from a permanent, sacrifice that permanent."
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "200"
+        artist = "Josh Hass"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg?1783937422"
+
+        ruling("2016-07-13", "If multiple effects say that a creature doesn't untap during your next untap step, those effects all apply during one untap step. For example, a creature that attacks while equipped with two Stitcher's Grafts will only spend one untap step without untapping.")
+        ruling("2016-07-13", "Stitcher's Graft becomes unattached from the creature it's equipping if you equip it to a new creature, if Stitcher's Graft leaves the battlefield, if the equipped creature ceases to be a creature, or if Stitcher's Graft ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won't do anything in that case.)")
+        ruling("2016-07-13", "If Stitcher's Graft's last triggered ability triggers, but you don't control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won't be able to sacrifice it.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StitchersGraftReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StitchersGraftReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val StitchersGraftReprint = Printing(
+    oracleId = "2b73a5ec-c52e-4074-a7cb-78d6eb2adef0",
+    name = "Stitcher's Graft",
+    setCode = "INR",
+    collectorNumber = "271",
+    scryfallId = "a5dad4be-599b-4c4d-a957-3fe6b52b4141",
+    artist = "Josh Hass",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5dad4be-599b-4c4d-a957-3fe6b52b4141.jpg?1783908061",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -2848,6 +2848,98 @@
     ]
 }
 
+// Stitcher's Graft
+{
+    "name": "Stitcher's Graft",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +3/+3.\nWhenever equipped creature attacks, it doesn't untap during its controller's next untap step.\nWhenever this Equipment becomes unattached from a permanent, sacrifice that permanent.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOESNT_UNTAP",
+                    "target": "EquippedCreature",
+                    "duration": "UntilAfterAffectedControllersNextUntap"
+                },
+                "descriptionOverride": "Whenever equipped creature attacks, it doesn't untap during its controller's next untap step."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesUnattachedEvent",
+                "effect": {
+                    "type": "SacrificeTarget",
+                    "target": "AttachedToTriggeringPermanent"
+                },
+                "descriptionOverride": "Whenever this Equipment becomes unattached from a permanent, sacrifice that permanent."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "RARE",
+        "artist": "Josh Hass",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb6d700e-0514-41d7-9255-cedd859316fc.jpg?1783937422",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "If multiple effects say that a creature doesn't untap during your next untap step, those effects all apply during one untap step. For example, a creature that attacks while equipped with two Stitcher's Grafts will only spend one untap step without untapping."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "Stitcher's Graft becomes unattached from the creature it's equipping if you equip it to a new creature, if Stitcher's Graft leaves the battlefield, if the equipped creature ceases to be a creature, or if Stitcher's Graft ceases to be an Equipment. (It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won't do anything in that case.)"
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If Stitcher's Graft's last triggered ability triggers, but you don't control the permanent it became unattached from at the time that ability resolves (perhaps because another player has somehow gained control of it), you won't be able to sacrifice it."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Subjugator Angel
 {
     "name": "Subjugator Angel",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1025,12 +1025,27 @@ data class PermanentAttachedEvent(
 ) : GameEvent
 
 /**
- * An Aura/Equipment became unattached from its host without moving zones (CR 701.3d). Emitted by
- * [com.wingedsheep.engine.handlers.effects.permanent.attachments.UnattachEquipmentExecutor] so
- * "becomes unattached" reactions and animations can fire.
+ * An Aura/Equipment became unattached from its host (CR 701.3d) — the mirror of
+ * [PermanentAttachedEvent], driving the "becomes unattached" trigger family
+ * ([com.wingedsheep.sdk.scripting.EventPattern.BecomesUnattachedEvent]): Stitcher's Graft.
+ *
+ * Emitted from **every** path that breaks an attachment, because the card asks for all of them:
+ * the explicit unattach effect
+ * ([com.wingedsheep.engine.handlers.effects.permanent.attachments.UnattachEquipmentExecutor]),
+ * re-equipping onto a different host
+ * ([com.wingedsheep.engine.handlers.effects.permanent.attachments.AttachEquipmentExecutor]), the
+ * CR 704.5m/n state-based unattach
+ * ([com.wingedsheep.engine.mechanics.sba.permanent.UnattachedAurasCheck]), and the attachment
+ * itself leaving the battlefield while attached
+ * ([com.wingedsheep.engine.handlers.effects.ZoneTransitionService]).
  *
  * @property attachmentId the aura/equipment that became unattached.
- * @property attachedToId the permanent it was attached to (its former host).
+ * @property attachedToId the permanent it was attached to (its former host). May already have left
+ *   the battlefield — that is the case where Stitcher's Graft's trigger fires but does nothing.
+ * @property controllerId the attachment's controller at the moment it unattached. Captured here
+ *   rather than read back off the entity because the leave-the-battlefield path has already
+ *   stripped `ControllerComponent` by the time triggers are detected (CR 603.6e last-known
+ *   information).
  */
 @Serializable
 @SerialName("PermanentUnattachedEvent")
@@ -1038,6 +1053,7 @@ data class PermanentUnattachedEvent(
     val attachmentId: EntityId,
     val attachmentName: String,
     val attachedToId: EntityId,
+    val controllerId: EntityId,
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -170,13 +170,24 @@ data class TriggerContext(
      */
     val capturedEntityIds: List<EntityId>? = null,
     /**
-     * For [com.wingedsheep.engine.core.PermanentAttachedEvent] triggers — the permanent the
-     * triggering attachment (Aura/Equipment) became attached to. Resolved by
+     * For [com.wingedsheep.engine.core.PermanentAttachedEvent] /
+     * [com.wingedsheep.engine.core.PermanentUnattachedEvent] triggers — the permanent the triggering
+     * attachment (Aura/Equipment) became attached to, or came off of. Resolved by
      * [com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent] so a
-     * "becomes attached" payoff can act on the host (Eriette gains control of it; Assimilation
-     * Aegis makes it a copy). `null` for non-attachment triggers.
+     * "becomes (un)attached" payoff can act on the host (Eriette gains control of it; Assimilation
+     * Aegis makes it a copy; Stitcher's Graft sacrifices it). `null` for non-attachment triggers.
      */
-    val attachedToEntityId: EntityId? = null
+    val attachedToEntityId: EntityId? = null,
+    /**
+     * For [com.wingedsheep.engine.core.PermanentUnattachedEvent] triggers only — the host the
+     * attachment came *off*. Deliberately separate from [attachedToEntityId]: an unattach payoff
+     * must not read the live `AttachedToComponent`, because by resolution it is either gone or
+     * already re-pointed at a different host (equipping the Graft away from a creature attaches it
+     * elsewhere in the same action). Resolves
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent] in that
+     * case, and leaves the attach case on its live read (CR 611.2b). `null` otherwise.
+     */
+    val unattachedFromEntityId: EntityId? = null
 ) {
     companion object {
         fun fromEvent(event: com.wingedsheep.engine.core.GameEvent): TriggerContext {
@@ -325,6 +336,13 @@ data class TriggerContext(
                     triggeringEntityId = event.attachmentId,
                     triggeringPlayerId = event.controllerId,
                     attachedToEntityId = event.attachedToId
+                )
+                is com.wingedsheep.engine.core.PermanentUnattachedEvent -> TriggerContext(
+                    // Mirror of the attach case: the attachment triggers, and the host it came off
+                    // rides along as "that permanent" (Stitcher's Graft sacrifices it).
+                    triggeringEntityId = event.attachmentId,
+                    triggeringPlayerId = event.controllerId,
+                    unattachedFromEntityId = event.attachedToId
                 )
                 is BecomesTargetEvent -> TriggerContext(
                     triggeringEntityId = event.targetEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1495,7 +1495,61 @@ class TriggerDetector(
             detectExploitedSelfSacrificeTriggers(state, index.statics, event, triggers)
         }
 
+        // Handle a "becomes unattached" trigger borne by an attachment that unattached *because* it
+        // left the battlefield — it is in the graveyard/exile by now, so the battlefield index scan
+        // above can't see it.
+        if (event is com.wingedsheep.engine.core.PermanentUnattachedEvent) {
+            detectUnattachedAfterLeavingTriggers(state, index.statics, event, triggers)
+        }
+
         return triggers
+    }
+
+    /**
+     * Detect a [EventPattern.BecomesUnattachedEvent] trigger on an attachment that is no longer on
+     * the battlefield — it became unattached precisely *because* it left (destroyed, bounced,
+     * exiled), which is one of the paths the card asks for.
+     *
+     * CR 603.6e / 603.10: the ability triggers based on the game state before the event, so an
+     * Equipment destroyed while equipping something still sees its own unattach. Stitcher's Graft is
+     * the card that needs it — destroying the Graft is how the equipped creature dies.
+     *
+     * Guarded on the attachment having actually left, so this never double-fires with the index scan
+     * that covers the three unattaches where the attachment stays on the battlefield (an explicit
+     * unattach effect, re-equipping elsewhere, and the CR 704.5n state-based unattach).
+     */
+    private fun detectUnattachedAfterLeavingTriggers(
+        state: GameState,
+        statics: BattlefieldStaticsIndex,
+        event: com.wingedsheep.engine.core.PermanentUnattachedEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        val attachmentId = event.attachmentId
+        if (attachmentId in state.getBattlefield()) return
+
+        val container = state.getEntity(attachmentId) ?: return
+        val cardComponent = container.get<CardComponent>() ?: return
+
+        val abilities = abilityResolver.getTriggeredAbilities(attachmentId, cardComponent.cardDefinitionId, state, statics)
+        for (ability in abilities) {
+            if (ability.trigger !is EventPattern.BecomesUnattachedEvent) continue
+            // The ability functioned from the battlefield right up to the moment it left; a
+            // graveyard/exile-active ability is a different thing entirely.
+            if (ability.activeZone != Zone.BATTLEFIELD) continue
+            if (!matcher.matchesTrigger(
+                    ability.trigger, ability.binding, event, attachmentId, event.controllerId, state
+                )
+            ) continue
+            triggers.add(
+                PendingTrigger(
+                    ability = ability,
+                    sourceId = attachmentId,
+                    sourceName = cardComponent.name,
+                    controllerId = event.controllerId,
+                    triggerContext = TriggerContext.fromEvent(event)
+                )
+            )
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -88,6 +88,7 @@ enum class TriggerCategory {
     BECAME_SADDLED,
     CREW_OR_SADDLE_CONTRIBUTION,
     BECOMES_ATTACHED,
+    BECOMES_UNATTACHED,
     SAGA_CHAPTER_RESOLVED,
     PLAYER_LOST,
 }
@@ -283,6 +284,7 @@ class TriggerIndex(
                 is SdkGameEvent.CrewsEvent,
                 is SdkGameEvent.SaddlesEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
+                is SdkGameEvent.BecomesUnattachedEvent -> BECOMES_UNATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
                 is SdkGameEvent.PlayerLostGameEvent -> PLAYER_LOST_LIST
                 // These are handled by specialized detect methods, not the main loop
@@ -333,6 +335,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
             is CrewOrSaddleContributionEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
+            is com.wingedsheep.engine.core.PermanentUnattachedEvent -> BECOMES_UNATTACHED_LIST
             is com.wingedsheep.engine.core.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
             is com.wingedsheep.engine.core.PlayerLostEvent -> PLAYER_LOST_LIST
             else -> emptyList()
@@ -377,6 +380,7 @@ class TriggerIndex(
         private val CREW_OR_SADDLE_CONTRIBUTION_LIST =
             listOf(TriggerCategory.CREW_OR_SADDLE_CONTRIBUTION)
         private val BECOMES_ATTACHED_LIST = listOf(TriggerCategory.BECOMES_ATTACHED)
+        private val BECOMES_UNATTACHED_LIST = listOf(TriggerCategory.BECOMES_UNATTACHED)
         private val SAGA_CHAPTER_RESOLVED_LIST = listOf(TriggerCategory.SAGA_CHAPTER_RESOLVED)
         private val PLAYER_LOST_LIST = listOf(TriggerCategory.PLAYER_LOST)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -409,6 +409,38 @@ class TriggerMatcher(
                     )
                 } else true
             }
+            is EventPattern.BecomesUnattachedEvent -> {
+                if (event !is com.wingedsheep.engine.core.PermanentUnattachedEvent) return false
+                // SELF binding = "whenever THIS Equipment becomes unattached" (Stitcher's Graft).
+                if (binding == TriggerBinding.SELF && event.attachmentId != sourceId) return false
+                // The attachment's controller as of the unattach — carried on the event because the
+                // leave-the-battlefield path has already stripped ControllerComponent by now.
+                if (!matchesPlayer(trigger.attachmentController, event.controllerId, controllerId)) return false
+                val attachmentCtx = com.wingedsheep.engine.handlers.PredicateContext(
+                    controllerId = controllerId,
+                    sourceId = sourceId,
+                )
+                if (trigger.attachmentFilter != GameObjectFilter.Any &&
+                    !PredicateEvaluator().matches(
+                        state, state.projectedState, event.attachmentId, trigger.attachmentFilter, attachmentCtx
+                    )
+                ) return false
+                // The former host, with the attachment exposed as EntityReference.Triggering so
+                // relative predicates resolve against it (mirrors BecomesAttachedEvent). A host that
+                // left the battlefield can't satisfy a battlefield filter, so an unfiltered trigger
+                // (Stitcher's Graft) is the shape that still fires in that case — matching the
+                // ruling that the ability triggers but does nothing.
+                if (trigger.unattachedFromFilter != GameObjectFilter.Any) {
+                    val hostCtx = com.wingedsheep.engine.handlers.PredicateContext(
+                        controllerId = controllerId,
+                        sourceId = sourceId,
+                        triggeringEntityId = event.attachmentId,
+                    )
+                    PredicateEvaluator().matches(
+                        state, state.projectedState, event.attachedToId, trigger.unattachedFromFilter, hostCtx
+                    )
+                } else true
+            }
             is EventPattern.TargetsChosenEvent -> {
                 event is com.wingedsheep.engine.core.TargetsChosenEvent &&
                     matchesPlayer(trigger.player, event.chooserId, controllerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -806,6 +806,7 @@ class TriggerProcessor(
             triggerLastKnownBlockingOrBlockedByIds =
                 trigger.triggerContext.lastKnownBlockingOrBlockedByIds,
             targetingSourceEntityId = trigger.triggerContext.targetingSourceEntityId,
+            triggerUnattachedFromEntityId = trigger.triggerContext.unattachedFromEntityId,
             lastKnownPower = trigger.triggerContext.lastKnownPower,
             lastKnownToughness = trigger.triggerContext.lastKnownToughness,
             diedBatchTotalPower = trigger.triggerContext.diedBatchTotalPower,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -216,6 +216,13 @@ data class EffectContext(
     /** The spell or ability that targeted a permanent (for ward triggers) */
     val targetingSourceEntityId: EntityId? = null,
     /**
+     * The host an attachment came *off*, captured when a "becomes unattached" trigger fired. Backs
+     * [com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent] there,
+     * where the live `AttachedToComponent` is by resolution either gone or already re-pointed at a
+     * new host — Stitcher's Graft's "sacrifice that permanent". Null for every other trigger.
+     */
+    val triggerUnattachedFromEntityId: EntityId? = null,
+    /**
      * The defending player for a per-defender combat legality check (CR 508.1 attack
      * declaration). Bound by [com.wingedsheep.engine.mechanics.combat.rules.CantAttackUnlessDefenderRule]
      * so `Player.DefendingPlayer` conditions ("can't attack unless defending player controls

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -84,9 +84,18 @@ object TargetResolutionUtils {
             return entity.get<CardComponent>()?.ownerId
         }
         if (effectTarget is EffectTarget.AttachedToTriggeringPermanent) {
-            // The triggering entity is the attachment (Aura/Equipment) that became attached; the
-            // host is its current attachment target. Reading it live means a "for as long as
-            // attached" payoff does nothing if the attachment already left (CR 611.2b).
+            // "Becomes unattached": the host recorded when the trigger fired is the only right
+            // answer — the live link is by now either gone or, if the unattach was caused by
+            // equipping the attachment elsewhere, pointing at the *new* host. Scoped to the
+            // battlefield so a former host that has itself left resolves to nothing, which is
+            // Stitcher's Graft's "the triggered ability won't do anything in that case".
+            context.triggerUnattachedFromEntityId?.let {
+                return it.takeIf { id -> id in state.getBattlefield() }
+            }
+            // "Becomes attached": the triggering entity is the attachment, and the host is its
+            // current attachment target. Reading it live means a "for as long as attached" payoff
+            // does nothing if the attachment has already moved or left (CR 611.2b) — what Eriette
+            // and Assimilation Aegis want.
             val attachmentId = context.triggeringEntityId ?: return null
             return state.getEntity(attachmentId)?.get<AttachedToComponent>()?.targetId
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -287,6 +287,46 @@ object ZoneMovementUtils {
     }
 
     /**
+     * Break an attachment: clear the attachment's [AttachedToComponent], drop it from the host's
+     * [AttachmentsComponent], and report the [PermanentUnattachedEvent] that drives "becomes
+     * unattached" triggers (CR 701.3d).
+     *
+     * The single chokepoint for *staying-on-the-battlefield* unattaches — the explicit unattach
+     * effect, the CR 704.5m/n state-based unattach, and re-equipping onto a different host all go
+     * through it, so none of them can silently skip the event. (The attachment leaving the
+     * battlefield is the fourth path; it lives in [ZoneTransitionService], which must emit the
+     * event *before* [stripBattlefieldComponents] erases the link.)
+     *
+     * A no-op returning no events when the attachment isn't attached to anything, so callers can
+     * invoke it unconditionally — an already-detached attachment emitted its event when it actually
+     * came off, and must not emit a second one.
+     */
+    fun unattachEmittingEvent(
+        state: GameState,
+        attachmentId: EntityId,
+    ): Pair<GameState, List<EngineGameEvent>> {
+        val container = state.getEntity(attachmentId) ?: return state to emptyList()
+        val formerHostId = container.get<AttachedToComponent>()?.targetId
+            ?: return state to emptyList()
+
+        var newState = cleanupReverseAttachmentLink(state, attachmentId)
+        newState = newState.updateEntity(attachmentId) { c -> c.without<AttachedToComponent>() }
+
+        return newState to listOf(
+            com.wingedsheep.engine.core.PermanentUnattachedEvent(
+                attachmentId = attachmentId,
+                attachmentName = container.get<CardComponent>()?.name ?: "",
+                attachedToId = formerHostId,
+                // Read before the detach so a control-changing effect on the attachment is honored;
+                // falls back to the owner for an attachment already off the battlefield.
+                controllerId = container.get<ControllerComponent>()?.playerId
+                    ?: container.get<CardComponent>()?.ownerId
+                    ?: formerHostId,
+            )
+        )
+    }
+
+    /**
      * Mark every Aura/Equipment attached to a permanent that is leaving the battlefield so the
      * unattached-permanents state-based action ([UnattachedAurasCheck]) detaches/graveyards it
      * afterwards (CR 400.7 new object; 704.5n unattaches Equipment, 704.5m graveyards Auras).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -319,6 +319,23 @@ object ZoneTransitionService {
 
         // 4. EXIT CLEANUP if leaving battlefield
         if (leavingBattlefield) {
+            // An attached Aura/Equipment that leaves the battlefield becomes unattached from its
+            // host (CR 701.3d) — Stitcher's Graft's "sacrifice that permanent" fires off exactly
+            // this when the Equipment is destroyed. Reported here, before the link and the
+            // ControllerComponent are cleared, so the trigger has its last-known information
+            // (CR 603.6e). The three unattaches that leave the attachment on the battlefield run
+            // through ZoneMovementUtils.unattachEmittingEvent instead.
+            newState.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+                ?.let { attached ->
+                    events += com.wingedsheep.engine.core.PermanentUnattachedEvent(
+                        attachmentId = entityId,
+                        attachmentName = cardComponent.name,
+                        attachedToId = attached.targetId,
+                        // `controllerId` above is already the projected last-known controller.
+                        controllerId = controllerId,
+                    )
+                }
             newState = cleanupReverseAttachmentLink(newState, entityId)
             newState = cleanupCombatReferences(newState, entityId)
             // Equipment/Auras attached *to* this permanent come off when their host leaves the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/AttachEquipmentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/AttachEquipmentExecutor.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.PermanentAttachedEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
@@ -32,24 +33,20 @@ class AttachEquipmentExecutor : EffectExecutor<AttachEquipmentEffect> {
             ?: return EffectResult.error(state, "No valid target for attach equipment")
 
         var newState = state
+        val unattachEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
 
-        // Detach from current creature if already attached
+        // Detach from the current creature if already attached. Moving an Equipment onto a *new*
+        // host makes it become unattached from the old one first (CR 701.3d), so this goes through
+        // the shared chokepoint and reports a PermanentUnattachedEvent — that is how Stitcher's
+        // Graft's "sacrifice that permanent" fires when you equip it away. Re-affirming the same
+        // host is not an unattach, so it emits nothing.
         val currentAttachment = newState.getEntity(equipmentId)?.get<AttachedToComponent>()
-        if (currentAttachment != null) {
-            val oldTargetId = currentAttachment.targetId
-            newState = newState.updateEntity(oldTargetId) { container ->
-                val attachments = container.get<AttachmentsComponent>()
-                if (attachments != null) {
-                    val updatedIds = attachments.attachedIds.filter { it != equipmentId }
-                    if (updatedIds.isEmpty()) {
-                        container.without<AttachmentsComponent>()
-                    } else {
-                        container.with(AttachmentsComponent(updatedIds))
-                    }
-                } else {
-                    container
-                }
-            }
+        if (currentAttachment != null && currentAttachment.targetId != targetId) {
+            val (detachedState, events) = ZoneMovementUtils.unattachEmittingEvent(newState, equipmentId)
+            newState = detachedState
+            unattachEvents += events
+        } else if (currentAttachment != null) {
+            newState = ZoneMovementUtils.cleanupReverseAttachmentLink(newState, equipmentId)
         }
 
         // Attach to new creature
@@ -68,13 +65,11 @@ class AttachEquipmentExecutor : EffectExecutor<AttachEquipmentEffect> {
         // right moment.
         val events = if (currentAttachment?.targetId != targetId) {
             val container = newState.getEntity(equipmentId)
-            listOf(
-                PermanentAttachedEvent(
-                    attachmentId = equipmentId,
-                    attachmentName = container?.get<CardComponent>()?.name ?: "Equipment",
-                    attachedToId = targetId,
-                    controllerId = container?.get<ControllerComponent>()?.playerId ?: context.controllerId,
-                )
+            unattachEvents + PermanentAttachedEvent(
+                attachmentId = equipmentId,
+                attachmentName = container?.get<CardComponent>()?.name ?: "Equipment",
+                attachedToId = targetId,
+                controllerId = container?.get<ControllerComponent>()?.playerId ?: context.controllerId,
             )
         } else emptyList()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/UnattachEquipmentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/UnattachEquipmentExecutor.kt
@@ -1,13 +1,12 @@
 package com.wingedsheep.engine.handlers.effects.permanent.attachments
 
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.PermanentUnattachedEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.UnattachEquipmentEffect
 import kotlin.reflect.KClass
 
@@ -31,39 +30,9 @@ class UnattachEquipmentExecutor : EffectExecutor<UnattachEquipmentEffect> {
         val attachmentId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.success(state) // target gone / illegal — nothing to unattach
 
-        val currentAttachment = state.getEntity(attachmentId)?.get<AttachedToComponent>()
-            ?: return EffectResult.success(state) // not attached to anything — no-op
-
-        val hostId = currentAttachment.targetId
-        var newState = state
-
-        // Drop the attachment id from the host's attachment list.
-        newState = newState.updateEntity(hostId) { container ->
-            val attachments = container.get<AttachmentsComponent>()
-            if (attachments != null) {
-                val updatedIds = attachments.attachedIds.filter { it != attachmentId }
-                if (updatedIds.isEmpty()) container.without<AttachmentsComponent>()
-                else container.with(AttachmentsComponent(updatedIds))
-            } else {
-                container
-            }
-        }
-
-        // Clear the attachment's own AttachedToComponent.
-        newState = newState.updateEntity(attachmentId) { container ->
-            container.without<AttachedToComponent>()
-        }
-
-        val attachmentName = state.getEntity(attachmentId)?.get<CardComponent>()?.name ?: ""
-        return EffectResult.success(
-            newState,
-            listOf(
-                PermanentUnattachedEvent(
-                    attachmentId = attachmentId,
-                    attachmentName = attachmentName,
-                    attachedToId = hostId
-                )
-            )
-        )
+        // The shared chokepoint clears both ends of the link and reports the
+        // PermanentUnattachedEvent; it no-ops when the target isn't attached to anything.
+        val (newState, events) = ZoneMovementUtils.unattachEmittingEvent(state, attachmentId)
+        return EffectResult.success(newState, events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/SacrificeTargetExecutor.kt
@@ -34,7 +34,10 @@ class SacrificeTargetExecutor : EffectExecutor<SacrificeTargetEffect> {
         effect: SacrificeTargetEffect,
         context: EffectContext
     ): EffectResult {
-        val targetId = context.resolveTarget(effect.target)
+        // The state-taking overload — relational targets (the equipped creature, the host an
+        // attachment just came off) need the board to resolve at all; the no-state overload
+        // silently yields null for them and the sacrifice would quietly no-op.
+        val targetId = context.resolveTarget(effect.target, state)
             ?: return EffectResult.success(state)
 
         // Find the zone the permanent is in

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -3,7 +3,7 @@ package com.wingedsheep.engine.mechanics.sba.permanent
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
-import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.cleanupReverseAttachmentLink
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.unattachEmittingEvent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.SbaZoneMovementHelper
@@ -100,10 +100,9 @@ class UnattachedAurasCheck(
                     // attachment in place; the legality checks below validate the new host instead.
                     val current = container.get<AttachedToComponent>()
                     if (current == null || current.targetId == hostLeft.lastKnownHostId) {
-                        newState = cleanupReverseAttachmentLink(newState, entityId)
-                        newState = newState.updateEntity(entityId) { c ->
-                            c.without<AttachedToComponent>()
-                        }
+                        val (detached, unattachEvents) = unattachEmittingEvent(newState, entityId)
+                        newState = detached
+                        events.addAll(unattachEvents)
                     }
                 }
                 continue
@@ -139,10 +138,9 @@ class UnattachedAurasCheck(
                         events.addAll(result.events)
                     } else {
                         // Equipment's target gone - just detach, stays on battlefield
-                        newState = cleanupReverseAttachmentLink(newState, entityId)
-                        newState = newState.updateEntity(entityId) { c ->
-                            c.without<AttachedToComponent>()
-                        }
+                        val (detached, unattachEvents) = unattachEmittingEvent(newState, entityId)
+                        newState = detached
+                        events.addAll(unattachEvents)
                     }
                 } else if (
                     isEquipment && (
@@ -158,10 +156,9 @@ class UnattachedAurasCheck(
                     )
                 ) {
                     // Illegal attachment: the Equipment unattaches but stays on the battlefield.
-                    newState = cleanupReverseAttachmentLink(newState, entityId)
-                    newState = newState.updateEntity(entityId) { c ->
-                        c.without<AttachedToComponent>()
-                    }
+                    val (detached, unattachEvents) = unattachEmittingEvent(newState, entityId)
+                    newState = detached
+                    events.addAll(unattachEvents)
                 } else if (
                     isAura && hostFailsEnchantRestriction(state, projected, entityId, cardComponent, attachedTo.targetId)
                 ) {
@@ -189,10 +186,9 @@ class UnattachedAurasCheck(
                         newState = result.newState
                         events.addAll(result.events)
                     } else {
-                        newState = cleanupReverseAttachmentLink(newState, entityId)
-                        newState = newState.updateEntity(entityId) { c ->
-                            c.without<AttachedToComponent>()
-                        }
+                        val (detached, unattachEvents) = unattachEmittingEvent(newState, entityId)
+                        newState = detached
+                        events.addAll(unattachEvents)
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2384,6 +2384,7 @@ class StackResolver(
             triggeringEntityId = abilityComponent.triggeringEntityId,
             triggeringPlayerId = abilityComponent.triggeringPlayerId,
             targetingSourceEntityId = abilityComponent.targetingSourceEntityId,
+            triggerUnattachedFromEntityId = abilityComponent.triggerUnattachedFromEntityId,
             triggerLastKnownPower = abilityComponent.lastKnownPower,
             triggerLastKnownToughness = abilityComponent.lastKnownToughness,
             triggerDiedBatchTotalPower = abilityComponent.diedBatchTotalPower,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -165,6 +165,13 @@ data class TriggeredAbilityOnStackComponent(
     /** Creatures blocking/blocked by the trigger's source on leave-battlefield (CR 509 LKI, Abu Ja'far). */
     val triggerLastKnownBlockingOrBlockedByIds: List<EntityId>? = null,
     val targetingSourceEntityId: EntityId? = null,  // The spell/ability that targeted this permanent (for ward)
+    /**
+     * The host an attachment came *off*, captured when a "becomes unattached" trigger fired.
+     * Resolves [com.wingedsheep.sdk.scripting.targets.EffectTarget.AttachedToTriggeringPermanent]
+     * there, where the live link is by resolution either gone or already re-pointed at a new host
+     * (Stitcher's Graft's "sacrifice that permanent"). Null for every other trigger.
+     */
+    val triggerUnattachedFromEntityId: EntityId? = null,
     val damageDistribution: Map<EntityId, Int>? = null,  // For DividedDamageEffect - pre-chosen damage allocation
     val copyIndex: Int? = null,    // Which copy number this is (1, 2, 3...) for storm/copy effects
     val copyTotal: Int? = null,    // Total number of copies being created

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchersGraftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchersGraftScenarioTest.kt
@@ -1,0 +1,201 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stitcher's Graft — "Equipped creature gets +3/+3. Whenever equipped creature attacks, it doesn't
+ * untap during its controller's next untap step. Whenever this Equipment becomes unattached from a
+ * permanent, sacrifice that permanent. Equip {2}."
+ *
+ * The card exists to exercise [com.wingedsheep.sdk.dsl.Triggers.becomesUnattached], so the tests
+ * walk the unattach paths the 2016-07-13 ruling enumerates: re-equipping elsewhere, the Equipment
+ * leaving the battlefield, and the host leaving the battlefield (where the trigger fires but has
+ * nothing left to sacrifice). The CR 704.5n state-based unattach shares the same chokepoint.
+ */
+class StitchersGraftScenarioTest : ScenarioTestBase() {
+
+    private val equipAbilityId by lazy {
+        cardRegistry.requireCard("Stitcher's Graft").activatedAbilities[0].id
+    }
+
+    /** Board: player 1 has the Graft plus two vanilla creatures and enough lands to equip twice. */
+    private fun board() = scenario()
+        .withPlayers()
+        .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+        .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+        .withCardOnBattlefield(1, "Stitcher's Graft")
+        .withLandsOnBattlefield(1, "Forest", 6)
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(2, "Island")
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("equipped creature gets +3/+3") {
+            val game = board()
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val graft = game.findPermanent("Stitcher's Graft")!!
+
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.state.projectedState.getPower(bears) shouldBe 5
+            game.state.projectedState.getToughness(bears) shouldBe 5
+        }
+
+        test("attacking with the equipped creature keeps it tapped through its controller's next untap step") {
+            val game = board()
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val graft = game.findPermanent("Stitcher's Graft")!!
+
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+            // Put the "doesn't untap" trigger on the stack and resolve it.
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("attacking taps the Bears") {
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+            }
+
+            // Roll forward until player 1 is the active player again in their main phase — that is
+            // past player 1's next untap step, the one the grant eats.
+            var guard = 0
+            while (!(game.state.activePlayerId == game.player1Id &&
+                    game.state.step == Step.PRECOMBAT_MAIN) && guard++ < 20
+            ) {
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                if (game.state.activePlayerId == game.player1Id) break
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+            }
+
+            withClue(
+                "the Bears skipped their controller's next untap step (turn ${game.state.turnNumber}, " +
+                    "active = ${game.state.activePlayerId})"
+            ) {
+                game.state.activePlayerId shouldBe game.player1Id
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+            }
+        }
+
+        test("equipping the Graft onto another creature sacrifices the creature it came off") {
+            val game = board()
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val giant = game.findPermanent("Hill Giant")!!
+            val graft = game.findPermanent("Stitcher's Graft")!!
+
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+            game.state.getEntity(graft)?.get<AttachedToComponent>()?.targetId shouldBe bears
+
+            // Move the Graft to the Hill Giant — the Bears become unattached from it.
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(giant)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Graft moved onto the Hill Giant") {
+                game.state.getEntity(graft)?.get<AttachedToComponent>()?.targetId shouldBe giant
+            }
+            withClue("the Bears were sacrificed when the Graft came off them") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+                game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1
+            }
+            withClue("the Hill Giant is unharmed and now carries the +3/+3") {
+                game.state.projectedState.getPower(giant) shouldBe 6
+            }
+        }
+
+        test("destroying the Graft sacrifices the creature it was equipping") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Stitcher's Graft")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withCardInHand(2, "Naturalize")
+                .withLandsOnBattlefield(2, "Forest", 4)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val graft = game.findPermanent("Stitcher's Graft")!!
+
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Opponent blows up the Graft. It becomes unattached because it left the battlefield,
+            // so its own last trigger still fires (CR 603.6e) and eats the Bears.
+            game.passPriority()
+            game.castSpell(2, "Naturalize", targetId = graft).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Graft is in the graveyard") {
+                game.findPermanent("Stitcher's Graft") shouldBe null
+            }
+            withClue("the Bears were sacrificed by the Graft's unattach trigger") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+                game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 1
+            }
+        }
+
+        test("the equipped creature leaving the battlefield fires the trigger but sacrifices nothing") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                .withCardOnBattlefield(1, "Stitcher's Graft")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withCardInHand(2, "Murder")
+                .withLandsOnBattlefield(2, "Swamp", 4)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Swamp")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val giant = game.findPermanent("Hill Giant")!!
+            val graft = game.findPermanent("Stitcher's Graft")!!
+
+            game.execute(
+                ActivateAbility(game.player1Id, graft, equipAbilityId, listOf(ChosenTarget.Permanent(bears)))
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.passPriority()
+            game.castSpell(2, "Murder", targetId = bears).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Bears died to the removal spell") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+            }
+            withClue("the Graft unattached (CR 704.5n) and stayed on the battlefield") {
+                game.findPermanent("Stitcher's Graft") shouldBe graft
+                game.state.getEntity(graft)?.has<AttachedToComponent>() shouldBe false
+            }
+            withClue("the trigger had nothing to sacrifice — the untouched Hill Giant survives") {
+                game.findPermanent("Hill Giant") shouldBe giant
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why one card

I went to pick a handful from Innistrad Remastered's 46 missing cards and found the tail is entirely mechanic-gated. Of the 46:

- **madness** (9): Alchemist's Greeting, Asylum Visitor, Bloodhall Priest, Bloodmad Vampire, Fiery Temper, Gisa's Bidding, Murderous Compulsion, Stensia Masquerade, Stromkirk Occultist — plus Falkenrath Gorger, which *grants* madness
- **transform / werewolf DFC** (14): Arlinn Kord, Duskwatch Recruiter, Garruk Relentless, Geier Reach Bandit, Hanweir Watchkeep, Hinterland Logger, Huntmaster of the Fells, Kruin Outlaw, Mayor of Avabruck, Scorned Villager, Village Messenger, Villagers of Estwald, …
- **emerge** (6): Abundant Maw, Decimator of the Provinces, Distended Mindbender, Elder Deep-Fiend, It of the Horrid Swarm, Wretched Gryff
- **escalate** (4): Borrowed Hostility, Collective Brutality, Collective Defiance, Savage Alliance
- **disturb** (3), **soulbond** (2), **splice onto Arcane** (Through the Breach), **battle/siege** (Invasion of Innistrad), **eminence** (Edgar Markov)

None of the 46 has a canonical `CardDefinition` elsewhere in the repo, so none is a free `Printing` row either. The remainder (Emrakul, Tamiyo, Mirrorwing Dragon, Edgar's Awakening) each need their own subsystem — an emblem that waives mana costs, hand-zone trigger indexing, a copy-for-each-with-distinct-targets effect.

**Stitcher's Graft** was the one card whose missing capability was a single reusable primitive, so this PR is that primitive plus the card. Per the brief's "pick fewer cards if they are complex".

## What's here

```
{1}  Artifact — Equipment
Equipped creature gets +3/+3.
Whenever equipped creature attacks, it doesn't untap during its controller's next untap step.
Whenever this Equipment becomes unattached from a permanent, sacrifice that permanent.
Equip {2}
```

Canonical goes in **EMN** (earliest real printing, 2016-07-22); **INR** gets a `Printing` row. `just check-card-printing` is clean.

The +3/+3 and the attack rider are existing vocabulary — `ModifyStats` and the same `AbilityFlag.DOESNT_UNTAP` + `Duration.UntilAfterAffectedControllersNextUntap` pair Crippling Chill uses. The third line needed a new trigger.

### `Triggers.becomesUnattached`

The mirror of `becomesAttached`, backed by `PermanentUnattachedEvent` — which previously only `Effects.UnattachEquipment` emitted. The card's ruling enumerates every way an Equipment comes off, so all of them now report it:

| path | emits from |
|---|---|
| explicit unattach effect | `UnattachEquipmentExecutor` |
| equipping onto a different host | `AttachEquipmentExecutor` |
| CR 704.5m/n state-based unattach | `UnattachedAurasCheck` (4 branches) |
| host leaves the battlefield | `UnattachedAurasCheck` host-left branch |
| the attachment leaves the battlefield | `ZoneTransitionService` |

The three that leave the attachment on the battlefield route through one new chokepoint, `ZoneMovementUtils.unattachEmittingEvent`, so none can silently skip the event. The leave path emits from `ZoneTransitionService` *before* the link and `ControllerComponent` are cleared, so the trigger keeps its last-known information (CR 603.6e). Because the unattach can be *caused* by the attachment leaving, `TriggerDetector` gains a pass for a source no longer on the battlefield, mirroring `detectExploitedSelfSacrificeTriggers`.

### "That permanent"

Reuses `EffectTarget.AttachedToTriggeringPermanent`, but the two trigger kinds need different resolution and the difference is load-bearing:

- **attach** resolves it *live* off the attachment's `AttachedToComponent` — so a "for as long as attached" payoff does nothing if the attachment already moved or left (CR 611.2b). That's what Eriette and Assimilation Aegis want, and it is unchanged.
- **unattach** cannot, because by resolution the link is either gone or — when the unattach was caused by equipping the attachment *elsewhere* — already re-pointed at the **new** host. Reading live there would have Stitcher's Graft sacrifice the creature it just moved onto. It instead reads the host recorded on the trigger (`TriggerContext.unattachedFromEntityId`), scoped to the battlefield so a former host that has itself left resolves to nothing.

That last scoping is precisely the ruling: *"It also becomes unattached if the equipped creature leaves the battlefield, but the triggered ability won't do anything in that case."*

### Drive-by fix

`SacrificeTargetExecutor` resolved its target through the **no-state** `resolveTarget` overload, which returns null for every relational target (the equipped creature, the host an attachment came off) — making the sacrifice a quiet no-op rather than an error. Switched to the state-taking overload.

## Verification

`just build` green. `StitchersGraftScenarioTest` covers five cases:

- equipped creature gets +3/+3
- attacking skips the controller's next untap step (turn pinned so the assertion isn't vacuous)
- equipping the Graft onto another creature sacrifices the creature it came off — and the new host is unharmed
- destroying the Graft sacrifices the creature it was equipping (the leave-the-battlefield detection path)
- the equipped creature dying fires the trigger but sacrifices nothing; the Graft unattaches and stays on the battlefield

EMN golden re-blessed — only Stitcher's Graft moved.

No new decision UI: both triggers are automatic and untargeted, and equip is the existing flow, so no `decisions/` component and no E2E test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)