### PR TITLE
Replace qualified OwnerComponent references

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
 import com.wingedsheep.engine.state.components.player.ManaSpentOnSpellsThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -1648,7 +1649,7 @@ class TriggerMatcher(
         }
         SpellCastPredicate.NotOwnedByController -> {
             val ownerId = state.getEntity(event.spellEntityId)
-                ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()
+                ?.get<OwnerComponent>()
                 ?.playerId
             ownerId != null && ownerId != controllerId
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -277,7 +277,7 @@ class LibraryAndZoneContinuationResumer(
             // When underOwnersControl, use the next aura's owner as its controller
             val nextControllerId = if (continuation.underOwnersControl) {
                 val e = newState.getEntity(nextAuraId)
-                e?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+                e?.get<OwnerComponent>()?.playerId
                     ?: e?.get<CardComponent>()?.ownerId
                     ?: continuation.controllerId
             } else continuation.controllerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
@@ -182,7 +183,7 @@ object TargetResolutionUtils {
             }
             .mapNotNull { id ->
                 val container = state.getEntity(id)
-                container?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+                container?.get<OwnerComponent>()?.playerId
                     ?: container?.get<CardComponent>()?.ownerId
             }
             .distinct()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChooseNModalPreChosenTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChooseNModalPreChosenTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.support.GameTestDriver
@@ -166,7 +167,7 @@ class ChooseNModalPreChosenTest : FunSpec({
         // resolution — easier than scheduling another spell). Use replaceState to move it to the
         // graveyard zone directly.
         val beforeResolution = d.state
-        val lionsOwner = beforeResolution.getEntity(lions)?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId ?: p1
+        val lionsOwner = beforeResolution.getEntity(lions)?.get<OwnerComponent>()?.playerId ?: p1
         val battlefieldZoneKey = com.wingedsheep.engine.state.ZoneKey(p1, com.wingedsheep.sdk.core.Zone.BATTLEFIELD)
         val graveyardZoneKey = com.wingedsheep.engine.state.ZoneKey(lionsOwner, com.wingedsheep.sdk.core.Zone.GRAVEYARD)
         val relocated = beforeResolution

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombat
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Phase
@@ -678,7 +679,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
         // Every component derived from the printed definition (can't-be-countered/copied, morph,
@@ -727,7 +728,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
         container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
@@ -774,7 +775,7 @@ class GameTestDriver {
 
         val container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
 
@@ -815,7 +816,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
         container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
@@ -863,7 +864,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId),
             com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
         )
@@ -927,7 +928,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
         container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
@@ -991,7 +992,7 @@ class GameTestDriver {
      */
     fun moveToGraveyard(entityId: EntityId) {
         val ownerId = _state.getEntity(entityId)
-            ?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+            ?.get<OwnerComponent>()?.playerId
             ?: return
         // Remove from every zone the entity currently occupies rather than assuming battlefield;
         // otherwise discarding a hand card here is a no-op and any "while in hand" setup loop spins
@@ -1043,7 +1044,7 @@ class GameTestDriver {
 
         var container = com.wingedsheep.engine.state.ComponentContainer.of(
             cardComponent,
-            com.wingedsheep.engine.state.components.identity.OwnerComponent(playerId),
+            OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
         container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)


### PR DESCRIPTION
## Summary
- import `OwnerComponent` where it was referenced by its fully qualified name
- use the short type name across production code, shared test fixtures, and tests
- leave package declarations, imports, and unrelated qualified references unchanged

## Verification
- `just test-rules`
- `git diff --check`